### PR TITLE
Service for manipulating Custom MongoDB Roles

### DIFF
--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -13,6 +13,7 @@ type CustomDBRolesService interface {
 	Get(context.Context, string, string) (*CustomDbRole, *Response, error)
 	Create(context.Context, string, *CustomDbRole) (*CustomDbRole, *Response, error)
 	Update(context.Context, string, string, *CustomDbRole) (*CustomDbRole, *Response, error)
+	Delete(context.Context, string, string) (*Response, error)
 }
 
 //CustomDBRolesServiceOp handles communication with the CustomDBRoles related methods of the
@@ -132,4 +133,22 @@ func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, rol
 	}
 
 	return root, resp, err
+}
+
+func (s *CustomDBRolesServiceOp) Delete(ctx context.Context, groupID string, roleName string) (*Response, error) {
+	if roleName == "" {
+		return nil, NewArgError("roleName", "must be set")
+	}
+
+	basePath := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, roleName)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
 }

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -8,6 +8,9 @@ import (
 
 const dbCustomDBRolesBasePath = "groups/%s/customDBRoles/roles"
 
+// CustomDBRolesService is an interface for working wit the Custom MongoDB Roles
+// endpoints of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/custom-roles/
 type CustomDBRolesService interface {
 	List(context.Context, string, *ListOptions) (*[]CustomDbRole, *Response, error)
 	Get(context.Context, string, string) (*CustomDbRole, *Response, error)
@@ -24,22 +27,26 @@ type CustomDBRolesServiceOp struct {
 
 var _ CustomDBRolesService = &CustomDBRolesServiceOp{}
 
+// A Resource describes a specific resource the Role will allow operating on.
 type Resource struct {
 	Collection string `json:"collection,omitempty"`
 	Db         string `json:"db,omitempty"`
 	Cluster    bool   `json:"cluster,omitempty"`
 }
 
+// An Action describes the operation the role will include, for a specific set of Resources.
 type Action struct {
 	Action    string     `json:"action,omitempty"`
 	Resources []Resource `json:"resources,omitempty"`
 }
 
+// An InheritedRole describes the role that this Role inherits from.
 type InheritedRole struct {
 	Db   string `json:"db,omitempty"`
 	Role string `json:"role,omitempty"`
 }
 
+// CustomDBRole represents a Custom MongoDB Role in your cluster.
 type CustomDbRole struct {
 	Actions        []Action        `json:"actions,omitempty"`
 	InheritedRoles []InheritedRole `json:"inheritedRoles,omitempty"`
@@ -70,6 +77,8 @@ func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listO
 	return root, resp, nil
 }
 
+// Gets a single Custom MongoDB Role in the project.
+// See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-get-single-role/
 func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleName string) (*CustomDbRole, *Response, error) {
 	if roleName == "" {
 		return nil, nil, NewArgError("roleName", "must be set")
@@ -92,6 +101,8 @@ func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleNa
 	return root, resp, err
 }
 
+// Creates a new Custom MongoDB Role in the project.
+// See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-create-a-role/
 func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, createRequest *CustomDbRole) (*CustomDbRole, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
@@ -113,6 +124,8 @@ func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, cre
 	return root, resp, err
 }
 
+// Updates a single Custom MongoDB Role.
+// See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-update-a-role/
 func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, roleName string, updateRequest *CustomDbRole) (*CustomDbRole, *Response, error) {
 	if updateRequest == nil {
 		return nil, nil, NewArgError("updateRequest", "cannot be nil")
@@ -135,6 +148,8 @@ func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, rol
 	return root, resp, err
 }
 
+// Deletes a single Custom MongoDB Role.
+// See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-delete-a-role/
 func (s *CustomDBRolesServiceOp) Delete(ctx context.Context, groupID string, roleName string) (*Response, error) {
 	if roleName == "" {
 		return nil, NewArgError("roleName", "must be set")

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -12,6 +12,7 @@ type CustomDBRolesService interface {
 	List(context.Context, string, *ListOptions) (*[]CustomDbRole, *Response, error)
 	Get(context.Context, string, string) (*CustomDbRole, *Response, error)
 	Create(context.Context, string, *CustomDbRole) (*CustomDbRole, *Response, error)
+	Update(context.Context, string, string, *CustomDbRole) (*CustomDbRole, *Response, error)
 }
 
 //CustomDBRolesServiceOp handles communication with the CustomDBRoles related methods of the
@@ -98,6 +99,28 @@ func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, cre
 	path := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CustomDbRole)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, roleName string, updateRequest *CustomDbRole) (*CustomDbRole, *Response, error) {
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	basePath := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, roleName)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -10,6 +10,7 @@ const dbCustomDBRolesBasePath = "groups/%s/customDBRoles/roles"
 
 type CustomDBRolesService interface {
 	List(context.Context, string, *ListOptions) (*[]CustomDbRole, *Response, error)
+	Get(context.Context, string, string) (*CustomDbRole, *Response, error)
 }
 
 //CustomDBRolesServiceOp handles communication with the CustomDBRoles related methods of the
@@ -64,4 +65,26 @@ func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listO
 	}
 
 	return root, resp, nil
+}
+
+func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleName string) (*CustomDbRole, *Response, error) {
+	if roleName == "" {
+		return nil, nil, NewArgError("roleName", "must be set")
+	}
+
+	basePath := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, roleName)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CustomDbRole)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
 }

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -11,6 +11,7 @@ const dbCustomDBRolesBasePath = "groups/%s/customDBRoles/roles"
 type CustomDBRolesService interface {
 	List(context.Context, string, *ListOptions) (*[]CustomDbRole, *Response, error)
 	Get(context.Context, string, string) (*CustomDbRole, *Response, error)
+	Create(context.Context, string, *CustomDbRole) (*CustomDbRole, *Response, error)
 }
 
 //CustomDBRolesServiceOp handles communication with the CustomDBRoles related methods of the
