### PR TITLE
 Encryption At Rest Service

### DIFF
--- a/mongodbatlas/encryptions_at_rest.go
+++ b/mongodbatlas/encryptions_at_rest.go
@@ -1,0 +1,180 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/mwielbut/pointy"
+)
+
+const (
+	// CaCentral1 represents the CA_CENTRAL_1 America region for AWS Configuration
+	CaCentral1 = "CA_CENTRAL_1"
+	// UsEast1 represents the US_EAST_1 America region for AWS Configuration
+	UsEast1 = "US_EAST_1"
+	// UsEast2 represents the US_EAST_2 America region for AWS Configuration
+	UsEast2 = "US_EAST_2"
+	// UsWest1 represents the US_WEST_1 America region for AWS Configuration
+	UsWest1 = "US_WEST_1"
+	// UsWest2 represents the US_WEST_2 America region for AWS Configuration
+	UsWest2 = "US_WEST_2"
+	// SaEast1 represents the SA_EAST_1 America region for AWS Configuration
+	SaEast1 = "SA_EAST_1"
+
+	// ApNortheast1 represents the AP_NORTHEAST_1 Asia region for AWS Configuration
+	ApNortheast1 = "AP_NORTHEAST_1"
+	// ApNortheast2 represents the AP_NORTHEAST_2 Asia region for AWS Configuration
+	ApNortheast2 = "AP_NORTHEAST_2"
+	// ApSouth1 represents the AP_SOUTH_1 Asia region for AWS Configuration
+	ApSouth1 = "AP_SOUTH_1"
+	// ApSoutheast1 represents the AP_SOUTHEAST_1 Asia region for AWS Configuration
+	ApSoutheast1 = "AP_SOUTHEAST_1"
+	// ApSoutheast2 represents the AP_SOUTHEAST_2 Asia region for AWS Configuration
+	ApSoutheast2 = "AP_SOUTHEAST_2"
+
+	// EuCentral1 represents the EU_CENTRAL_1 Europe region for AWS Configuration
+	EuCentral1 = "EU_CENTRAL_1"
+	// EuWest1 represents the EU_WEST_1 Europe region for AWS Configuration
+	EuWest1 = "EU_WEST_1"
+	// EuWest2 represents the EU_WEST_2 Europe region for AWS Configuration
+	EuWest2 = "EU_WEST_2"
+	// EuWest3 represents the EU_WEST_3 Europe region for AWS Configuration
+	EuWest3 = "EU_WEST_3"
+
+	// Azure represents `AZURE` where the Azure account credencials reside
+	Azure = "AZURE"
+	// AzureChina represents `AZURE_CHINA` AZURE where the Azure account credencials reside
+	AzureChina = "AZURE_CHINA"
+	// AzureGermany represents `AZURE_GERMANY` AZURE where the Azure account credencials reside
+	AzureGermany = "AZURE_GERMANY"
+
+	encryptionsAtRestBasePath = "groups/%s/encryptionAtRest"
+)
+
+// EncryptionsAtRestService is an interface for interfacing with the Encryption at Rest
+// endpoints of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/encryption-at-rest/
+type EncryptionsAtRestService interface {
+	Create(context.Context, *EncryptionAtRest) (*EncryptionAtRest, *Response, error)
+	Get(context.Context, string) (*EncryptionAtRest, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+//EncryptionsAtRestServiceOp handles communication with the DatabaseUsers related methos of the
+//MongoDB Atlas API
+type EncryptionsAtRestServiceOp struct {
+	client *Client
+}
+
+var _ EncryptionsAtRestService = &EncryptionsAtRestServiceOp{}
+
+// EncryptionAtRest represents a configuration Encryption at Rest for an Atlas project.
+type EncryptionAtRest struct {
+	GroupID        string                            `json:"groupId,omitempty"` // The unique identifier for the project.
+	AwsKms         `json:"awsKms,omitempty"`         // AwsKms specifies AWS KMS configuration details and whether Encryption at Rest is enabled for an Atlas project.
+	AzureKeyVault  `json:"azureKeyVault,omitempty"`  // AzureKeyVault specifies Azure Key Vault configuration details and whether Encryption at Rest is enabled for an Atlas project.
+	GoogleCloudKms `json:"googleCloudKms,omitempty"` // Specifies GCP KMS configuration details and whether Encryption at Rest is enabled for an Atlas project.
+}
+
+// AwsKms specifies AWS KMS configuration details and whether Encryption at Rest is enabled for an Atlas project.
+type AwsKms struct {
+	Enabled             *bool  `json:"enabled,omitempty"`             // Specifies whether Encryption at Rest is enabled for an Atlas project, To disable Encryption at Rest, pass only this parameter with a value of false, When you disable Encryption at Rest, Atlas also removes the configuration details.
+	AccessKeyID         string `json:"accessKeyID,omitempty"`         // The IAM access key ID with permissions to access the customer master key specified by customerMasterKeyID.
+	SecretAccessKey     string `json:"secretAccessKey,omitempty"`     // The IAM secret access key with permissions to access the customer master key specified by customerMasterKeyID.
+	CustomerMasterKeyID string `json:"customerMasterKeyID,omitempty"` // The AWS customer master key used to encrypt and decrypt the MongoDB master keys.
+	Region              string `json:"region,omitempty"`              // The AWS region in which the AWS customer master key exists: CA_CENTRAL_1, US_EAST_1, US_EAST_2, US_WEST_1, US_WEST_2, SA_EAST_1
+}
+
+// AzureKeyVault specifies Azure Key Vault configuration details and whether Encryption at Rest is enabled for an Atlas project.
+type AzureKeyVault struct {
+	Enabled           *bool  `json:"enabled,omitempty"`           // Specifies whether Encryption at Rest is enabled for an Atlas project. To disable Encryption at Rest, pass only this parameter with a value of false. When you disable Encryption at Rest, Atlas also removes the configuration details.
+	ClientID          string `json:"clientID,omitempty"`          // The client ID, also known as the application ID, for an Azure application associated with the Azure AD tenant.
+	AzureEnvironment  string `json:"azureEnvironment,omitempty"`  // The Azure environment where the Azure account credentials reside. Valid values are the following: AZURE, AZURE_CHINA, AZURE_GERMANY
+	SubscriptionID    string `json:"subscriptionID,omitempty"`    // The unique identifier associated with an Azure subscription.
+	ResourceGroupName string `json:"resourceGroupName,omitempty"` // The name of the Azure Resource group that contains an Azure Key Vault.
+	KeyVaultName      string `json:"keyVaultName,omitempty"`      // The name of an Azure Key Vault containing your key.
+	KeyIdentifier     string `json:"keyIdentifier,omitempty"`     // The unique identifier of a key in an Azure Key Vault.
+	Secret            string `json:"secret,omitempty"`            // The secret associated with the Azure Key Vault specified by azureKeyVault.tenantID.
+	TenantID          string `json:"tenantID,omitempty"`          // The unique identifier for an Azure AD tenant within an Azure subscription.
+}
+
+// GoogleCloudKms specifies GCP KMS configuration details and whether Encryption at Rest is enabled for an Atlas project.
+type GoogleCloudKms struct {
+	Enabled              *bool  `json:"enabled,omitempty"`              // Specifies whether Encryption at Rest is enabled for an Atlas project. To disable Encryption at Rest, pass only this parameter with a value of false. When you disable Encryption at Rest, Atlas also removes the configuration details.
+	ServiceAccountKey    string `json:"serviceAccountKey,omitempty"`    // String-formatted JSON object containing GCP KMS credentials from your GCP account.
+	KeyVersionResourceID string `json:"keyVersionResourceID,omitempty"` // 	The Key Version Resource ID from your GCP account.
+}
+
+//Create takes one on-demand snapshot. Atlas takes on-demand snapshots immediately, unlike scheduled snapshots which occur at regular intervals.
+//See more: https://docs.atlas.mongodb.com/reference/api/enable-configure-encryptionatrest/
+func (s *EncryptionsAtRestServiceOp) Create(ctx context.Context, createRequest *EncryptionAtRest) (*EncryptionAtRest, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+	if createRequest.GroupID == "" {
+		return nil, nil, NewArgError("groupId", "must be set")
+	}
+
+	path := fmt.Sprintf(encryptionsAtRestBasePath, createRequest.GroupID)
+	createRequest.GroupID = ""
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(EncryptionAtRest)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, err
+}
+
+// Get retrieves the current configuration for Encryption at Rest for an Atlas project.
+//See more: https://docs.atlas.mongodb.com/reference/api/get-configuration-encryptionatrest/
+func (s *EncryptionsAtRestServiceOp) Get(ctx context.Context, groupID string) (*EncryptionAtRest, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupId", "must be set")
+	}
+
+	path := fmt.Sprintf(encryptionsAtRestBasePath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(EncryptionAtRest)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+//Delete disable the AWS, Azure and Google Encryption at Rest.
+// See more: https://docs.atlas.mongodb.com/reference/api/enable-configure-encryptionatrest/
+func (s *EncryptionsAtRestServiceOp) Delete(ctx context.Context, groupID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupId", "must be set")
+	}
+
+	createRequest := EncryptionAtRest{
+		AwsKms:         AwsKms{Enabled: pointy.Bool(false)},
+		AzureKeyVault:  AzureKeyVault{Enabled: pointy.Bool(false)},
+		GoogleCloudKms: GoogleCloudKms{Enabled: pointy.Bool(false)},
+	}
+
+	path := fmt.Sprintf(encryptionsAtRestBasePath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, createRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/mongodbatlas/encryptions_at_rest_test.go
+++ b/mongodbatlas/encryptions_at_rest_test.go
@@ -1,0 +1,211 @@
+package mongodbatlas
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/mwielbut/pointy"
+)
+
+func TestEncryptionsAtRest_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &EncryptionAtRest{
+		GroupID: "6d2065c687d9d64ae7acdg41",
+		AwsKms: AwsKms{
+			Enabled:             pointy.Bool(true),
+			AccessKeyID:         "AKIAIOSFODNN7EXAMPLE",
+			SecretAccessKey:     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			CustomerMasterKeyID: "030gce02-586d-48d2-a966-05ea954fde0g",
+			Region:              CaCentral1,
+		},
+		AzureKeyVault: AzureKeyVault{
+			Enabled:           pointy.Bool(true),
+			ClientID:          "g54f9e2-89e3-40fd-8188-EXAMPLEID",
+			AzureEnvironment:  Azure,
+			SubscriptionID:    "0ec944e3-g725-44f9-a147-EXAMPLEID",
+			ResourceGroupName: "ExampleRGName",
+			KeyVaultName:      "EXAMPLEKeyVault",
+			KeyIdentifier:     "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86",
+			Secret:            "EXAMPLESECRET",
+			TenantID:          "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID",
+		},
+		GoogleCloudKms: GoogleCloudKms{
+			Enabled:              pointy.Bool(true),
+			ServiceAccountKey:    "{\"type\": \"service_account\",\"project_id\": \"my-project-common-0\",\"private_key_id\": \"e120598ea4f88249469fcdd75a9a785c1bb3\",\"private_key\": \"-----BEGIN PRIVATE KEY-----\\nMIIEuwIBA(truncated)SfecnS0mT94D9\\n-----END PRIVATE KEY-----\\n\",\"client_email\": \"my-email-kms-0@my-project-common-0.iam.gserviceaccount.com\",\"client_id\": \"10180967717292066\",\"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",\"token_uri\": \"https://accounts.google.com/o/oauth2/token\",\"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",\"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/my-email-kms-0%40my-project-common-0.iam.gserviceaccount.com\"}",
+			KeyVersionResourceID: "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1",
+		},
+	}
+
+	mux.HandleFunc(fmt.Sprintf("/"+encryptionsAtRestBasePath, createRequest.GroupID), func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"awsKms": map[string]interface{}{
+				"enabled":             true,
+				"accessKeyID":         "AKIAIOSFODNN7EXAMPLE",
+				"secretAccessKey":     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				"customerMasterKeyID": "030gce02-586d-48d2-a966-05ea954fde0g",
+				"region":              CaCentral1,
+			},
+			"azureKeyVault": map[string]interface{}{
+				"enabled":           true,
+				"clientID":          "g54f9e2-89e3-40fd-8188-EXAMPLEID",
+				"azureEnvironment":  Azure,
+				"subscriptionID":    "0ec944e3-g725-44f9-a147-EXAMPLEID",
+				"resourceGroupName": "ExampleRGName",
+				"keyVaultName":      "EXAMPLEKeyVault",
+				"keyIdentifier":     "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86",
+				"secret":            "EXAMPLESECRET",
+				"tenantID":          "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID",
+			},
+			"googleCloudKms": map[string]interface{}{
+				"enabled":              true,
+				"serviceAccountKey":    "{\"type\": \"service_account\",\"project_id\": \"my-project-common-0\",\"private_key_id\": \"e120598ea4f88249469fcdd75a9a785c1bb3\",\"private_key\": \"-----BEGIN PRIVATE KEY-----\\nMIIEuwIBA(truncated)SfecnS0mT94D9\\n-----END PRIVATE KEY-----\\n\",\"client_email\": \"my-email-kms-0@my-project-common-0.iam.gserviceaccount.com\",\"client_id\": \"10180967717292066\",\"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",\"token_uri\": \"https://accounts.google.com/o/oauth2/token\",\"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",\"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/my-email-kms-0%40my-project-common-0.iam.gserviceaccount.com\"}",
+				"keyVersionResourceID": "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1",
+			},
+		}
+
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Decode json: %v", err)
+		}
+
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
+		}
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprintf(w, `{
+			"awsKms": {
+				"enabled": true,
+				"accessKeyID": "AKIAIOSFODNN7EXAMPLE",
+				"customerMasterKeyID": "030gce02-586d-48d2-a966-05ea954fde0g",
+				"region": "US_EAST_1"
+			},
+			"azureKeyVault": {
+				"enabled": true,
+				"clientID": "g54f9e2-89e3-40fd-8188-EXAMPLEID",
+				"azureEnvironment": "AZURE",
+				"subscriptionID": "0ec944e3-g725-44f9-a147-EXAMPLEID",
+				"resourceGroupName": "ExampleRGName",
+				"keyVaultName": "EXAMPLEKeyVault",
+				"keyIdentifier": "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86",
+				"tenantID": "e8e4b6ba-ff32-4c88-a9af-dc17efegdf63"
+			},
+			"googleCloudKms": {
+				"enabled": true,
+				"keyVersionResourceID": "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1"
+			}
+		}`)
+	})
+
+	cloudProviderSnapshot, _, err := client.EncryptionsAtRest.Create(ctx, createRequest)
+	if err != nil {
+		t.Errorf("EncryptionsAtRest.Create returned error: %v", err)
+	}
+
+	expected := &EncryptionAtRest{
+		AwsKms: AwsKms{
+			Enabled:             pointy.Bool(true),
+			AccessKeyID:         "AKIAIOSFODNN7EXAMPLE",
+			CustomerMasterKeyID: "030gce02-586d-48d2-a966-05ea954fde0g",
+			Region:              "US_EAST_1",
+		},
+		AzureKeyVault: AzureKeyVault{
+			Enabled:           pointy.Bool(true),
+			ClientID:          "g54f9e2-89e3-40fd-8188-EXAMPLEID",
+			AzureEnvironment:  "AZURE",
+			SubscriptionID:    "0ec944e3-g725-44f9-a147-EXAMPLEID",
+			ResourceGroupName: "ExampleRGName",
+			KeyVaultName:      "EXAMPLEKeyVault",
+			KeyIdentifier:     "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86",
+			TenantID:          "e8e4b6ba-ff32-4c88-a9af-dc17efegdf63",
+		},
+		GoogleCloudKms: GoogleCloudKms{
+			Enabled:              pointy.Bool(true),
+			KeyVersionResourceID: "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1",
+		},
+	}
+
+	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
+		t.Errorf("EncryptionsAtRest.Create\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
+	}
+}
+
+func TestEncryptionsAtRest_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	groupID := "6d2065c687d9d64ae7acdg41"
+
+	mux.HandleFunc(fmt.Sprintf("/"+encryptionsAtRestBasePath, groupID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"awsKms": {
+				"enabled": true,
+				"accessKeyID": "AKIAIOSFODNN7EXAMPLE",
+				"customerMasterKeyID": "030gce02-586d-48d2-a966-05ea954fde0g",
+				"region": "US_EAST_1"
+			},
+			"azureKeyVault": {
+				"enabled": true,
+				"azureEnvironment": "AZURE",
+				"clientID": "g54f9e2-89e3-40fd-8188-EXAMPLEID",
+				"keyIdentifier": "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86",
+				"keyVaultName": "EXAMPLEKeyVault",
+				"resourceGroupName": "ExampleRGName",
+				"subscriptionID": "0ec944e3-g725-44f9-a147-EXAMPLEID",
+				"tenantID": "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID"
+			},
+			"googleCloudKms": {
+				"enabled": true,
+				"keyVersionResourceID": "projects/my-project/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1"
+			}
+		}`)
+	})
+
+	cloudProviderSnapshot, _, err := client.EncryptionsAtRest.Get(ctx, groupID)
+	if err != nil {
+		t.Errorf("EncryptionsAtRest.Get returned error: %v", err)
+	}
+
+	expected := &EncryptionAtRest{
+		AwsKms: AwsKms{
+			Enabled:             pointy.Bool(true),
+			AccessKeyID:         "AKIAIOSFODNN7EXAMPLE",
+			CustomerMasterKeyID: "030gce02-586d-48d2-a966-05ea954fde0g",
+			Region:              "US_EAST_1",
+		},
+		AzureKeyVault: AzureKeyVault{
+			Enabled:           pointy.Bool(true),
+			AzureEnvironment:  "AZURE",
+			ClientID:          "g54f9e2-89e3-40fd-8188-EXAMPLEID",
+			KeyIdentifier:     "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86",
+			KeyVaultName:      "EXAMPLEKeyVault",
+			ResourceGroupName: "ExampleRGName",
+			SubscriptionID:    "0ec944e3-g725-44f9-a147-EXAMPLEID",
+			TenantID:          "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID",
+		},
+		GoogleCloudKms: GoogleCloudKms{
+			Enabled:              pointy.Bool(true),
+			KeyVersionResourceID: "projects/my-project/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1",
+		},
+	}
+
+	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
+		t.Errorf("EncryptionsAtRest.Get\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
+	}
+}

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -40,6 +40,7 @@ type Client struct {
 	CloudProviderSnapshotRestoreJobs CloudProviderSnapshotRestoreJobsService
 	Peers                            PeersService
 	Containers                       ContainersService
+	EncryptionsAtRest                EncryptionsAtRestService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -140,6 +141,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.CloudProviderSnapshotRestoreJobs = &CloudProviderSnapshotRestoreJobsServiceOp{client: c}
 	c.Peers = &PeersServiceOp{client: c}
 	c.Containers = &ContainersServiceOp{client: c}
+	c.EncryptionsAtRest = &EncryptionsAtRestServiceOp{client: c}
 
 	return c
 }


### PR DESCRIPTION
Added:

- encryptions_at_rest file to handle API calls.
- encryptions_at_rest_test file to Test.

https://docs.atlas.mongodb.com/reference/api/encryption-at-rest/