### PR TITLE
Fix cluster struct to allow pasue/start a cluster

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -81,9 +81,9 @@ type ConnectionStrings struct {
 
 // Cluster represents MongoDB cluster.
 type Cluster struct {
-	AutoScaling              AutoScaling              `json:"autoScaling,omitempty"`
+	AutoScaling              *AutoScaling             `json:"autoScaling,omitempty"`
 	BackupEnabled            *bool                    `json:"backupEnabled,omitempty"`
-	BiConnector              BiConnector              `json:"biConnector,omitempty"`
+	BiConnector              *BiConnector             `json:"biConnector,omitempty"`
 	ClusterType              string                   `json:"clusterType,omitempty"`
 	DiskSizeGB               *float64                 `json:"diskSizeGB,omitempty"`
 	EncryptionAtRestProvider string                   `json:"encryptionAtRestProvider,omitempty"`

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -129,9 +129,9 @@ func TestClusters_ListClusters(t *testing.T) {
 	}
 
 	cluster1 := Cluster{
-		AutoScaling:   AutoScaling{DiskGBEnabled: pointy.Bool(true)},
+		AutoScaling:   &AutoScaling{DiskGBEnabled: pointy.Bool(true)},
 		BackupEnabled: pointy.Bool(true),
-		BiConnector:   BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		BiConnector:   &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
 		ClusterType:   "REPLICASET",
 		ConnectionStrings: &ConnectionStrings{
 			Standard:          "mongodb://cluster0-shard-00-00-auylw.mongodb.net:27017,cluster0-shard-00-01-auylw.mongodb.net:27017,cluster0-shard-00-02-auylw.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0",
@@ -263,9 +263,9 @@ func TestClusters_Create(t *testing.T) {
 
 	createRequest := &Cluster{
 		ID:                       "1",
-		AutoScaling:              AutoScaling{DiskGBEnabled: pointy.Bool(true)},
+		AutoScaling:              &AutoScaling{DiskGBEnabled: pointy.Bool(true)},
 		BackupEnabled:            pointy.Bool(true),
-		BiConnector:              BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		BiConnector:              &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
 		DiskSizeGB:               pointy.Float64(160),
 		EncryptionAtRestProvider: "AWS",
@@ -423,9 +423,9 @@ func TestClusters_Update(t *testing.T) {
 
 	updateRequest := &Cluster{
 		ID:                       "1",
-		AutoScaling:              AutoScaling{DiskGBEnabled: pointy.Bool(true)},
+		AutoScaling:              &AutoScaling{DiskGBEnabled: pointy.Bool(true)},
 		BackupEnabled:            pointy.Bool(true),
-		BiConnector:              BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		BiConnector:              &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
 		DiskSizeGB:               pointy.Float64(160),
 		EncryptionAtRestProvider: "AWS",
@@ -772,9 +772,9 @@ func TestClusters_Get(t *testing.T) {
 
 	expected := &Cluster{
 		ID:            "1",
-		AutoScaling:   AutoScaling{DiskGBEnabled: pointy.Bool(true)},
+		AutoScaling:   &AutoScaling{DiskGBEnabled: pointy.Bool(true)},
 		BackupEnabled: pointy.Bool(true),
-		BiConnector:   BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		BiConnector:   &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
 		ClusterType:   "REPLICASET",
 		ConnectionStrings: &ConnectionStrings{
 			Standard:          "mongodb://cluster0-shard-00-00-auylw.mongodb.net:27017,cluster0-shard-00-01-auylw.mongodb.net:27017,cluster0-shard-00-02-auylw.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0",


### PR DESCRIPTION
## Proposed changes

**Breaking change**

Currently if you want to pause or restart a cluster you can only send the `Paused` property and nothing else or you'll get errors like "Can't pause and update a cluster at the same time"

Having some internal structs as non-pointers were making go serialize them so we could never do this kind of operation

Sadly this may be a breaking change as we are changing the type of the struct and those depending on it may need to update after this change

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
