### PR TITLE
Three new fields for Snapshot restore jobs options

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -30,19 +30,21 @@ var _ CloudProviderSnapshotRestoreJobsService = &CloudProviderSnapshotRestoreJob
 
 // CloudProviderSnapshotRestoreJob represents the structure of a cloudProviderSnapshotRestoreJob.
 type CloudProviderSnapshotRestoreJob struct {
-	ID                string   `json:"id,omitempty"`                // The unique identifier of the restore job.
-	SnapshotID        string   `json:"snapshotId,omitempty"`        // Unique identifier of the snapshot to restore.
-	DeliveryType      string   `json:"deliveryType,omitempty"`      // Type of restore job to create. Possible values are: automated or download
-	DeliveryURL       []string `json:"deliveryUrl,omitempty"`       // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
-	TargetClusterName string   `json:"targetClusterName,omitempty"` // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
-	TargetGroupID     string   `json:"targetGroupId,omitempty"`     // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
-	Cancelled         bool     `json:"cancelled,omitempty"`         // Indicates whether the restore job was canceled.
-	CreatedAt         string   `json:"createdAt,omitempty"`         // UTC ISO 8601 formatted point in time when Atlas created the restore job.
-	Expired           bool     `json:"expired,omitempty"`           // Indicates whether the restore job expired.
-	ExpiresAt         string   `json:"expiresAt,omitempty"`         // UTC ISO 8601 formatted point in time when the restore job expires.
-	FinishedAt        string   `json:"finishedAt,omitempty"`        // UTC ISO 8601 formatted point in time when the restore job completed.
-	Links             []*Link  `json:"links,omitempty"`             // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
-	Timestamp         string   `json:"timestamp,omitempty"`         // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
+	ID                    string   `json:"id,omitempty"`                    // The unique identifier of the restore job.
+	SnapshotID            string   `json:"snapshotId,omitempty"`            // Unique identifier of the snapshot to restore.
+	DeliveryType          string   `json:"deliveryType,omitempty"`          // Type of restore job to create. Possible values are: automated or download
+	DeliveryURL           []string `json:"deliveryUrl,omitempty"`           // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
+	TargetClusterName     string   `json:"targetClusterName,omitempty"`     // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
+	TargetGroupID         string   `json:"targetGroupId,omitempty"`         // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
+	Cancelled             bool     `json:"cancelled,omitempty"`             // Indicates whether the restore job was canceled.
+	CreatedAt             string   `json:"createdAt,omitempty"`             // UTC ISO 8601 formatted point in time when Atlas created the restore job.
+	Expired               bool     `json:"expired,omitempty"`               // Indicates whether the restore job expired.
+	ExpiresAt             string   `json:"expiresAt,omitempty"`             // UTC ISO 8601 formatted point in time when the restore job expires.
+	FinishedAt            string   `json:"finishedAt,omitempty"`            // UTC ISO 8601 formatted point in time when the restore job completed.
+	Links                 []*Link  `json:"links,omitempty"`                 // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
+	Timestamp             string   `json:"timestamp,omitempty"`             // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
+	OplogTs               string   `json:"oplogTs,omitempty"`               // If your cluster has Point-in-Time restores enabled, you can specify a timestamp from the oplog from which to restore a backup.
+	PointInTimeUTCSeconds int64    `json:"pointInTimeUTCSeconds,omitempty"` // If your cluster has Point-in-Time restores enabled, you can specify a Unix time in seconds since epoch from which to restore a backup.
 }
 
 // CloudProviderSnapshotRestoreJobs represents an array of cloudProviderSnapshotRestoreJob

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -32,7 +32,7 @@ var _ CloudProviderSnapshotRestoreJobsService = &CloudProviderSnapshotRestoreJob
 type CloudProviderSnapshotRestoreJob struct {
 	ID                    string   `json:"id,omitempty"`                    // The unique identifier of the restore job.
 	SnapshotID            string   `json:"snapshotId,omitempty"`            // Unique identifier of the snapshot to restore.
-	DeliveryType          string   `json:"deliveryType,omitempty"`          // Type of restore job to create. Possible values are: automated or download
+	DeliveryType          string   `json:"deliveryType,omitempty"`          // Type of restore job to create. Possible values are: automated or download or pointInTime
 	DeliveryURL           []string `json:"deliveryUrl,omitempty"`           // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
 	TargetClusterName     string   `json:"targetClusterName,omitempty"`     // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
 	TargetGroupID         string   `json:"targetGroupId,omitempty"`         // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
@@ -43,8 +43,9 @@ type CloudProviderSnapshotRestoreJob struct {
 	FinishedAt            string   `json:"finishedAt,omitempty"`            // UTC ISO 8601 formatted point in time when the restore job completed.
 	Links                 []*Link  `json:"links,omitempty"`                 // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
 	Timestamp             string   `json:"timestamp,omitempty"`             // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
-	OplogTs               string   `json:"oplogTs,omitempty"`               // If your cluster has Point-in-Time restores enabled, you can specify a timestamp from the oplog from which to restore a backup.
-	PointInTimeUTCSeconds int64    `json:"pointInTimeUTCSeconds,omitempty"` // If your cluster has Point-in-Time restores enabled, you can specify a Unix time in seconds since epoch from which to restore a backup.
+	OplogTs               int64    `json:"oplogTs,omitempty"`               // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot. This is the first part of an Oplog timestamp.
+	OplogInc              int64    `json:"oplogInc,omitempty"`              // Oplog operation number from which to you want to restore this snapshot. This is the second part of an Oplog timestamp.
+	PointInTimeUTCSeconds int64    `json:"pointInTimeUTCSeconds,omitempty"` // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which you want to restore this snapshot.
 }
 
 // CloudProviderSnapshotRestoreJobs represents an array of cloudProviderSnapshotRestoreJob

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
@@ -86,7 +86,9 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 						}
 					],
 					"snapshotId": "5b6211ff87d9d663c59d3feg",
-					"timestamp": "2018-08-01T20:02:07Z"
+					"timestamp": "2018-08-01T20:02:07Z",
+					"oplogTs":	"2018-08-01T20:02:07Z",
+					"pointInTimeUTCSeconds":	1583753751
 				}
 			],
 			"totalCount": 2
@@ -161,8 +163,10 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 						Rel:  "http://mms.mongodb.com/group",
 					},
 				},
-				SnapshotID: "5b6211ff87d9d663c59d3feg",
-				Timestamp:  "2018-08-01T20:02:07Z",
+				SnapshotID:            "5b6211ff87d9d663c59d3feg",
+				Timestamp:             "2018-08-01T20:02:07Z",
+				OplogTs:               "2018-08-01T20:02:07Z",
+				PointInTimeUTCSeconds: 1583753751,
 			},
 		},
 		TotalCount: 2,
@@ -214,7 +218,9 @@ func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
 			"snapshotId": "5b6211ff87d9d663c59d3feg",
 			"targetClusterName": "MyOtherCluster",
 			"targetGroupId": "5b6212af90dc76637950a2c6",
-			"timestamp": "2018-08-01T20:02:07Z"
+			"timestamp": "2018-08-01T20:02:07Z",
+			"oplogTs":	"2018-08-01T20:02:07Z",
+			"pointInTimeUTCSeconds": 1583753751
 		}`)
 	})
 
@@ -247,10 +253,12 @@ func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
 				Rel:  "http://mms.mongodb.com/group",
 			},
 		},
-		SnapshotID:        "5b6211ff87d9d663c59d3feg",
-		TargetClusterName: "MyOtherCluster",
-		TargetGroupID:     "5b6212af90dc76637950a2c6",
-		Timestamp:         "2018-08-01T20:02:07Z",
+		SnapshotID:            "5b6211ff87d9d663c59d3feg",
+		TargetClusterName:     "MyOtherCluster",
+		TargetGroupID:         "5b6212af90dc76637950a2c6",
+		Timestamp:             "2018-08-01T20:02:07Z",
+		OplogTs:               "2018-08-01T20:02:07Z",
+		PointInTimeUTCSeconds: 1583753751,
 	}
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
@@ -321,7 +329,9 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 			"snapshotId": "5b6211ff87d9d663c59d3feg",
 			"targetClusterName": "MyOtherCluster",
 			"targetGroupId": "5b6212af90dc76637950a2c6",
-			"timestamp": "2018-08-01T20:02:07Z"
+			"timestamp": "2018-08-01T20:02:07Z",
+			"oplogTs":	"2018-08-01T20:02:07Z",
+			"pointInTimeUTCSeconds": 1583753751
 		}`)
 	})
 
@@ -354,10 +364,12 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 				Rel:  "http://mms.mongodb.com/group",
 			},
 		},
