### PR TITLE
CLOUDP-60177: Implement Get Measurements of a Disk for a MongoDB Process, Atlas

### DIFF
--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -68,7 +68,7 @@ type Client struct {
 	Processes                           ProcessesService
 	ProcessMeasurements                 ProcessMeasurementsService
 	ProcessDisks                        ProcessDisksService
-	DiskMeasurements                    ProcessDiskMeasurementsService
+	ProcessDiskMeasurements             ProcessDiskMeasurementsService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -190,7 +190,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Processes = &ProcessesServiceOp{Client: c}
 	c.ProcessMeasurements = &ProcessMeasurementsServiceOp{Client: c}
 	c.ProcessDisks = &ProcessDisksServiceOp{Client: c}
-	c.DiskMeasurements = &ProcessDiskMeasurementsServiceOp{Client: c}
+	c.ProcessDiskMeasurements = &ProcessDiskMeasurementsServiceOp{Client: c}
 
 	return c
 }

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -68,6 +68,7 @@ type Client struct {
 	Processes                           ProcessesService
 	ProcessMeasurements                 ProcessMeasurementsService
 	ProcessDisks                        ProcessDisksService
+	DiskMeasurements                    ProcessDiskMeasurementsService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -189,6 +190,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Processes = &ProcessesServiceOp{Client: c}
 	c.ProcessMeasurements = &ProcessMeasurementsServiceOp{Client: c}
 	c.ProcessDisks = &ProcessDisksServiceOp{Client: c}
+	c.DiskMeasurements = &ProcessDiskMeasurementsServiceOp{Client: c}
 
 	return c
 }

--- a/mongodbatlas/process_disk_measurements.go
+++ b/mongodbatlas/process_disk_measurements.go
@@ -12,7 +12,7 @@ const ProcessDiskMeasurementsPath = processesDisksPath + "/%s/measurements"
 // endpoints of the MongoDB Atlas API.
 // See more: https://docs.atlas.mongodb.com/reference/api/process-disks-measurements/#get-measurements-of-a-disk-for-a-mongodb-process
 type ProcessDiskMeasurementsService interface {
-	Get(context.Context, string, string, int, string, *ProcessMeasurementListOptions) (*ProcessDiskMeasurements, *Response, error)
+	List(context.Context, string, string, int, string, *ProcessMeasurementListOptions) (*ProcessDiskMeasurements, *Response, error)
 }
 
 // ProcessDiskMeasurementsServiceOp handles communication with the Process Disk Measurements related methods of the
@@ -31,7 +31,7 @@ var _ ProcessDiskMeasurementsService = &ProcessDiskMeasurementsServiceOp{}
 
 // Get gets measurements for a specific Atlas MongoDB disk.
 // See more: https://docs.atlas.mongodb.com/reference/api/process-disks-measurements/#get-measurements-of-a-disk-for-a-mongodb-process
