### PR TITLE
feature: add scope support for db users

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -43,8 +43,15 @@ type DatabaseUser struct {
 	AWSIAMType      string  `json:"awsIAMType,omitempty"`
 	GroupID         string  `json:"groupId,omitempty"`
 	Roles           []Role  `json:"roles,omitempty"`
+	Scopes          []Scope `json:"scopes,omitempty"`
 	Password        string  `json:"password,omitempty"`
 	Username        string  `json:"username,omitempty"`
+}
+
+// Scope represents a level of access to a particular cluster o data lake a database user may have
+type Scope struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 // Label containing key-value pairs that tag and categorize the database user

--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -48,7 +48,8 @@ type DatabaseUser struct {
 	Username        string  `json:"username,omitempty"`
 }
 
-// Scope represents a level of access to a particular cluster o data lake a database user may have
+// Scope if presents a database user only have access to the indicated resource
+// if none is given then it has access to all
 type Scope struct {
 	Name string `json:"name"`
 	Type string `json:"type"`


### PR DESCRIPTION
## Description

Adds support for scoping db users to a particular cluster or data lake

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code