### PR TITLE
Cloud Provider Snapshot Restore Job Support

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -111,7 +111,7 @@ func (s *CloudProviderSnapshotRestoreJobsServiceOp) Get(ctx context.Context, req
 	return root, resp, err
 }
 
-//Create 	creates a new restore job from a cloud provider snapshot associated to the specified cluster.
+//Create creates a new restore job from a cloud provider snapshot associated to the specified cluster.
 //See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs-create-one/
 func (s *CloudProviderSnapshotRestoreJobsServiceOp) Create(ctx context.Context, requestParameters *SnapshotReqPathParameters, createRequest *CloudProviderSnapshotRestoreJob) (*CloudProviderSnapshotRestoreJob, *Response, error) {
 	// Verify if is download or automated

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -1,0 +1,176 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	cloudProviderSnapshotRestoreJobBasePath = "groups"
+)
+
+// CloudProviderSnapshotRestoreJobsService is an interface for interfacing with the CloudProviderSnapshotRestoreJobs
+// endpoints of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/cloudProviderSnapshotRestoreJobs/
+type CloudProviderSnapshotRestoreJobsService interface {
+	List(context.Context, *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJobs, *Response, error)
+	Get(context.Context, *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJob, *Response, error)
+	Create(context.Context, *SnapshotReqPathParameters, *CloudProviderSnapshotRestoreJob) (*CloudProviderSnapshotRestoreJob, *Response, error)
+	Delete(context.Context, *SnapshotReqPathParameters) (*Response, error)
+}
+
+//CloudProviderSnapshotRestoreJobsServiceOp handles communication with the CloudProviderSnapshotRestoreJobs related methos of the
+//MongoDB Atlas API
+type CloudProviderSnapshotRestoreJobsServiceOp struct {
+	client *Client
+}
+
+var _ CloudProviderSnapshotRestoreJobsService = &CloudProviderSnapshotRestoreJobsServiceOp{}
+
+// CloudProviderSnapshotRestoreJob represents the structure of a cloudProviderSnapshotRestoreJob.
+type CloudProviderSnapshotRestoreJob struct {
+	ID                string   `json:"id,omitempty"`                // The unique identifier of the restore job.
+	SnapshotID        string   `json:"snapshotId,omitempty"`        // Unique identifier of the snapshot to restore.
+	DeliveryType      string   `json:"deliveryType,omitempty"`      // Type of restore job to create. Possible values are: automated or download
+	DeliveryURL       []string `json:"deliveryUrl,omitempty"`       // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
+	TargetClusterName string   `json:"targetClusterName,omitempty"` // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
+	TargetGroupID     string   `json:"targetGroupId,omitempty"`     // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
+	Cancelled         bool     `json:"cancelled,omitempty"`         // Indicates whether the restore job was canceled.
+	CreatedAt         string   `json:"createdAt,omitempty"`         // UTC ISO 8601 formatted point in time when Atlas created the restore job.
+	Expired           bool     `json:"expired,omitempty"`           // Indicates whether the restore job expired.
+	ExpiresAt         string   `json:"expiresAt,omitempty"`         // UTC ISO 8601 formatted point in time when the restore job expires.
+	FinishedAt        string   `json:"finishedAt,omitempty"`        // UTC ISO 8601 formatted point in time when the restore job completed.
+	Links             []*Link  `json:"links,omitempty"`             // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
+	Timestamp         string   `json:"timestamp,omitempty"`         // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
+}
+
+// CloudProviderSnapshotRestoreJobs represents an array of cloudProviderSnapshotRestoreJob
+type CloudProviderSnapshotRestoreJobs struct {
+	Links      []*Link                            `json:"links"`
+	Results    []*CloudProviderSnapshotRestoreJob `json:"results"`
+	TotalCount int                                `json:"totalCount"`
+}
+
+//List gets all cloud provider snapshot restore jobs for the specified cluster.
+//See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs-get-all/
+func (s *CloudProviderSnapshotRestoreJobsServiceOp) List(ctx context.Context, requestParameters *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJobs, *Response, error) {
+	if requestParameters.GroupID == "" {
+		return nil, nil, NewArgError("groupId", "must be set")
+	}
+	if requestParameters.ClusterName == "" {
+		return nil, nil, NewArgError("clusterName", "must be set")
+	}
+
+	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CloudProviderSnapshotRestoreJobs)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root, resp, nil
+}
+
+//Get gets one cloud provider snapshot restore jobs for the specified cluster.
+//See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs-get-one/
+func (s *CloudProviderSnapshotRestoreJobsServiceOp) Get(ctx context.Context, requestParameters *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJob, *Response, error) {
+	if requestParameters.GroupID == "" {
+		return nil, nil, NewArgError("groupId", "must be set")
+	}
+	if requestParameters.ClusterName == "" {
+		return nil, nil, NewArgError("clusterName", "must be set")
+	}
+	if requestParameters.JobID == "" {
+		return nil, nil, NewArgError("jobId", "must be set")
+	}
+
+	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs/%s", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName, requestParameters.JobID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CloudProviderSnapshotRestoreJob)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+//Create 	creates a new restore job from a cloud provider snapshot associated to the specified cluster.
+//See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs-create-one/
+func (s *CloudProviderSnapshotRestoreJobsServiceOp) Create(ctx context.Context, requestParameters *SnapshotReqPathParameters, createRequest *CloudProviderSnapshotRestoreJob) (*CloudProviderSnapshotRestoreJob, *Response, error) {
+	// Verify if is download or automated
+	if requestParameters.GroupID == "" {
+		return nil, nil, NewArgError("groupId", "must be set")
+	}
+	if requestParameters.ClusterName == "" {
+		return nil, nil, NewArgError("clusterName", "must be set")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	if createRequest.DeliveryType == "download" {
+		createRequest.TargetClusterName = ""
+		createRequest.TargetGroupID = ""
+	}
+
+	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs", cloudProviderSnapshotRestoreJobBasePath, requestParameters.GroupID, requestParameters.ClusterName)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CloudProviderSnapshotRestoreJob)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root, resp, err
+}
+
+//Delete cancels the cloud provider snapshot manual download restore job associated to {JOB-ID}.
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs-delete-one/
+func (s *CloudProviderSnapshotRestoreJobsServiceOp) Delete(ctx context.Context, requestParameters *SnapshotReqPathParameters) (*Response, error) {
+	if requestParameters.GroupID == "" {
+		return nil, NewArgError("groupId", "must be set")
+	}
+	if requestParameters.ClusterName == "" {
+		return nil, NewArgError("clusterName", "must be set")
+	}
+	if requestParameters.JobID == "" {
+		return nil, NewArgError("jobId", "must be set")
+	}
+
+	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs/%s", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName, requestParameters.JobID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
@@ -1,0 +1,401 @@
+package mongodbatlas
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	requestParameters := &SnapshotReqPathParameters{
+		GroupID:     "5b6212af90dc76637950a2c6",
+		ClusterName: "MyCluster",
+	}
+
+	path := fmt.Sprintf("/groups/%s/clusters/%s/backup/restoreJobs", requestParameters.GroupID, requestParameters.ClusterName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs?pageNum=1&itemsPerPage=100",
+					"rel": "self"
+				}
+			],
+			"results": [
+				{
+					"cancelled": false,
+					"deliveryType": "automated",
+					"expired": false,
+					"expiresAt": "2018-08-02T02:08:48Z",
+					"id": "5b622f7087d9d6039fafe03f",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622f7087d9d6039fafe03f",
+							"rel": "self"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+							"rel": "http://mms.mongodb.com/snapshot"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+							"rel": "http://mms.mongodb.com/cluster"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+							"rel": "http://mms.mongodb.com/group"
+						}
+					],
+					"snapshotId": "5b6211ff87d9d663c59d3feg",
+					"targetClusterName": "MyOtherCluster",
+					"targetGroupId": "5b6212af90dc76637950a2c6",
+					"timestamp": "2018-08-01T20:02:07Z"
+				},
+				{
+					"cancelled": false,
+					"createdAt": "2018-08-01T22:05:41Z",
+					"deliveryType": "download",
+					"deliveryUrl": ["https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f.tar.gz"],
+					"expired": false,
+					"expiresAt": "2018-08-02T02:03:33Z",
+					"id": "5b622e3587d9d6039faf713f",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622e3587d9d6039faf713f",
+							"rel": "self"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+							"rel": "http://mms.mongodb.com/snapshot"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+							"rel": "http://mms.mongodb.com/cluster"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+							"rel": "http://mms.mongodb.com/group"
+						}
+					],
+					"snapshotId": "5b6211ff87d9d663c59d3feg",
+					"timestamp": "2018-08-01T20:02:07Z"
+				}
+			],
+			"totalCount": 2
+		}`)
+	})
+
+	cloudProviderSnapshots, _, err := client.CloudProviderSnapshotRestoreJobs.List(ctx, requestParameters)
+	if err != nil {
+		t.Errorf("CloudProviderSnapshotRestoreJobs.List returned error: %v", err)
+	}
+
+	expected := &CloudProviderSnapshotRestoreJobs{
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs?pageNum=1&itemsPerPage=100",
+				Rel:  "self",
+			},
+		},
+		Results: []*CloudProviderSnapshotRestoreJob{
+			{
+				Cancelled:    false,
+				DeliveryType: "automated",
+				Expired:      false,
+				ExpiresAt:    "2018-08-02T02:08:48Z",
+				ID:           "5b622f7087d9d6039fafe03f",
+				Links: []*Link{
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622f7087d9d6039fafe03f",
+						Rel:  "self",
+					},
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+						Rel:  "http://mms.mongodb.com/snapshot",
+					},
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+						Rel:  "http://mms.mongodb.com/cluster",
+					},
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+						Rel:  "http://mms.mongodb.com/group",
+					},
+				},
+				SnapshotID:        "5b6211ff87d9d663c59d3feg",
+				TargetClusterName: "MyOtherCluster",
+				TargetGroupID:     "5b6212af90dc76637950a2c6",
+				Timestamp:         "2018-08-01T20:02:07Z",
+			},
+			{
+				Cancelled:    false,
+				CreatedAt:    "2018-08-01T22:05:41Z",
+				DeliveryType: "download",
+				DeliveryURL:  []string{"https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f.tar.gz"},
+				Expired:      false,
+				ExpiresAt:    "2018-08-02T02:03:33Z",
+				ID:           "5b622e3587d9d6039faf713f",
+				Links: []*Link{
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622e3587d9d6039faf713f",
+						Rel:  "self",
+					},
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+						Rel:  "http://mms.mongodb.com/snapshot",
+					},
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+						Rel:  "http://mms.mongodb.com/cluster",
+					},
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+						Rel:  "http://mms.mongodb.com/group",
+					},
+				},
+				SnapshotID: "5b6211ff87d9d663c59d3feg",
+				Timestamp:  "2018-08-01T20:02:07Z",
+			},
+		},
+		TotalCount: 2,
+	}
+
+	if diff := deep.Equal(cloudProviderSnapshots, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(cloudProviderSnapshots, expected) {
+		t.Errorf("CloudProviderSnapshotRestoreJobs.List\n got=%#v\nwant=%#v", cloudProviderSnapshots, expected)
+	}
+}
+
+func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	requestParameters := &SnapshotReqPathParameters{
+		GroupID:     "5b6212af90dc76637950a2c6",
+		ClusterName: "MyCluster",
+		JobID:       "5b622f7087d9d6039fafe03f",
+	}
+
+	path := fmt.Sprintf("/groups/%s/clusters/%s/backup/restoreJobs/%s", requestParameters.GroupID, requestParameters.ClusterName, requestParameters.JobID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"cancelled": false,
+			"deliveryType": "automated",
+			"expired": false,
+			"expiresAt": "2018-08-02T02:08:48Z",
+			"id": "5b622f7087d9d6039fafe03f",
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622f7087d9d6039fafe03f",
+					"rel": "self"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+					"rel": "http://mms.mongodb.com/snapshot"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+					"rel": "http://mms.mongodb.com/cluster"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+					"rel": "http://mms.mongodb.com/group"
+				}
+			],
+			"snapshotId": "5b6211ff87d9d663c59d3feg",
+			"targetClusterName": "MyOtherCluster",
+			"targetGroupId": "5b6212af90dc76637950a2c6",
+			"timestamp": "2018-08-01T20:02:07Z"
+		}`)
+	})
+
+	cloudProviderSnapshot, _, err := client.CloudProviderSnapshotRestoreJobs.Get(ctx, requestParameters)
+	if err != nil {
+		t.Errorf("CloudProviderSnapshotRestoreJobs.Get returned error: %v", err)
+	}
+
+	expected := &CloudProviderSnapshotRestoreJob{
+		Cancelled:    false,
+		DeliveryType: "automated",
+		Expired:      false,
+		ExpiresAt:    "2018-08-02T02:08:48Z",
+		ID:           "5b622f7087d9d6039fafe03f",
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622f7087d9d6039fafe03f",
+				Rel:  "self",
+			},
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+				Rel:  "http://mms.mongodb.com/snapshot",
+			},
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+				Rel:  "http://mms.mongodb.com/cluster",
+			},
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+				Rel:  "http://mms.mongodb.com/group",
+			},
+		},
+		SnapshotID:        "5b6211ff87d9d663c59d3feg",
+		TargetClusterName: "MyOtherCluster",
+		TargetGroupID:     "5b6212af90dc76637950a2c6",
+		Timestamp:         "2018-08-01T20:02:07Z",
+	}
+
+	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
+		t.Errorf("CloudProviderSnapshotRestoreJobs.Get\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
+	}
+}
+
+func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	requestParameters := &SnapshotReqPathParameters{
+		GroupID:     "5b6212af90dc76637950a2c6",
+		ClusterName: "MyClusterName",
+	}
+
+	createRequest := &CloudProviderSnapshotRestoreJob{
+		SnapshotID:        "5b6211ff87d9d663c59d3feg",
+		DeliveryType:      "automated",
+		TargetClusterName: "MyOtherCluster",
+		TargetGroupID:     "5b6212af90dc76637950a2c6",
+	}
+
+	path := fmt.Sprintf("/groups/%s/clusters/%s/backup/restoreJobs", requestParameters.GroupID, requestParameters.ClusterName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"snapshotId":        "5b6211ff87d9d663c59d3feg",
+			"deliveryType":      "automated",
+			"targetClusterName": "MyOtherCluster",
+			"targetGroupId":     "5b6212af90dc76637950a2c6",
+		}
+
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Decode json: %v", err)
+		}
+
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
+		}
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprintf(w, `{
+			"cancelled": false,
+			"deliveryType": "automated",
+			"expired": false,
+			"expiresAt": "2018-08-02T02:08:48Z",
+			"id": "5b622f7087d9d6039fafe03f",
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622f7087d9d6039fafe03f",
+					"rel": "self"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+					"rel": "http://mms.mongodb.com/snapshot"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+					"rel": "http://mms.mongodb.com/cluster"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+					"rel": "http://mms.mongodb.com/group"
+				}
+			],
+			"snapshotId": "5b6211ff87d9d663c59d3feg",
+			"targetClusterName": "MyOtherCluster",
+			"targetGroupId": "5b6212af90dc76637950a2c6",
+			"timestamp": "2018-08-01T20:02:07Z"
+		}`)
+	})
+
+	cloudProviderSnapshot, _, err := client.CloudProviderSnapshotRestoreJobs.Create(ctx, requestParameters, createRequest)
+	if err != nil {
+		t.Errorf("CloudProviderSnapshotRestoreJobs.Create returned error: %v", err)
+	}
+
+	expected := &CloudProviderSnapshotRestoreJob{
+		Cancelled:    false,
+		DeliveryType: "automated",
+		Expired:      false,
+		ExpiresAt:    "2018-08-02T02:08:48Z",
+		ID:           "5b622f7087d9d6039fafe03f",
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/restoreJobs/5b622f7087d9d6039fafe03f",
+				Rel:  "self",
+			},
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0/backup/snapshots/5b6211ff87d9d663c59d3dee",
+				Rel:  "http://mms.mongodb.com/snapshot",
+			},
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6/clusters/Cluster0",
+				Rel:  "http://mms.mongodb.com/cluster",
+			},
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5b6212af90dc76637950a2c6",
+				Rel:  "http://mms.mongodb.com/group",
+			},
+		},
+		SnapshotID:        "5b6211ff87d9d663c59d3feg",
+		TargetClusterName: "MyOtherCluster",
+		TargetGroupID:     "5b6212af90dc76637950a2c6",
+		Timestamp:         "2018-08-01T20:02:07Z",
+	}
+
+	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
+		t.Errorf("CloudProviderSnapshotRestoreJobs.Create\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
+	}
+}
+
+func TestCloudProviderSnapshotRestoreJobs_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	requestParameters := &SnapshotReqPathParameters{
+		GroupID:     "5b6212af90dc76637950a2c6",
+		ClusterName: "MyCluster",
+		JobID:       "5b622f7087d9d6039fafe03f",
+	}
+
+	path := fmt.Sprintf("/groups/%s/clusters/%s/backup/restoreJobs/%s", requestParameters.GroupID, requestParameters.ClusterName, requestParameters.JobID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.CloudProviderSnapshotRestoreJobs.Delete(ctx, requestParameters)
+	if err != nil {
+		t.Errorf("CloudProviderSnapshotRestoreJobs.Delete returned error: %v", err)
+	}
+}