-func (s *ProcessDiskMeasurementsServiceOp) Get(ctx context.Context, groupID, hostName string, port int, diskName string, opts *ProcessMeasurementListOptions) (*ProcessDiskMeasurements, *Response, error) {
+func (s *ProcessDiskMeasurementsServiceOp) List(ctx context.Context, groupID, hostName string, port int, diskName string, opts *ProcessMeasurementListOptions) (*ProcessDiskMeasurements, *Response, error) {
 
 	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")

--- a/mongodbatlas/process_disk_measurements.go
+++ b/mongodbatlas/process_disk_measurements.go
@@ -1,0 +1,68 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const ProcessDiskMeasurementsPath = processesDisksPath + "/%s/measurements"
+
+// ProcessDiskMeasurementsService is an interface for interfacing with the Process Disk Measurements
+// endpoints of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/process-disks-measurements/#get-measurements-of-a-disk-for-a-mongodb-process
+type ProcessDiskMeasurementsService interface {
+	Get(context.Context, string, string, int, string, *ProcessMeasurementListOptions) (*ProcessDiskMeasurements, *Response, error)
+}
+
+// ProcessDiskMeasurementsServiceOp handles communication with the Process Disk Measurements related methods of the
+// MongoDB Atlas API
+type ProcessDiskMeasurementsServiceOp struct {
+	Client RequestDoer
+}
+
+// ProcessDiskMeasurements represents a MongoDB Process Disk Measurements.
+type ProcessDiskMeasurements struct {
+	*ProcessMeasurements
+	PartitionName string `json:"partitionName"`
+}
+
+var _ ProcessDiskMeasurementsService = &ProcessDiskMeasurementsServiceOp{}
+
+// Get gets measurements for a specific Atlas MongoDB disk.
+// See more: https://docs.atlas.mongodb.com/reference/api/process-disks-measurements/#get-measurements-of-a-disk-for-a-mongodb-process
+func (s *ProcessDiskMeasurementsServiceOp) Get(ctx context.Context, groupID, hostName string, port int, diskName string, opts *ProcessMeasurementListOptions) (*ProcessDiskMeasurements, *Response, error) {
+
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	if hostName == "" {
+		return nil, nil, NewArgError("hostName", "must be set")
+	}
+
+	if diskName == "" {
+		return nil, nil, NewArgError("diskName", "must be set")
+	}
+
+	basePath := fmt.Sprintf(ProcessDiskMeasurementsPath, groupID, hostName, port, diskName)
+
+	//Add query params from listOptions
+	path, err := setListOptions(basePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(ProcessDiskMeasurements)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}

--- a/mongodbatlas/process_disk_measurements_test.go
+++ b/mongodbatlas/process_disk_measurements_test.go
@@ -53,7 +53,7 @@ func TestDiskMeasurements_List(t *testing.T) {
 		Period:      "PT1M",
 	}
 
-	measurements, _, err := client.DiskMeasurements.Get(ctx, groups, host, port, disk, opts)
+	measurements, _, err := client.ProcessDiskMeasurements.List(ctx, groups, host, port, disk, opts)
 	if err != nil {
 		t.Fatalf("Teams.Get returned error: %v", err)
 	}

--- a/mongodbatlas/process_disk_measurements_test.go
+++ b/mongodbatlas/process_disk_measurements_test.go
@@ -1,0 +1,102 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestDiskMeasurements_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	groups := "12345678"
+	host := "shard-00-00.mongodb.net"
+	port := 27017
+	disk := "disk"
+
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/processes/%s:%d/disks/%s/measurements", groups, host, port, disk), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+				  "end" : "2017-08-22T20:31:14Z",
+				  "granularity" : "PT1M",
+				  "groupId" : "12345678",
+				  "hostId" : "shard-00-00.mongodb.net:27017",
+				  "links" : [ {
+					"href" : "https://cloud.mongodb.com/api/atlas/v1.0/groups/12345678/processes/shard-00-00.mongodb.net:27017/measurements?granularity=PT1M&period=PT1M",
+					"rel" : "self"
+				  }, {
+					"href" : "https://cloud.mongodb.com/api/atlas/v1.0/groups/12345678/processes/shard-00-00.mongodb.net:27017",
+					"rel" : "http://mms.mongodb.com/host"
+				  } ],
+				  "measurements" : [ {
+					"dataPoints" : [ {
+					  "timestamp" : "2017-08-22T20:31:12Z",
+					  "value" : null
+					}, {
+					  "timestamp" : "2017-08-22T20:31:14Z",
+					  "value" : null
+					} ],
+					"name" : "DISK_PARTITION_IOPS_READ",
+					"units" : "SCALAR_PER_SECOND"
+				  }],
+                  "partitionName":"xvdb",
+				  "processId" : "shard-00-00.mongodb.net:27017",
+				  "start" : "2017-08-22T20:30:45Z"
+				}`)
+	})
+
+	opts := &ProcessMeasurementListOptions{
+		Granularity: "PT1M",
+		Period:      "PT1M",
+	}
+
+	measurements, _, err := client.DiskMeasurements.Get(ctx, groups, host, port, disk, opts)
+	if err != nil {
+		t.Fatalf("Teams.Get returned error: %v", err)
+	}
+
+	expected := &ProcessDiskMeasurements{
+		ProcessMeasurements: &ProcessMeasurements{
+			End:         "2017-08-22T20:31:14Z",
+			Granularity: "PT1M",
+			GroupID:     "12345678",
+			HostID:      "shard-00-00.mongodb.net:27017",
+			Links: []*Link{
+				{
+					Rel:  "self",
+					Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/12345678/processes/shard-00-00.mongodb.net:27017/measurements?granularity=PT1M&period=PT1M",
+				},
+				{
+					Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/12345678/processes/shard-00-00.mongodb.net:27017",
+					Rel:  "http://mms.mongodb.com/host",
+				},
+			},
+			Measurements: []*Measurements{
+				{
+					DataPoints: []*DataPoints{
+						{
+							Timestamp: "2017-08-22T20:31:12Z",
+							Value:     nil,
+						},
+						{
+							Timestamp: "2017-08-22T20:31:14Z",
+							Value:     nil,
+						},
+					},
+					Name:  "DISK_PARTITION_IOPS_READ",
+					Units: "SCALAR_PER_SECOND",
+				},
+			},
+			ProcessID: "shard-00-00.mongodb.net:27017",
+			Start:     "2017-08-22T20:30:45Z",
+		},
+		PartitionName: "xvdb",
+	}
+
+	if diff := deep.Equal(measurements, expected); diff != nil {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
[CLOUDP-60177](https://jira.mongodb.org/browse/CLOUDP-60177)


Response from the API call:
```

{
	"end": "2020-04-06T17:19:48Z",
	"granularity": "PT1M",
	"groupId": "5e4e593f70dfbf1010295836",
	"hostId": "cluster0-shard-00-00-ajlj3.mongodb-dev.net:27017",
	"links": [
		{
			"rel": "self",
			"href": "https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/5e4e593f70dfbf1010295836/processes/cluster0-shard-00-00-ajlj3.mongodb-dev.net:27017/disks/data/measurements?ListOptions=\u0026granularity=PT1M\u0026period=PT1M"
		},
		{
			"rel": "http://mms.mongodb.com/host",
			"href": "https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/5e4e593f70dfbf1010295836/processes/cluster0-shard-00-00-ajlj3.mongodb-dev.net:27017"
		}
	],
	"measurements": [
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": null
				}
			],
			"name": "DISK_PARTITION_IOPS_READ",
			"units": "SCALAR_PER_SECOND"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": null
				}
			],
			"name": "DISK_PARTITION_IOPS_WRITE",
			"units": "SCALAR_PER_SECOND"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": null
				}
			],
			"name": "DISK_PARTITION_IOPS_TOTAL",
			"units": "SCALAR_PER_SECOND"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": null
				}
			],
			"name": "DISK_PARTITION_UTILIZATION",
			"units": "PERCENT"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": null
				}
			],
			"name": "DISK_PARTITION_LATENCY_READ",
			"units": "MILLISECONDS"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": null
				}
			],
			"name": "DISK_PARTITION_LATENCY_WRITE",
			"units": "MILLISECONDS"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": 9087066000
				}
			],
			"name": "DISK_PARTITION_SPACE_FREE",
			"units": "BYTES"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": 1639866400
				}
			],
			"name": "DISK_PARTITION_SPACE_USED",
			"units": "BYTES"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": 84.71262
				}
			],
			"name": "DISK_PARTITION_SPACE_PERCENT_FREE",
			"units": "PERCENT"
		},
		{
			"dataPoints": [
				{
					"timestamp": "2020-04-06T17:19:48Z",
					"value": 15.2873745
				}
			],
			"name": "DISK_PARTITION_SPACE_PERCENT_USED",
			"units": "PERCENT"
		}
	],
	"processId": "cluster0-shard-00-00-ajlj3.mongodb-dev.net:27017",
	"start": "2020-04-06T17:19:48Z",
	"partitionName": "nvme1n1"
}
```
