### PR TITLE
CLOUDP-70755: Add DELETE /groups/{GROUP-ID}/users/{USER-ID} to atlas go client

### DIFF
--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -31,6 +31,7 @@ type ProjectsService interface {
 	Delete(context.Context, string) (*Response, error)
 	GetProjectTeamsAssigned(context.Context, string) (*TeamsAssigned, *Response, error)
 	AddTeamsToProject(context.Context, string, []*ProjectTeam) (*TeamsAssigned, *Response, error)
+	RemoveUserFromProject(context.Context, string, string) (*Response, error)
 }
 
 // ProjectsServiceOp handles communication with the Projects related methods of the
@@ -232,4 +233,25 @@ func (s *ProjectsServiceOp) AddTeamsToProject(ctx context.Context, projectID str
 	}
 
 	return root, resp, err
+}
+
+// RemoveUserFromProject removes user from a project
+// See more: https://docs.atlas.mongodb.com/reference/api/project-remove-user/
+func (s *ProjectsServiceOp) RemoveUserFromProject(ctx context.Context, projectID, userID string) (*Response, error){
+	if projectID == "" {
+		return nil, NewArgError("projectID", "must be set")
+	}
+
+	if userID == "" {
+		return nil, NewArgError("userID", "must be set")
+	}
+
+	path := fmt.Sprintf("%s/%s/users/%s", projectBasePath, projectID, userID)
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil,err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+	return resp, err
 }

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -237,7 +237,7 @@ func (s *ProjectsServiceOp) AddTeamsToProject(ctx context.Context, projectID str
 
 // RemoveUserFromProject removes user from a project
 // See more: https://docs.atlas.mongodb.com/reference/api/project-remove-user/
-func (s *ProjectsServiceOp) RemoveUserFromProject(ctx context.Context, projectID, userID string) (*Response, error){
+func (s *ProjectsServiceOp) RemoveUserFromProject(ctx context.Context, projectID, userID string) (*Response, error) {
 	if projectID == "" {
 		return nil, NewArgError("projectID", "must be set")
 	}
@@ -249,7 +249,7 @@ func (s *ProjectsServiceOp) RemoveUserFromProject(ctx context.Context, projectID
 	path := fmt.Sprintf("%s/%s/users/%s", projectBasePath, projectID, userID)
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
-		return nil,err
+		return nil, err
 	}
 
 	resp, err := s.Client.Do(ctx, req, nil)

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -22,6 +22,7 @@ const (
 
 // ProjectsService is an interface for interfacing with the Projects
 // endpoints of the MongoDB Atlas API.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/projects/
 type ProjectsService interface {
 	GetAllProjects(context.Context, *ListOptions) (*Projects, *Response, error)
@@ -78,6 +79,7 @@ type TeamsAssigned struct {
 }
 
 // GetAllProjects gets all project.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-get-all/
 func (s *ProjectsServiceOp) GetAllProjects(ctx context.Context, listOptions *ListOptions) (*Projects, *Response, error) {
 	path, err := setListOptions(projectBasePath, listOptions)
@@ -104,6 +106,7 @@ func (s *ProjectsServiceOp) GetAllProjects(ctx context.Context, listOptions *Lis
 }
 
 // GetOneProject gets a single project.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-get-one/
 func (s *ProjectsServiceOp) GetOneProject(ctx context.Context, projectID string) (*Project, *Response, error) {
 	if projectID == "" {
@@ -127,6 +130,7 @@ func (s *ProjectsServiceOp) GetOneProject(ctx context.Context, projectID string)
 }
 
 // GetOneProjectByName gets a single project by its name.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-get-one-by-name/
 func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName string) (*Project, *Response, error) {
 	if projectName == "" {
@@ -150,6 +154,7 @@ func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName
 }
 
 // Create creates a project.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-create-one/
 func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project) (*Project, *Response, error) {
 	if createRequest == nil {
@@ -171,6 +176,7 @@ func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project) 
 }
 
 // Delete deletes a project.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-delete-one/
 func (s *ProjectsServiceOp) Delete(ctx context.Context, projectID string) (*Response, error) {
 	if projectID == "" {
@@ -190,6 +196,7 @@ func (s *ProjectsServiceOp) Delete(ctx context.Context, projectID string) (*Resp
 }
 
 // GetProjectTeamsAssigned gets all the teams assigned to a project.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-get-teams/
 func (s *ProjectsServiceOp) GetProjectTeamsAssigned(ctx context.Context, projectID string) (*TeamsAssigned, *Response, error) {
 	if projectID == "" {
@@ -213,6 +220,7 @@ func (s *ProjectsServiceOp) GetProjectTeamsAssigned(ctx context.Context, project
 }
 
 // AddTeamsToProject adds teams to a project
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-add-team/
 func (s *ProjectsServiceOp) AddTeamsToProject(ctx context.Context, projectID string, createRequest []*ProjectTeam) (*TeamsAssigned, *Response, error) {
 	if createRequest == nil {
@@ -236,6 +244,7 @@ func (s *ProjectsServiceOp) AddTeamsToProject(ctx context.Context, projectID str
 }
 
 // RemoveUserFromProject removes user from a project
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/project-remove-user/
 func (s *ProjectsServiceOp) RemoveUserFromProject(ctx context.Context, projectID, userID string) (*Response, error) {
 	if projectID == "" {

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -371,15 +371,14 @@ func TestProject_AddTeamsToProject(t *testing.T) {
 	}
 }
 
-
 func TestProject_RemoveUserFromProject(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
 
 	projectID := "5a0a1e7e0f2912c554080adc"
-	userID:="1213232233243434"
+	userID := "1213232233243434"
 
-	mux.HandleFunc(fmt.Sprintf("/groups/%s/users/%s", projectID,userID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/users/%s", projectID, userID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -370,3 +370,21 @@ func TestProject_AddTeamsToProject(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+
+func TestProject_RemoveUserFromProject(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	projectID := "5a0a1e7e0f2912c554080adc"
+	userID:="1213232233243434"
+
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/users/%s", projectID,userID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.Projects.RemoveUserFromProject(ctx, projectID, userID)
+	if err != nil {
+		t.Fatalf("Projects.RemoveUserFromProject returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Description
Adding API call to [Remove One User from a Project](https://docs.atlas.mongodb.com/reference/api/project-remove-user/) that we need to implement the mongocli command `mongocli iam projects user(s) delete|rm`
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

