### PR TITLE
Validate base url trailing slash

### DIFF
--- a/mongodbatlas/alert_configurations_test.go
+++ b/mongodbatlas/alert_configurations_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAlertConfiguration_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -112,7 +112,7 @@ func TestAlertConfiguration_Create(t *testing.T) {
 }
 
 func TestAlertConfiguration_EnableAnAlertConfig(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"
@@ -184,7 +184,7 @@ func TestAlertConfiguration_EnableAnAlertConfig(t *testing.T) {
 }
 
 func TestAlertConfiguration_GetAnAlertConfig(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"
@@ -268,7 +268,7 @@ func TestAlertConfiguration_GetAnAlertConfig(t *testing.T) {
 }
 
 func TestAlertConfiguration_GetOpenAlertsConfig(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"
@@ -355,7 +355,7 @@ func TestAlertConfiguration_GetOpenAlertsConfig(t *testing.T) {
 }
 
 func TestAlertConfiguration_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"
@@ -507,7 +507,7 @@ func TestAlertConfiguration_List(t *testing.T) {
 }
 
 func TestAlertConfiguration_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -607,7 +607,7 @@ func TestAlertConfiguration_Update(t *testing.T) {
 }
 
 func TestAlertConfiguration_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"
@@ -624,7 +624,7 @@ func TestAlertConfiguration_Delete(t *testing.T) {
 }
 
 func TestAlertConfiguration_ListMatcherFields(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/alertConfigs/matchers/fieldNames", func(w http.ResponseWriter, r *http.Request) {

--- a/mongodbatlas/api_keys_test.go
+++ b/mongodbatlas/api_keys_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAPIKeys_ListAPIKeys(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/orgs/1/apiKeys", func(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +100,7 @@ func TestAPIKeys_ListAPIKeys(t *testing.T) {
 }
 
 func TestAPIKeys_ListAPIKeysMultiplePages(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/orgs/1/apiKeys", func(w http.ResponseWriter, r *http.Request) {
@@ -163,7 +163,7 @@ func TestAPIKeys_ListAPIKeysMultiplePages(t *testing.T) {
 }
 
 func TestAPIKeys_RetrievePageByNumber(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	jBlob := `
@@ -218,7 +218,7 @@ func TestAPIKeys_RetrievePageByNumber(t *testing.T) {
 }
 
 func TestAPIKeys_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -282,7 +282,7 @@ func TestAPIKeys_Create(t *testing.T) {
 }
 
 func TestAPIKeys_GetAPIKey(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/orgs/1/apiKeys/5c47503320eef5699e1cce8d", func(w http.ResponseWriter, r *http.Request) {
@@ -303,7 +303,7 @@ func TestAPIKeys_GetAPIKey(t *testing.T) {
 }
 
 func TestAPIKeys_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -367,7 +367,7 @@ func TestAPIKeys_Update(t *testing.T) {
 }
 
 func TestAPIKeys_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"

--- a/mongodbatlas/atlas_alerts_test.go
+++ b/mongodbatlas/atlas_alerts_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAlert_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"
@@ -92,7 +92,7 @@ func TestAlert_Get(t *testing.T) {
 }
 
 func TestAlerts_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"
@@ -244,7 +244,7 @@ func TestAlerts_List(t *testing.T) {
 }
 
 func TestAlert_Acknowledge(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "535683b3794d371327b"

--- a/mongodbatlas/atlas_users_test.go
+++ b/mongodbatlas/atlas_users_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAtlasUsers_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/users", func(w http.ResponseWriter, r *http.Request) {
@@ -128,7 +128,7 @@ func TestAtlasUsers_List(t *testing.T) {
 }
 
 func TestAtlasUsers_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	userID := "5af1c27a0a7fa48c76d3a761"
@@ -201,7 +201,7 @@ func TestAtlasUsers_Get(t *testing.T) {
 }
 
 func TestAtlasUsers_GetByName(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	username := "john.doe@example.com"
@@ -274,7 +274,7 @@ func TestAtlasUsers_GetByName(t *testing.T) {
 }
 
 func TestAtlasUsers_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	createRequest := &AtlasUser{

--- a/mongodbatlas/auditing_test.go
+++ b/mongodbatlas/auditing_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestConfigureAuditing(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -65,7 +65,7 @@ func TestConfigureAuditing(t *testing.T) {
 }
 
 func TestAuditing_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"

--- a/mongodbatlas/checkpoints_test.go
+++ b/mongodbatlas/checkpoints_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCheckpoints_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6b8cd3c380eef5349ef77gf7"
@@ -246,7 +246,7 @@ func TestCheckpoints_List(t *testing.T) {
 }
 
 func TestCheckpoints_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6b8cd3c380eef5349ef77gf7"

--- a/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCloudProviderSnapshotBackupPolicies_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "5b6212af90dc76637950a2c6"
@@ -130,7 +130,7 @@ func TestCloudProviderSnapshotBackupPolicies_Get(t *testing.T) {
 }
 
 func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "5b6212af90dc76637950a2c6"

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{
@@ -174,7 +174,7 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 }
 
 func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{
@@ -259,7 +259,7 @@ func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
 }
 
 func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{
@@ -366,7 +366,7 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 }
 
 func TestCloudProviderSnapshotRestoreJobs_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{

--- a/mongodbatlas/cloud_provider_snapshots_test.go
+++ b/mongodbatlas/cloud_provider_snapshots_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCloudProviderSnapshots_GetAllCloudProviderSnapshots(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{
@@ -94,7 +94,7 @@ func TestCloudProviderSnapshots_GetAllCloudProviderSnapshots(t *testing.T) {
 }
 
 func TestCloudProviderSnapshots_GetOneCloudProviderSnapshot(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{
@@ -163,7 +163,7 @@ func TestCloudProviderSnapshots_GetOneCloudProviderSnapshot(t *testing.T) {
 }
 
 func TestCloudProviderSnapshots_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{
@@ -249,7 +249,7 @@ func TestCloudProviderSnapshots_Create(t *testing.T) {
 }
 
 func TestCloudProviderSnapshots_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	requestParameters := &SnapshotReqPathParameters{

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClusters_ListClusters(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/clusters", func(w http.ResponseWriter, r *http.Request) {
@@ -178,7 +178,7 @@ func TestClusters_ListClusters(t *testing.T) {
 }
 
 func TestClusters_ListClustersMultiplePages(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/clusters", func(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +211,7 @@ func TestClusters_ListClustersMultiplePages(t *testing.T) {
 }
 
 func TestClusters_RetrievePageByNumber(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	jBlob := `
@@ -256,7 +256,7 @@ func TestClusters_RetrievePageByNumber(t *testing.T) {
 }
 
 func TestClusters_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -415,7 +415,7 @@ func TestClusters_Create(t *testing.T) {
 }
 
 func TestClusters_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -569,7 +569,7 @@ func TestClusters_Update(t *testing.T) {
 }
 
 func TestClusters_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -586,7 +586,7 @@ func TestClusters_Delete(t *testing.T) {
 }
 
 func TestClusters_UpdateProcessArgs(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -657,7 +657,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 }
 
 func TestClusters_GetProcessArgs(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -703,7 +703,7 @@ func TestClusters_checkClusterNameParam(t *testing.T) {
 }
 
 func TestClusters_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/containers_test.go
+++ b/mongodbatlas/containers_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestContainers_ListContainers(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/containers", func(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +70,7 @@ func TestContainers_ListContainers(t *testing.T) {
 }
 
 func TestContainers_ListContainersMultiplePages(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/containers", func(w http.ResponseWriter, r *http.Request) {
@@ -117,7 +117,7 @@ func TestContainers_ListContainersMultiplePages(t *testing.T) {
 }
 
 func TestContainers_RetrievePageByNumber(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	jBlob := `
@@ -166,7 +166,7 @@ func TestContainers_RetrievePageByNumber(t *testing.T) {
 }
 
 func TestContainers_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -228,7 +228,7 @@ func TestContainers_Create(t *testing.T) {
 }
 
 func TestContainers_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -293,7 +293,7 @@ func TestContainers_Update(t *testing.T) {
 }
 
 func TestContainers_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/continuous_restore_jobs_test.go
+++ b/mongodbatlas/continuous_restore_jobs_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestContinuousBackupRestore_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/6b77777887d9d61443b41645/clusters/Cluster0/restoreJobs", func(w http.ResponseWriter, r *http.Request) {
@@ -126,7 +126,7 @@ func TestContinuousBackupRestore_List(t *testing.T) {
 }
 
 func TestContinuousBackupRestore_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/5a66666887d9d61443b41645/clusters/Cluster0/restoreJobs/5a6669d9fcc178211a0d86b9", func(w http.ResponseWriter, r *http.Request) {
@@ -221,7 +221,7 @@ func TestContinuousBackupRestore_Get(t *testing.T) {
 }
 
 func TestContinuousBackupRestore_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/5a66666887d9d61443b41645/clusters/Cluster0/restoreJobs", func(w http.ResponseWriter, r *http.Request) {

--- a/mongodbatlas/continuous_snapshots_test.go
+++ b/mongodbatlas/continuous_snapshots_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContinuousSnapshots_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6c7498dg87d9e6526801572b"
@@ -121,7 +121,7 @@ func TestContinuousSnapshots_List(t *testing.T) {
 }
 
 func TestContinuousSnapshots_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6c7498dg87d9e6526801572b"
@@ -212,7 +212,7 @@ func TestContinuousSnapshots_Get(t *testing.T) {
 }
 
 func TestContinuousSnapshots_ChangeExpiry(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6c7498dg87d9e6526801572b"
@@ -325,7 +325,7 @@ func TestContinuousSnapshots_ChangeExpiry(t *testing.T) {
 }
 
 func TestContinuousSnapshots_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6c7498dg87d9e6526801572b"

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/customDBRoles/roles", func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +45,7 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 }
 
 func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/customDBRoles/roles/test-role-name", func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +78,7 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 }
 
 func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	createRequest := &CustomDBRole{
@@ -159,7 +159,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 }
 
 func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	updateRequest := &CustomDBRole{
@@ -240,7 +240,7 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 }
 
 func TestDatabaseUsers_DeleteCustomDBRole(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/database_users_test.go
+++ b/mongodbatlas/database_users_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestDatabaseUsers_ListDatabaseUsers(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/databaseUsers", func(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +31,7 @@ func TestDatabaseUsers_ListDatabaseUsers(t *testing.T) {
 }
 
 func TestDatabaseUsers_ListDatabaseUsersMultiplePages(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/databaseUsers", func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +64,7 @@ func TestDatabaseUsers_ListDatabaseUsersMultiplePages(t *testing.T) {
 }
 
 func TestDatabaseUsers_RetrievePageByNumber(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	jBlob := `
@@ -121,7 +121,7 @@ func TestDatabaseUsers_RetrievePageByNumber(t *testing.T) {
 }
 
 func TestDatabaseUsers_CreateWithX509Type(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -188,7 +188,7 @@ func TestDatabaseUsers_CreateWithX509Type(t *testing.T) {
 }
 
 func TestDatabaseUsers_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -263,7 +263,7 @@ func TestDatabaseUsers_Create(t *testing.T) {
 }
 
 func TestDatabaseUsers_GetDatabaseUser(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/databaseUsers/admin/test-username", func(w http.ResponseWriter, r *http.Request) {
@@ -283,7 +283,7 @@ func TestDatabaseUsers_GetDatabaseUser(t *testing.T) {
 }
 
 func TestDatabaseUsers_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -358,7 +358,7 @@ func TestDatabaseUsers_Update(t *testing.T) {
 }
 
 func TestDatabaseUsers_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/encryptions_at_rest_test.go
+++ b/mongodbatlas/encryptions_at_rest_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEncryptionsAtRest_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	createRequest := &EncryptionAtRest{
@@ -136,7 +136,7 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 }
 
 func TestEncryptionsAtRest_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"

--- a/mongodbatlas/events_test.go
+++ b/mongodbatlas/events_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEvents_ListOrganizationEvents(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "5b478b3afc4625789ce616a3"
@@ -122,7 +122,7 @@ func TestEvents_ListOrganizationEvents(t *testing.T) {
 }
 
 func TestEvents_GetOrganizationEvent(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "5b478b3afc4625789ce616a3"
@@ -178,7 +178,7 @@ func TestEvents_GetOrganizationEvent(t *testing.T) {
 }
 
 func TestEvents_ListProjectEvents(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "5b43d04087d9d6357de591a2"
@@ -291,7 +291,7 @@ func TestEvents_ListProjectEvents(t *testing.T) {
 }
 
 func TestEvents_GetProjectEvent(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "5b478b3afc4625789ce616a3"

--- a/mongodbatlas/global_clusters_test.go
+++ b/mongodbatlas/global_clusters_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGlobalClusters_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -84,7 +84,7 @@ func TestGlobalClusters_Get(t *testing.T) {
 }
 
 func TestGlobalClusters_AddManagedNamespace(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -174,7 +174,7 @@ func TestGlobalClusters_AddManagedNamespace(t *testing.T) {
 }
 
 func TestGlobalClusters_DeleteManagedNamespace(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -267,7 +267,7 @@ func TestGlobalClusters_DeleteManagedNamespace(t *testing.T) {
 }
 
 func TestGlobalClusters_AddCustomZoneMappings(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -329,7 +329,7 @@ func TestGlobalClusters_AddCustomZoneMappings(t *testing.T) {
 }
 
 func TestGlobalClusters_DeleteCustomZoneMappings(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/indexes_test.go
+++ b/mongodbatlas/indexes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestIndexesServiceOp_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/logs_test.go
+++ b/mongodbatlas/logs_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLogs_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/maintenance_test.go
+++ b/mongodbatlas/maintenance_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMaintenanceWindows_UpdateWithSheduleTime(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -52,7 +52,7 @@ func TestMaintenanceWindows_UpdateWithSheduleTime(t *testing.T) {
 }
 
 func TestMaintenanceWindows_UpdateWithStartNow(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -87,7 +87,7 @@ func TestMaintenanceWindows_UpdateWithStartNow(t *testing.T) {
 }
 
 func TestMaintenanceWindows_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -118,7 +118,7 @@ func TestMaintenanceWindows_Get(t *testing.T) {
 }
 
 func TestMaintenanceWindows_Defer(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -135,7 +135,7 @@ func TestMaintenanceWindows_Defer(t *testing.T) {
 }
 
 func TestMaintenanceWindows_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-querystring/query"
 )
@@ -258,6 +259,9 @@ func SetUserAgent(ua string) ClientOpt {
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
 func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+	if !strings.HasSuffix(c.BaseURL.Path, "/") {
+		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL)
+	}
 	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err

--- a/mongodbatlas/peers_test.go
+++ b/mongodbatlas/peers_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPeers_ListPeers(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/peers", func(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +56,7 @@ func TestPeers_ListPeers(t *testing.T) {
 }
 
 func TestPeers_ListPeersMultiplePages(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/peers", func(w http.ResponseWriter, r *http.Request) {
@@ -101,7 +101,7 @@ func TestPeers_ListPeersMultiplePages(t *testing.T) {
 }
 
 func TestPeers_RetrievePageByNumber(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	jBlob := `
@@ -148,7 +148,7 @@ func TestPeers_RetrievePageByNumber(t *testing.T) {
 }
 
 func TestPeers_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -211,7 +211,7 @@ func TestPeers_Create(t *testing.T) {
 }
 
 func TestPeers_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -275,7 +275,7 @@ func TestPeers_Update(t *testing.T) {
 }
 
 func TestPeers_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/private_endpoints_test.go
+++ b/mongodbatlas/private_endpoints_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPrivateEndpoint_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -67,7 +67,7 @@ func TestPrivateEndpoint_Create(t *testing.T) {
 }
 
 func TestPrivateEndpoints_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -103,7 +103,7 @@ func TestPrivateEndpoints_Get(t *testing.T) {
 }
 
 func TestPrivateEndpoints_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -156,7 +156,7 @@ func TestPrivateEndpoints_List(t *testing.T) {
 }
 
 func TestPrivateEndpoints_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -173,7 +173,7 @@ func TestPrivateEndpoints_Delete(t *testing.T) {
 }
 
 func TestPrivateEndpoint_AddOneInterfaceEndpoint(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -220,7 +220,7 @@ func TestPrivateEndpoint_AddOneInterfaceEndpoint(t *testing.T) {
 }
 
 func TestPrivateEndpoints_GetOneInterfaceEndpoint(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -253,7 +253,7 @@ func TestPrivateEndpoints_GetOneInterfaceEndpoint(t *testing.T) {
 }
 
 func TestPrivateEndpoints_DeleteOneInterfaceEndpoint(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/private_ip_mode_test.go
+++ b/mongodbatlas/private_ip_mode_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPrivateIPMode_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "6d2065c687d9d64ae7acdg41"
@@ -38,7 +38,7 @@ func TestPrivateIPMode_Get(t *testing.T) {
 }
 
 func TestPrivateIPMode_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/process_database_measurements_test.go
+++ b/mongodbatlas/process_database_measurements_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProcessDatabaseMeasurements_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groups := "12345678"

--- a/mongodbatlas/process_databases_test.go
+++ b/mongodbatlas/process_databases_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProcessDatabasesService_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 	mux.HandleFunc("/groups/12345678/processes/shard-00-00.mongodb.net:27017/databases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/mongodbatlas/process_disk_measurements_test.go
+++ b/mongodbatlas/process_disk_measurements_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProcessDiskMeasurements_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groups := "12345678"

--- a/mongodbatlas/process_disks_test.go
+++ b/mongodbatlas/process_disks_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestProcessDisksService_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
-	// https://cloud.mongodb.com/api/atlas/v1.0/groups/12345678/processes/shard-00-00.mongodb.net:27017/disks
+
 	mux.HandleFunc("/groups/12345678/processes/shard-00-00.mongodb.net:27017/disks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{

--- a/mongodbatlas/process_measurements_test.go
+++ b/mongodbatlas/process_measurements_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProcessMeasurements_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groups := "12345678"

--- a/mongodbatlas/processes_test.go
+++ b/mongodbatlas/processes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestProcesses_ListProcesses(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/processes", func(w http.ResponseWriter, r *http.Request) {
@@ -91,7 +91,7 @@ func TestProcesses_ListProcesses(t *testing.T) {
 }
 
 func TestProcesses_ListProcessesMultiplePages(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/processes", func(w http.ResponseWriter, r *http.Request) {
@@ -158,7 +158,7 @@ func TestProcesses_ListProcessesMultiplePages(t *testing.T) {
 }
 
 func TestProcesses_RetrievePageByNumber(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	jBlob := `

--- a/mongodbatlas/project_api_key_test.go
+++ b/mongodbatlas/project_api_key_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestProjectAPIKeys_ListAPIKeys(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/apiKeys", func(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +100,7 @@ func TestProjectAPIKeys_ListAPIKeys(t *testing.T) {
 }
 
 func TestProjectAPIKeys_Assign(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "5953c5f380eef53887615f9a"
@@ -117,7 +117,7 @@ func TestProjectAPIKeys_Assign(t *testing.T) {
 }
 
 func TestProjectAPIKeys_Unassign(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "5953c5f380eef53887615f9a"
@@ -134,7 +134,7 @@ func TestProjectAPIKeys_Unassign(t *testing.T) {
 }
 
 func TestProjectAPIKeys_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"

--- a/mongodbatlas/project_ip_whitelist_test.go
+++ b/mongodbatlas/project_ip_whitelist_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestProjectIPWhitelist_ListProjectIPWhitelist(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/whitelist", func(w http.ResponseWriter, r *http.Request) {
@@ -30,7 +30,7 @@ func TestProjectIPWhitelist_ListProjectIPWhitelist(t *testing.T) {
 }
 
 func TestProjectIPWhitelist_ListProjectIPWhitelistMultiplePages(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups/1/whitelist", func(w http.ResponseWriter, r *http.Request) {
@@ -63,7 +63,7 @@ func TestProjectIPWhitelist_ListProjectIPWhitelistMultiplePages(t *testing.T) {
 }
 
 func TestProjectIPWhitelist_RetrievePageByNumber(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	jBlob := `
@@ -113,7 +113,7 @@ func TestProjectIPWhitelist_RetrievePageByNumber(t *testing.T) {
 }
 
 func TestProjectIPWhitelist_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -175,7 +175,7 @@ func TestProjectIPWhitelist_Create(t *testing.T) {
 }
 
 func TestProjectIPWhitelist_GetProjectIPWhitelist(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	ipAddress := "0.0.0.0"
@@ -198,7 +198,7 @@ func TestProjectIPWhitelist_GetProjectIPWhitelist(t *testing.T) {
 }
 
 func TestProjectIPWhitelist_GetProjectIPWhitelistByCIDR(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	cidr := "0.0.0.0/32"
@@ -220,7 +220,7 @@ func TestProjectIPWhitelist_GetProjectIPWhitelistByCIDR(t *testing.T) {
 }
 
 func TestProjectIPWhitelist_Update(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -277,7 +277,7 @@ func TestProjectIPWhitelist_Update(t *testing.T) {
 }
 
 func TestProjectIPWhitelist_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProject_GetAllProjects(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/groups", func(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func TestProject_GetAllProjects(t *testing.T) {
 }
 
 func TestProject_GetOneProject(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	projectID := "5a0a1e7e0f2912c554080adc"
@@ -138,7 +138,7 @@ func TestProject_GetOneProject(t *testing.T) {
 }
 
 func TestProject_GetOneProjectByName(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	projectName := "5a0a1e7e0f2912c554080adc"
@@ -183,7 +183,7 @@ func TestProject_GetOneProjectByName(t *testing.T) {
 }
 
 func TestProject_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	createRequest := &Project{
@@ -230,7 +230,7 @@ func TestProject_Create(t *testing.T) {
 }
 
 func TestProject_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	projectID := "5a0a1e7e0f2912c554080adc"
@@ -246,7 +246,7 @@ func TestProject_Delete(t *testing.T) {
 }
 
 func TestProject_GetProjectTeamsAssigned(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	projectID := "5a0a1e7e0f2912c554080adc"
@@ -311,7 +311,7 @@ func TestProject_GetProjectTeamsAssigned(t *testing.T) {
 }
 
 func TestProject_AddTeamsToProject(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	projectID := "5a0a1e7e0f2912c554080adc"

--- a/mongodbatlas/teams_test.go
+++ b/mongodbatlas/teams_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTeams_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/orgs/1/teams", func(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +61,7 @@ func TestTeams_List(t *testing.T) {
 }
 
 func TestTeams_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -97,7 +97,7 @@ func TestTeams_Get(t *testing.T) {
 }
 
 func TestTeams_GetOneTeamByName(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -133,7 +133,7 @@ func TestTeams_GetOneTeamByName(t *testing.T) {
 }
 
 func TestProject_GetTeamUsersAssigned(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "5a0a1e7e0f2912c554080adc"
@@ -214,7 +214,7 @@ func TestProject_GetTeamUsersAssigned(t *testing.T) {
 }
 
 func TestTeams_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -276,7 +276,7 @@ func TestTeams_Create(t *testing.T) {
 }
 
 func TestTeams_Rename(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -328,7 +328,7 @@ func TestTeams_Rename(t *testing.T) {
 }
 
 func TestTeams_UpdateTeamRoles(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -404,7 +404,7 @@ func TestTeams_UpdateTeamRoles(t *testing.T) {
 }
 
 func TestTeams_AddUsersToTeam(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -504,7 +504,7 @@ func TestTeams_AddUsersToTeam(t *testing.T) {
 }
 
 func TestTeams_RemoveUserToTeam(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -523,7 +523,7 @@ func TestTeams_RemoveUserToTeam(t *testing.T) {
 }
 
 func TestTeams_RemoveTeamFromOrganization(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "1"
@@ -540,7 +540,7 @@ func TestTeams_RemoveTeamFromOrganization(t *testing.T) {
 }
 
 func TestTeams_RemoveTeamFromProject(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"

--- a/mongodbatlas/whitelist_api_keys_test.go
+++ b/mongodbatlas/whitelist_api_keys_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWhitelistAPIKeys_List(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "ORG-ID"
@@ -110,7 +110,7 @@ func TestWhitelistAPIKeys_List(t *testing.T) {
 }
 
 func TestWhitelistAPIKeys_Get(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "ORG-ID"
@@ -157,7 +157,7 @@ func TestWhitelistAPIKeys_Get(t *testing.T) {
 }
 
 func TestWhitelistAPIKeys_Create(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "ORG-ID"
@@ -280,7 +280,7 @@ func TestWhitelistAPIKeys_Create(t *testing.T) {
 }
 
 func TestWhitelistAPIKeys_Delete(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	orgID := "ORG-ID"

--- a/mongodbatlas/x509_authentication_database_users_test.go
+++ b/mongodbatlas/x509_authentication_database_users_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestX509AuthDBUsers_CreateUserCertificate(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -55,7 +55,7 @@ func TestX509AuthDBUsers_CreateUserCertificate(t *testing.T) {
 }
 
 func TestX509AuthDBUsers_GetUserCertificates(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -118,7 +118,7 @@ func TestX509AuthDBUsers_GetUserCertificates(t *testing.T) {
 }
 
 func TestX509AuthDBUsers_SaveConfiguration(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -164,7 +164,7 @@ func TestX509AuthDBUsers_SaveConfiguration(t *testing.T) {
 }
 
 func TestX509AuthDBUsers_GetCurrentX509Conf(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"
@@ -194,7 +194,7 @@ func TestX509AuthDBUsers_GetCurrentX509Conf(t *testing.T) {
 }
 
 func TestX509AuthDBUsers_DisableCustomerX509(t *testing.T) {
-	setup()
+	client, mux, _, teardown := setup()
 	defer teardown()
 
 	groupID := "1"


### PR DESCRIPTION
## Proposed changes

This is not so much a problem for Atlas but for Ops Manager where you set a custom url we are having users face this problem

This change is two fold, we validate the request to be correct and we ensure in tests that devs use a relative path and not an absolute one

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