@@ -76,6 +77,27 @@ func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleNa
 	path := fmt.Sprintf("%s/%s", basePath, roleName)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CustomDbRole)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, createRequest *CustomDbRole) (*CustomDbRole, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -1,0 +1,67 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const dbCustomDBRolesBasePath = "groups/%s/customDBRoles/roles"
+
+type CustomDBRolesService interface {
+	List(context.Context, string, *ListOptions) (*[]CustomDbRole, *Response, error)
+}
+
+//CustomDBRolesServiceOp handles communication with the CustomDBRoles related methods of the
+//MongoDB Atlas API
+type CustomDBRolesServiceOp struct {
+	client *Client
+}
+
+var _ CustomDBRolesService = &CustomDBRolesServiceOp{}
+
+type Resource struct {
+	Collection string `json:"collection,omitempty"`
+	Db         string `json:"db,omitempty"`
+	Cluster    bool   `json:"cluster,omitempty"`
+}
+
+type Action struct {
+	Action    string     `json:"action,omitempty"`
+	Resources []Resource `json:"resources,omitempty"`
+}
+
+type InheritedRole struct {
+	Db   string `json:"db,omitempty"`
+	Role string `json:"role,omitempty"`
+}
+
+type CustomDbRole struct {
+	Actions        []Action        `json:"actions,omitempty"`
+	InheritedRoles []InheritedRole `json:"inheritedRoles,omitempty"`
+	RoleName       string          `json:"roleName,omitempty"`
+}
+
+//List gets all custom db roles in the project.
+//See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-get-all-roles/
+func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listOptions *ListOptions) (*[]CustomDbRole, *Response, error) {
+	path := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
+
+	path, err := setListOptions(path, listOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new([]CustomDbRole)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, nil
+}

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -12,10 +12,10 @@ const dbCustomDBRolesBasePath = "groups/%s/customDBRoles/roles"
 // endpoints of the MongoDB Atlas API.
 // See more: https://docs.atlas.mongodb.com/reference/api/custom-roles/
 type CustomDBRolesService interface {
-	List(context.Context, string, *ListOptions) (*[]CustomDbRole, *Response, error)
-	Get(context.Context, string, string) (*CustomDbRole, *Response, error)
-	Create(context.Context, string, *CustomDbRole) (*CustomDbRole, *Response, error)
-	Update(context.Context, string, string, *CustomDbRole) (*CustomDbRole, *Response, error)
+	List(context.Context, string, *ListOptions) (*[]CustomDBRole, *Response, error)
+	Get(context.Context, string, string) (*CustomDBRole, *Response, error)
+	Create(context.Context, string, *CustomDBRole) (*CustomDBRole, *Response, error)
+	Update(context.Context, string, string, *CustomDBRole) (*CustomDBRole, *Response, error)
 	Delete(context.Context, string, string) (*Response, error)
 }
 
@@ -47,7 +47,7 @@ type InheritedRole struct {
 }
 
 // CustomDBRole represents a Custom MongoDB Role in your cluster.
-type CustomDbRole struct {
+type CustomDBRole struct {
 	Actions        []Action        `json:"actions,omitempty"`
 	InheritedRoles []InheritedRole `json:"inheritedRoles,omitempty"`
 	RoleName       string          `json:"roleName,omitempty"`
@@ -55,7 +55,7 @@ type CustomDbRole struct {
 
 //List gets all custom db roles in the project.
 //See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-get-all-roles/
-func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listOptions *ListOptions) (*[]CustomDbRole, *Response, error) {
+func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listOptions *ListOptions) (*[]CustomDBRole, *Response, error) {
 	path := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
 
 	path, err := setListOptions(path, listOptions)
@@ -68,7 +68,7 @@ func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listO
 		return nil, nil, err
 	}
 
-	root := new([]CustomDbRole)
+	root := new([]CustomDBRole)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
@@ -79,7 +79,7 @@ func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listO
 
 // Gets a single Custom MongoDB Role in the project.
 // See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-get-single-role/
-func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleName string) (*CustomDbRole, *Response, error) {
+func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleName string) (*CustomDBRole, *Response, error) {
 	if roleName == "" {
 		return nil, nil, NewArgError("roleName", "must be set")
 	}
@@ -92,7 +92,7 @@ func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleNa
 		return nil, nil, err
 	}
 
-	root := new(CustomDbRole)
+	root := new(CustomDBRole)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
@@ -103,7 +103,7 @@ func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleNa
 
 // Creates a new Custom MongoDB Role in the project.
 // See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-create-a-role/
-func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, createRequest *CustomDbRole) (*CustomDbRole, *Response, error) {
+func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, createRequest *CustomDBRole) (*CustomDBRole, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
@@ -115,7 +115,7 @@ func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, cre
 		return nil, nil, err
 	}
 
-	root := new(CustomDbRole)
+	root := new(CustomDBRole)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
@@ -126,7 +126,7 @@ func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, cre
 
 // Updates a single Custom MongoDB Role.
 // See more: https://docs.atlas.mongodb.com/reference/api/custom-roles-update-a-role/
-func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, roleName string, updateRequest *CustomDbRole) (*CustomDbRole, *Response, error) {
+func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, roleName string, updateRequest *CustomDBRole) (*CustomDBRole, *Response, error) {
 	if updateRequest == nil {
 		return nil, nil, NewArgError("updateRequest", "cannot be nil")
 	}
@@ -139,7 +139,7 @@ func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, rol
 		return nil, nil, err
 	}
 