--- a/mongodbatlas/cloud_provider_snapshots_test.go
+++ b/mongodbatlas/cloud_provider_snapshots_test.go
@@ -257,7 +257,7 @@ func TestCloudProviderSnapshots_Create(t *testing.T) {
 		t.Error(diff)
 	}
 	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
-		t.Errorf("DatabaseUsers.Get\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
+		t.Errorf("CloudProviderSnapshots.Create\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
 	}
 }
 

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -31,12 +31,13 @@ type Client struct {
 	UserAgent string
 
 	//Services used for communicating with the API
-	DatabaseUsers          DatabaseUsersService
-	ProjectIPWhitelist     ProjectIPWhitelistService
-	Projects               ProjectsService
-	Clusters               ClustersService
-	CloudProviderSnapshots CloudProviderSnapshotsService
-	APIKeys                APIKeysService
+	DatabaseUsers                    DatabaseUsersService
+	ProjectIPWhitelist               ProjectIPWhitelistService
+	Projects                         ProjectsService
+	Clusters                         ClustersService
+	CloudProviderSnapshots           CloudProviderSnapshotsService
+	APIKeys                          APIKeysService
+	CloudProviderSnapshotRestoreJobs CloudProviderSnapshotRestoreJobsService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -134,6 +135,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Clusters = &ClustersServiceOp{client: c}
 	c.CloudProviderSnapshots = &CloudProviderSnapshotsServiceOp{client: c}
 	c.APIKeys = &APIKeysServiceOp{client: c}
+	c.CloudProviderSnapshotRestoreJobs = &CloudProviderSnapshotRestoreJobsServiceOp{client: c}
 
 	return c
 }


### PR DESCRIPTION
Added:

- cloud_provider_snapshot_restore_jobs file to handle API calls.
- cloud_provider_snapshot_restore_jobs_test file to Test.

https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs/