### PR TITLE
feat: support the pagination at CloudProviderSnapshotRestoreJobsService.List

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -14,7 +14,7 @@ const (
 // endpoints of the MongoDB Atlas API.
 // See more: https://docs.atlas.mongodb.com/reference/api/cloudProviderSnapshotRestoreJobs/
 type CloudProviderSnapshotRestoreJobsService interface {
-	List(context.Context, *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJobs, *Response, error)
+	List(context.Context, *SnapshotReqPathParameters, *ListOptions) (*CloudProviderSnapshotRestoreJobs, *Response, error)
 	Get(context.Context, *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJob, *Response, error)
 	Create(context.Context, *SnapshotReqPathParameters, *CloudProviderSnapshotRestoreJob) (*CloudProviderSnapshotRestoreJob, *Response, error)
 	Delete(context.Context, *SnapshotReqPathParameters) (*Response, error)
@@ -57,7 +57,7 @@ type CloudProviderSnapshotRestoreJobs struct {
 
 //List gets all cloud provider snapshot restore jobs for the specified cluster.
 //See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs-get-all/
-func (s *CloudProviderSnapshotRestoreJobsServiceOp) List(ctx context.Context, requestParameters *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJobs, *Response, error) {
+func (s *CloudProviderSnapshotRestoreJobsServiceOp) List(ctx context.Context, requestParameters *SnapshotReqPathParameters, listOptions *ListOptions) (*CloudProviderSnapshotRestoreJobs, *Response, error) {
 	if requestParameters.GroupID == "" {
 		return nil, nil, NewArgError("groupId", "must be set")
 	}
@@ -66,6 +66,10 @@ func (s *CloudProviderSnapshotRestoreJobsServiceOp) List(ctx context.Context, re
 	}
 
 	path := fmt.Sprintf("%s/%s/clusters/%s/backup/restoreJobs", cloudProviderSnapshotsBasePath, requestParameters.GroupID, requestParameters.ClusterName)
+	path, err := setListOptions(path, listOptions)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
@@ -95,7 +95,7 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 		}`)
 	})
 
-	cloudProviderSnapshots, _, err := client.CloudProviderSnapshotRestoreJobs.List(ctx, requestParameters)
+	cloudProviderSnapshots, _, err := client.CloudProviderSnapshotRestoreJobs.List(ctx, requestParameters, nil)
 	if err != nil {
 		t.Fatalf("CloudProviderSnapshotRestoreJobs.List returned error: %v", err)
 	}


### PR DESCRIPTION
## Proposed changes

https://github.com/mongodb/go-client-mongodb-atlas/issues/95

Support the pagination of [CloudProviderSnapshotRestoreJobsService.List](https://pkg.go.dev/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas?tab=doc#CloudProviderSnapshotRestoreJobsService) and [CloudProviderSnapshotRestoreJobsServiceOp.List](https://pkg.go.dev/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas?tab=doc#CloudProviderSnapshotRestoreJobsServiceOp.List).

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

### Breaking change

The signature of [CloudProviderSnapshotRestoreJobsService.List](https://pkg.go.dev/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas?tab=doc#CloudProviderSnapshotRestoreJobsService) and [CloudProviderSnapshotRestoreJobsServiceOp.List](https://pkg.go.dev/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas?tab=doc#CloudProviderSnapshotRestoreJobsServiceOp.List) are changed.

The parameter `listOptions` is added.