### PR TITLE
Setting the right auth db name 

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -9,13 +9,13 @@ import (
 const dbUsersBasePath = "groups/%s/databaseUsers"
 
 var adminX509Type = map[string]struct{}{
-	"MANAGED":  struct{}{},
-	"CUSTOMER": struct{}{},
+	"MANAGED":  {},
+	"CUSTOMER": {},
 }
 
 var awsIAMType = map[string]struct{}{
-	"USER": struct{}{},
-	"ROLE": struct{}{},
+	"USER": {},
+	"ROLE": {},
 }
 
 // DatabaseUsersService is an interface for interfacing with the Database Users

--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -58,6 +58,20 @@ type DatabaseUser struct {
 	Username        string  `json:"username,omitempty"`
 }
 
+//GetAuthDB by now just two dbs admin and &external
+func (user DatabaseUser) GetAuthDB() (name string) {
+	// base documentation https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/database_user
+	name = "admin"
+	_, isX509 := adminX509Type[user.X509Type]
+	_, isIAM := awsIAMType[user.AWSIAMType]
+
+	if isX509 || isIAM {
+		name = "$external"
+	}
+
+	return
+}
+
 // Scope if presents a database user only have access to the indicated resource
 // if none is given then it has access to all
 type Scope struct {
@@ -169,18 +183,7 @@ func (s *DatabaseUsersServiceOp) Update(ctx context.Context, groupID, username s
 
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
 
-	// documentation
-	// https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/database_user
-	authDatabaseName := "admin"
-
-	_, isX509 := adminX509Type[updateRequest.Username]
-	_, isIAM := awsIAMType[updateRequest.AWSIAMType]
-
-	if isX509 || isIAM {
-		authDatabaseName = "$external"
-	}
-
-	path := fmt.Sprintf("%s/%s/%s", basePath, authDatabaseName, username)
+	path := fmt.Sprintf("%s/%s/%s", basePath, updateRequest.GetAuthDB(), username)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {

--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -58,8 +58,8 @@ type DatabaseUser struct {
 	Username        string  `json:"username,omitempty"`
 }
 
-//GetAuthDB by now just two dbs admin and &external
-func (user DatabaseUser) GetAuthDB() (name string) {
+// GetAuthDB by now just two dbs admin and &external
+func (user *DatabaseUser) GetAuthDB() (name string) {
 	// base documentation https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/database_user
 	name = "admin"
 	_, isX509 := adminX509Type[user.X509Type]

--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -58,14 +58,18 @@ type DatabaseUser struct {
 	Username        string  `json:"username,omitempty"`
 }
 
-// GetAuthDB by now just two dbs admin and &external
+// GetAuthDB determines the authentication database based on the type of user.
+// LDAP, X509 and AWSIAM should all use $external.
+// SCRAM-SHA should use admin
 func (user *DatabaseUser) GetAuthDB() (name string) {
 	// base documentation https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/database_user
 	name = "admin"
 	_, isX509 := adminX509Type[user.X509Type]
 	_, isIAM := awsIAMType[user.AWSIAMType]
 
-	if isX509 || isIAM {
+	isLDAP := len(user.LDAPAuthType) > 0 && user.LDAPAuthType != "NONE"
+
+	if isX509 || isIAM || isLDAP {
 		name = "$external"
 	}
 

--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -158,7 +158,15 @@ func (s *DatabaseUsersServiceOp) Update(ctx context.Context, groupID, username s
 	}
 
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
-	path := fmt.Sprintf("%s/admin/%s", basePath, username)
+
+	// default
+	authDatabaseName := "admin"
+
+	if updateRequest.DatabaseName != "" {
+		authDatabaseName = updateRequest.DatabaseName
+	}
+
+	path := fmt.Sprintf("%s/%s/%s", basePath, authDatabaseName, username)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {


### PR DESCRIPTION
## Description

This small fix is related to https://github.com/mongodb/terraform-provider-mongodbatlas/issues/292
just extracting the **auth** db name in case of update minimal change. 

Tested locally (custom build) before updating the reference in the terraform repo 
```
leofigy@DESKTOP-IQOJR0Q:~/mongo/staging> terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # mongodbatlas_database_user.atlasexternal will be created
  + resource "mongodbatlas_database_user" "atlasexternal" {
      + auth_database_name = "$external"
      + aws_iam_type       = "NONE"
      + id                 = (known after apply)
      + project_id         = "REDACTED"
      + username           = "C=US,ST=California,L=CITY,O=COMPANY,OU=UNIT,CN=sampleuserX"
      + x509_type          = "CUSTOMER"

      + labels {
          + key   = "TestUser"
          + value = "External test"
        }

      + roles {
          + collection_name = (known after apply)
          + database_name   = "admin"
          + role_name       = "readWriteAnyDatabase"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mongodbatlas_database_user.atlasexternal: Creating...
mongodbatlas_database_user.atlasexternal: Creation complete after 1s [id=YXV0aF9kYXRhYmFzZV9uYW1l:JGV4dGVybmFs-cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2-dXNlcm5hbWU=:Qz1VUyxTVD1DYWxpZm9ybmlhLEw9Q0lUWSxPPUNPTVBBTlksT1U9VU5JVCxDTj1zYW1wbGV1c2VyWA==]


 ~ update in-place

Terraform will perform the following actions:

  # mongodbatlas_database_user.atlasexternal will be updated in-place
  ~ resource "mongodbatlas_database_user" "atlasexternal" {
        auth_database_name = "$external"
        aws_iam_type       = "NONE"
        id                 = "cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2-dXNlcm5hbWU=:Qz1VUyxTVD1DYWxpZm9ybmlhLEw9Q0lUWSxPPUNPTVBBTlksT1U9VU5JVCxDTj1zYW1wbGV1c2VyWA==-YXV0aF9kYXRhYmFzZV9uYW1l:JGV4dGVybmFs"
        project_id         = "5cf5a45a9ccf6400e60981b6"
        username           = "C=US,ST=California,L=CITY,O=COMPANY,OU=UNIT,CN=sampleuserX"
        x509_type          = "CUSTOMER"

        labels {
            key   = "TestUser"
            value = "External test"
        }

      - roles {
          - database_name = "admin" -> null
          - role_name     = "readWriteAnyDatabase" -> null
        }
      + roles {
          + collection_name = (known after apply)
          + database_name   = "admin"
          + role_name       = "atlasAdmin"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Terraform will perform the following actions:

  # mongodbatlas_database_user.atlasexternal will be updated in-place
  ~ resource "mongodbatlas_database_user" "atlasexternal" {
        auth_database_name = "$external"
        aws_iam_type       = "NONE"
        id                 = "dXNlcm5hbWU=:Qz1VUyxTVD1DYWxpZm9ybmlhLEw9Q0lUWSxPPUNPTVBBTlksT1U9VU5JVCxDTj1zYW1wbGV1c2VyWA==-YXV0aF9kYXRhYmFzZV9uYW1l:JGV4dGVybmFs-cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2"
        project_id         = "REDACTED"
        username           = "C=US,ST=California,L=CITY,O=COMPANY,OU=UNIT,CN=sampleuserX"
        x509_type          = "CUSTOMER"

        labels {
            key   = "TestUser"
            value = "External test"
        }

      - roles {
          - database_name = "admin" -> null
          - role_name     = "readWriteAnyDatabase" -> null
        }
      + roles {
          + collection_name = (known after apply)
          + database_name   = "admin"
          + role_name       = "atlasAdmin"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

```

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

