### PR TITLE
Make the measurements param an array

### DIFF
--- a/mongodbatlas/process_measurements.go
+++ b/mongodbatlas/process_measurements.go
@@ -51,10 +51,10 @@ type DataPoints struct {
 // ProcessMeasurementListOptions contains the list of options for Process Measurements.
 type ProcessMeasurementListOptions struct {
 	*ListOptions
-	Granularity string `url:"granularity"`
-	Period      string `url:"period,omitempty"`
-	Start       string `url:"start,omitempty"`
-	End         string `url:"end,omitempty"`
+	Granularity string   `url:"granularity"`
+	Period      string   `url:"period,omitempty"`
+	Start       string   `url:"start,omitempty"`
+	End         string   `url:"end,omitempty"`
 	M           []string `url:"m,omitempty"`
 }
 

--- a/mongodbatlas/process_measurements.go
+++ b/mongodbatlas/process_measurements.go
@@ -55,10 +55,10 @@ type ProcessMeasurementListOptions struct {
 	Period      string `url:"period,omitempty"`
 	Start       string `url:"start,omitempty"`
 	End         string `url:"end,omitempty"`
-	M           string `url:"m,omitempty"`
+	M           []string `url:"m,omitempty"`
 }
 
-// Get gets measurements for a specific Atlas MongoDB process.
+// List lists measurements for a specific Atlas MongoDB process.
 // See more: https://docs.atlas.mongodb.com/reference/api/process-measurements/
 func (s *ProcessMeasurementsServiceOp) List(ctx context.Context, groupID string, host string, port int, opts *ProcessMeasurementListOptions) (*ProcessMeasurements, *Response, error) {
 


### PR DESCRIPTION
## Proposed changes
the `m` param is actually an array so fixing this

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code