### PR TITLE
fix: add more fields to the search field

### DIFF
--- a/mongodbatlas/search.go
+++ b/mongodbatlas/search.go
@@ -219,8 +219,23 @@ type IndexMapping struct {
 
 // IndexField field specifications.
 type IndexField struct {
-	Analyzer string `json:"analyzer"`
-	Type     string `json:"type"`
+	Analyzer       string                 `json:"analyzer,omitempty"`
+	Type           string                 `json:"type"`
+	Tokenization   string                 `json:"tokenization,omitempty"` // edgeGram|nGram
+	MinGrams       *int                   `json:"minGrams,omitempty"`
+	MaxGrams       *int                   `json:"maxGrams,omitempty"`
+	FoldDiacritics *bool                  `json:"foldDiacritics,omitempty"`
+	Fields         *map[string]IndexField `json:"fields,omitempty"`
+	SearchAnalyzer string                 `json:"searchAnalyzer,omitempty"`
+	IndexOptions   string                 `json:"indexOptions,omitempty"` // docs|freqs|positions
+	Store          *bool                  `json:"store,omitempty"`
+	IgnoreAbove    *int                   `json:"ignoreAbove,omitempty"`
+	Norms          string                 `json:"norms,omitempty"` // include|omit
+	Dynamic        *bool                  `json:"dynamic,omitempty"`
+	Representation string                 `json:"representation,omitempty"`
+	IndexIntegers  *bool                  `json:"indexIntegers,omitempty"`
+	IndexDoubles   *bool                  `json:"indexDoubles,omitempty"`
+	IndexShapes    *bool                  `json:"indexShapes,omitempty"`
 }
 
 // SearchAnalyzer custom analyzer definition.


### PR DESCRIPTION
## Description

There are more properties to a search field than fully documented on the API

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code