-	root := new(CustomDbRole)
+	root := new(CustomDBRole)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -40,3 +40,37 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 		t.Errorf("CustomDBRoles.List\n got=%#v\nwant=%#v", customDBRoles, expected)
 	}
 }
+
+func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/groups/1/customDBRoles/roles/test-role-name", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"actions":[{"action":"CREATE_INDEX","resources":[{"collection":"test-collection","db":"test-db"}]}],"inheritedRoles":[{"db":"test-db","role":"read"}],"roleName":"test-role-name"}`)
+	})
+
+	customDBRole, _, err := client.CustomDBRoles.Get(ctx, "1", "test-role-name")
+	if err != nil {
+		t.Errorf("CustomDBRoles.Get returned error: %v", err)
+	}
+
+	expected := &CustomDbRole{
+		Actions: []Action{{
+			Action: "CREATE_INDEX",
+			Resources: []Resource{{
+				Collection: "test-collection",
+				Db:         "test-db",
+				Cluster:    false,
+			}},
+		}},
+		InheritedRoles: []InheritedRole{{
+			Db:   "test-db",
+			Role: "read",
+		}},
+		RoleName: "test-role-name",
+	}
+	if !reflect.DeepEqual(customDBRole, expected) {
+		t.Errorf("CustomDBRoles.List\n got=%#v\nwant=%#v", customDBRole, expected)
+	}
+}

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -1,0 +1,42 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/groups/1/customDBRoles/roles", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[{"actions":[{"action":"CREATE_INDEX","resources":[{"collection":"test-collection","db":"test-db"}]}],"inheritedRoles":[{"db":"test-db","role":"read"}],"roleName":"test-role-name"}]`)
+	})
+
+	customDBRoles, _, err := client.CustomDBRoles.List(ctx, "1", nil)
+	if err != nil {
+		t.Errorf("CustomDBRoles.List returned error: %v", err)
+	}
+
+	expected := &[]CustomDbRole{{
+		Actions: []Action{{
+			Action: "CREATE_INDEX",
+			Resources: []Resource{{
+				Collection: "test-collection",
+				Db:         "test-db",
+				Cluster:    false,
+			}},
+		}},
+		InheritedRoles: []InheritedRole{{
+			Db:   "test-db",
+			Role: "read",
+		}},
+		RoleName: "test-role-name",
+	}}
+	if !reflect.DeepEqual(customDBRoles, expected) {
+		t.Errorf("CustomDBRoles.List\n got=%#v\nwant=%#v", customDBRoles, expected)
+	}
+}

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -239,3 +239,20 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 		t.Errorf("expected roleName '%s', received '%s'", "test-role-name", roleName)
 	}
 }
