### PR TITLE
Atlas Users Service

### DIFF
--- a/mongodbatlas/atlas_users.go
+++ b/mongodbatlas/atlas_users.go
@@ -1,0 +1,145 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	usersBasePath = "groups/%s/users"
+)
+
+// AtlasUsersService is an interface for interfacing with the AtlasUsers
+// endpoints of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/users/
+type AtlasUsersService interface {
+	List(context.Context, string, *ListOptions) ([]AtlasUser, *Response, error)
+	Get(context.Context, string) (*AtlasUser, *Response, error)
+	GetByName(context.Context, string) (*AtlasUser, *Response, error)
+	Create(context.Context, *AtlasUser) (*AtlasUser, *Response, error)
+}
+
+//AtlasUsersServiceOp handles communication with the AtlasUsers related methos of the
+//MongoDB Atlas API
+type AtlasUsersServiceOp struct {
+	client *Client
+}
+
+var _ AtlasUsersService = &AtlasUsersServiceOp{}
+
+// AtlasUsers represents a array of project
+type AtlasUsersResponse struct {
+	Links      []*Link     `json:"links"`
+	Results    []AtlasUser `json:"results"`
+	TotalCount int         `json:"totalCount"`
+}
+
+type AtlasUser struct {
+	EmailAddress string      `json:"emailAddress"`
+	FirstName    string      `json:"firstName"`
+	ID           string      `json:"id,omitempty"`
+	LastName     string      `json:"lastName"`
+	Roles        []AtlasRole `json:"roles"`
+	TeamIds      []string    `json:"teamIds,omitempty"`
+	Username     string      `json:"username"`
+	MobileNumber string      `json:"mobileNumber"`
+	Password     string      `json:"password"`
+	Country      string      `json:"country"`
+}
+
+//GetAllAtlasUsers gets all users.
+//See more: https://docs.atlas.mongodb.com/reference/api/user-get-all/
+func (s *AtlasUsersServiceOp) List(ctx context.Context, orgID string, listOptions *ListOptions) ([]AtlasUser, *Response, error) {
+	path := fmt.Sprintf(usersBasePath, orgID)
+
+	//Add query params from listOptions
+	path, err := setListOptions(path, listOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AtlasUsersResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Results, resp, nil
+}
+
+//Get gets a single atlas user.
+//See more: https://docs.atlas.mongodb.com/reference/api/user-get-by-id/
+func (s *AtlasUsersServiceOp) Get(ctx context.Context, userID string) (*AtlasUser, *Response, error) {
+	if userID == "" {
+		return nil, nil, NewArgError("userID", "must be set")
+	}
+
+	path := fmt.Sprintf("users/%s", userID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AtlasUser)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+//Get gets a single atlas user by name.
+//See more: https://docs.atlas.mongodb.com/reference/api/user-get-one-by-name/
+func (s *AtlasUsersServiceOp) GetByName(ctx context.Context, username string) (*AtlasUser, *Response, error) {
+	if username == "" {
+		return nil, nil, NewArgError("username", "must be set")
+	}
+
+	path := fmt.Sprintf("users/byName/%s", username)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AtlasUser)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+//Create creates an Atlas User.
+//See more: https://docs.atlas.mongodb.com/reference/api/user-create/
+func (s *AtlasUsersServiceOp) Create(ctx context.Context, createRequest *AtlasUser) (*AtlasUser, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, fmt.Sprintf("users"), createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AtlasUser)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}

--- a/mongodbatlas/atlas_users.go
+++ b/mongodbatlas/atlas_users.go
@@ -48,7 +48,7 @@ type AtlasUser struct {
 	Country      string      `json:"country"`
 }
 
-//GetAllAtlasUsers gets all users.
+//List gets all users.
 //See more: https://docs.atlas.mongodb.com/reference/api/user-get-all/
 func (s *AtlasUsersServiceOp) List(ctx context.Context, orgID string, listOptions *ListOptions) ([]AtlasUser, *Response, error) {
 	path := fmt.Sprintf(usersBasePath, orgID)
@@ -100,7 +100,7 @@ func (s *AtlasUsersServiceOp) Get(ctx context.Context, userID string) (*AtlasUse
 	return root, resp, err
 }
 
-//Get gets a single atlas user by name.
+//GetByName gets a single atlas user by name.
 //See more: https://docs.atlas.mongodb.com/reference/api/user-get-one-by-name/
 func (s *AtlasUsersServiceOp) GetByName(ctx context.Context, username string) (*AtlasUser, *Response, error) {
 	if username == "" {

--- a/mongodbatlas/atlas_users_test.go
+++ b/mongodbatlas/atlas_users_test.go
@@ -1,0 +1,384 @@
+package mongodbatlas
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestAtlasUsers_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/groups/1/users", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/1/users?pretty=true&pageNum=1&itemsPerPage=100",
+					"rel": "self"
+				}
+			],
+			"results": [
+				{
+					"emailAddress": "joe.bloggs@example.com",
+					"firstName": "Joe",
+					"id": "1",
+					"lastName": "Bloggs",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/1",
+							"rel": "self"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/1/whitelist",
+							"rel": "http://mms.mongodb.com/whitelist"
+						}
+					],
+					"roles": [
+						{
+							"groupId": "1",
+							"roleName": "GROUP_OWNER"
+						},
+						{
+							"groupId": "2",
+							"roleName": "GROUP_OWNER"
+						}
+					],
+					"username": "joe.bloggs"
+				},
+				{
+					"emailAddress": "jim.bloggs@example.com",
+					"firstName": "Jim",
+					"id": "2",
+					"lastName": "Bloggs",
+					"links": [
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/2",
+							"rel": "self"
+						},
+						{
+							"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/2/whitelist",
+							"rel": "http://mms.mongodb.com/whitelist"
+						}
+					],
+					"roles": [
+						{
+							"roleName": "GLOBAL_READ_ONLY"
+						},
+						{
+							"groupId": "1",
+							"roleName": "GROUP_OWNER"
+						}
+					],
+					"username": "jim.bloggs"
+				}
+			],
+			"totalCount": 2
+		}`)
+	})
+
+	teams, _, err := client.AtlasUsers.List(ctx, "1", nil)
+
+	if err != nil {
+		t.Errorf("AtlasUsers.List returned error: %v", err)
+	}
+
+	expected := []AtlasUser{
+		{
+			ID:           "1",
+			EmailAddress: "joe.bloggs@example.com",
+			FirstName:    "Joe",
+			LastName:     "Bloggs",
+			Roles: []AtlasRole{
+				{
+					GroupID:  "1",
+					RoleName: "GROUP_OWNER",
+				},
+				{
+					GroupID:  "2",
+					RoleName: "GROUP_OWNER",
+				},
+			},
+			Username: "joe.bloggs",
+		},
+		{
+			EmailAddress: "jim.bloggs@example.com",
+			FirstName:    "Jim",
+			ID:           "2",
+			LastName:     "Bloggs",
+			Roles: []AtlasRole{
+				{
+					RoleName: "GLOBAL_READ_ONLY",
+				},
+				{
+					GroupID:  "1",
+					RoleName: "GROUP_OWNER",
+				},
+			},
+			Username: "jim.bloggs",
+		},
+	}
+	if !reflect.DeepEqual(teams, expected) {
+		t.Errorf("AtlasUsers.List\n got=%#v\nwant=%#v", teams, expected)
+	}
+}
+
+func TestAtlasUsers_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	userID := "5af1c27a0a7fa48c76d3a761"
+
+	mux.HandleFunc(fmt.Sprintf("/users/%s", userID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"emailAddress": "john.doe@example.com",
+			"firstName": "John",
+			"id": "5af1c27a0a7fa48c76d3a761",
+			"lastName": "Doe",
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/5af1c27a0a7fa48c76d3a761",
+					"rel": "self"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/5af1c27a0a7fa48c76d3a761/whitelist",
+					"rel": "http://mms.mongodb.com/whitelist"
+				}
+			],
+			"mobileNumber" : "2125550198",
+			"roles": [
+				{
+					"orgId": "5af1c27a0a7fa48c76d3a762",
+					"roleName": "ORG_OWNER"
+				},
+				{
+					"groupId": "5af1c27a0a7fa48c76d3a763",
+					"roleName": "GROUP_OWNER"
+				}
+			],
+			"teamIds": [
+				"5af1c27a0a7fa48c76d3a764"
+			],
+			"username": "john.doe@example.com"
+		}`)
+	})
+
+	team, _, err := client.AtlasUsers.Get(ctx, userID)
+	if err != nil {
+		t.Errorf("AtlasUsers.Get returned error: %v", err)
+	}
+
+	expected := &AtlasUser{
+		ID:           "5af1c27a0a7fa48c76d3a761",
+		EmailAddress: "john.doe@example.com",
+		FirstName:    "John",
+		LastName:     "Doe",
+		MobileNumber: "2125550198",
+		Roles: []AtlasRole{
+			{
+				OrgID:    "5af1c27a0a7fa48c76d3a762",
+				RoleName: "ORG_OWNER",
+			},
+			{
+				GroupID:  "5af1c27a0a7fa48c76d3a763",
+				RoleName: "GROUP_OWNER",
+			},
+		},
+		TeamIds: []string{
+			"5af1c27a0a7fa48c76d3a764",
+		},
+		Username: "john.doe@example.com",
+	}
+
+	if !reflect.DeepEqual(team, expected) {
+		t.Errorf("AtlasUsers.Get\n got=%#v\nwant=%#v", team, expected)
+	}
+}
+
+func TestAtlasUsers_GetByName(t *testing.T) {
+	setup()
+	defer teardown()
+
+	username := "john.doe@example.com"
+
+	mux.HandleFunc(fmt.Sprintf("/users/byName/%s", username), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"emailAddress": "john.doe@example.com",
+			"firstName": "John",
+			"id": "5af1c27a0a7fa48c76d3a761",
+			"lastName": "Doe",
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/5af1c27a0a7fa48c76d3a761",
+					"rel": "self"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/5af1c27a0a7fa48c76d3a761/whitelist",
+					"rel": "http://mms.mongodb.com/whitelist"
+				}
+			],
+			"mobileNumber" : "2125550198",
+			"roles": [
+				{
+					"orgId": "5af1c27a0a7fa48c76d3a762",
+					"roleName": "ORG_OWNER"
+				},
+				{
+					"groupId": "5af1c27a0a7fa48c76d3a763",
+					"roleName": "GROUP_OWNER"
+				}
+			],
+			"teamIds": [
+				"5af1c27a0a7fa48c76d3a764"
+			],
+			"username": "john.doe@example.com"
+		}`)
+	})
+
+	team, _, err := client.AtlasUsers.GetByName(ctx, username)
+	if err != nil {
+		t.Errorf("AtlasUsers.GetByName returned error: %v", err)
+	}
+
+	expected := &AtlasUser{
+		ID:           "5af1c27a0a7fa48c76d3a761",
+		EmailAddress: "john.doe@example.com",
+		FirstName:    "John",
+		LastName:     "Doe",
+		MobileNumber: "2125550198",
+		Roles: []AtlasRole{
+			{
+				OrgID:    "5af1c27a0a7fa48c76d3a762",
+				RoleName: "ORG_OWNER",
+			},
+			{
+				GroupID:  "5af1c27a0a7fa48c76d3a763",
+				RoleName: "GROUP_OWNER",
+			},
+		},
+		TeamIds: []string{
+			"5af1c27a0a7fa48c76d3a764",
+		},
+		Username: "john.doe@example.com",
+	}
+
+	if !reflect.DeepEqual(team, expected) {
+		t.Errorf("AtlasUsers.Get\n got=%#v\nwant=%#v", team, expected)
+	}
+}
+
+func TestAtlasUsers_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &AtlasUser{
+
+		Username:     "john.doe@example.com",
+		Password:     "myPassword1@",
+		EmailAddress: "john.doe@example.com",
+		MobileNumber: "2125550198",
+		FirstName:    "John",
+		LastName:     "Doe",
+		Roles: []AtlasRole{
+			{
+				OrgID:    "8dbbe4570bd55b23f25444db",
+				RoleName: "ORG_MEMBER",
+			},
+			{
+				GroupID:  "2ddoa1233ef88z75f64578ff",
+				RoleName: "GROUP_READ_ONLY",
+			},
+		},
+		Country: "US",
+	}
+
+	mux.HandleFunc(fmt.Sprintf("/users"), func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"username":     "john.doe@example.com",
+			"password":     "myPassword1@",
+			"emailAddress": "john.doe@example.com",
+			"mobileNumber": "2125550198",
+			"firstName":    "John",
+			"lastName":     "Doe",
+			"roles": []interface{}{
+				map[string]interface{}{
+					"orgId":    "8dbbe4570bd55b23f25444db",
+					"roleName": "ORG_MEMBER",
+				},
+				map[string]interface{}{
+					"groupId":  "2ddoa1233ef88z75f64578ff",
+					"roleName": "GROUP_READ_ONLY",
+				},
+			},
+			"country": "US",
+		}
+
+		jsonBlob := `
+		{
+			"emailAddress": "john.doe@example.com",
+			"firstName": "John",
+			"id": "5b06ed7083fb5a40df86e93b",
+			"lastName": "Doe",
+			"links": [
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/5b06ed7083fb5a40df86e93b",
+					"rel": "self"
+				},
+				{
+					"href": "https://cloud.mongodb.com/api/atlas/v1.0/users/5b06ed7083fb5a40df86e93b/whitelist",
+					"rel": "http://mms.mongodb.com/whitelist"
+				}
+			],
+			"mobileNumber" : "2125550198",
+			"roles": [
+			  {
+				"orgId" : "8dbbe4570bd55b23f25444db",
+				"roleName" : "ORG_MEMBER"
+		
+			  },
+			  {
+				"groupId" : "2ddoa1233ef88z75f64578ff",
+				"roleName" : "GROUP_READ_ONLY"
+		
+			  }
+			],
+			"teamIds": [],
+			"username": "john.doe@example.com"
+		}
+		`
+
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprint(w, jsonBlob)
+	})
+
+	atlasUser, _, err := client.AtlasUsers.Create(ctx, createRequest)
+	if err != nil {
+		t.Errorf("AtlasUsers.Create returned error: %v", err)
+	}
+
+	if name := atlasUser.Username; name != "john.doe@example.com" {
+		t.Errorf("expected name '%s', received '%s'", "john.doe@example.com", name)
+	}
+
+	if id := atlasUser.ID; id != "5b06ed7083fb5a40df86e93b" {
+		t.Errorf("expected id '%s', received '%s'", "5b06ed7083fb5a40df86e93b", id)
+	}
+
+	if roles := len(atlasUser.Roles); roles != 2 {
+		t.Errorf("expected len(roles) '%d', received '%d'", 2, roles)
+	}
+}

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -117,11 +117,11 @@ type clustersResponse struct {
 // DefaultDiskSizeGB represents the Tier and the default disk size for each one
 // it can be use like: DefaultDiskSizeGB["AWS"]["M10"]
 var DefaultDiskSizeGB map[string]map[string]float64 = map[string]map[string]float64{
-	"TENANT": map[string]float64{
+	"TENANT": {
 		"M2": 2,
 		"M5": 5,
 	},
-	"AWS": map[string]float64{
+	"AWS": {
 		"M10":       10,
 		"M20":       20,
 		"M30":       40,
@@ -146,7 +146,7 @@ var DefaultDiskSizeGB map[string]map[string]float64 = map[string]map[string]floa
 		"R400":      3000,
 		"M400_NVME": 4000,
 	},
-	"GCP": map[string]float64{
+	"GCP": {
 		"M10":  10,
 		"M20":  20,
 		"M30":  40,
@@ -157,7 +157,7 @@ var DefaultDiskSizeGB map[string]map[string]float64 = map[string]map[string]floa
 		"M200": 1500,
 		"M300": 2200,
 	},
-	"AZURE": map[string]float64{
+	"AZURE": {
 		"M10":  32,
 		"M20":  32,
 		"M30":  32,

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -46,6 +46,7 @@ type Client struct {
 	PrivateIPMode                    PrivateIpModeService
 	MaintenanceWindows               MaintenanceWindowsService
 	Teams                            TeamsService
+	AtlasUsers                       AtlasUsersService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -151,6 +152,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.PrivateIPMode = &PrivateIpModeServiceOp{client: c}
 	c.MaintenanceWindows = &MaintenanceWindowsServiceOp{client: c}
 	c.Teams = &TeamsServiceOp{client: c}
+	c.AtlasUsers = &AtlasUsersServiceOp{client: c}
 
 	return c
 }

--- a/mongodbatlas/teams.go
+++ b/mongodbatlas/teams.go
@@ -55,16 +55,6 @@ type AtlasUserAssigned struct {
 	TotalCount int         `json:"totalCount"`
 }
 
-type AtlasUser struct {
-	EmailAddress string      `json:"emailAddress"`
-	FirstName    string      `json:"firstName"`
-	ID           string      `json:"id"`
-	LastName     string      `json:"lastName"`
-	Roles        []AtlasRole `json:"roles"`
-	TeamIds      []string    `json:"teamIds"`
-	Username     string      `json:"username"`
-}
-
 type TeamUpdateRoles struct {
 	RoleNames []string `json:"roleNames"`
 }


### PR DESCRIPTION
Add Atlas Users Service to perform the following requests:

1. Get all users from the project.
2. Get by ID
3. Get by Username
4. Create Atlas Users.

> **NOTE**: We are pending with Update and Delete Atlas User since these calls are not enabled in the public API.