### PR TITLE
Whitelist API Keys

### DIFF
--- a/mongodbatlas/api_keys.go
+++ b/mongodbatlas/api_keys.go
@@ -9,9 +9,9 @@ import (
 
 const apiKeysPath = "orgs/%s/apiKeys"
 
-//APIKeysService is an interface for interfacing with the APIKeys
+// APIKeysService is an interface for interfacing with the APIKeys
 // endpoints of the MongoDB Atlas API.
-//See more: https://docs.atlas.mongodb.com/reference/api/clusters/
+//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys/
 type APIKeysService interface {
 	List(context.Context, string, *ListOptions) ([]APIKey, *Response, error)
 	Get(context.Context, string, string) (*APIKey, *Response, error)
@@ -20,7 +20,7 @@ type APIKeysService interface {
 	Delete(context.Context, string, string) (*Response, error)
 }
 
-//APIKeysServiceOp handles communication with the APIKey related methods
+// APIKeysServiceOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API
 type APIKeysServiceOp struct {
 	client *Client
@@ -28,13 +28,13 @@ type APIKeysServiceOp struct {
 
 var _ APIKeysService = &APIKeysServiceOp{}
 
-// APIKeyInput represents MongoDB cluster input reuest for Create and Update.
+// APIKeyInput represents MongoDB API key input request for Create.
 type APIKeyInput struct {
 	Desc  string   `json:"desc,omitempty"`
 	Roles []string `json:"roles,omitempty"`
 }
 
-// APIKey represents MongoDB cluster.
+// APIKey represents MongoDB API Key.
 type APIKey struct {
 	ID         string       `json:"id,omitempty"`
 	Desc       string       `json:"desc,omitempty"`
@@ -43,6 +43,7 @@ type APIKey struct {
 	PublicKey  string       `json:"publicKey,omitempty"`
 }
 
+// APIKeyRole represents a role name of API key
 type APIKeyRole struct {
 	GroupID  string `json:"groupId,omitempty"`
 	OrgID    string `json:"orgId,omitempty"`
@@ -158,7 +159,7 @@ func (s *APIKeysServiceOp) Update(ctx context.Context, orgID string, apiKeyID st
 }
 
 //Delete the API Key specified to {API-KEY-ID} from the organization associated to {ORG-ID}.
-// See more: https://docs.atlas.mongodb.com/reference/api/clusters-delete-one/
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKey-delete-one-apiKey/
 func (s *APIKeysServiceOp) Delete(ctx context.Context, orgID string, apiKeyID string) (*Response, error) {
 	if apiKeyID == "" {
 		return nil, NewArgError("apiKeyID", "must be set")

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -42,6 +42,7 @@ type Client struct {
 	Peers                            PeersService
 	Containers                       ContainersService
 	EncryptionsAtRest                EncryptionsAtRestService
+	WhitelistAPIKeys                 WhitelistAPIKeysService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -144,6 +145,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Peers = &PeersServiceOp{client: c}
 	c.Containers = &ContainersServiceOp{client: c}
 	c.EncryptionsAtRest = &EncryptionsAtRestServiceOp{client: c}
+	c.WhitelistAPIKeys = &WhitelistAPIKeysServiceOp{client: c}
 
 	return c
 }

--- a/mongodbatlas/project_api_key.go
+++ b/mongodbatlas/project_api_key.go
@@ -56,7 +56,7 @@ func (s *ProjectAPIKeysOp) List(ctx context.Context, groupID string, listOptions
 }
 
 //Create an API Key by the {GROUP-ID}.
-//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-create-one/
+//See more: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/create-one-apiKey-in-one-project/
 func (s *ProjectAPIKeysOp) Create(ctx context.Context, groupID string, createRequest *APIKeyInput) (*APIKey, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
@@ -78,8 +78,8 @@ func (s *ProjectAPIKeysOp) Create(ctx context.Context, groupID string, createReq
 	return root, resp, err
 }
 
-//Assign an API-KEY related to {GROUP-ID} to a the project with {PROJECT-ID}.
-//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-get-all/
+//Assign an API-KEY related to {GROUP-ID} to a the project with {API-KEY-ID}.
+//See more: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/assign-one-org-apiKey-to-one-project/
 func (s *ProjectAPIKeysOp) Assign(ctx context.Context, groupID string, keyID string) (*Response, error) {
 	if groupID == "" {
 		return nil, NewArgError("apiKeyID", "must be set")
@@ -103,8 +103,8 @@ func (s *ProjectAPIKeysOp) Assign(ctx context.Context, groupID string, keyID str
 	return resp, err
 }
 
-//Unassign an API-KEY related to {GROUP-ID} to a the project with {PROJECT-ID}.
-//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-get-all/
+//Unassign an API-KEY related to {GROUP-ID} to a the project with {API-KEY-ID}.
+//See more: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/delete-one-apiKey-in-one-project/
 func (s *ProjectAPIKeysOp) Unassign(ctx context.Context, groupID string, keyID string) (*Response, error) {
 	if groupID == "" {
 		return nil, NewArgError("apiKeyID", "must be set")

--- a/mongodbatlas/whitelist_api_keys.go
+++ b/mongodbatlas/whitelist_api_keys.go
@@ -1,0 +1,163 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const whitelistAPIKeysPath = "orgs/%s/apiKeys/%s/whitelist"
+
+// WhitelistAPIKeysService is an interface for interfacing with the Whitelist API Keys
+// endpoints of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKeys/#organization-api-key-endpoints
+type WhitelistAPIKeysService interface {
+	List(context.Context, string, string) (*WhitelistAPIKeys, *Response, error)
+	Get(context.Context, string, string, string) (*WhitelistAPIKey, *Response, error)
+	Create(context.Context, string, string, *[]WhitelistAPIKeysReq) (*WhitelistAPIKeys, *Response, error)
+	Delete(context.Context, string, string, string) (*Response, error)
+}
+
+// WhitelistAPIKeysServiceOp handles communication with the Whitelist API keys related methods of the
+// MongoDB Atlas API
+type WhitelistAPIKeysServiceOp struct {
+	client *Client
+}
+
+var _ WhitelistAPIKeysService = &WhitelistAPIKeysServiceOp{}
+
+// WhitelistAPIKey represents a Whitelist API key.
+type WhitelistAPIKey struct {
+	CidrBlock       string  `json:"cidrBlock,omitempty"`       // CIDR-notated range of whitelisted IP addresses.
+	Count           int     `json:"count,omitempty"`           // Total number of requests that have originated from this IP address.
+	Created         string  `json:"created,omitempty"`         // Date this IP address was added to the whitelist.
+	IPAddress       string  `json:"ipAddress,omitempty"`       // Whitelisted IP address.
+	LastUsed        string  `json:"lastUsed,omitempty"`        // Date of the most recent request that originated from this IP address. This field only appears if at least one request has originated from this IP address, and is only updated when a whitelisted resource is accessed.
+	LastUsedAddress string  `json:"lastUsedAddress,omitempty"` // IP address from which the last call to the API was issued. This field only appears if at least one request has originated from this IP address.
+	Links           []*Link `json:"links,omitempty"`           // An array of documents, representing a link to one or more sub-resources and/or related resources such as list pagination. See Linking for more information.}
+}
+
+// WhitelistAPIKeys represents all Whitelist API keys.
+type WhitelistAPIKeys struct {
+	Results    []*WhitelistAPIKey `json:"results,omitempty"`    // Includes one WhitelistAPIKey object for each item detailed in the results array section.
+	Links      []*Link            `json:"links,omitempty"`      // One or more links to sub-resources and/or related resources.
+	TotalCount int                `json:"totalCount,omitempty"` // Count of the total number of items in the result set. It may be greater than the number of objects in the results array if the entire result set is paginated.
+}
+
+// WhitelistAPIKeysReq represents the request to the mehtod create
+type WhitelistAPIKeysReq struct {
+	IPAddress string `json:"ipAddress,omitempty"` // IP address to be added to the whitelist for the API key.
+	CidrBlock string `json:"cidrBlock,omitempty"` // Whitelist entry in CIDR notation to be added for the API key.
+}
+
+// List gets all Whitelist API keys.
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-get-all/
+func (s *WhitelistAPIKeysServiceOp) List(ctx context.Context, orgID string, apiKeyID string) (*WhitelistAPIKeys, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath, orgID, apiKeyID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(WhitelistAPIKeys)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root, resp, nil
+}
+
+//Get gets the Whitelist API keys.
+//See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-get-one/
+func (s *WhitelistAPIKeysServiceOp) Get(ctx context.Context, orgID string, apiKeyID string, ipAddress string) (*WhitelistAPIKey, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+	if ipAddress == "" {
+		return nil, nil, NewArgError("ipAddress", "must be set")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(WhitelistAPIKey)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Create a submit a POST request containing ipAddress or cidrBlock values which are not already present in the whitelist, Atlas adds those entries to the list of existing entries in the whitelist.
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-create/
+func (s *WhitelistAPIKeysServiceOp) Create(ctx context.Context, orgID string, apiKeyID string, createRequest *[]WhitelistAPIKeysReq) (*WhitelistAPIKeys, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath, orgID, apiKeyID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(WhitelistAPIKeys)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Delete deletes the Whitelist API keys.
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-delete-one/
+func (s *WhitelistAPIKeysServiceOp) Delete(ctx context.Context, orgID string, apiKeyID string, ipAddress string) (*Response, error) {
+	if orgID == "" {
+		return nil, NewArgError("groupId", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, NewArgError("clusterName", "must be set")
+	}
+	if ipAddress == "" {
+		return nil, NewArgError("snapshotId", "must be set")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/mongodbatlas/whitelist_api_keys_test.go
+++ b/mongodbatlas/whitelist_api_keys_test.go
@@ -1,0 +1,311 @@
+package mongodbatlas
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestWhitelistAPIKeys_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	orgID := "ORG-ID"
+	apiKeyID := "API-KEY-ID"
+
+	mux.HandleFunc(fmt.Sprintf("/"+whitelistAPIKeysPath, orgID, apiKeyID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/599c510c80eef518f3b63fe1/apiKeys/5c49e72980eef544a218f8f8/whitelist/?pretty=true&pageNum=1&itemsPerPage=100",
+					"rel": "self"
+				}
+			],
+			"results": [
+				{
+					"cidrBlock": "147.58.184.16/32",
+					"count": 0,
+					"created": "2019-01-24T16:34:57Z",
+					"ipAddress": "147.58.184.16",
+					"lastUsed": "2019-01-24T20:18:25Z",
+					"lastUsedAddress": "147.58.184.16",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/147.58.184.16",
+							"rel": "self"
+						}
+					]
+				},
+				{
+					"cidrBlock": "84.255.48.125/32",
+					"count": 0,
+					"created": "2019-01-24T16:26:37Z",
+					"ipAddress": "84.255.48.125",
+					"lastUsed": "2019-01-24T20:18:25Z",
+					"lastUsedAddress": "84.255.48.125",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/206.252.195.126",
+							"rel": "self"
+						}
+					]
+				}
+			],
+			"totalCount": 2
+		}`)
+	})
+
+	whitelistAPIKeys, _, err := client.WhitelistAPIKeys.List(ctx, orgID, apiKeyID)
+	if err != nil {
+		t.Errorf("WhitelistAPIKeys.List returned error: %v", err)
+	}
+
+	expected := &WhitelistAPIKeys{
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/599c510c80eef518f3b63fe1/apiKeys/5c49e72980eef544a218f8f8/whitelist/?pretty=true&pageNum=1&itemsPerPage=100",
+				Rel:  "self",
+			},
+		},
+		Results: []*WhitelistAPIKey{
+			{
+				CidrBlock:       "147.58.184.16/32",
+				Count:           0,
+				Created:         "2019-01-24T16:34:57Z",
+				IPAddress:       "147.58.184.16",
+				LastUsed:        "2019-01-24T20:18:25Z",
+				LastUsedAddress: "147.58.184.16",
+				Links: []*Link{
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/147.58.184.16",
+						Rel:  "self",
+					},
+				},
+			},
+			{
+				CidrBlock:       "84.255.48.125/32",
+				Count:           0,
+				Created:         "2019-01-24T16:26:37Z",
+				IPAddress:       "84.255.48.125",
+				LastUsed:        "2019-01-24T20:18:25Z",
+				LastUsedAddress: "84.255.48.125",
+				Links: []*Link{
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/206.252.195.126",
+						Rel:  "self",
+					},
+				},
+			},
+		},
+		TotalCount: 2,
+	}
+
+	if diff := deep.Equal(whitelistAPIKeys, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(whitelistAPIKeys, expected) {
+		t.Errorf("WhitelistAPIKeys.List\n got=%#v\nwant=%#v", whitelistAPIKeys, expected)
+	}
+}
+
+func TestWhitelistAPIKeys_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	orgID := "ORG-ID"
+	apiKeyID := "API-KEY-ID"
+	ipAddress := "IP-ADDRESS"
+
+	mux.HandleFunc(fmt.Sprintf("/"+whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"cidrBlock": "147.58.184.16/32",
+			"count": 0,
+			"created": "2019-01-24T16:34:57Z",
+			"ipAddress": "147.58.184.16",
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/147.58.184.16",
+					"rel": "self"
+				}
+			]
+		}`)
+	})
+
+	whitelistAPIKey, _, err := client.WhitelistAPIKeys.Get(ctx, orgID, apiKeyID, ipAddress)
+	if err != nil {
+		t.Errorf("WhitelistAPIKeys.Get returned error: %v", err)
+	}
+
+	expected := &WhitelistAPIKey{
+		CidrBlock: "147.58.184.16/32",
+		Count:     0,
+		Created:   "2019-01-24T16:34:57Z",
+		IPAddress: "147.58.184.16",
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/147.58.184.16",
+				Rel:  "self",
+			},
+		},
+	}
+
+	if diff := deep.Equal(whitelistAPIKey, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(whitelistAPIKey, expected) {
+		t.Errorf("WhitelistAPIKeys.Get\n got=%#v\nwant=%#v", whitelistAPIKey, expected)
+	}
+}
+
+func TestWhitelistAPIKeys_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	orgID := "ORG-ID"
+	apiKeyID := "API-KEY-ID"
+
+	createRequest := &[]WhitelistAPIKeysReq{
+		{
+			IPAddress: "77.54.32.11",
+			CidrBlock: "77.54.32.11/32",
+		},
+	}
+
+	mux.HandleFunc(fmt.Sprintf("/"+whitelistAPIKeysPath, orgID, apiKeyID), func(w http.ResponseWriter, r *http.Request) {
+		expected := []map[string]interface{}{
+			{
+				"ipAddress": "77.54.32.11",
+				"cidrBlock": "77.54.32.11/32",
+			},
+		}
+
+		var v []map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Decode json: %v", err)
+		}
+
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
+		}
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprintf(w, `{
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/599c510c80eef518f3b63fe1/apiKeys/5c49e72980eef544a218f8f8/whitelist/?pretty=true&pageNum=1&itemsPerPage=100",
+					"rel": "self"
+				}
+			],
+			"results": [
+				{
+					"cidrBlock": "147.58.184.16/32",
+					"count": 0,
+					"created": "2019-01-24T16:34:57Z",
+					"ipAddress": "147.58.184.16",
+					"lastUsed": "2019-01-24T20:18:25Z",
+					"lastUsedAddress": "147.58.184.16",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/147.58.184.16",
+							"rel": "self"
+						}
+					]
+				},
+				{
+					"cidrBlock": "77.54.32.11/32",
+					"count": 0,
+					"created": "2019-01-24T16:26:37Z",
+					"ipAddress": "77.54.32.11",
+					"lastUsed": "2019-01-24T20:18:25Z",
+					"lastUsedAddress": "77.54.32.11",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/77.54.32.11",
+							"rel": "self"
+						}
+					]
+				}
+			],
+			"totalCount": 2
+		}`)
+	})
+
+	whitelistAPIKey, _, err := client.WhitelistAPIKeys.Create(ctx, orgID, apiKeyID, createRequest)
+	if err != nil {
+		t.Errorf("WhitelistAPIKeys.Create returned error: %v", err)
+	}
+
+	expected := &WhitelistAPIKeys{
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/599c510c80eef518f3b63fe1/apiKeys/5c49e72980eef544a218f8f8/whitelist/?pretty=true&pageNum=1&itemsPerPage=100",
+				Rel:  "self",
+			},
+		},
+		Results: []*WhitelistAPIKey{
+			{
+				CidrBlock:       "147.58.184.16/32",
+				Count:           0,
+				Created:         "2019-01-24T16:34:57Z",
+				IPAddress:       "147.58.184.16",
+				LastUsed:        "2019-01-24T20:18:25Z",
+				LastUsedAddress: "147.58.184.16",
+				Links: []*Link{
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/147.58.184.16",
+						Rel:  "self",
+					},
+				},
+			},
+			{
+				CidrBlock:       "77.54.32.11/32",
+				Count:           0,
+				Created:         "2019-01-24T16:26:37Z",
+				IPAddress:       "77.54.32.11",
+				LastUsed:        "2019-01-24T20:18:25Z",
+				LastUsedAddress: "77.54.32.11",
+				Links: []*Link{
+					{
+						Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/whitelist/77.54.32.11",
+						Rel:  "self",
+					},
+				},
+			},
+		},
+		TotalCount: 2,
+	}
+
+	if diff := deep.Equal(whitelistAPIKey, expected); diff != nil {
+		t.Error(diff)
+	}
+	if !reflect.DeepEqual(whitelistAPIKey, expected) {
+		t.Errorf("WhitelistAPIKeys.Create\n got=%#v\nwant=%#v", whitelistAPIKey, expected)
+	}
+}
+
+func TestWhitelistAPIKeys_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	orgID := "ORG-ID"
+	apiKeyID := "API-KEY-ID"
+	ipAddress := "IP-ADDRESS"
+
+	mux.HandleFunc(fmt.Sprintf("/"+whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.WhitelistAPIKeys.Delete(ctx, orgID, apiKeyID, ipAddress)
+	if err != nil {
+		t.Errorf("WhitelistAPIKeys.Delete returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Added:

    whitelist_api_keys file to handle API calls.
    whitelist_api_keys_test file to Test.

https://docs.atlas.mongodb.com/reference/api/apiKeys/