### PR TITLE
chore: update supported go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.12.x
-  - 1.13.x
   - 1.14.x
+  - 1.15.x
   - tip
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Go HTTP client for the [MongoDB Atlas API](https://docs.atlas.mongodb.com/api/).
 
-Currently, **atlas requires Go version 1.12 or greater**.
+Note that atlas only supports the two most recent major versions of Go.
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mongodb.org/atlas
 
-go 1.12
+go 1.14
 
 require (
 	github.com/go-test/deep v1.0.7


### PR DESCRIPTION
## Description

Go 1.15 was released the other day, we are adding support on our testing and I'm also proposing we follow a similar approach to go where they only support the last two major releases

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
