### PR TITLE
CLOUDP-66612: fix json marshaling

### DIFF
--- a/mongodbatlas/data_lakes.go
+++ b/mongodbatlas/data_lakes.go
@@ -99,8 +99,8 @@ type DataLake struct {
 
 // DataLakeReqPathParameters represents all possible fields that can be updated in a data lake
 type DataLakeUpdateRequest struct {
-	CloudProviderConfig CloudProviderConfig `json:"cloudProviderConfig,omitempty"`
-	DataProcessRegion   DataProcessRegion   `json:"dataProcessRegion,omitempty"`
+	CloudProviderConfig *CloudProviderConfig `json:"cloudProviderConfig,omitempty"`
+	DataProcessRegion   *DataProcessRegion   `json:"dataProcessRegion,omitempty"`
 }
 
 // DataLakeReqPathParameters represents the required fields to create a new data lake

--- a/mongodbatlas/data_lakes_test.go
+++ b/mongodbatlas/data_lakes_test.go
@@ -216,13 +216,13 @@ func TestDataLake_Update(t *testing.T) {
 	dataLakeName := "UserMetricData"
 
 	updateRequest := &DataLakeUpdateRequest{
-		CloudProviderConfig: CloudProviderConfig{
+		CloudProviderConfig: &CloudProviderConfig{
 			AWSConfig: AwsCloudProviderConfig{
 				IAMAssumedRoleARN: "new_arn",
 				TestS3Bucket:      "new_bucket",
 			},
 		},
-		DataProcessRegion: DataProcessRegion{
+		DataProcessRegion: &DataProcessRegion{
 			CloudProvider: "AWS",
 			Region:        "DUBLIN_IRL",
 		},


### PR DESCRIPTION
## Description

This fixes marshalling so that it doesn't serialise an empty json object if some of the flags are not provided.

Link to any related issue(s): 
https://github.com/mongodb/mongocli/pull/240

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