-		SnapshotID:        "5b6211ff87d9d663c59d3feg",
-		TargetClusterName: "MyOtherCluster",
-		TargetGroupID:     "5b6212af90dc76637950a2c6",
-		Timestamp:         "2018-08-01T20:02:07Z",
+		SnapshotID:            "5b6211ff87d9d663c59d3feg",
+		TargetClusterName:     "MyOtherCluster",
+		TargetGroupID:         "5b6212af90dc76637950a2c6",
+		Timestamp:             "2018-08-01T20:02:07Z",
+		OplogTs:               "2018-08-01T20:02:07Z",
+		PointInTimeUTCSeconds: 1583753751,
 	}
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
@@ -87,8 +87,8 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 					],
 					"snapshotId": "5b6211ff87d9d663c59d3feg",
 					"timestamp": "2018-08-01T20:02:07Z",
-					"oplogTs":	"2018-08-01T20:02:07Z",
-					"pointInTimeUTCSeconds":	1583753751
+					"oplogTs":	1583753751,
+					"oplogInc":	1
 				}
 			],
 			"totalCount": 2
@@ -163,10 +163,10 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 						Rel:  "http://mms.mongodb.com/group",
 					},
 				},
-				SnapshotID:            "5b6211ff87d9d663c59d3feg",
-				Timestamp:             "2018-08-01T20:02:07Z",
-				OplogTs:               "2018-08-01T20:02:07Z",
-				PointInTimeUTCSeconds: 1583753751,
+				SnapshotID: "5b6211ff87d9d663c59d3feg",
+				Timestamp:  "2018-08-01T20:02:07Z",
+				OplogTs:    1583753751,
+				OplogInc:   1,
 			},
 		},
 		TotalCount: 2,
@@ -219,8 +219,8 @@ func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
 			"targetClusterName": "MyOtherCluster",
 			"targetGroupId": "5b6212af90dc76637950a2c6",
 			"timestamp": "2018-08-01T20:02:07Z",
-			"oplogTs":	"2018-08-01T20:02:07Z",
-			"pointInTimeUTCSeconds": 1583753751
+			"oplogTs":	1583753751,
+			"oplogInc":	1
 		}`)
 	})
 
@@ -253,12 +253,12 @@ func TestCloudProviderSnapshotRestoreJobs_Get(t *testing.T) {
 				Rel:  "http://mms.mongodb.com/group",
 			},
 		},
-		SnapshotID:            "5b6211ff87d9d663c59d3feg",
-		TargetClusterName:     "MyOtherCluster",
-		TargetGroupID:         "5b6212af90dc76637950a2c6",
-		Timestamp:             "2018-08-01T20:02:07Z",
-		OplogTs:               "2018-08-01T20:02:07Z",
-		PointInTimeUTCSeconds: 1583753751,
+		SnapshotID:        "5b6211ff87d9d663c59d3feg",
+		TargetClusterName: "MyOtherCluster",
+		TargetGroupID:     "5b6212af90dc76637950a2c6",
+		Timestamp:         "2018-08-01T20:02:07Z",
+		OplogTs:           1583753751,
+		OplogInc:          1,
 	}
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
@@ -330,8 +330,8 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 			"targetClusterName": "MyOtherCluster",
 			"targetGroupId": "5b6212af90dc76637950a2c6",
 			"timestamp": "2018-08-01T20:02:07Z",
-			"oplogTs":	"2018-08-01T20:02:07Z",
-			"pointInTimeUTCSeconds": 1583753751
+			"oplogTs":	1583753751,
+			"oplogInc":	1
 		}`)
 	})
 
@@ -364,12 +364,12 @@ func TestCloudProviderSnapshotRestoreJobs_Create(t *testing.T) {
 				Rel:  "http://mms.mongodb.com/group",
 			},
 		},
-		SnapshotID:            "5b6211ff87d9d663c59d3feg",
-		TargetClusterName:     "MyOtherCluster",
-		TargetGroupID:         "5b6212af90dc76637950a2c6",
-		Timestamp:             "2018-08-01T20:02:07Z",
-		OplogTs:               "2018-08-01T20:02:07Z",
-		PointInTimeUTCSeconds: 1583753751,
+		SnapshotID:        "5b6211ff87d9d663c59d3feg",
+		TargetClusterName: "MyOtherCluster",
+		TargetGroupID:     "5b6212af90dc76637950a2c6",
+		Timestamp:         "2018-08-01T20:02:07Z",
+		OplogTs:           1583753751,
+		OplogInc:          1,
 	}
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {


### PR DESCRIPTION
Added new three fields for Snapshot restore jobs called `oplogTs`, `oplogInc` and `pointInTimeUTCSeconds` and its test