### PR TITLE
Make the ServiceOp depend on an interface

### DIFF
--- a/mongodbatlas/alert_configurations.go
+++ b/mongodbatlas/alert_configurations.go
@@ -24,7 +24,7 @@ type AlertConfigurationsService interface {
 // AlertConfigurationsServiceOp handles communication with the AlertConfiguration related methods
 // of the MongoDB Atlas API
 type AlertConfigurationsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ AlertConfigurationsService = &AlertConfigurationsServiceOp{}
@@ -124,13 +124,13 @@ func (s *AlertConfigurationsServiceOp) Create(ctx context.Context, groupID strin
 
 	path := fmt.Sprintf(alertConfigurationPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createReq)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AlertConfiguration)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -151,13 +151,13 @@ func (s *AlertConfigurationsServiceOp) EnableAnAlertConfig(ctx context.Context, 
 	basePath := fmt.Sprintf(alertConfigurationPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, alertConfigID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, AlertConfiguration{Enabled: enabled})
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, AlertConfiguration{Enabled: enabled})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AlertConfiguration)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -178,13 +178,13 @@ func (s *AlertConfigurationsServiceOp) GetAnAlertConfig(ctx context.Context, gro
 	basePath := fmt.Sprintf(alertConfigurationPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, alertConfigID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AlertConfiguration)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -205,13 +205,13 @@ func (s *AlertConfigurationsServiceOp) GetOpenAlertsConfig(ctx context.Context, 
 	basePath := fmt.Sprintf(alertConfigurationPath, groupID)
 	path := fmt.Sprintf("%s/%s/alerts", basePath, alertConfigID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AlertConfigurationsResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -237,13 +237,13 @@ func (s *AlertConfigurationsServiceOp) List(ctx context.Context, groupID string,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AlertConfigurationsResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -271,13 +271,13 @@ func (s *AlertConfigurationsServiceOp) Update(ctx context.Context, groupID, aler
 	basePath := fmt.Sprintf(alertConfigurationPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, alertConfigID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPut, path, updateReq)
+	req, err := s.Client.NewRequest(ctx, http.MethodPut, path, updateReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AlertConfiguration)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -298,12 +298,12 @@ func (s *AlertConfigurationsServiceOp) Delete(ctx context.Context, groupID, aler
 	basePath := fmt.Sprintf(alertConfigurationPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, alertConfigID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/alert_configurations.go
+++ b/mongodbatlas/alert_configurations.go
@@ -24,7 +24,7 @@ type AlertConfigurationsService interface {
 // AlertConfigurationsServiceOp handles communication with the AlertConfiguration related methods
 // of the MongoDB Atlas API
 type AlertConfigurationsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ AlertConfigurationsService = &AlertConfigurationsServiceOp{}

--- a/mongodbatlas/alert_configurations_test.go
+++ b/mongodbatlas/alert_configurations_test.go
@@ -40,7 +40,7 @@ func TestAlertConfiguration_Create(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", v, expected, diff)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, `{
@@ -79,7 +79,7 @@ func TestAlertConfiguration_Create(t *testing.T) {
 
 	alertConfiguration, _, err := client.AlertConfigurations.Create(ctx, groupID, alertReq)
 	if err != nil {
-		t.Errorf("AlertConfiguration.Create returned error: %v", err)
+		t.Fatalf("AlertConfiguration.Create returned error: %v", err)
 		return
 	}
 
@@ -103,7 +103,7 @@ func TestAlertConfiguration_Create(t *testing.T) {
 	}
 
 	if diff := deep.Equal(alertConfiguration, expected); diff != nil {
-		t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", alertConfiguration, expected, diff)
+		t.Error(diff)
 	}
 }
 
@@ -127,7 +127,7 @@ func TestAlertConfiguration_EnableAnAlertConfig(t *testing.T) {
 		}
 
 		if diff := deep.Equal(v, expected); diff != nil {
-			t.Errorf("Request body\n got=%#v\nwant=%#v \n\ndiff=%#v", v, expected, diff)
+			t.Error(diff)
 		}
 
 		fmt.Fprint(w, `{

--- a/mongodbatlas/api_keys.go
+++ b/mongodbatlas/api_keys.go
@@ -23,7 +23,7 @@ type APIKeysService interface {
 // APIKeysServiceOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API
 type APIKeysServiceOp struct {
-	client *Client
+	client *RequestDoer
 }
 
 var _ APIKeysService = &APIKeysServiceOp{}

--- a/mongodbatlas/api_keys.go
+++ b/mongodbatlas/api_keys.go
@@ -23,7 +23,7 @@ type APIKeysService interface {
 // APIKeysServiceOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API
 type APIKeysServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ APIKeysService = &APIKeysServiceOp{}
@@ -68,13 +68,13 @@ func (s *APIKeysServiceOp) List(ctx context.Context, orgID string, listOptions *
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(apiKeysResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -97,13 +97,13 @@ func (s *APIKeysServiceOp) Get(ctx context.Context, orgID string, apiKeyID strin
 	escapedEntry := url.PathEscape(apiKeyID)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(APIKey)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -120,13 +120,13 @@ func (s *APIKeysServiceOp) Create(ctx context.Context, orgID string, createReque
 
 	path := fmt.Sprintf(apiKeysPath, orgID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(APIKey)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -144,13 +144,13 @@ func (s *APIKeysServiceOp) Update(ctx context.Context, orgID string, apiKeyID st
 	basePath := fmt.Sprintf(apiKeysPath, orgID)
 	path := fmt.Sprintf("%s/%s", basePath, apiKeyID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(APIKey)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -169,12 +169,12 @@ func (s *APIKeysServiceOp) Delete(ctx context.Context, orgID string, apiKeyID st
 	escapedEntry := url.PathEscape(apiKeyID)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/api_keys.go
+++ b/mongodbatlas/api_keys.go
@@ -23,7 +23,7 @@ type APIKeysService interface {
 // APIKeysServiceOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API
 type APIKeysServiceOp struct {
-	client *RequestDoer
+	client RequestDoer
 }
 
 var _ APIKeysService = &APIKeysServiceOp{}

--- a/mongodbatlas/atlas_users.go
+++ b/mongodbatlas/atlas_users.go
@@ -23,7 +23,7 @@ type AtlasUsersService interface {
 //AtlasUsersServiceOp handles communication with the AtlasUsers related methos of the
 //MongoDB Atlas API
 type AtlasUsersServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ AtlasUsersService = &AtlasUsersServiceOp{}
@@ -59,13 +59,13 @@ func (s *AtlasUsersServiceOp) List(ctx context.Context, orgID string, listOption
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AtlasUsersResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -86,13 +86,13 @@ func (s *AtlasUsersServiceOp) Get(ctx context.Context, userID string) (*AtlasUse
 
 	path := fmt.Sprintf("users/%s", userID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AtlasUser)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -109,13 +109,13 @@ func (s *AtlasUsersServiceOp) GetByName(ctx context.Context, username string) (*
 
 	path := fmt.Sprintf("users/byName/%s", username)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AtlasUser)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -130,13 +130,13 @@ func (s *AtlasUsersServiceOp) Create(ctx context.Context, createRequest *AtlasUs
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, fmt.Sprintf("users"), createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, fmt.Sprintf("users"), createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AtlasUser)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/mongodbatlas/atlas_users.go
+++ b/mongodbatlas/atlas_users.go
@@ -23,7 +23,7 @@ type AtlasUsersService interface {
 //AtlasUsersServiceOp handles communication with the AtlasUsers related methos of the
 //MongoDB Atlas API
 type AtlasUsersServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ AtlasUsersService = &AtlasUsersServiceOp{}

--- a/mongodbatlas/auditing.go
+++ b/mongodbatlas/auditing.go
@@ -21,7 +21,7 @@ type AuditingsService interface {
 // AuditingsServiceOp handles communication with the Auditings related methods
 // of the MongoDB Atlas API
 type AuditingsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ AuditingsService = &AuditingsServiceOp{}

--- a/mongodbatlas/auditing.go
+++ b/mongodbatlas/auditing.go
@@ -21,7 +21,7 @@ type AuditingsService interface {
 // AuditingsServiceOp handles communication with the Auditings related methods
 // of the MongoDB Atlas API
 type AuditingsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ AuditingsService = &AuditingsServiceOp{}
@@ -42,13 +42,13 @@ func (s *AuditingsServiceOp) Get(ctx context.Context, groupID string) (*Auditing
 	}
 
 	path := fmt.Sprintf(auditingsPath, groupID)
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Auditing)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -68,13 +68,13 @@ func (s *AuditingsServiceOp) Configure(ctx context.Context, groupID string, conf
 
 	path := fmt.Sprintf(auditingsPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, configRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, configRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Auditing)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -23,7 +23,7 @@ type CloudProviderSnapshotRestoreJobsService interface {
 //CloudProviderSnapshotRestoreJobsServiceOp handles communication with the CloudProviderSnapshotRestoreJobs related methos of the
 //MongoDB Atlas API
 type CloudProviderSnapshotRestoreJobsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ CloudProviderSnapshotRestoreJobsService = &CloudProviderSnapshotRestoreJobsServiceOp{}
@@ -64,13 +64,13 @@ func (s *CloudProviderSnapshotRestoreJobsServiceOp) List(ctx context.Context, re
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CloudProviderSnapshotRestoreJobs)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -97,13 +97,13 @@ func (s *CloudProviderSnapshotRestoreJobsServiceOp) Get(ctx context.Context, req
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs/%s", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName, requestParameters.JobID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CloudProviderSnapshotRestoreJob)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -132,13 +132,13 @@ func (s *CloudProviderSnapshotRestoreJobsServiceOp) Create(ctx context.Context, 
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs", cloudProviderSnapshotRestoreJobBasePath, requestParameters.GroupID, requestParameters.ClusterName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CloudProviderSnapshotRestoreJob)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -165,12 +165,12 @@ func (s *CloudProviderSnapshotRestoreJobsServiceOp) Delete(ctx context.Context, 
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs/%s", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName, requestParameters.JobID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -23,7 +23,7 @@ type CloudProviderSnapshotRestoreJobsService interface {
 //CloudProviderSnapshotRestoreJobsServiceOp handles communication with the CloudProviderSnapshotRestoreJobs related methos of the
 //MongoDB Atlas API
 type CloudProviderSnapshotRestoreJobsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ CloudProviderSnapshotRestoreJobsService = &CloudProviderSnapshotRestoreJobsServiceOp{}

--- a/mongodbatlas/cloud_provider_snapshots.go
+++ b/mongodbatlas/cloud_provider_snapshots.go
@@ -23,7 +23,7 @@ type CloudProviderSnapshotsService interface {
 //CloudProviderSnapshotsServiceOp handles communication with the DatabaseUsers related methos of the
 //MongoDB Atlas API
 type CloudProviderSnapshotsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ CloudProviderSnapshotsService = &CloudProviderSnapshotsServiceOp{}
@@ -71,13 +71,13 @@ func (s *CloudProviderSnapshotsServiceOp) GetAllCloudProviderSnapshots(ctx conte
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/snapshots", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CloudProviderSnapshots)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -104,13 +104,13 @@ func (s *CloudProviderSnapshotsServiceOp) GetOneCloudProviderSnapshot(ctx contex
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/snapshots/%s", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName, requestParameters.SnapshotID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CloudProviderSnapshot)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -133,13 +133,13 @@ func (s *CloudProviderSnapshotsServiceOp) Create(ctx context.Context, requestPar
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/snapshots", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CloudProviderSnapshot)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -162,12 +162,12 @@ func (s *CloudProviderSnapshotsServiceOp) Delete(ctx context.Context, requestPar
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/snapshots/%s", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName, requestParameters.SnapshotID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/cloud_provider_snapshots.go
+++ b/mongodbatlas/cloud_provider_snapshots.go
@@ -23,7 +23,7 @@ type CloudProviderSnapshotsService interface {
 //CloudProviderSnapshotsServiceOp handles communication with the DatabaseUsers related methos of the
 //MongoDB Atlas API
 type CloudProviderSnapshotsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ CloudProviderSnapshotsService = &CloudProviderSnapshotsServiceOp{}

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -25,7 +25,7 @@ type ClustersService interface {
 //ClustersServiceOp handles communication with the Cluster related methods
 // of the MongoDB Atlas API
 type ClustersServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ ClustersService = &ClustersServiceOp{}
@@ -182,13 +182,13 @@ func (s *ClustersServiceOp) List(ctx context.Context, groupID string, listOption
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(clustersResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -211,13 +211,13 @@ func (s *ClustersServiceOp) Get(ctx context.Context, groupID string, clusterName
 	escapedEntry := url.PathEscape(clusterName)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Cluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -234,13 +234,13 @@ func (s *ClustersServiceOp) Create(ctx context.Context, groupID string, createRe
 
 	path := fmt.Sprintf(clustersPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Cluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -258,13 +258,13 @@ func (s *ClustersServiceOp) Update(ctx context.Context, groupID string, clusterN
 	basePath := fmt.Sprintf(clustersPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, clusterName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Cluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -283,12 +283,12 @@ func (s *ClustersServiceOp) Delete(ctx context.Context, groupID string, clusterN
 	escapedEntry := url.PathEscape(clusterName)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }
@@ -303,13 +303,13 @@ func (s *ClustersServiceOp) UpdateProcessArgs(ctx context.Context, groupID strin
 	basePath := fmt.Sprintf(clustersPath, groupID)
 	path := fmt.Sprintf("%s/%s/processArgs", basePath, clusterName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(ProcessArgs)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -328,13 +328,13 @@ func (s *ClustersServiceOp) GetProcessArgs(ctx context.Context, groupID string, 
 	escapedEntry := url.PathEscape(clusterName)
 	path := fmt.Sprintf("%s/%s/processArgs", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(ProcessArgs)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -25,7 +25,7 @@ type ClustersService interface {
 //ClustersServiceOp handles communication with the Cluster related methods
 // of the MongoDB Atlas API
 type ClustersServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ ClustersService = &ClustersServiceOp{}

--- a/mongodbatlas/containers.go
+++ b/mongodbatlas/containers.go
@@ -23,7 +23,7 @@ type ContainersService interface {
 //ContainersServiceOp handles communication with the Network Peering Container related methods
 // of the MongoDB Atlas API
 type ContainersServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ ContainersService = &ContainersServiceOp{}

--- a/mongodbatlas/containers.go
+++ b/mongodbatlas/containers.go
@@ -23,7 +23,7 @@ type ContainersService interface {
 //ContainersServiceOp handles communication with the Network Peering Container related methods
 // of the MongoDB Atlas API
 type ContainersServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ ContainersService = &ContainersServiceOp{}
@@ -66,13 +66,13 @@ func (s *ContainersServiceOp) List(ctx context.Context, groupID string, listOpti
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(containersResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -95,13 +95,13 @@ func (s *ContainersServiceOp) Get(ctx context.Context, groupID string, container
 	escapedEntry := url.PathEscape(containerID)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Container)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -118,13 +118,13 @@ func (s *ContainersServiceOp) Create(ctx context.Context, groupID string, create
 
 	path := fmt.Sprintf(containersPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Container)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -142,13 +142,13 @@ func (s *ContainersServiceOp) Update(ctx context.Context, groupID string, contai
 	basePath := fmt.Sprintf(containersPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, containerID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Container)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -167,7 +167,7 @@ func (s *ContainersServiceOp) Delete(ctx context.Context, groupID string, contai
 	escapedEntry := url.PathEscape(containerID)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (s *ContainersServiceOp) Delete(ctx context.Context, groupID string, contai
 	//To avoid API Issues
 	req.Header.Del("Content-Type")
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -22,7 +22,7 @@ type CustomDBRolesService interface {
 //CustomDBRolesServiceOp handles communication with the CustomDBRoles related methods of the
 //MongoDB Atlas API
 type CustomDBRolesServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ CustomDBRolesService = &CustomDBRolesServiceOp{}
@@ -63,13 +63,13 @@ func (s *CustomDBRolesServiceOp) List(ctx context.Context, groupID string, listO
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new([]CustomDBRole)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -87,13 +87,13 @@ func (s *CustomDBRolesServiceOp) Get(ctx context.Context, groupID string, roleNa
 	basePath := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, roleName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CustomDBRole)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -110,13 +110,13 @@ func (s *CustomDBRolesServiceOp) Create(ctx context.Context, groupID string, cre
 
 	path := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CustomDBRole)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -134,13 +134,13 @@ func (s *CustomDBRolesServiceOp) Update(ctx context.Context, groupID string, rol
 	basePath := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, roleName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(CustomDBRole)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -158,12 +158,12 @@ func (s *CustomDBRolesServiceOp) Delete(ctx context.Context, groupID string, rol
 	basePath := fmt.Sprintf(dbCustomDBRolesBasePath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, roleName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -22,7 +22,7 @@ type CustomDBRolesService interface {
 //CustomDBRolesServiceOp handles communication with the CustomDBRoles related methods of the
 //MongoDB Atlas API
 type CustomDBRolesServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ CustomDBRolesService = &CustomDBRolesServiceOp{}

--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -22,7 +22,7 @@ type DatabaseUsersService interface {
 //DatabaseUsersServiceOp handles communication with the DatabaseUsers related methos of the
 //MongoDB Atlas API
 type DatabaseUsersServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ DatabaseUsersService = &DatabaseUsersServiceOp{}
@@ -72,13 +72,13 @@ func (s *DatabaseUsersServiceOp) List(ctx context.Context, groupID string, listO
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(databaseUsers)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,13 +106,13 @@ func (s *DatabaseUsersServiceOp) Get(ctx context.Context, databaseName, groupID,
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
 	path := fmt.Sprintf("%s/%s/%s", basePath, databaseName, username)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(DatabaseUser)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -129,13 +129,13 @@ func (s *DatabaseUsersServiceOp) Create(ctx context.Context, groupID string, cre
 
 	path := fmt.Sprintf(dbUsersBasePath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(DatabaseUser)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -153,13 +153,13 @@ func (s *DatabaseUsersServiceOp) Update(ctx context.Context, groupID string, use
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
 	path := fmt.Sprintf("%s/admin/%s", basePath, username)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(DatabaseUser)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -183,12 +183,12 @@ func (s *DatabaseUsersServiceOp) Delete(ctx context.Context, databaseName, group
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
 	path := fmt.Sprintf("%s/%s/%s", basePath, databaseName, username)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -22,7 +22,7 @@ type DatabaseUsersService interface {
 //DatabaseUsersServiceOp handles communication with the DatabaseUsers related methos of the
 //MongoDB Atlas API
 type DatabaseUsersServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ DatabaseUsersService = &DatabaseUsersServiceOp{}

--- a/mongodbatlas/encryptions_at_rest.go
+++ b/mongodbatlas/encryptions_at_rest.go
@@ -64,7 +64,7 @@ type EncryptionsAtRestService interface {
 //EncryptionsAtRestServiceOp handles communication with the DatabaseUsers related methods of the
 //MongoDB Atlas API
 type EncryptionsAtRestServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ EncryptionsAtRestService = &EncryptionsAtRestServiceOp{}
@@ -89,7 +89,7 @@ type AwsKms struct {
 // AzureKeyVault specifies Azure Key Vault configuration details and whether Encryption at Rest is enabled for an Atlas project.
 type AzureKeyVault struct {
 	Enabled           *bool  `json:"enabled,omitempty"`           // Specifies whether Encryption at Rest is enabled for an Atlas project. To disable Encryption at Rest, pass only this parameter with a value of false. When you disable Encryption at Rest, Atlas also removes the configuration details.
-	ClientID          string `json:"clientID,omitempty"`          // The client ID, also known as the application ID, for an Azure application associated with the Azure AD tenant.
+	ClientID          string `json:"clientID,omitempty"`          // The Client ID, also known as the application ID, for an Azure application associated with the Azure AD tenant.
 	AzureEnvironment  string `json:"azureEnvironment,omitempty"`  // The Azure environment where the Azure account credentials reside. Valid values are the following: AZURE, AZURE_CHINA, AZURE_GERMANY
 	SubscriptionID    string `json:"subscriptionID,omitempty"`    // The unique identifier associated with an Azure subscription.
 	ResourceGroupName string `json:"resourceGroupName,omitempty"` // The name of the Azure Resource group that contains an Azure Key Vault.
@@ -119,12 +119,12 @@ func (s *EncryptionsAtRestServiceOp) Create(ctx context.Context, createRequest *
 	path := fmt.Sprintf(encryptionsAtRestBasePath, createRequest.GroupID)
 	createRequest.GroupID = ""
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 	root := new(EncryptionAtRest)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -140,13 +140,13 @@ func (s *EncryptionsAtRestServiceOp) Get(ctx context.Context, groupID string) (*
 
 	path := fmt.Sprintf(encryptionsAtRestBasePath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(EncryptionAtRest)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -169,12 +169,12 @@ func (s *EncryptionsAtRestServiceOp) Delete(ctx context.Context, groupID string)
 
 	path := fmt.Sprintf(encryptionsAtRestBasePath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, createRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/encryptions_at_rest.go
+++ b/mongodbatlas/encryptions_at_rest.go
@@ -64,7 +64,7 @@ type EncryptionsAtRestService interface {
 //EncryptionsAtRestServiceOp handles communication with the DatabaseUsers related methods of the
 //MongoDB Atlas API
 type EncryptionsAtRestServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ EncryptionsAtRestService = &EncryptionsAtRestServiceOp{}

--- a/mongodbatlas/global_clusters.go
+++ b/mongodbatlas/global_clusters.go
@@ -22,7 +22,7 @@ type GlobalClustersService interface {
 //GlobalClustersServiceOp handles communication with the GlobalClusters related methos of the
 //MongoDB Atlas API
 type GlobalClustersServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ GlobalClustersService = &GlobalClustersServiceOp{}

--- a/mongodbatlas/global_clusters.go
+++ b/mongodbatlas/global_clusters.go
@@ -22,7 +22,7 @@ type GlobalClustersService interface {
 //GlobalClustersServiceOp handles communication with the GlobalClusters related methos of the
 //MongoDB Atlas API
 type GlobalClustersServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ GlobalClustersService = &GlobalClustersServiceOp{}
@@ -60,13 +60,13 @@ func (s *GlobalClustersServiceOp) Get(ctx context.Context, groupID string, clust
 
 	path := fmt.Sprintf("groups/%s/clusters/%s/globalWrites", groupID, clusterName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(GlobalCluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -83,13 +83,13 @@ func (s *GlobalClustersServiceOp) AddManagedNamespace(ctx context.Context, group
 
 	path := fmt.Sprintf(globalClustersBasePath, groupID, clusterName, "managedNamespaces")
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(GlobalCluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,7 +106,7 @@ func (s *GlobalClustersServiceOp) DeleteManagedNamespace(ctx context.Context, gr
 
 	path := fmt.Sprintf(globalClustersBasePath, groupID, clusterName, "managedNamespaces")
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,7 +117,7 @@ func (s *GlobalClustersServiceOp) DeleteManagedNamespace(ctx context.Context, gr
 	req.URL.RawQuery = q.Encode()
 
 	root := new(GlobalCluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -134,13 +134,13 @@ func (s *GlobalClustersServiceOp) AddCustomZoneMappings(ctx context.Context, gro
 
 	path := fmt.Sprintf(globalClustersBasePath, groupID, clusterName, "customZoneMapping")
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(GlobalCluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -153,13 +153,13 @@ func (s *GlobalClustersServiceOp) AddCustomZoneMappings(ctx context.Context, gro
 func (s *GlobalClustersServiceOp) DeleteCustomZoneMappings(ctx context.Context, groupID string, clusterName string) (*GlobalCluster, *Response, error) {
 	path := fmt.Sprintf(globalClustersBasePath, groupID, clusterName, "customZoneMapping")
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(GlobalCluster)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/mongodbatlas/maintenance.go
+++ b/mongodbatlas/maintenance.go
@@ -37,7 +37,7 @@ type MaintenanceWindowsService interface {
 // MaintenanceWindowsServiceOp handles communication with the MaintenanceWindows related methods
 // of the MongoDB Atlas API
 type MaintenanceWindowsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ MaintenanceWindowsService = &MaintenanceWindowsServiceOp{}
@@ -58,13 +58,13 @@ func (s *MaintenanceWindowsServiceOp) Get(ctx context.Context, groupID string) (
 	}
 
 	path := fmt.Sprintf(maintenanceWindowsPath, groupID)
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(MaintenanceWindow)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -84,12 +84,12 @@ func (s *MaintenanceWindowsServiceOp) Update(ctx context.Context, groupID string
 
 	path := fmt.Sprintf(maintenanceWindowsPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -106,12 +106,12 @@ func (s *MaintenanceWindowsServiceOp) Defer(ctx context.Context, groupID string)
 
 	path := fmt.Sprintf(maintenanceWindowsPath+"/defer", groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }
@@ -125,12 +125,12 @@ func (s *MaintenanceWindowsServiceOp) Reset(ctx context.Context, groupID string)
 
 	path := fmt.Sprintf(maintenanceWindowsPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/maintenance.go
+++ b/mongodbatlas/maintenance.go
@@ -37,7 +37,7 @@ type MaintenanceWindowsService interface {
 // MaintenanceWindowsServiceOp handles communication with the MaintenanceWindows related methods
 // of the MongoDB Atlas API
 type MaintenanceWindowsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ MaintenanceWindowsService = &MaintenanceWindowsServiceOp{}

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -24,6 +24,12 @@ const (
 	mediaType      = "application/json"
 )
 
+type RequestDoer interface {
+	NewRequest( context.Context, string, string,  interface{}) (*http.Request, error)
+	Do(context.Context, *http.Request, interface{}) (*Response, error)
+	OnRequestCompleted(RequestCompletionCallback)
+}
+
 // Client manages communication with MongoDBAtlas v1.0 API
 type Client struct {
 	client    *http.Client

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -149,28 +149,28 @@ func NewClient(httpClient *http.Client) *Client {
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 
-	c.APIKeys = &APIKeysServiceOp{client: c}
-	c.CloudProviderSnapshots = &CloudProviderSnapshotsServiceOp{client: c}
-	c.CloudProviderSnapshotRestoreJobs = &CloudProviderSnapshotRestoreJobsServiceOp{client: c}
-	c.Clusters = &ClustersServiceOp{client: c}
-	c.Containers = &ContainersServiceOp{client: c}
-	c.CustomDBRoles = &CustomDBRolesServiceOp{client: c}
-	c.DatabaseUsers = &DatabaseUsersServiceOp{client: c}
-	c.EncryptionsAtRest = &EncryptionsAtRestServiceOp{client: c}
-	c.Projects = &ProjectsServiceOp{client: c}
-	c.ProjectAPIKeys = &ProjectAPIKeysOp{client: c}
-	c.Peers = &PeersServiceOp{client: c}
-	c.ProjectIPWhitelist = &ProjectIPWhitelistServiceOp{client: c}
-	c.WhitelistAPIKeys = &WhitelistAPIKeysServiceOp{client: c}
-	c.PrivateIPMode = &PrivateIPModeServiceOp{client: c}
-	c.MaintenanceWindows = &MaintenanceWindowsServiceOp{client: c}
-	c.Teams = &TeamsServiceOp{client: c}
-	c.AtlasUsers = &AtlasUsersServiceOp{client: c}
-	c.GlobalClusters = &GlobalClustersServiceOp{client: c}
-	c.Auditing = &AuditingsServiceOp{client: c}
-	c.AlertConfigurations = &AlertConfigurationsServiceOp{client: c}
-	c.PrivateEndpoints = &PrivateEndpointsServiceOp{client: c}
-	c.X509AuthDBUsers = &X509AuthDBUsersServiceOp{client: c}
+	c.APIKeys = &APIKeysServiceOp{Client: c}
+	c.CloudProviderSnapshots = &CloudProviderSnapshotsServiceOp{Client: c}
+	c.CloudProviderSnapshotRestoreJobs = &CloudProviderSnapshotRestoreJobsServiceOp{Client: c}
+	c.Clusters = &ClustersServiceOp{Client: c}
+	c.Containers = &ContainersServiceOp{Client: c}
+	c.CustomDBRoles = &CustomDBRolesServiceOp{Client: c}
+	c.DatabaseUsers = &DatabaseUsersServiceOp{Client: c}
+	c.EncryptionsAtRest = &EncryptionsAtRestServiceOp{Client: c}
+	c.Projects = &ProjectsServiceOp{Client: c}
+	c.ProjectAPIKeys = &ProjectAPIKeysOp{Client: c}
+	c.Peers = &PeersServiceOp{Client: c}
+	c.ProjectIPWhitelist = &ProjectIPWhitelistServiceOp{Client: c}
+	c.WhitelistAPIKeys = &WhitelistAPIKeysServiceOp{Client: c}
+	c.PrivateIPMode = &PrivateIPModeServiceOp{Client: c}
+	c.MaintenanceWindows = &MaintenanceWindowsServiceOp{Client: c}
+	c.Teams = &TeamsServiceOp{Client: c}
+	c.AtlasUsers = &AtlasUsersServiceOp{Client: c}
+	c.GlobalClusters = &GlobalClustersServiceOp{Client: c}
+	c.Auditing = &AuditingsServiceOp{Client: c}
+	c.AlertConfigurations = &AlertConfigurationsServiceOp{Client: c}
+	c.PrivateEndpoints = &PrivateEndpointsServiceOp{Client: c}
+	c.X509AuthDBUsers = &X509AuthDBUsersServiceOp{Client: c}
 
 	return c
 }
@@ -178,7 +178,7 @@ func NewClient(httpClient *http.Client) *Client {
 // ClientOpt are options for New.
 type ClientOpt func(*Client) error
 
-// New returns a new MongoDBAtlas API client instance.
+// New returns a new MongoDBAtlas API Client instance.
 func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
 	c := NewClient(httpClient)
 	for _, opt := range opts {
@@ -190,7 +190,7 @@ func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
 	return c, nil
 }
 
-// SetBaseURL is a client option for setting the base URL.
+// SetBaseURL is a Client option for setting the base URL.
 func SetBaseURL(bu string) ClientOpt {
 	return func(c *Client) error {
 		u, err := url.Parse(bu)
@@ -203,7 +203,7 @@ func SetBaseURL(bu string) ClientOpt {
 	}
 }
 
-// SetUserAgent is a client option for setting the user agent.
+// SetUserAgent is a Client option for setting the user agent.
 func SetUserAgent(ua string) ClientOpt {
 	return func(c *Client) error {
 		c.UserAgent = fmt.Sprintf("%s %s", ua, c.UserAgent)
@@ -321,7 +321,7 @@ func newResponse(r *http.Response) *Response {
 	return &response
 }
 
-// DoRequestWithClient submits an HTTP request using the specified client.
+// DoRequestWithClient submits an HTTP request using the specified Client.
 func DoRequestWithClient(
 	ctx context.Context,
 	client *http.Client,

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -25,7 +25,7 @@ const (
 )
 
 type RequestDoer interface {
-	NewRequest( context.Context, string, string,  interface{}) (*http.Request, error)
+	NewRequest(context.Context, string, string, interface{}) (*http.Request, error)
 	Do(context.Context, *http.Request, interface{}) (*Response, error)
 	OnRequestCompleted(RequestCompletionCallback)
 }

--- a/mongodbatlas/mongodbatlas_test.go
+++ b/mongodbatlas/mongodbatlas_test.go
@@ -197,7 +197,7 @@ func TestDo_httpError(t *testing.T) {
 	}
 }
 
-// Test handling of an error caused by the internal http client's Do()
+// Test handling of an error caused by the internal http Client's Do()
 // function.
 func TestDo_redirectLoop(t *testing.T) {
 	setup()

--- a/mongodbatlas/peers.go
+++ b/mongodbatlas/peers.go
@@ -23,7 +23,7 @@ type PeersService interface {
 //PeersServiceOp handles communication with the Network Peering Connection related methods
 // of the MongoDB Atlas API
 type PeersServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ PeersService = &PeersServiceOp{}

--- a/mongodbatlas/peers.go
+++ b/mongodbatlas/peers.go
@@ -23,7 +23,7 @@ type PeersService interface {
 //PeersServiceOp handles communication with the Network Peering Connection related methods
 // of the MongoDB Atlas API
 type PeersServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ PeersService = &PeersServiceOp{}
@@ -70,13 +70,13 @@ func (s *PeersServiceOp) List(ctx context.Context, groupID string, listOptions *
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(peersResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -99,13 +99,13 @@ func (s *PeersServiceOp) Get(ctx context.Context, groupID string, peerID string)
 	escapedEntry := url.PathEscape(peerID)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Peer)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -122,13 +122,13 @@ func (s *PeersServiceOp) Create(ctx context.Context, groupID string, createReque
 
 	path := fmt.Sprintf(peersPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Peer)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -146,13 +146,13 @@ func (s *PeersServiceOp) Update(ctx context.Context, groupID string, peerID stri
 	basePath := fmt.Sprintf(peersPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, peerID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Peer)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -171,12 +171,12 @@ func (s *PeersServiceOp) Delete(ctx context.Context, groupID string, peerID stri
 	escapedEntry := url.PathEscape(peerID)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/private_endpoints.go
+++ b/mongodbatlas/private_endpoints.go
@@ -24,7 +24,7 @@ type PrivateEndpointsService interface {
 // PrivateEndpointsServiceOp handles communication with the PrivateEndpoints related methods
 // of the MongoDB Atlas API
 type PrivateEndpointsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ PrivateEndpointsService = &PrivateEndpointsServiceOp{}
@@ -60,13 +60,13 @@ func (s *PrivateEndpointsServiceOp) Create(ctx context.Context, groupID string, 
 
 	path := fmt.Sprintf(privateEndpointsPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(PrivateEndpointConnection)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -87,13 +87,13 @@ func (s *PrivateEndpointsServiceOp) Get(ctx context.Context, groupID, privateLin
 	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, privateLinkID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(PrivateEndpointConnection)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -116,13 +116,13 @@ func (s *PrivateEndpointsServiceOp) List(ctx context.Context, groupID string, li
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new([]PrivateEndpointConnection)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -143,12 +143,12 @@ func (s *PrivateEndpointsServiceOp) Delete(ctx context.Context, groupID, private
 	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
 	path := fmt.Sprintf("%s/%s", basePath, privateLinkID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.Client.Do(ctx, req, nil)
 }
 
 // AddOneInterfaceEndpoint adds one interface endpoint to a private endpoint connection in an Atlas project.
@@ -167,13 +167,13 @@ func (s *PrivateEndpointsServiceOp) AddOneInterfaceEndpoint(ctx context.Context,
 	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
 	path := fmt.Sprintf("%s/%s/interfaceEndpoints", basePath, privateLinkID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, &InterfaceEndpointConnection{ID: interfaceEndpointID})
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, &InterfaceEndpointConnection{ID: interfaceEndpointID})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(InterfaceEndpointConnection)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -197,13 +197,13 @@ func (s *PrivateEndpointsServiceOp) GetOneInterfaceEndpoint(ctx context.Context,
 	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
 	path := fmt.Sprintf("%s/%s/interfaceEndpoints/%s", basePath, privateLinkID, interfaceEndpointID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(InterfaceEndpointConnection)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -227,10 +227,10 @@ func (s *PrivateEndpointsServiceOp) DeleteOneInterfaceEndpoint(ctx context.Conte
 	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
 	path := fmt.Sprintf("%s/%s/interfaceEndpoints/%s", basePath, privateLinkID, interfaceEndpointID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.Client.Do(ctx, req, nil)
 }

--- a/mongodbatlas/private_endpoints.go
+++ b/mongodbatlas/private_endpoints.go
@@ -24,7 +24,7 @@ type PrivateEndpointsService interface {
 // PrivateEndpointsServiceOp handles communication with the PrivateEndpoints related methods
 // of the MongoDB Atlas API
 type PrivateEndpointsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ PrivateEndpointsService = &PrivateEndpointsServiceOp{}

--- a/mongodbatlas/private_ip_mode.go
+++ b/mongodbatlas/private_ip_mode.go
@@ -19,7 +19,7 @@ type PrivateIPModeService interface {
 //PrivateIPModeServiceOp handles communication with the Private IP Mode related methods
 // of the MongoDB Atlas API
 type PrivateIPModeServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ PrivateIPModeService = &PrivateIPModeServiceOp{}

--- a/mongodbatlas/private_ip_mode.go
+++ b/mongodbatlas/private_ip_mode.go
@@ -19,7 +19,7 @@ type PrivateIPModeService interface {
 //PrivateIPModeServiceOp handles communication with the Private IP Mode related methods
 // of the MongoDB Atlas API
 type PrivateIPModeServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ PrivateIPModeService = &PrivateIPModeServiceOp{}
@@ -34,13 +34,13 @@ type PrivateIPMode struct {
 func (s *PrivateIPModeServiceOp) Get(ctx context.Context, groupID string) (*PrivateIPMode, *Response, error) {
 	path := fmt.Sprintf(privateIPModePath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(PrivateIPMode)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -57,13 +57,13 @@ func (s *PrivateIPModeServiceOp) Update(ctx context.Context, groupID string, upd
 
 	path := fmt.Sprintf(privateIPModePath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(PrivateIPMode)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/mongodbatlas/project_api_key.go
+++ b/mongodbatlas/project_api_key.go
@@ -21,7 +21,7 @@ type ProjectAPIKeysService interface {
 //ProjectAPIKeysOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API
 type ProjectAPIKeysOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ ProjectAPIKeysService = &ProjectAPIKeysOp{}

--- a/mongodbatlas/project_api_key.go
+++ b/mongodbatlas/project_api_key.go
@@ -21,7 +21,7 @@ type ProjectAPIKeysService interface {
 //ProjectAPIKeysOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API
 type ProjectAPIKeysOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ ProjectAPIKeysService = &ProjectAPIKeysOp{}
@@ -42,13 +42,13 @@ func (s *ProjectAPIKeysOp) List(ctx context.Context, groupID string, listOptions
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(apiKeysResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -69,13 +69,13 @@ func (s *ProjectAPIKeysOp) Create(ctx context.Context, groupID string, createReq
 
 	path := fmt.Sprintf(projectAPIKeysPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(APIKey)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -98,12 +98,12 @@ func (s *ProjectAPIKeysOp) Assign(ctx context.Context, groupID string, keyID str
 
 	path := fmt.Sprintf("%s/%s", basePath, keyID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, assignAPIKeyRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, assignAPIKeyRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }
@@ -123,12 +123,12 @@ func (s *ProjectAPIKeysOp) Unassign(ctx context.Context, groupID string, keyID s
 
 	path := fmt.Sprintf("%s/%s", basePath, keyID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/project_ip_whitelist.go
+++ b/mongodbatlas/project_ip_whitelist.go
@@ -23,7 +23,7 @@ type ProjectIPWhitelistService interface {
 //ProjectIPWhitelistServiceOp handles communication with the ProjectIPWhitelist related methods
 // of the MongoDB Atlas API
 type ProjectIPWhitelistServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ ProjectIPWhitelistService = &ProjectIPWhitelistServiceOp{}
@@ -54,13 +54,13 @@ func (s *ProjectIPWhitelistServiceOp) Create(ctx context.Context, groupID string
 
 	path := fmt.Sprintf(projectIPWhitelistPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(projectIPWhitelistsResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -83,13 +83,13 @@ func (s *ProjectIPWhitelistServiceOp) Get(ctx context.Context, groupID string, w
 	escapedEntry := url.PathEscape(whiteListEntry)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(ProjectIPWhitelist)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -108,13 +108,13 @@ func (s *ProjectIPWhitelistServiceOp) List(ctx context.Context, groupID string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(projectIPWhitelistsResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -135,13 +135,13 @@ func (s *ProjectIPWhitelistServiceOp) Update(ctx context.Context, groupID string
 
 	path := fmt.Sprintf(projectIPWhitelistPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, updateRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(projectIPWhitelistsResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -164,12 +164,12 @@ func (s *ProjectIPWhitelistServiceOp) Delete(ctx context.Context, groupID string
 	escapedEntry := url.PathEscape(whitelistEntry)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/project_ip_whitelist.go
+++ b/mongodbatlas/project_ip_whitelist.go
@@ -23,7 +23,7 @@ type ProjectIPWhitelistService interface {
 //ProjectIPWhitelistServiceOp handles communication with the ProjectIPWhitelist related methods
 // of the MongoDB Atlas API
 type ProjectIPWhitelistServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ ProjectIPWhitelistService = &ProjectIPWhitelistServiceOp{}

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -36,7 +36,7 @@ type ProjectsService interface {
 //ProjectsServiceOp handles communication with the Projects related methos of the
 //MongoDB Atlas API
 type ProjectsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ ProjectsService = &ProjectsServiceOp{}

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -36,7 +36,7 @@ type ProjectsService interface {
 //ProjectsServiceOp handles communication with the Projects related methos of the
 //MongoDB Atlas API
 type ProjectsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ ProjectsService = &ProjectsServiceOp{}
@@ -82,13 +82,13 @@ type TeamsAssigned struct {
 //See more: https://docs.atlas.mongodb.com/reference/api/project-get-all/
 func (s *ProjectsServiceOp) GetAllProjects(ctx context.Context) (*Projects, *Response, error) {
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, projectBasePath, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, projectBasePath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Projects)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -109,13 +109,13 @@ func (s *ProjectsServiceOp) GetOneProject(ctx context.Context, projectID string)
 
 	path := fmt.Sprintf("%s/%s", projectBasePath, projectID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Project)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -132,13 +132,13 @@ func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName
 
 	path := fmt.Sprintf("%s/byName/%s", projectBasePath, projectName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Project)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -153,13 +153,13 @@ func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project) 
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, projectBasePath, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, projectBasePath, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Project)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -176,12 +176,12 @@ func (s *ProjectsServiceOp) Delete(ctx context.Context, projectID string) (*Resp
 
 	basePath := fmt.Sprintf("%s/%s", projectBasePath, projectID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, basePath, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, basePath, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }
@@ -195,13 +195,13 @@ func (s *ProjectsServiceOp) GetProjectTeamsAssigned(ctx context.Context, project
 
 	path := fmt.Sprintf("%s/%s/teams", projectBasePath, projectID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(TeamsAssigned)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -218,13 +218,13 @@ func (s *ProjectsServiceOp) AddTeamsToProject(ctx context.Context, projectID str
 
 	path := fmt.Sprintf("%s/%s/teams", projectBasePath, projectID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(TeamsAssigned)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/mongodbatlas/teams.go
+++ b/mongodbatlas/teams.go
@@ -30,7 +30,7 @@ type TeamsService interface {
 //TeamsServiceOp handles communication with the Teams related methos of the
 //MongoDB Atlas API
 type TeamsServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ TeamsService = &TeamsServiceOp{}
@@ -82,13 +82,13 @@ func (s *TeamsServiceOp) List(ctx context.Context, orgID string, listOptions *Li
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(TeamsResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -110,13 +110,13 @@ func (s *TeamsServiceOp) Get(ctx context.Context, orgID string, teamID string) (
 	basePath := fmt.Sprintf(teamsBasePath, orgID)
 	path := fmt.Sprintf("%s/%s", basePath, teamID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Team)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -134,13 +134,13 @@ func (s *TeamsServiceOp) GetOneTeamByName(ctx context.Context, orgID, teamName s
 	basePath := fmt.Sprintf(teamsBasePath, orgID)
 	path := fmt.Sprintf("%s/byName/%s", basePath, teamName)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Team)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -158,13 +158,13 @@ func (s *TeamsServiceOp) GetTeamUsersAssigned(ctx context.Context, orgID, teamID
 	basePath := fmt.Sprintf(teamsBasePath, orgID)
 	path := fmt.Sprintf("%s/%s/users", basePath, teamID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AtlasUserAssigned)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -183,13 +183,13 @@ func (s *TeamsServiceOp) Create(ctx context.Context, orgID string, createRequest
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, fmt.Sprintf(teamsBasePath, orgID), createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, fmt.Sprintf(teamsBasePath, orgID), createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(Team)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -207,7 +207,7 @@ func (s *TeamsServiceOp) Rename(ctx context.Context, orgID, teamID, teamName str
 	basePath := fmt.Sprintf(teamsBasePath, orgID)
 	path := fmt.Sprintf("%s/%s", basePath, teamID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, map[string]interface{}{
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, map[string]interface{}{
 		"name": teamName,
 	})
 	if err != nil {
@@ -215,7 +215,7 @@ func (s *TeamsServiceOp) Rename(ctx context.Context, orgID, teamID, teamName str
 	}
 
 	root := new(Team)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -232,13 +232,13 @@ func (s *TeamsServiceOp) UpdateTeamRoles(ctx context.Context, orgID string, team
 
 	path := fmt.Sprintf("groups/%s/teams/%s", orgID, teamID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateTeamRolesRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateTeamRolesRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(TeamUpdateRolesResponse)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -265,14 +265,14 @@ func (s *TeamsServiceOp) AddUsersToTeam(ctx context.Context, orgID, teamID strin
 		users[i] = map[string]interface{}{"id": id}
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, users)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, users)
 
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(AtlasUserAssigned)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -294,12 +294,12 @@ func (s *TeamsServiceOp) RemoveUserToTeam(ctx context.Context, orgID, teamID, us
 	basePath := fmt.Sprintf(teamsBasePath, orgID)
 	path := fmt.Sprintf("%s/%s/users/%s", basePath, teamID, userID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -317,12 +317,12 @@ func (s *TeamsServiceOp) RemoveTeamFromOrganization(ctx context.Context, orgID, 
 	basePath := fmt.Sprintf(teamsBasePath, orgID)
 	path := fmt.Sprintf("%s/%s", basePath, teamID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -339,12 +339,12 @@ func (s *TeamsServiceOp) RemoveTeamFromProject(ctx context.Context, groupID, tea
 
 	path := fmt.Sprintf("groups/%s/teams/%s", groupID, teamID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/mongodbatlas/teams.go
+++ b/mongodbatlas/teams.go
@@ -30,7 +30,7 @@ type TeamsService interface {
 //TeamsServiceOp handles communication with the Teams related methos of the
 //MongoDB Atlas API
 type TeamsServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ TeamsService = &TeamsServiceOp{}

--- a/mongodbatlas/whitelist_api_keys.go
+++ b/mongodbatlas/whitelist_api_keys.go
@@ -21,7 +21,7 @@ type WhitelistAPIKeysService interface {
 // WhitelistAPIKeysServiceOp handles communication with the Whitelist API keys related methods of the
 // MongoDB Atlas API
 type WhitelistAPIKeysServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ WhitelistAPIKeysService = &WhitelistAPIKeysServiceOp{}

--- a/mongodbatlas/whitelist_api_keys.go
+++ b/mongodbatlas/whitelist_api_keys.go
@@ -21,7 +21,7 @@ type WhitelistAPIKeysService interface {
 // WhitelistAPIKeysServiceOp handles communication with the Whitelist API keys related methods of the
 // MongoDB Atlas API
 type WhitelistAPIKeysServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ WhitelistAPIKeysService = &WhitelistAPIKeysServiceOp{}
@@ -62,13 +62,13 @@ func (s *WhitelistAPIKeysServiceOp) List(ctx context.Context, orgID string, apiK
 
 	path := fmt.Sprintf(whitelistAPIKeysPath, orgID, apiKeyID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(WhitelistAPIKeys)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -95,13 +95,13 @@ func (s *WhitelistAPIKeysServiceOp) Get(ctx context.Context, orgID string, apiKe
 
 	path := fmt.Sprintf(whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(WhitelistAPIKey)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -124,13 +124,13 @@ func (s *WhitelistAPIKeysServiceOp) Create(ctx context.Context, orgID string, ap
 
 	path := fmt.Sprintf(whitelistAPIKeysPath, orgID, apiKeyID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(WhitelistAPIKeys)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -153,11 +153,11 @@ func (s *WhitelistAPIKeysServiceOp) Delete(ctx context.Context, orgID string, ap
 
 	path := fmt.Sprintf(whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := s.client.Do(ctx, req, nil)
+	resp, err := s.Client.Do(ctx, req, nil)
 
 	return resp, err
 }

--- a/mongodbatlas/x509_authentication_database_users.go
+++ b/mongodbatlas/x509_authentication_database_users.go
@@ -23,7 +23,7 @@ type X509AuthDBUsersService interface {
 // X509AuthDBUsersServiceOp handles communication with the  X509AuthDBUsers related methods
 // of the MongoDB Atlas API
 type X509AuthDBUsersServiceOp struct {
-	client *Client
+	client RequestDoer
 }
 
 var _ X509AuthDBUsersService = &X509AuthDBUsersServiceOp{}

--- a/mongodbatlas/x509_authentication_database_users.go
+++ b/mongodbatlas/x509_authentication_database_users.go
@@ -23,7 +23,7 @@ type X509AuthDBUsersService interface {
 // X509AuthDBUsersServiceOp handles communication with the  X509AuthDBUsers related methods
 // of the MongoDB Atlas API
 type X509AuthDBUsersServiceOp struct {
-	client RequestDoer
+	Client RequestDoer
 }
 
 var _ X509AuthDBUsersService = &X509AuthDBUsersServiceOp{}
@@ -77,13 +77,13 @@ func (s *X509AuthDBUsersServiceOp) CreateUserCertificate(ctx context.Context, gr
 
 	path := fmt.Sprintf(x509AuthDBUsersPath, groupID, username)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, userCertificate)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, userCertificate)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var cer bytes.Buffer
-	resp, err := s.client.Do(ctx, req, &cer)
+	resp, err := s.Client.Do(ctx, req, &cer)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -106,13 +106,13 @@ func (s *X509AuthDBUsersServiceOp) GetUserCertificates(ctx context.Context, grou
 
 	path := fmt.Sprintf(x509AuthDBUsersPath, groupID, username)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(UserCertificates)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -136,13 +136,13 @@ func (s *X509AuthDBUsersServiceOp) SaveConfiguration(ctx context.Context, groupI
 
 	path := fmt.Sprintf(x509CustomerAuthDBUserPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, &UserSecurity{CustomerX509: *customerX509})
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, &UserSecurity{CustomerX509: *customerX509})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(UserSecurity)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -159,13 +159,13 @@ func (s *X509AuthDBUsersServiceOp) GetCurrentX509Conf(ctx context.Context, group
 
 	path := fmt.Sprintf(x509CustomerAuthDBUserPath, groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	root := new(UserSecurity)
-	resp, err := s.client.Do(ctx, req, root)
+	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -182,10 +182,10 @@ func (s *X509AuthDBUsersServiceOp) DisableCustomerX509(ctx context.Context, grou
 
 	path := fmt.Sprintf(x509CustomerAuthDBUserPath+"/customerX509", groupID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.client.Do(ctx, req, nil)
+	return s.Client.Do(ctx, req, nil)
 }


### PR DESCRIPTION
Making the ServiceOp structs depend on an interfaces enables me to inject my own client for the Ops manager an Cloud manager API
This should be a non breaking change that enables a more flexible extention of the structs