### PR TITLE
Simplify tests

### DIFF
--- a/mongodbatlas/alert_configurations_test.go
+++ b/mongodbatlas/alert_configurations_test.go
@@ -6,9 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/mwielbut/pointy"
-
 	"github.com/go-test/deep"
+	"github.com/mwielbut/pointy"
 )
 
 func TestAlertConfiguration_Create(t *testing.T) {
@@ -153,7 +152,7 @@ func TestAlertConfiguration_EnableAnAlertConfig(t *testing.T) {
 
 	alertConfiguration, _, err := client.AlertConfigurations.EnableAnAlertConfig(ctx, groupID, alertConfigID, pointy.Bool(true))
 	if err != nil {
-		t.Errorf("AlertConfiguration.EnableAnAlertConfig returned error: %v", err)
+		t.Fatalf("AlertConfiguration.EnableAnAlertConfig returned error: %v", err)
 	}
 
 	expected := &AlertConfiguration{
@@ -176,7 +175,7 @@ func TestAlertConfiguration_EnableAnAlertConfig(t *testing.T) {
 	}
 
 	if diff := deep.Equal(alertConfiguration, expected); diff != nil {
-		t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", alertConfiguration, expected, diff)
+		t.Error(diff)
 	}
 }
 
@@ -223,7 +222,7 @@ func TestAlertConfiguration_GetAnAlertConfig(t *testing.T) {
 
 	alertConfiguration, _, err := client.AlertConfigurations.GetAnAlertConfig(ctx, groupID, alertConfigID)
 	if err != nil {
-		t.Errorf("AlertConfigurations.GetAnAlertConfig returned error: %v", err)
+		t.Fatalf("AlertConfigurations.GetAnAlertConfig returned error: %v", err)
 	}
 
 	expected := &AlertConfiguration{
@@ -258,7 +257,7 @@ func TestAlertConfiguration_GetAnAlertConfig(t *testing.T) {
 	}
 
 	if diff := deep.Equal(alertConfiguration, expected); diff != nil {
-		t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", alertConfiguration, expected, diff)
+		t.Error(diff)
 	}
 }
 
@@ -309,7 +308,7 @@ func TestAlertConfiguration_GetOpenAlertsConfig(t *testing.T) {
 
 	alertConfigurations, _, err := client.AlertConfigurations.GetOpenAlertsConfig(ctx, groupID, alertConfigID)
 	if err != nil {
-		t.Errorf("AlertConfigurations.GetOpenAlertsConfig returned error: %v", err)
+		t.Fatalf("AlertConfigurations.GetOpenAlertsConfig returned error: %v", err)
 	}
 
 	expected := []AlertConfiguration{
@@ -345,7 +344,7 @@ func TestAlertConfiguration_GetOpenAlertsConfig(t *testing.T) {
 	}
 
 	if diff := deep.Equal(alertConfigurations, expected); diff != nil {
-		t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", alertConfigurations, expected, diff)
+		t.Error(diff)
 	}
 }
 
@@ -426,7 +425,7 @@ func TestAlertConfiguration_List(t *testing.T) {
 
 	alertConfigurations, _, err := client.AlertConfigurations.List(ctx, groupID, nil)
 	if err != nil {
-		t.Errorf("AlertConfigurations.List returned error: %v", err)
+		t.Fatalf("AlertConfigurations.List returned error: %v", err)
 	}
 
 	expected := []AlertConfiguration{
@@ -493,7 +492,7 @@ func TestAlertConfiguration_List(t *testing.T) {
 	}
 
 	if diff := deep.Equal(alertConfigurations, expected); diff != nil {
-		t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", alertConfigurations, expected, diff)
+		t.Error(diff)
 	}
 }
 
@@ -566,7 +565,7 @@ func TestAlertConfiguration_Update(t *testing.T) {
 
 	alertConfiguration, _, err := client.AlertConfigurations.Update(ctx, groupID, alertConfigID, alertReq)
 	if err != nil {
-		t.Errorf("AlertConfiguration.Update returned error: %v", err)
+		t.Fatalf("AlertConfiguration.Update returned error: %v", err)
 		return
 	}
 
@@ -589,7 +588,7 @@ func TestAlertConfiguration_Update(t *testing.T) {
 	}
 
 	if diff := deep.Equal(alertConfiguration, expected); diff != nil {
-		t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", alertConfiguration, expected, diff)
+		t.Error(diff)
 	}
 }
 
@@ -606,6 +605,6 @@ func TestAlertConfiguration_Delete(t *testing.T) {
 
 	_, err := client.AlertConfigurations.Delete(ctx, groupID, alertConfigID)
 	if err != nil {
-		t.Errorf("AlertConfigurations.Delete returned error: %v", err)
+		t.Fatalf("AlertConfigurations.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/api_keys_test.go
+++ b/mongodbatlas/api_keys_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -58,7 +57,7 @@ func TestAPIKeys_ListAPIKeys(t *testing.T) {
 	apiKeys, _, err := client.APIKeys.List(ctx, "1", nil)
 
 	if err != nil {
-		t.Errorf("APIKeys.List returned error: %v", err)
+		t.Fatalf("APIKeys.List returned error: %v", err)
 	}
 
 	expected := []APIKey{
@@ -95,8 +94,8 @@ func TestAPIKeys_ListAPIKeys(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(apiKeys, expected) {
-		t.Errorf("APIKeys.List\n got=%#v\nwant=%#v", apiKeys, expected)
+	if diff := deep.Equal(apiKeys, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -261,11 +260,7 @@ func TestAPIKeys_Create(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Clusters.Create Request Body = %v", diff)
-		}
-
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -304,10 +299,6 @@ func TestAPIKeys_GetAPIKey(t *testing.T) {
 
 	if diff := deep.Equal(apiKeys, expected); diff != nil {
 		t.Errorf("Clusters.Get = %v", diff)
-	}
-
-	if !reflect.DeepEqual(apiKeys, expected) {
-		t.Errorf("APIKeys.Get\n got=%#v\nwant=%#v", apiKeys, expected)
 	}
 }
 
@@ -353,8 +344,8 @@ func TestAPIKeys_Update(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -362,7 +353,7 @@ func TestAPIKeys_Update(t *testing.T) {
 
 	apiKey, _, err := client.APIKeys.Update(ctx, orgID, "5c47503320eef5699e1cce8d", updateRequest)
 	if err != nil {
-		t.Errorf("APIKeys.Create returned error: %v", err)
+		t.Fatalf("APIKeys.Create returned error: %v", err)
 	}
 
 	if desc := apiKey.Desc; desc != "test-apikey" {

--- a/mongodbatlas/atlas_users_test.go
+++ b/mongodbatlas/atlas_users_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/go-test/deep"
 )
 
 func TestAtlasUsers_List(t *testing.T) {
@@ -83,7 +84,7 @@ func TestAtlasUsers_List(t *testing.T) {
 	teams, _, err := client.AtlasUsers.List(ctx, "1", nil)
 
 	if err != nil {
-		t.Errorf("AtlasUsers.List returned error: %v", err)
+		t.Fatalf("AtlasUsers.List returned error: %v", err)
 	}
 
 	expected := []AtlasUser{
@@ -121,8 +122,8 @@ func TestAtlasUsers_List(t *testing.T) {
 			Username: "jim.bloggs",
 		},
 	}
-	if !reflect.DeepEqual(teams, expected) {
-		t.Errorf("AtlasUsers.List\n got=%#v\nwant=%#v", teams, expected)
+	if diff := deep.Equal(teams, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -169,7 +170,7 @@ func TestAtlasUsers_Get(t *testing.T) {
 
 	team, _, err := client.AtlasUsers.Get(ctx, userID)
 	if err != nil {
-		t.Errorf("AtlasUsers.Get returned error: %v", err)
+		t.Fatalf("AtlasUsers.Get returned error: %v", err)
 	}
 
 	expected := &AtlasUser{
@@ -194,8 +195,8 @@ func TestAtlasUsers_Get(t *testing.T) {
 		Username: "john.doe@example.com",
 	}
 
-	if !reflect.DeepEqual(team, expected) {
-		t.Errorf("AtlasUsers.Get\n got=%#v\nwant=%#v", team, expected)
+	if diff := deep.Equal(team, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -242,7 +243,7 @@ func TestAtlasUsers_GetByName(t *testing.T) {
 
 	team, _, err := client.AtlasUsers.GetByName(ctx, username)
 	if err != nil {
-		t.Errorf("AtlasUsers.GetByName returned error: %v", err)
+		t.Fatalf("AtlasUsers.GetByName returned error: %v", err)
 	}
 
 	expected := &AtlasUser{
@@ -267,8 +268,8 @@ func TestAtlasUsers_GetByName(t *testing.T) {
 		Username: "john.doe@example.com",
 	}
 
-	if !reflect.DeepEqual(team, expected) {
-		t.Errorf("AtlasUsers.Get\n got=%#v\nwant=%#v", team, expected)
+	if diff := deep.Equal(team, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -358,8 +359,8 @@ func TestAtlasUsers_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -367,7 +368,7 @@ func TestAtlasUsers_Create(t *testing.T) {
 
 	atlasUser, _, err := client.AtlasUsers.Create(ctx, createRequest)
 	if err != nil {
-		t.Errorf("AtlasUsers.Create returned error: %v", err)
+		t.Fatalf("AtlasUsers.Create returned error: %v", err)
 	}
 
 	if name := atlasUser.Username; name != "john.doe@example.com" {

--- a/mongodbatlas/auditing_test.go
+++ b/mongodbatlas/auditing_test.go
@@ -49,8 +49,7 @@ func TestConfigureAuditing(t *testing.T) {
 
 	auditingResponse, _, err := client.Auditing.Configure(ctx, groupID, auditingRequest)
 	if err != nil {
-		t.Errorf("Auditing.Configure returned error: %v", err)
-		return
+		t.Fatalf("Auditing.Configure returned error: %v", err)
 	}
 
 	expected := &Auditing{
@@ -83,7 +82,7 @@ func TestAuditing_Get(t *testing.T) {
 
 	auditing, _, err := client.Auditing.Get(ctx, groupID)
 	if err != nil {
-		t.Errorf("Auditing.Get returned error: %v", err)
+		t.Fatalf("Auditing.Get returned error: %v", err)
 	}
 
 	expected := &Auditing{

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -96,7 +95,7 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 
 	cloudProviderSnapshots, _, err := client.CloudProviderSnapshotRestoreJobs.List(ctx, requestParameters)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshotRestoreJobs.List returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshotRestoreJobs.List returned error: %v", err)
 	}
 
 	expected := &CloudProviderSnapshotRestoreJobs{
@@ -172,9 +171,6 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 	if diff := deep.Equal(cloudProviderSnapshots, expected); diff != nil {
 		t.Error(diff)
 	}
-	if !reflect.DeepEqual(cloudProviderSnapshots, expected) {
-		t.Errorf("CloudProviderSnapshotRestoreJobs.List\n got=%#v\nwant=%#v", cloudProviderSnapshots, expected)
-	}
 }
 
 func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
@@ -224,7 +220,7 @@ func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
 
 	cloudProviderSnapshot, _, err := client.CloudProviderSnapshotRestoreJobs.Get(ctx, requestParameters)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshotRestoreJobs.Get returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshotRestoreJobs.Get returned error: %v", err)
 	}
 
 	expected := &CloudProviderSnapshotRestoreJob{
@@ -259,9 +255,6 @@ func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
-		t.Errorf("CloudProviderSnapshotRestoreJobs.Get\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
 	}
 }
 
@@ -300,9 +293,6 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 		if diff := deep.Equal(v, expected); diff != nil {
 			t.Error(diff)
 		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
-		}
 
 		fmt.Fprint(w, `{
 			"cancelled": false,
@@ -337,7 +327,7 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 
 	cloudProviderSnapshot, _, err := client.CloudProviderSnapshotRestoreJobs.Create(ctx, requestParameters, createRequest)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshotRestoreJobs.Create returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshotRestoreJobs.Create returned error: %v", err)
 	}
 
 	expected := &CloudProviderSnapshotRestoreJob{
@@ -373,9 +363,6 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
 		t.Error(diff)
 	}
-	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
-		t.Errorf("CloudProviderSnapshotRestoreJobs.Create\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
-	}
 }
 
 func TestCloudProviderSnapshotRestoreJobs_Delete(t *testing.T) {
@@ -396,6 +383,6 @@ func TestCloudProviderSnapshotRestoreJobs_Delete(t *testing.T) {
 
 	_, err := client.CloudProviderSnapshotRestoreJobs.Delete(ctx, requestParameters)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshotRestoreJobs.Delete returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshotRestoreJobs.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/cloud_provider_snapshots_test.go
+++ b/mongodbatlas/cloud_provider_snapshots_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -56,7 +55,7 @@ func TestCloudProviderSnapshots_GetAllCloudProviderSnapshots(t *testing.T) {
 
 	cloudProviderSnapshots, _, err := client.CloudProviderSnapshots.GetAllCloudProviderSnapshots(ctx, requestParameters)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshots.GetAllCloudProviderSnapshots returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshots.GetAllCloudProviderSnapshots returned error: %v", err)
 	}
 
 	expected := &CloudProviderSnapshots{
@@ -91,9 +90,6 @@ func TestCloudProviderSnapshots_GetAllCloudProviderSnapshots(t *testing.T) {
 
 	if diff := deep.Equal(cloudProviderSnapshots, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(cloudProviderSnapshots, expected) {
-		t.Errorf("CloudProviderSnapshots.GetAllCloudProviderSnapshots\n got=%#v\nwant=%#v", cloudProviderSnapshots, expected)
 	}
 }
 
@@ -136,7 +132,7 @@ func TestCloudProviderSnapshots_GetOneCloudProviderSnapshot(t *testing.T) {
 
 	cloudProviderSnapshot, _, err := client.CloudProviderSnapshots.GetOneCloudProviderSnapshot(ctx, requestParameters)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshots.GetOneCloudProviderSnapshot returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshots.GetOneCloudProviderSnapshot returned error: %v", err)
 	}
 
 	expected := &CloudProviderSnapshot{
@@ -163,9 +159,6 @@ func TestCloudProviderSnapshots_GetOneCloudProviderSnapshot(t *testing.T) {
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
-		t.Errorf("CloudProviderSnapshots.GetOneCloudProviderSnapshot\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
 	}
 }
 
@@ -199,9 +192,6 @@ func TestCloudProviderSnapshots_Create(t *testing.T) {
 		if diff := deep.Equal(v, expected); diff != nil {
 			t.Error(diff)
 		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
-		}
 
 		fmt.Fprint(w, `{
 			"createdAt": "2018-12-31T20:54:03Z",
@@ -228,7 +218,7 @@ func TestCloudProviderSnapshots_Create(t *testing.T) {
 
 	cloudProviderSnapshot, _, err := client.CloudProviderSnapshots.Create(ctx, requestParameters, createRequest)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshots.Create returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshots.Create returned error: %v", err)
 	}
 
 	expected := &CloudProviderSnapshot{
@@ -256,9 +246,6 @@ func TestCloudProviderSnapshots_Create(t *testing.T) {
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
 		t.Error(diff)
 	}
-	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
-		t.Errorf("CloudProviderSnapshots.Create\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
-	}
 }
 
 func TestCloudProviderSnapshots_Delete(t *testing.T) {
@@ -279,6 +266,6 @@ func TestCloudProviderSnapshots_Delete(t *testing.T) {
 
 	_, err := client.CloudProviderSnapshots.Delete(ctx, requestParameters)
 	if err != nil {
-		t.Errorf("CloudProviderSnapshots.Delete returned error: %v", err)
+		t.Fatalf("CloudProviderSnapshots.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -102,7 +101,7 @@ func TestClusters_ListClusters(t *testing.T) {
 
 	clusters, _, err := client.Clusters.List(ctx, "1", nil)
 	if err != nil {
-		t.Errorf("Clusters.List returned error: %v", err)
+		t.Fatalf("Clusters.List returned error: %v", err)
 	}
 
 	cluster1 := Cluster{
@@ -141,8 +140,8 @@ func TestClusters_ListClusters(t *testing.T) {
 	}
 
 	expected := []Cluster{cluster1, cluster1}
-	if !reflect.DeepEqual(clusters, expected) {
-		t.Errorf("Clusters.List\n got=%#v\nwant=%#v", clusters, expected)
+	if diff := deep.Equal(clusters, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -358,16 +357,12 @@ func TestClusters_Create(t *testing.T) {
 			t.Errorf("Clusters.Create Request Body = %v", diff)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
-		}
-
 		fmt.Fprint(w, jsonBlob)
 	})
 
 	cluster, _, err := client.Clusters.Create(ctx, groupID, createRequest)
 	if err != nil {
-		t.Errorf("Clusters.Create returned error: %v", err)
+		t.Fatalf("Clusters.Create returned error: %v", err)
 	}
 
 	expectedName := "AppData"
@@ -516,16 +511,13 @@ func TestClusters_Update(t *testing.T) {
 		if diff := deep.Equal(v, expected); diff != nil {
 			t.Errorf("Clusters.Update Request Body = %v", diff)
 		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
-		}
 
 		fmt.Fprint(w, jsonBlob)
 	})
 
 	dbUser, _, err := client.Clusters.Update(ctx, groupID, clusterName, updateRequest)
 	if err != nil {
-		t.Errorf("Clusters.Update returned error: %v", err)
+		t.Fatalf("Clusters.Update returned error: %v", err)
 	}
 
 	if name := dbUser.Name; name != clusterName {
@@ -551,7 +543,7 @@ func TestClusters_Delete(t *testing.T) {
 
 	_, err := client.Clusters.Delete(ctx, groupID, name)
 	if err != nil {
-		t.Errorf("Cluster.Delete returned error: %v", err)
+		t.Fatalf("Cluster.Delete returned error: %v", err)
 	}
 }
 
@@ -605,11 +597,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Clusters.UpdateProcessArgs Request Body = %v", diff)
-		}
-
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -617,7 +605,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 
 	processArgs, _, err := client.Clusters.UpdateProcessArgs(ctx, groupID, clusterName, updateRequest)
 	if err != nil {
-		t.Errorf("Clusters.UpdateProcessArgs returned error: %v", err)
+		t.Fatalf("Clusters.UpdateProcessArgs returned error: %v", err)
 	}
 
 	if tls := processArgs.MinimumEnabledTLSProtocol; tls != tlsProtocol {
@@ -652,7 +640,7 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 
 	processArgs, _, err := client.Clusters.GetProcessArgs(ctx, groupID, clusterName)
 	if err != nil {
-		t.Errorf("Clusters.GetProcessArgs returned error: %v", err)
+		t.Fatalf("Clusters.GetProcessArgs returned error: %v", err)
 	}
 
 	expected := &ProcessArgs{
@@ -665,14 +653,14 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 		SampleRefreshIntervalBIConnector: pointy.Int64(300),
 	}
 
-	if !reflect.DeepEqual(processArgs, expected) {
-		t.Errorf("Clusters.GetProcessArgs\n got=%#v\nwant=%#v", processArgs, expected)
+	if diff := deep.Equal(processArgs, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
 func TestClusters_checkClusterNameParam(t *testing.T) {
 	if err := checkClusterNameParam(""); err == nil {
-		t.Errorf("checkClusterNameParam didn't return error")
+		t.Fatalf("checkClusterNameParam didn't return error")
 	}
 }
 
@@ -728,7 +716,7 @@ func TestClusters_Get(t *testing.T) {
 
 	cluster, _, err := client.Clusters.Get(ctx, groupID, clusterName)
 	if err != nil {
-		t.Errorf("Clusters.Get returned error: %v", err)
+		t.Fatalf("Clusters.Get returned error: %v", err)
 	}
 
 	expected := &Cluster{
@@ -767,7 +755,7 @@ func TestClusters_Get(t *testing.T) {
 		StateName:  "IDLE",
 	}
 
-	if !reflect.DeepEqual(cluster, expected) {
-		t.Errorf("Clusters.Get\n got=%#v\nwant=%#v", cluster, expected)
+	if diff := deep.Equal(cluster, expected); diff != nil {
+		t.Error(diff)
 	}
 }

--- a/mongodbatlas/containers_test.go
+++ b/mongodbatlas/containers_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -42,7 +41,7 @@ func TestContainers_ListContainers(t *testing.T) {
 
 	containers, _, err := client.Containers.List(ctx, "1", nil)
 	if err != nil {
-		t.Errorf("Containers.List returned error: %v", err)
+		t.Fatalf("Containers.List returned error: %v", err)
 	}
 
 	GCPContainer := Container{
@@ -64,8 +63,9 @@ func TestContainers_ListContainers(t *testing.T) {
 	}
 
 	expected := []Container{GCPContainer, AWSContainer}
-	if !reflect.DeepEqual(containers, expected) {
-		t.Errorf("Containers.List\n got=%#v\nwant=%#v", containers, expected)
+
+	if diff := deep.Equal(containers, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -199,11 +199,7 @@ func TestContainers_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Containers.Create Request Body = %v", diff)
-		}
-
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -211,7 +207,7 @@ func TestContainers_Create(t *testing.T) {
 
 	container, _, err := client.Containers.Create(ctx, groupID, createRequest)
 	if err != nil {
-		t.Errorf("Containers.Create returned error: %v", err)
+		t.Fatalf("Containers.Create returned error: %v", err)
 	}
 
 	expectedCID := "1112269b3bf99403840e8934"
@@ -269,10 +265,7 @@ func TestContainers_Update(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Containers.Update Request Body = %v", diff)
-		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -280,7 +273,7 @@ func TestContainers_Update(t *testing.T) {
 
 	container, _, err := client.Containers.Update(ctx, groupID, containerID, updateRequest)
 	if err != nil {
-		t.Errorf("Containers.Update returned error: %v", err)
+		t.Fatalf("Containers.Update returned error: %v", err)
 	}
 
 	if cID := container.ID; cID != containerID {
@@ -312,6 +305,6 @@ func TestContainers_Delete(t *testing.T) {
 
 	_, err := client.Containers.Delete(ctx, groupID, id)
 	if err != nil {
-		t.Errorf("Container.Delete returned error: %v", err)
+		t.Fatalf("Container.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/go-test/deep"
 )
 
 func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
@@ -19,7 +21,7 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 
 	customDBRoles, _, err := client.CustomDBRoles.List(ctx, "1", nil)
 	if err != nil {
-		t.Errorf("CustomDBRoles.List returned error: %v", err)
+		t.Fatalf("CustomDBRoles.List returned error: %v", err)
 	}
 
 	expected := &[]CustomDBRole{{
@@ -37,8 +39,9 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 		}},
 		RoleName: "test-role-name",
 	}}
-	if !reflect.DeepEqual(customDBRoles, expected) {
-		t.Errorf("CustomDBRoles.List\n got=%#v\nwant=%#v", customDBRoles, expected)
+
+	if diff := deep.Equal(customDBRoles, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -53,7 +56,7 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 
 	customDBRole, _, err := client.CustomDBRoles.Get(ctx, "1", "test-role-name")
 	if err != nil {
-		t.Errorf("CustomDBRoles.Get returned error: %v", err)
+		t.Fatalf("CustomDBRoles.Get returned error: %v", err)
 	}
 
 	expected := &CustomDBRole{
@@ -71,8 +74,8 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 		}},
 		RoleName: "test-role-name",
 	}
-	if !reflect.DeepEqual(customDBRole, expected) {
-		t.Errorf("CustomDBRoles.List\n got=%#v\nwant=%#v", customDBRole, expected)
+	if diff := deep.Equal(customDBRole, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -141,8 +144,8 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -150,7 +153,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 
 	customDBRole, _, err := client.CustomDBRoles.Create(ctx, "1", createRequest)
 	if err != nil {
-		t.Errorf("CustomDBRoles.Create returned error: %v", err)
+		t.Fatalf("CustomDBRoles.Create returned error: %v", err)
 	}
 
 	if roleName := customDBRole.RoleName; roleName != "test-role-name" {
@@ -232,7 +235,7 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 
 	customDBRole, _, err := client.CustomDBRoles.Update(ctx, "1", "test-role-name", updateRequest)
 	if err != nil {
-		t.Errorf("CustomDBRoles.Update returned error: %v", err)
+		t.Fatalf("CustomDBRoles.Update returned error: %v", err)
 	}
 
 	if roleName := customDBRole.RoleName; roleName != "test-role-name" {
@@ -253,6 +256,6 @@ func TestDatabaseUsers_DeleteCustomDBRole(t *testing.T) {
 
 	_, err := client.CustomDBRoles.Delete(ctx, groupID, roleName)
 	if err != nil {
-		t.Errorf("CustomDBRole.Delete returned error: %v", err)
+		t.Fatalf("CustomDBRole.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/database_users_test.go
+++ b/mongodbatlas/database_users_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/go-test/deep"
 )
 
 func TestDatabaseUsers_ListDatabaseUsers(t *testing.T) {
@@ -19,12 +20,12 @@ func TestDatabaseUsers_ListDatabaseUsers(t *testing.T) {
 
 	dbUsers, _, err := client.DatabaseUsers.List(ctx, "1", nil)
 	if err != nil {
-		t.Errorf("DatabaseUsers.List returned error: %v", err)
+		t.Fatalf("DatabaseUsers.List returned error: %v", err)
 	}
 
 	expected := []DatabaseUser{{GroupID: "1", Username: "test-username"}, {GroupID: "1", Username: "test-username-1"}}
-	if !reflect.DeepEqual(dbUsers, expected) {
-		t.Errorf("DatabaseUsers.List\n got=%#v\nwant=%#v", dbUsers, expected)
+	if diff := deep.Equal(dbUsers, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -171,8 +172,8 @@ func TestDatabaseUsers_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -180,7 +181,7 @@ func TestDatabaseUsers_Create(t *testing.T) {
 
 	dbUser, _, err := client.DatabaseUsers.Create(ctx, groupID, createRequest)
 	if err != nil {
-		t.Errorf("DatabaseUsers.Create returned error: %v", err)
+		t.Fatalf("DatabaseUsers.Create returned error: %v", err)
 	}
 
 	if username := dbUser.Username; username != "test-username" {
@@ -204,12 +205,12 @@ func TestDatabaseUsers_GetDatabaseUser(t *testing.T) {
 
 	dbUsers, _, err := client.DatabaseUsers.Get(ctx, "1", "test-username")
 	if err != nil {
-		t.Errorf("DatabaseUser.Get returned error: %v", err)
+		t.Fatalf("DatabaseUser.Get returned error: %v", err)
 	}
 
 	expected := &DatabaseUser{Username: "test-username"}
-	if !reflect.DeepEqual(dbUsers, expected) {
-		t.Errorf("DatabaseUsers.Get\n got=%#v\nwant=%#v", dbUsers, expected)
+	if diff := deep.Equal(dbUsers, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -266,8 +267,8 @@ func TestDatabaseUsers_Update(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -275,7 +276,7 @@ func TestDatabaseUsers_Update(t *testing.T) {
 
 	dbUser, _, err := client.DatabaseUsers.Update(ctx, groupID, "test-username", createRequest)
 	if err != nil {
-		t.Errorf("DatabaseUsers.Update returned error: %v", err)
+		t.Fatalf("DatabaseUsers.Update returned error: %v", err)
 	}
 
 	if username := dbUser.Username; username != "test-username" {
@@ -301,6 +302,6 @@ func TestDatabaseUsers_Delete(t *testing.T) {
 
 	_, err := client.DatabaseUsers.Delete(ctx, groupID, username)
 	if err != nil {
-		t.Errorf("DatabaseUser.Delete returned error: %v", err)
+		t.Fatalf("DatabaseUser.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/encryptions_at_rest_test.go
+++ b/mongodbatlas/encryptions_at_rest_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -78,9 +77,6 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 		if diff := deep.Equal(v, expected); diff != nil {
 			t.Error(diff)
 		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
-		}
 
 		fmt.Fprint(w, `{
 			"awsKms": {
@@ -108,7 +104,7 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 
 	cloudProviderSnapshot, _, err := client.EncryptionsAtRest.Create(ctx, createRequest)
 	if err != nil {
-		t.Errorf("EncryptionsAtRest.Create returned error: %v", err)
+		t.Fatalf("EncryptionsAtRest.Create returned error: %v", err)
 	}
 
 	expected := &EncryptionAtRest{
@@ -136,9 +132,6 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
-		t.Errorf("EncryptionsAtRest.Create\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
 	}
 }
 
@@ -176,7 +169,7 @@ func TestEncryptionsAtRest_Get(t *testing.T) {
 
 	cloudProviderSnapshot, _, err := client.EncryptionsAtRest.Get(ctx, groupID)
 	if err != nil {
-		t.Errorf("EncryptionsAtRest.Get returned error: %v", err)
+		t.Fatalf("EncryptionsAtRest.Get returned error: %v", err)
 	}
 
 	expected := &EncryptionAtRest{
@@ -204,8 +197,5 @@ func TestEncryptionsAtRest_Get(t *testing.T) {
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(cloudProviderSnapshot, expected) {
-		t.Errorf("EncryptionsAtRest.Get\n got=%#v\nwant=%#v", cloudProviderSnapshot, expected)
 	}
 }

--- a/mongodbatlas/global_clusters_test.go
+++ b/mongodbatlas/global_clusters_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -48,7 +47,7 @@ func TestGlobalClusters_Get(t *testing.T) {
 
 	cluster, _, err := client.GlobalClusters.Get(ctx, groupID, clusterName)
 	if err != nil {
-		t.Errorf("GlobalClusters.Get returned error: %v", err)
+		t.Fatalf("GlobalClusters.Get returned error: %v", err)
 	}
 
 	expected := &GlobalCluster{
@@ -79,8 +78,8 @@ func TestGlobalClusters_Get(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(cluster, expected) {
-		t.Errorf("GlobalClusters.Get\n got=%#v\nwant=%#v", cluster, expected)
+	if diff := deep.Equal(cluster, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -138,11 +137,7 @@ func TestGlobalClusters_AddManagedNamespace(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 		if diff := deep.Equal(v, expectedRequest); diff != nil {
-			t.Errorf("GlobalClusters.AddManagedNamespace Request Body = %v", diff)
-		}
-
-		if !reflect.DeepEqual(v, expectedRequest) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expectedRequest)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -235,7 +230,7 @@ func TestGlobalClusters_DeleteManagedNamespace(t *testing.T) {
 	globalCluster, _, err := client.GlobalClusters.DeleteManagedNamespace(ctx, groupID, name, &mn)
 
 	if err != nil {
-		t.Errorf("GlobalClusters.DeleteManagedNamespace returned error: %v", err)
+		t.Fatalf("GlobalClusters.DeleteManagedNamespace returned error: %v", err)
 	}
 
 	expected := &GlobalCluster{
@@ -267,7 +262,7 @@ func TestGlobalClusters_DeleteManagedNamespace(t *testing.T) {
 	}
 
 	if diff := deep.Equal(globalCluster, expected); diff != nil {
-		t.Errorf("GlobalClusters.DeleteCustomZoneMappings Response Body = %v", diff)
+		t.Error(diff)
 	}
 }
 
@@ -313,11 +308,7 @@ func TestGlobalClusters_AddCustomZoneMappings(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 		if diff := deep.Equal(v, expectedRequest); diff != nil {
-			t.Errorf("GlobalClusters.AddCustomZoneMappings Request Body = %v", diff)
-		}
-
-		if !reflect.DeepEqual(v, expectedRequest) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expectedRequest)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -325,7 +316,7 @@ func TestGlobalClusters_AddCustomZoneMappings(t *testing.T) {
 
 	globalCluster, _, err := client.GlobalClusters.AddCustomZoneMappings(ctx, groupID, clusterName, createRequest)
 	if err != nil {
-		t.Errorf("GlobalClusters.AddCustomZoneMappings returned error: %v", err)
+		t.Fatalf("GlobalClusters.AddCustomZoneMappings returned error: %v", err)
 	}
 
 	if namespacesCount := len(globalCluster.ManagedNamespaces); namespacesCount != 1 {
@@ -335,7 +326,6 @@ func TestGlobalClusters_AddCustomZoneMappings(t *testing.T) {
 	if id := globalCluster.CustomZoneMapping["CA"]; id != "5b50bf4180eef547653df4d0" {
 		t.Errorf("expected CustomZoneMapping.CA '%s', received '%s'", "5b50bf4180eef547653df4d0", id)
 	}
-
 }
 
 func TestGlobalClusters_DeleteCustomZoneMappings(t *testing.T) {
@@ -365,7 +355,7 @@ func TestGlobalClusters_DeleteCustomZoneMappings(t *testing.T) {
 	globalCluster, _, err := client.GlobalClusters.DeleteCustomZoneMappings(ctx, groupID, name)
 
 	if err != nil {
-		t.Errorf("Cluster.Delete returned error: %v", err)
+		t.Fatalf("Cluster.Delete returned error: %v", err)
 	}
 
 	expected := &GlobalCluster{
@@ -380,6 +370,6 @@ func TestGlobalClusters_DeleteCustomZoneMappings(t *testing.T) {
 	}
 
 	if diff := deep.Equal(globalCluster, expected); diff != nil {
-		t.Errorf("GlobalClusters.AddCustomZoneMappings Response Body = %v", diff)
+		t.Error(diff)
 	}
 }

--- a/mongodbatlas/maintenance_test.go
+++ b/mongodbatlas/maintenance_test.go
@@ -31,7 +31,7 @@ func TestMaintenanceWindows_UpdateWithSheduleTime(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", v, expected, diff)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, `{}`)
@@ -46,7 +46,7 @@ func TestMaintenanceWindows_UpdateWithSheduleTime(t *testing.T) {
 
 	_, err := client.MaintenanceWindows.Update(ctx, groupID, maintenanceRequest)
 	if err != nil {
-		t.Errorf("MaintenanceWindow.Update returned error: %v", err)
+		t.Fatalf("MaintenanceWindow.Update returned error: %v", err)
 		return
 	}
 }
@@ -69,7 +69,7 @@ func TestMaintenanceWindows_UpdateWithStartNow(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", v, expected, diff)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, `{}`)
@@ -113,7 +113,7 @@ func TestMaintenanceWindows_Get(t *testing.T) {
 	}
 
 	if diff := deep.Equal(maintenanceWindow, expected); diff != nil {
-		t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", maintenanceWindow, expected, diff)
+		t.Error(diff)
 	}
 }
 

--- a/mongodbatlas/peers_test.go
+++ b/mongodbatlas/peers_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -39,7 +38,7 @@ func TestPeers_ListPeers(t *testing.T) {
 
 	peers, _, err := client.Peers.List(ctx, "1", nil)
 	if err != nil {
-		t.Errorf("Peers.List returned error: %v", err)
+		t.Fatalf("Peers.List returned error: %v", err)
 	}
 
 	peer := Peer{
@@ -51,8 +50,8 @@ func TestPeers_ListPeers(t *testing.T) {
 	}
 
 	expected := []Peer{peer, peer}
-	if !reflect.DeepEqual(peers, expected) {
-		t.Errorf("Peers.List\n got=%#v\nwant=%#v", peers, expected)
+	if diff := deep.Equal(peers, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -187,11 +186,7 @@ func TestPeers_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Peers.Create Request Body = %v", diff)
-		}
-
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -199,7 +194,7 @@ func TestPeers_Create(t *testing.T) {
 
 	peer, _, err := client.Peers.Create(ctx, groupID, createRequest)
 	if err != nil {
-		t.Errorf("Peers.Create returned error: %v", err)
+		t.Fatalf("Peers.Create returned error: %v", err)
 	}
 
 	expectedCID := "507f1f77bcf86cd799439011"
@@ -258,16 +253,13 @@ func TestPeers_Update(t *testing.T) {
 		if diff := deep.Equal(v, expected); diff != nil {
 			t.Errorf("Peers.Update Request Body = %v", diff)
 		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
-		}
 
 		fmt.Fprint(w, jsonBlob)
 	})
 
 	perr, _, err := client.Peers.Update(ctx, groupID, peerID, updateRequest)
 	if err != nil {
-		t.Errorf("Peers.Update returned error: %v", err)
+		t.Fatalf("Peers.Update returned error: %v", err)
 	}
 
 	if pID := perr.ID; pID != peerID {
@@ -295,6 +287,6 @@ func TestPeers_Delete(t *testing.T) {
 
 	_, err := client.Peers.Delete(ctx, groupID, id)
 	if err != nil {
-		t.Errorf("Peer.Delete returned error: %v", err)
+		t.Fatalf("Peer.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/private_ip_mode_test.go
+++ b/mongodbatlas/private_ip_mode_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -26,7 +25,7 @@ func TestPrivateIPMode_Get(t *testing.T) {
 
 	privateIPMode, _, err := client.PrivateIPMode.Get(ctx, groupID)
 	if err != nil {
-		t.Errorf("PrivateIPMode.Get returned error: %v", err)
+		t.Fatalf("PrivateIPMode.Get returned error: %v", err)
 	}
 
 	expected := &PrivateIPMode{
@@ -35,10 +34,6 @@ func TestPrivateIPMode_Get(t *testing.T) {
 
 	if diff := deep.Equal(privateIPMode, expected); diff != nil {
 		t.Error(diff)
-	}
-
-	if !reflect.DeepEqual(privateIPMode, expected) {
-		t.Errorf("PrivateIPMode.Get\n got=%#v\nwant=%#v", privateIPMode, expected)
 	}
 }
 
@@ -70,10 +65,7 @@ func TestPrivateIPMode_Update(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("PrivateIPMode.Update Request Body = %v", diff)
-		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -81,7 +73,7 @@ func TestPrivateIPMode_Update(t *testing.T) {
 
 	privateIPMode, _, err := client.PrivateIPMode.Update(ctx, groupID, updateRequest)
 	if err != nil {
-		t.Errorf("PrivateIPMode.Update returned error: %v", err)
+		t.Fatalf("PrivateIPMode.Update returned error: %v", err)
 	}
 
 	if enabled := pointy.BoolValue(privateIPMode.Enabled, false); !enabled {

--- a/mongodbatlas/project_api_key_test.go
+++ b/mongodbatlas/project_api_key_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -58,7 +57,7 @@ func TestProjectAPIKeys_ListAPIKeys(t *testing.T) {
 	apiKeys, _, err := client.ProjectAPIKeys.List(ctx, "1", nil)
 
 	if err != nil {
-		t.Errorf("APIKeys.List returned error: %v", err)
+		t.Fatalf("APIKeys.List returned error: %v", err)
 	}
 
 	expected := []APIKey{
@@ -95,8 +94,8 @@ func TestProjectAPIKeys_ListAPIKeys(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(apiKeys, expected) {
-		t.Errorf("APIKeys.List\n got=%#v\nwant=%#v", apiKeys, expected)
+	if diff := deep.Equal(apiKeys, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -130,7 +129,7 @@ func TestProjectAPIKeys_Unassign(t *testing.T) {
 
 	_, err := client.ProjectAPIKeys.Unassign(ctx, groupID, keyID)
 	if err != nil {
-		t.Errorf("ProjectAPIKeys.Unassign returned error: %v", err)
+		t.Fatalf("ProjectAPIKeys.Unassign returned error: %v", err)
 	}
 }
 
@@ -177,11 +176,7 @@ func TestProjectAPIKeys_Create(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Clusters.Create Request Body = %v", diff)
-		}
-
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -189,7 +184,7 @@ func TestProjectAPIKeys_Create(t *testing.T) {
 
 	apiKey, _, err := client.ProjectAPIKeys.Create(ctx, orgID, createRequest)
 	if err != nil {
-		t.Errorf("ProjectAPIKeys.Create returned error: %v", err)
+		t.Fatalf("ProjectAPIKeys.Create returned error: %v", err)
 	}
 
 	if desc := apiKey.Desc; desc != "test-apikey" {

--- a/mongodbatlas/project_ip_whitelist_test.go
+++ b/mongodbatlas/project_ip_whitelist_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/go-test/deep"
 )
 
 func TestProjectIPWhitelist_ListProjectIPWhitelist(t *testing.T) {
@@ -19,12 +20,12 @@ func TestProjectIPWhitelist_ListProjectIPWhitelist(t *testing.T) {
 
 	projectIPWhitelists, _, err := client.ProjectIPWhitelist.List(ctx, "1", nil)
 	if err != nil {
-		t.Errorf("ProjectIPWhitelist.List returned error: %v", err)
+		t.Fatalf("ProjectIPWhitelist.List returned error: %v", err)
 	}
 
 	expected := []ProjectIPWhitelist{{GroupID: "1", CIDRBlock: "0.0.0.0/12", IPAddress: "0.0.0.0"}, {GroupID: "1", CIDRBlock: "0.0.0.1/12", IPAddress: "0.0.0.1"}}
-	if !reflect.DeepEqual(projectIPWhitelists, expected) {
-		t.Errorf("ProjectIPWhitelist.List\n got=%#v\nwant=%#v", projectIPWhitelists, expected)
+	if diff := deep.Equal(projectIPWhitelists, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -147,8 +148,8 @@ func TestProjectIPWhitelist_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -156,8 +157,7 @@ func TestProjectIPWhitelist_Create(t *testing.T) {
 
 	projectIPWhitelist, _, err := client.ProjectIPWhitelist.Create(ctx, groupID, createRequest)
 	if err != nil {
-		t.Errorf("ProjectIPWhitelist.Create returned error: %v", err)
-		return
+		t.Fatalf("ProjectIPWhitelist.Create returned error: %v", err)
 	}
 
 	if len(projectIPWhitelist) > 1 {
@@ -187,12 +187,13 @@ func TestProjectIPWhitelist_GetProjectIPWhitelist(t *testing.T) {
 
 	projectIPWhitelists, _, err := client.ProjectIPWhitelist.Get(ctx, "1", ipAddress)
 	if err != nil {
-		t.Errorf("ProjectIPWhitelist.Get returned error: %v", err)
+		t.Fatalf("ProjectIPWhitelist.Get returned error: %v", err)
 	}
 
 	expected := &ProjectIPWhitelist{IPAddress: ipAddress}
-	if !reflect.DeepEqual(projectIPWhitelists, expected) {
-		t.Errorf("ProjectIPWhitelist.Get\n got=%#v\nwant=%#v", projectIPWhitelists, expected)
+
+	if diff := deep.Equal(projectIPWhitelists, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -209,12 +210,12 @@ func TestProjectIPWhitelist_GetProjectIPWhitelistByCIDR(t *testing.T) {
 
 	projectIPWhitelists, _, err := client.ProjectIPWhitelist.Get(ctx, "1", cidr)
 	if err != nil {
-		t.Errorf("ProjectIPWhitelist.Get returned error: %v", err)
+		t.Fatalf("ProjectIPWhitelist.Get returned error: %v", err)
 	}
 
 	expected := &ProjectIPWhitelist{CIDRBlock: cidr}
-	if !reflect.DeepEqual(projectIPWhitelists, expected) {
-		t.Errorf("ProjectIPWhitelist.Get\n got=%#v\nwant=%#v", projectIPWhitelists, expected)
+	if diff := deep.Equal(projectIPWhitelists, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -253,8 +254,8 @@ func TestProjectIPWhitelist_Update(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -262,8 +263,7 @@ func TestProjectIPWhitelist_Update(t *testing.T) {
 
 	projectIPWhitelist, _, err := client.ProjectIPWhitelist.Update(ctx, groupID, createRequest)
 	if err != nil {
-		t.Errorf("ProjectIPWhitelist.Update returned error: %v", err)
-		return
+		t.Fatalf("ProjectIPWhitelist.Update returned error: %v", err)
 	}
 
 	if ip := projectIPWhitelist[0].IPAddress; ip != ipAddress {
@@ -289,6 +289,6 @@ func TestProjectIPWhitelist_Delete(t *testing.T) {
 
 	_, err := client.ProjectIPWhitelist.Delete(ctx, groupID, ipAddress)
 	if err != nil {
-		t.Errorf("ProjectIPWhitelist.Delete returned error: %v", err)
+		t.Fatalf("ProjectIPWhitelist.Delete returned error: %v", err)
 	}
 }

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -3,7 +3,6 @@ package mongodbatlas
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -47,7 +46,7 @@ func TestProject_GetAllProjects(t *testing.T) {
 
 	projects, _, err := client.Projects.GetAllProjects(ctx)
 	if err != nil {
-		t.Errorf("Projects.GetAllProjects returned error: %v", err)
+		t.Fatalf("Projects.GetAllProjects returned error: %v", err)
 	}
 
 	expected := &Projects{
@@ -88,8 +87,8 @@ func TestProject_GetAllProjects(t *testing.T) {
 		TotalCount: 2,
 	}
 
-	if !reflect.DeepEqual(projects, expected) {
-		t.Errorf("Projects.GetAllProjects\n got=%#v\nwant=%#v", projects, expected)
+	if diff := deep.Equal(projects, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -133,8 +132,8 @@ func TestProject_GetOneProject(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(projectResponse, expected) {
-		t.Errorf("Projects.GetOneProject\n got=%#v\nwant=%#v", projectResponse, expected)
+	if diff := deep.Equal(projectResponse, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -161,7 +160,7 @@ func TestProject_GetOneProjectByName(t *testing.T) {
 
 	projectResponse, _, err := client.Projects.GetOneProjectByName(ctx, projectName)
 	if err != nil {
-		t.Errorf("Projects.GetOneProject returned error: %v", err)
+		t.Fatalf("Projects.GetOneProject returned error: %v", err)
 	}
 
 	expected := &Project{
@@ -180,9 +179,6 @@ func TestProject_GetOneProjectByName(t *testing.T) {
 
 	if diff := deep.Equal(projectResponse, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(projectResponse, expected) {
-		t.Errorf("Projects.GetOneProject\n got=%#v\nwant=%#v", projectResponse, expected)
 	}
 }
 
@@ -211,7 +207,7 @@ func TestProject_Create(t *testing.T) {
 
 	project, _, err := client.Projects.Create(ctx, createRequest)
 	if err != nil {
-		t.Errorf("Projects.Create returned error: %v", err)
+		t.Fatalf("Projects.Create returned error: %v", err)
 	}
 
 	expected := &Project{
@@ -231,9 +227,6 @@ func TestProject_Create(t *testing.T) {
 	if diff := deep.Equal(project, expected); diff != nil {
 		t.Error(diff)
 	}
-	if !reflect.DeepEqual(project, expected) {
-		t.Errorf("DatabaseUsers.Get\n got=%#v\nwant=%#v", project, expected)
-	}
 }
 
 func TestProject_Delete(t *testing.T) {
@@ -248,7 +241,7 @@ func TestProject_Delete(t *testing.T) {
 
 	_, err := client.Projects.Delete(ctx, projectID)
 	if err != nil {
-		t.Errorf("Projects.Delete returned error: %v", err)
+		t.Fatalf("Projects.Delete returned error: %v", err)
 	}
 }
 
@@ -287,7 +280,7 @@ func TestProject_GetProjectTeamsAssigned(t *testing.T) {
 
 	teamsAssigned, _, err := client.Projects.GetProjectTeamsAssigned(ctx, projectID)
 	if err != nil {
-		t.Errorf("Projects.GetProjectTeamsAssigned returned error: %v", err)
+		t.Fatalf("Projects.GetProjectTeamsAssigned returned error: %v", err)
 	}
 
 	expected := &TeamsAssigned{
@@ -314,10 +307,6 @@ func TestProject_GetProjectTeamsAssigned(t *testing.T) {
 
 	if diff := deep.Equal(teamsAssigned, expected); diff != nil {
 		t.Error(diff)
-	}
-
-	if !reflect.DeepEqual(teamsAssigned, expected) {
-		t.Errorf("Projects.GetProjectTeamsAssigned\n got=%+v\nwant=%+v", teamsAssigned, expected)
 	}
 }
 
@@ -379,8 +368,5 @@ func TestProject_AddTeamsToProject(t *testing.T) {
 
 	if diff := deep.Equal(team, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(team, expected) {
-		t.Errorf("DatabaseUsers.Get\n got=%#v\nwant=%#v", team, expected)
 	}
 }

--- a/mongodbatlas/teams_test.go
+++ b/mongodbatlas/teams_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -38,7 +37,7 @@ func TestTeams_List(t *testing.T) {
 	teams, _, err := client.Teams.List(ctx, "1", nil)
 
 	if err != nil {
-		t.Errorf("Teams.List returned error: %v", err)
+		t.Fatalf("Teams.List returned error: %v", err)
 	}
 
 	expected := []Team{
@@ -55,8 +54,9 @@ func TestTeams_List(t *testing.T) {
 			Name: "Technical Documentation",
 		},
 	}
-	if !reflect.DeepEqual(teams, expected) {
-		t.Errorf("Teams.List\n got=%#v\nwant=%#v", teams, expected)
+
+	if diff := deep.Equal(teams, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -83,7 +83,7 @@ func TestTeams_Get(t *testing.T) {
 
 	team, _, err := client.Teams.Get(ctx, orgID, teamID)
 	if err != nil {
-		t.Errorf("Teams.Get returned error: %v", err)
+		t.Fatalf("Teams.Get returned error: %v", err)
 	}
 
 	expected := &Team{
@@ -91,8 +91,8 @@ func TestTeams_Get(t *testing.T) {
 		Name: "myNewTeam",
 	}
 
-	if !reflect.DeepEqual(team, expected) {
-		t.Errorf("Teams.Get\n got=%#v\nwant=%#v", team, expected)
+	if diff := deep.Equal(team, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -119,7 +119,7 @@ func TestTeams_GetOneTeamByName(t *testing.T) {
 
 	team, _, err := client.Teams.GetOneTeamByName(ctx, orgID, teamName)
 	if err != nil {
-		t.Errorf("Teams.Get returned error: %v", err)
+		t.Fatalf("Teams.Get returned error: %v", err)
 	}
 
 	expected := &Team{
@@ -127,8 +127,8 @@ func TestTeams_GetOneTeamByName(t *testing.T) {
 		Name: "myNewTeam",
 	}
 
-	if !reflect.DeepEqual(team, expected) {
-		t.Errorf("Teams.Get\n got=%#v\nwant=%#v", team, expected)
+	if diff := deep.Equal(team, expected); diff != nil {
+		t.Error(diff)
 	}
 }
 
@@ -181,7 +181,7 @@ func TestProject_GetTeamUsersAssigned(t *testing.T) {
 
 	teamsAssigned, _, err := client.Teams.GetTeamUsersAssigned(ctx, orgID, "1")
 	if err != nil {
-		t.Errorf("Projects.GetTeamUsersAssigned returned error: %v", err)
+		t.Fatalf("Projects.GetTeamUsersAssigned returned error: %v", err)
 	}
 
 	expected := []AtlasUser{
@@ -210,10 +210,6 @@ func TestProject_GetTeamUsersAssigned(t *testing.T) {
 
 	if diff := deep.Equal(teamsAssigned, expected); diff != nil {
 		t.Error(diff)
-	}
-
-	if !reflect.DeepEqual(teamsAssigned, expected) {
-		t.Errorf("Projects.GetProjectTeamsAssigned\n got=%+v\nwant=%+v", teamsAssigned, expected)
 	}
 }
 
@@ -254,8 +250,8 @@ func TestTeams_Create(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -263,7 +259,7 @@ func TestTeams_Create(t *testing.T) {
 
 	team, _, err := client.Teams.Create(ctx, orgID, createRequest)
 	if err != nil {
-		t.Errorf("Teams.Create returned error: %v", err)
+		t.Fatalf("Teams.Create returned error: %v", err)
 	}
 
 	if name := team.Name; name != "myNewTeam" {
@@ -310,8 +306,8 @@ func TestTeams_Rename(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -319,7 +315,7 @@ func TestTeams_Rename(t *testing.T) {
 
 	team, _, err := client.Teams.Rename(ctx, orgID, teamID, renameRequest)
 	if err != nil {
-		t.Errorf("Teams.Rename returned error: %v", err)
+		t.Fatalf("Teams.Rename returned error: %v", err)
 	}
 
 	if name := team.Name; name != renameRequest {
@@ -329,7 +325,6 @@ func TestTeams_Rename(t *testing.T) {
 	if id := team.ID; id != teamID {
 		t.Errorf("expected id '%s', received '%s'", teamID, id)
 	}
-
 }
 
 func TestTeams_UpdateTeamRoles(t *testing.T) {
@@ -387,8 +382,8 @@ func TestTeams_UpdateTeamRoles(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		if diff := deep.Equal(v, expected); diff != nil {
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, jsonBlob)
@@ -396,7 +391,7 @@ func TestTeams_UpdateTeamRoles(t *testing.T) {
 
 	teams, _, err := client.Teams.UpdateTeamRoles(ctx, orgID, teamID, updateTeamRolesRequest)
 	if err != nil {
-		t.Errorf("Teams.UpdateTeamRoles returned error: %v", err)
+		t.Fatalf("Teams.UpdateTeamRoles returned error: %v", err)
 	}
 
 	if teamCount := len(teams); teamCount != 3 {
@@ -406,7 +401,6 @@ func TestTeams_UpdateTeamRoles(t *testing.T) {
 	if id := teams[0].TeamID; id != teamID {
 		t.Errorf("expected id '%s', received '%s'", teamID, id)
 	}
-
 }
 
 func TestTeams_AddUsersToTeam(t *testing.T) {
@@ -435,7 +429,7 @@ func TestTeams_AddUsersToTeam(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Diff\n got=%#v\nwant=%#v \n\ndiff=%#v", v, expected, diff)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, `{
@@ -501,7 +495,7 @@ func TestTeams_AddUsersToTeam(t *testing.T) {
 
 	atlasUsers, _, err := client.Teams.AddUsersToTeam(ctx, orgID, teamID, usersID)
 	if err != nil {
-		t.Errorf("Teams.AddUsersToTeam returned error: %v", err)
+		t.Fatalf("Teams.AddUsersToTeam returned error: %v", err)
 	}
 
 	if userCount := len(atlasUsers); userCount != 2 {
@@ -524,7 +518,7 @@ func TestTeams_RemoveUserToTeam(t *testing.T) {
 
 	_, err := client.Teams.RemoveUserToTeam(ctx, orgID, teamID, userID)
 	if err != nil {
-		t.Errorf("Teams.RemoveUserToTeam returned error: %v", err)
+		t.Fatalf("Teams.RemoveUserToTeam returned error: %v", err)
 	}
 }
 
@@ -541,7 +535,7 @@ func TestTeams_RemoveTeamFromOrganization(t *testing.T) {
 
 	_, err := client.Teams.RemoveTeamFromOrganization(ctx, orgID, teamID)
 	if err != nil {
-		t.Errorf("Teams.RemoveTeamFromOrganization returned error: %v", err)
+		t.Fatalf("Teams.RemoveTeamFromOrganization returned error: %v", err)
 	}
 }
 
@@ -558,6 +552,6 @@ func TestTeams_RemoveTeamFromProject(t *testing.T) {
 
 	_, err := client.Teams.RemoveTeamFromProject(ctx, groupID, teamID)
 	if err != nil {
-		t.Errorf("Teams.RemoveTeamFromProject returned error: %v", err)
+		t.Fatalf("Teams.RemoveTeamFromProject returned error: %v", err)
 	}
 }

--- a/mongodbatlas/whitelist_api_keys_test.go
+++ b/mongodbatlas/whitelist_api_keys_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -62,7 +61,7 @@ func TestWhitelistAPIKeys_List(t *testing.T) {
 
 	whitelistAPIKeys, _, err := client.WhitelistAPIKeys.List(ctx, orgID, apiKeyID)
 	if err != nil {
-		t.Errorf("WhitelistAPIKeys.List returned error: %v", err)
+		t.Fatalf("WhitelistAPIKeys.List returned error: %v", err)
 	}
 
 	expected := &WhitelistAPIKeys{
@@ -108,9 +107,6 @@ func TestWhitelistAPIKeys_List(t *testing.T) {
 	if diff := deep.Equal(whitelistAPIKeys, expected); diff != nil {
 		t.Error(diff)
 	}
-	if !reflect.DeepEqual(whitelistAPIKeys, expected) {
-		t.Errorf("WhitelistAPIKeys.List\n got=%#v\nwant=%#v", whitelistAPIKeys, expected)
-	}
 }
 
 func TestWhitelistAPIKeys_Get(t *testing.T) {
@@ -139,7 +135,7 @@ func TestWhitelistAPIKeys_Get(t *testing.T) {
 
 	whitelistAPIKey, _, err := client.WhitelistAPIKeys.Get(ctx, orgID, apiKeyID, ipAddress)
 	if err != nil {
-		t.Errorf("WhitelistAPIKeys.Get returned error: %v", err)
+		t.Fatalf("WhitelistAPIKeys.Get returned error: %v", err)
 	}
 
 	expected := &WhitelistAPIKey{
@@ -157,9 +153,6 @@ func TestWhitelistAPIKeys_Get(t *testing.T) {
 
 	if diff := deep.Equal(whitelistAPIKey, expected); diff != nil {
 		t.Error(diff)
-	}
-	if !reflect.DeepEqual(whitelistAPIKey, expected) {
-		t.Errorf("WhitelistAPIKeys.Get\n got=%#v\nwant=%#v", whitelistAPIKey, expected)
 	}
 }
 
@@ -193,9 +186,6 @@ func TestWhitelistAPIKeys_Create(t *testing.T) {
 
 		if diff := deep.Equal(v, expected); diff != nil {
 			t.Error(diff)
-		}
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
 		}
 
 		fmt.Fprint(w, `{
@@ -241,7 +231,7 @@ func TestWhitelistAPIKeys_Create(t *testing.T) {
 
 	whitelistAPIKey, _, err := client.WhitelistAPIKeys.Create(ctx, orgID, apiKeyID, createRequest)
 	if err != nil {
-		t.Errorf("WhitelistAPIKeys.Create returned error: %v", err)
+		t.Fatalf("WhitelistAPIKeys.Create returned error: %v", err)
 	}
 
 	expected := &WhitelistAPIKeys{
@@ -287,9 +277,6 @@ func TestWhitelistAPIKeys_Create(t *testing.T) {
 	if diff := deep.Equal(whitelistAPIKey, expected); diff != nil {
 		t.Error(diff)
 	}
-	if !reflect.DeepEqual(whitelistAPIKey, expected) {
-		t.Errorf("WhitelistAPIKeys.Create\n got=%#v\nwant=%#v", whitelistAPIKey, expected)
-	}
 }
 
 func TestWhitelistAPIKeys_Delete(t *testing.T) {
@@ -306,6 +293,6 @@ func TestWhitelistAPIKeys_Delete(t *testing.T) {
 
 	_, err := client.WhitelistAPIKeys.Delete(ctx, orgID, apiKeyID, ipAddress)
 	if err != nil {
-		t.Errorf("WhitelistAPIKeys.Delete returned error: %v", err)
+		t.Fatalf("WhitelistAPIKeys.Delete returned error: %v", err)
 	}
 }


### PR DESCRIPTION
- Prefer deep.Equal over reflect.DeepEqual, some places were doing both some others a mix
- If there's an unexpected error then prefer t.Fatal over t.Error as Fatal will prevent any other case from executing (which would fail anyway)