+
+func TestDatabaseUsers_DeleteCustomDBRole(t *testing.T) {
+	setup()
+	defer teardown()
+
+	groupID := "1"
+	roleName := "test-role-name"
+
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/customDBRoles/roles/%s", groupID, roleName), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.CustomDBRoles.Delete(ctx, groupID, roleName)
+	if err != nil {
+		t.Errorf("CustomDBRole.Delete returned error: %v", err)
+	}
+}

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -157,3 +157,85 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 		t.Errorf("expected roleName '%s', received '%s'", "test-role-name", roleName)
 	}
 }
+
+func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
+	setup()
+	defer teardown()
+
+	updateRequest := &CustomDbRole{
+		Actions: []Action{{
+			Action: "CREATE_INDEX",
+			Resources: []Resource{{
+				Collection: "test-collection",
+				Db:         "test-db",
+				Cluster:    false,
+			}},
+		}},
+		InheritedRoles: []InheritedRole{{
+			Db:   "test-db",
+			Role: "read",
+		}},
+		RoleName: "test-role-name",
+	}
+
+	mux.HandleFunc("/groups/1/customDBRoles/roles/test-role-name", func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"actions": []interface{}{map[string]interface{}{
+				"action": "CREATE_INDEX",
+				"resources": []interface{}{map[string]interface{}{
+					"collection": "test-collection",
+					"db":         "test-db",
+				}},
+			}},
+			"inheritedRoles": []interface{}{map[string]interface{}{
+				"db":   "test-db",
+				"role": "read",
+			}},
+			"roleName": "test-role-name",
+		}
+
+		jsonBlob := `
+		{
+			"actions": [
+				{
+					"action": "CREATE_INDEX",
+					"resources": [
+						{
+							"collection": "test-collection",
+							"db": "test-db"
+						}
+					]
+				}
+			],
+			"inheritedRoles": [
+				{
+					"db": "test-db",
+					"role": "read"
+				}
+			],
+			"roleName":"test-role-name"
+		}
+		`
+
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprintf(w, jsonBlob)
+	})
+
+	customDBRole, _, err := client.CustomDBRoles.Update(ctx, "1", "test-role-name", updateRequest)
+	if err != nil {
+		t.Errorf("CustomDBRoles.Update returned error: %v", err)
+	}
+
+	if roleName := customDBRole.RoleName; roleName != "test-role-name" {
+		t.Errorf("expected roleName '%s', received '%s'", "test-role-name", roleName)
+	}
+}

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -22,7 +22,7 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 		t.Errorf("CustomDBRoles.List returned error: %v", err)
 	}
 
-	expected := &[]CustomDbRole{{
+	expected := &[]CustomDBRole{{
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
@@ -56,7 +56,7 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 		t.Errorf("CustomDBRoles.Get returned error: %v", err)
 	}
 
-	expected := &CustomDbRole{
+	expected := &CustomDBRole{
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
@@ -80,7 +80,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 	setup()
 	defer teardown()
 
-	createRequest := &CustomDbRole{
+	createRequest := &CustomDBRole{
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
@@ -162,7 +162,7 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 	setup()
 	defer teardown()
 
-	updateRequest := &CustomDbRole{
+	updateRequest := &CustomDBRole{
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -31,6 +31,7 @@ type Client struct {
 	UserAgent string
 
 	//Services used for communicating with the API
+	CustomDBRoles                    CustomDBRolesService
 	DatabaseUsers                    DatabaseUsersService
 	ProjectIPWhitelist               ProjectIPWhitelistService
 	Projects                         ProjectsService
@@ -139,6 +140,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.CloudProviderSnapshotRestoreJobs = &CloudProviderSnapshotRestoreJobsServiceOp{client: c}
 	c.Clusters = &ClustersServiceOp{client: c}
 	c.Containers = &ContainersServiceOp{client: c}
+	c.CustomDBRoles = &CustomDBRolesServiceOp{client: c}
 	c.DatabaseUsers = &DatabaseUsersServiceOp{client: c}
 	c.EncryptionsAtRest = &EncryptionsAtRestServiceOp{client: c}
 	c.Projects = &ProjectsServiceOp{client: c}


### PR DESCRIPTION
I created a new service for operating the API for Custom MongoDB Roles. This is in preparation for adding a new resource for roles to the Terraform MongoDB Atlas provider.

Tried to follow the conventions of the rest of the code. Thinks I wasn't sure about:

* whether I should enumerate somewhere the possible [Custom Role Actions](https://docs.atlas.mongodb.com/reference/api/custom-role-actions/), but I figured these might change with time and perhaps are better left as plain strings.
* whether I should also test paging parameters, because the response structure for the Custom MongoDB Roles list is different from the other APIs -- does not have `Links`, `Results` nor `TotalCount`.

I can, of course, add both of the above, if so requested.