### PR TITLE
Enable golint and fix errors

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ fmt:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	golangci-lint run $(TEST) -E gofmt
+	golangci-lint run $(TEST) -E gofmt -E golint -E misspell
 
 check: test lint
 

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -168,6 +168,7 @@ var DefaultDiskSizeGB map[string]map[string]float64 = map[string]map[string]floa
 		"M200": 256,
 	},
 }
+
 //List all clusters in the project associated to {GROUP-ID}.
 //See more: https://docs.atlas.mongodb.com/reference/api/clusters-get-all/
 func (s *ClustersServiceOp) List(ctx context.Context, groupID string, listOptions *ListOptions) ([]Cluster, *Response, error) {

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -114,61 +114,6 @@ type clustersResponse struct {
 	TotalCount int       `json:"totalCount,omitempty"`
 }
 
-// DefaultDiskSizeGB represents the Tier and the default disk size for each one
-// it can be use like: DefaultDiskSizeGB["AWS"]["M10"]
-var DefaultDiskSizeGB map[string]map[string]float64 = map[string]map[string]float64{
-	"TENANT": {
-		"M2": 2,
-		"M5": 5,
-	},
-	"AWS": {
-		"M10":       10,
-		"M20":       20,
-		"M30":       40,
-		"M40":       80,
-		"R40":       80,
-		"M40_NVME":  380,
-		"M50":       160,
-		"R50":       160,
-		"M50_NVME":  760,
-		"M60":       320,
-		"R60":       320,
-		"M60_NVME":  1600,
-		"M80":       750,
-		"R80":       750,
-		"M80_NVME":  1600,
-		"M140":      1000,
-		"M200":      1500,
-		"R200":      1500,
-		"M200_NVME": 3100,
-		"M300":      2000,
-		"R300":      2000,
-		"R400":      3000,
-		"M400_NVME": 4000,
-	},
-	"GCP": {
-		"M10":  10,
-		"M20":  20,
-		"M30":  40,
-		"M40":  80,
-		"M50":  160,
-		"M60":  320,
-		"M80":  750,
-		"M200": 1500,
-		"M300": 2200,
-	},
-	"AZURE": {
-		"M10":  32,
-		"M20":  32,
-		"M30":  32,
-		"M40":  128,
-		"M50":  128,
-		"M60":  128,
-		"M80":  256,
-		"M200": 256,
-	},
-}
-
 //List all clusters in the project associated to {GROUP-ID}.
 //See more: https://docs.atlas.mongodb.com/reference/api/clusters-get-all/
 func (s *ClustersServiceOp) List(ctx context.Context, groupID string, listOptions *ListOptions) ([]Cluster, *Response, error) {

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -114,6 +114,60 @@ type clustersResponse struct {
 	TotalCount int       `json:"totalCount,omitempty"`
 }
 
+// DefaultDiskSizeGB represents the Tier and the default disk size for each one
+// it can be use like: DefaultDiskSizeGB["AWS"]["M10"]
+var DefaultDiskSizeGB map[string]map[string]float64 = map[string]map[string]float64{
+	"TENANT": {
+		"M2": 2,
+		"M5": 5,
+	},
+	"AWS": {
+		"M10":       10,
+		"M20":       20,
+		"M30":       40,
+		"M40":       80,
+		"R40":       80,
+		"M40_NVME":  380,
+		"M50":       160,
+		"R50":       160,
+		"M50_NVME":  760,
+		"M60":       320,
+		"R60":       320,
+		"M60_NVME":  1600,
+		"M80":       750,
+		"R80":       750,
+		"M80_NVME":  1600,
+		"M140":      1000,
+		"M200":      1500,
+		"R200":      1500,
+		"M200_NVME": 3100,
+		"M300":      2000,
+		"R300":      2000,
+		"R400":      3000,
+		"M400_NVME": 4000,
+	},
+	"GCP": {
+		"M10":  10,
+		"M20":  20,
+		"M30":  40,
+		"M40":  80,
+		"M50":  160,
+		"M60":  320,
+		"M80":  750,
+		"M200": 1500,
+		"M300": 2200,
+	},
+	"AZURE": {
+		"M10":  32,
+		"M20":  32,
+		"M30":  32,
+		"M40":  128,
+		"M50":  128,
+		"M60":  128,
+		"M80":  256,
+		"M200": 256,
+	},
+}
 //List all clusters in the project associated to {GROUP-ID}.
 //See more: https://docs.atlas.mongodb.com/reference/api/clusters-get-all/
 func (s *ClustersServiceOp) List(ctx context.Context, groupID string, listOptions *ListOptions) ([]Cluster, *Response, error) {

--- a/mongodbatlas/encryptions_at_rest.go
+++ b/mongodbatlas/encryptions_at_rest.go
@@ -42,11 +42,11 @@ const (
 	// EuWest3 represents the EU_WEST_3 Europe region for AWS Configuration
 	EuWest3 = "EU_WEST_3"
 
-	// Azure represents `AZURE` where the Azure account credencials reside
+	// Azure represents `AZURE` where the Azure account credentials reside
 	Azure = "AZURE"
-	// AzureChina represents `AZURE_CHINA` AZURE where the Azure account credencials reside
+	// AzureChina represents `AZURE_CHINA` AZURE where the Azure account credentials reside
 	AzureChina = "AZURE_CHINA"
-	// AzureGermany represents `AZURE_GERMANY` AZURE where the Azure account credencials reside
+	// AzureGermany represents `AZURE_GERMANY` AZURE where the Azure account credentials reside
 	AzureGermany = "AZURE_GERMANY"
 
 	encryptionsAtRestBasePath = "groups/%s/encryptionAtRest"
@@ -61,7 +61,7 @@ type EncryptionsAtRestService interface {
 	Delete(context.Context, string) (*Response, error)
 }
 
-//EncryptionsAtRestServiceOp handles communication with the DatabaseUsers related methos of the
+//EncryptionsAtRestServiceOp handles communication with the DatabaseUsers related methods of the
 //MongoDB Atlas API
 type EncryptionsAtRestServiceOp struct {
 	client *Client

--- a/mongodbatlas/global_clusters_test.go
+++ b/mongodbatlas/global_clusters_test.go
@@ -267,7 +267,7 @@ func TestGlobalClusters_DeleteManagedNamespace(t *testing.T) {
 	}
 
 	if diff := deep.Equal(globalCluster, expected); diff != nil {
-		t.Errorf("GlobalClusters.DeleteCustomZoneMappings Reponse Body = %v", diff)
+		t.Errorf("GlobalClusters.DeleteCustomZoneMappings Response Body = %v", diff)
 	}
 }
 
@@ -380,6 +380,6 @@ func TestGlobalClusters_DeleteCustomZoneMappings(t *testing.T) {
 	}
 
 	if diff := deep.Equal(globalCluster, expected); diff != nil {
-		t.Errorf("GlobalClusters.AddCustomZoneMappings Reponse Body = %v", diff)
+		t.Errorf("GlobalClusters.AddCustomZoneMappings Response Body = %v", diff)
 	}
 }

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -44,7 +44,7 @@ type Client struct {
 	Containers                       ContainersService
 	EncryptionsAtRest                EncryptionsAtRestService
 	WhitelistAPIKeys                 WhitelistAPIKeysService
-	PrivateIPMode                    PrivateIpModeService
+	PrivateIPMode                    PrivateIPModeService
 	MaintenanceWindows               MaintenanceWindowsService
 	Teams                            TeamsService
 	AtlasUsers                       AtlasUsersService
@@ -152,7 +152,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Peers = &PeersServiceOp{client: c}
 	c.ProjectIPWhitelist = &ProjectIPWhitelistServiceOp{client: c}
 	c.WhitelistAPIKeys = &WhitelistAPIKeysServiceOp{client: c}
-	c.PrivateIPMode = &PrivateIpModeServiceOp{client: c}
+	c.PrivateIPMode = &PrivateIPModeServiceOp{client: c}
 	c.MaintenanceWindows = &MaintenanceWindowsServiceOp{client: c}
 	c.Teams = &TeamsServiceOp{client: c}
 	c.AtlasUsers = &AtlasUsersServiceOp{client: c}

--- a/mongodbatlas/peers.go
+++ b/mongodbatlas/peers.go
@@ -31,7 +31,7 @@ var _ PeersService = &PeersServiceOp{}
 // Peer represents MongoDB peer connection.
 type Peer struct {
 	AccepterRegionName  string `json:"accepterRegionName,omitempty"`
-	AWSAccountId        string `json:"awsAccountId,omitempty"`
+	AWSAccountID        string `json:"awsAccountId,omitempty"`
 	ConnectionID        string `json:"connectionId,omitempty"`
 	ContainerID         string `json:"containerId,omitempty"`
 	ErrorStateName      string `json:"errorStateName,omitempty"`
@@ -42,7 +42,7 @@ type Peer struct {
 	VpcID               string `json:"vpcId,omitempty"`
 	AtlasCIDRBlock      string `json:"atlasCidrBlock,omitempty"`
 	AzureDirectoryID    string `json:"azureDirectoryId,omitempty"`
-	AzureSubscriptionId string `json:"azureSubscriptionId,omitempty"`
+	AzureSubscriptionID string `json:"azureSubscriptionId,omitempty"`
 	ResourceGroupName   string `json:"resourceGroupName,omitempty"`
 	VNetName            string `json:"vnetName,omitempty"`
 	ErrorState          string `json:"errorState,omitempty"`

--- a/mongodbatlas/private_ip_mode.go
+++ b/mongodbatlas/private_ip_mode.go
@@ -6,23 +6,23 @@ import (
 	"net/http"
 )
 
-const privateIpModePath = "groups/%s/privateIpMode"
+const privateIPModePath = "groups/%s/privateIpMode"
 
-//PrivateIpModeService is an interface for interfacing with the PrivateIpMode
+//PrivateIPModeService is an interface for interfacing with the PrivateIpMode
 // endpoints of the MongoDB Atlas API.
 //See more: https://docs.atlas.mongodb.com/reference/api/get-private-ip-mode-for-project/
-type PrivateIpModeService interface {
+type PrivateIPModeService interface {
 	Get(context.Context, string) (*PrivateIPMode, *Response, error)
 	Update(context.Context, string, *PrivateIPMode) (*PrivateIPMode, *Response, error)
 }
 
-//PrivateIpModeServiceOp handles communication with the Private IP Mode related methods
+//PrivateIPModeServiceOp handles communication with the Private IP Mode related methods
 // of the MongoDB Atlas API
-type PrivateIpModeServiceOp struct {
+type PrivateIPModeServiceOp struct {
 	client *Client
 }
 
-var _ PrivateIpModeService = &PrivateIpModeServiceOp{}
+var _ PrivateIPModeService = &PrivateIPModeServiceOp{}
 
 // PrivateIPMode represents MongoDB Private IP Mode Configutation.
 type PrivateIPMode struct {
@@ -31,8 +31,8 @@ type PrivateIPMode struct {
 
 //Get Verify Connect via Peering Only Mode from the project associated to {GROUP-ID}.
 //See more: https://docs.atlas.mongodb.com/reference/api/get-private-ip-mode-for-project/
-func (s *PrivateIpModeServiceOp) Get(ctx context.Context, groupID string) (*PrivateIPMode, *Response, error) {
-	path := fmt.Sprintf(privateIpModePath, groupID)
+func (s *PrivateIPModeServiceOp) Get(ctx context.Context, groupID string) (*PrivateIPMode, *Response, error) {
+	path := fmt.Sprintf(privateIPModePath, groupID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -50,12 +50,12 @@ func (s *PrivateIpModeServiceOp) Get(ctx context.Context, groupID string) (*Priv
 
 //Update connection via Peering Only Mode in the project associated to {GROUP-ID}
 //See more: https://docs.atlas.mongodb.com/reference/api/set-private-ip-mode-for-project/
-func (s *PrivateIpModeServiceOp) Update(ctx context.Context, groupID string, updateRequest *PrivateIPMode) (*PrivateIPMode, *Response, error) {
+func (s *PrivateIPModeServiceOp) Update(ctx context.Context, groupID string, updateRequest *PrivateIPMode) (*PrivateIPMode, *Response, error) {
 	if updateRequest == nil {
 		return nil, nil, NewArgError("updateRequest", "cannot be nil")
 	}
 
-	path := fmt.Sprintf(privateIpModePath, groupID)
+	path := fmt.Sprintf(privateIPModePath, groupID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {

--- a/mongodbatlas/private_ip_mode_test.go
+++ b/mongodbatlas/private_ip_mode_test.go
@@ -17,14 +17,14 @@ func TestPrivateIPMode_Get(t *testing.T) {
 
 	groupID := "6d2065c687d9d64ae7acdg41"
 
-	mux.HandleFunc(fmt.Sprintf("/"+privateIpModePath, groupID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/"+privateIPModePath, groupID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
 			"enabled": true
 		}`)
 	})
 
-	privateIpMode, _, err := client.PrivateIPMode.Get(ctx, groupID)
+	privateIPMode, _, err := client.PrivateIPMode.Get(ctx, groupID)
 	if err != nil {
 		t.Errorf("PrivateIPMode.Get returned error: %v", err)
 	}
@@ -33,12 +33,12 @@ func TestPrivateIPMode_Get(t *testing.T) {
 		Enabled: pointy.Bool(true),
 	}
 
-	if diff := deep.Equal(privateIpMode, expected); diff != nil {
+	if diff := deep.Equal(privateIPMode, expected); diff != nil {
 		t.Error(diff)
 	}
 
-	if !reflect.DeepEqual(privateIpMode, expected) {
-		t.Errorf("PrivateIPMode.Get\n got=%#v\nwant=%#v", privateIpMode, expected)
+	if !reflect.DeepEqual(privateIPMode, expected) {
+		t.Errorf("PrivateIPMode.Get\n got=%#v\nwant=%#v", privateIPMode, expected)
 	}
 }
 
@@ -52,7 +52,7 @@ func TestPrivateIPMode_Update(t *testing.T) {
 		Enabled: pointy.Bool(true),
 	}
 
-	mux.HandleFunc(fmt.Sprintf("/"+privateIpModePath, groupID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/"+privateIPModePath, groupID), func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
 			"enabled": true,
 		}
@@ -79,12 +79,12 @@ func TestPrivateIPMode_Update(t *testing.T) {
 		fmt.Fprint(w, jsonBlob)
 	})
 
-	privateIpMode, _, err := client.PrivateIPMode.Update(ctx, groupID, updateRequest)
+	privateIPMode, _, err := client.PrivateIPMode.Update(ctx, groupID, updateRequest)
 	if err != nil {
 		t.Errorf("PrivateIPMode.Update returned error: %v", err)
 	}
 
-	if enabled := pointy.BoolValue(privateIpMode.Enabled, false); !enabled {
+	if enabled := pointy.BoolValue(privateIPMode.Enabled, false); !enabled {
 		t.Errorf("expected privateIPMode '%t', received '%t'", true, enabled)
 	}
 }

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -7,12 +7,17 @@ import (
 )
 
 const (
-	GROUP_OWNER                  = "GROUP_OWNER"                  //GROUP_OWNER - Project Owner
-	GROUP_READ_ONLY              = "GROUP_READ_ONLY"              //GROUP_READ_ONLY - Project Read Only
-	GROUP_DATA_ACCESS_ADMIN      = "GROUP_DATA_ACCESS_ADMIN"      //GROUP_DATA_ACCESS_ADMIN - Project Data Access Admin
-	GROUP_DATA_ACCESS_READ_WRITE = "GROUP_DATA_ACCESS_READ_WRITE" //GROUP_DATA_ACCESS_READ_WRITE - Project Data Access Read/Write
-	GROUP_DATA_ACCESS_READ_ONLY  = "GROUP_DATA_ACCESS_READ_ONLY"  //GROUP_DATA_ACCESS_READ_ONLY - Project Data Access Read Only
-	projectBasePath              = "groups"
+	// GroupOwner - Project Owner
+	GroupOwner = "GROUP_OWNER"
+	// GroupReadOnly - Project Read Only
+	GroupReadOnly = "GROUP_READ_ONLY"
+	// GroupDataAccessAdmin - Project Data Access Admin
+	GroupDataAccessAdmin = "GROUP_DATA_ACCESS_ADMIN"
+	// GroupDataAccessReadWrite - Project Data Access Read/Write
+	GroupDataAccessReadWrite = "GROUP_DATA_ACCESS_READ_WRITE"
+	// GroupDataAccessReadOnly - Project Data Access Read Only
+	GroupDataAccessReadOnly = "GROUP_DATA_ACCESS_READ_ONLY"
+	projectBasePath         = "groups"
 )
 
 // ProjectsService is an interface for interfacing with the Projects

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -330,8 +330,8 @@ func TestProject_AddTeamsToProject(t *testing.T) {
 	createRequest := &ProjectTeam{
 		TeamID: "{TEAM-ID}",
 		Roles: []*RoleName{
-			{RoleName: GROUP_OWNER},
-			{RoleName: GROUP_READ_ONLY},
+			{RoleName: GroupOwner},
+			{RoleName: GroupReadOnly},
 		},
 	}
 


### PR DESCRIPTION
This enables golint to be run as part of make lint and fixes some warnings flagged by it
this aims to make the codebase more homogenous as part of the code seemed to be linted and other not

**Warning**: this may be a breaking change as the name of some public interfaces are changing