### PR TITLE
CLOUDP-62220: Update the AcknowledgedUntil field to be a pointer in the atlas client

### DIFF
--- a/mongodbatlas/atlas_alerts.go
+++ b/mongodbatlas/atlas_alerts.go
@@ -52,8 +52,8 @@ type Alert struct {
 
 // AlertsRequest contains the request Body Parameters
 type AcknowledgeRequest struct {
-	AcknowledgedUntil      string `json:"acknowledgedUntil,omitempty"`      // The date through which the alert has been acknowledged. Will not be present if the alert has never been acknowledged.
-	AcknowledgementComment string `json:"acknowledgementComment,omitempty"` // The comment left by the user who acknowledged the alert. Will not be present if the alert has never been acknowledged.
+	AcknowledgedUntil      *string `json:"acknowledgedUntil,omitempty"`      // The date through which the alert has been acknowledged. Will not be present if the alert has never been acknowledged.
+	AcknowledgementComment string  `json:"acknowledgementComment,omitempty"` // The comment left by the user who acknowledged the alert. Will not be present if the alert has never been acknowledged.
 }
 
 // AlertsListOptions contains the list of options for Alerts

--- a/mongodbatlas/atlas_alerts_test.go
+++ b/mongodbatlas/atlas_alerts_test.go
@@ -249,9 +249,10 @@ func TestAlert_Acknowledge(t *testing.T) {
 
 	groupID := "535683b3794d371327b"
 	alertID := "533dc40ae4b00835ff81eaee"
+	acknowledgedUntil := "2026-10-01T00:00:00-0400"
 
 	params := AcknowledgeRequest{
-		AcknowledgedUntil:      "2026-10-01T00:00:00-0400",
+		AcknowledgedUntil:      &acknowledgedUntil,
 		AcknowledgementComment: "This is normal. Please ignore.",
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to go-client-mongodb-atlas!

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->
[CLOUDP-62220](https://jira.mongodb.org/browse/CLOUDP-62220)
<!--
What go-client-mongodb-atlas issue does this PR address? (for example, #1234), remove this section if none
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->

We have recently discovered that the **AcknowledgedUntil** field must be set to null in order to unack an alert. As a result, we decided to make this field a pointer.
