### PR TITLE
Custom db roles

### DIFF
--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -47,7 +47,7 @@ type InheritedRole struct {
 // CustomDBRole represents a Custom MongoDB Role in your cluster.
 type CustomDBRole struct {
 	Actions        []Action        `json:"actions,omitempty"`
-	InheritedRoles []InheritedRole `json:"inheritedRoles,omitempty"`
+	InheritedRoles []InheritedRole `json:"inheritedRoles"`
 	RoleName       string          `json:"roleName,omitempty"`
 }
 


### PR DESCRIPTION
## Description

- Removed the omitempty label from the InheritedRoles attribute, it allows removing the inherited roles properly as MongoDB documentation explains (if you want to remove them you need to pass an empty array to do it, with omitempty label it doesn't pass)


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code


