### PR TITLE
CLOUDP-72727: Fix LDAPConfigurationsService.Save to pass LDAPConfiguration as input

### DIFF
--- a/mongodbatlas/ldap_configurations.go
+++ b/mongodbatlas/ldap_configurations.go
@@ -188,7 +188,7 @@ func (s *LDAPConfigurationsServiceOp) Delete(ctx context.Context, groupID string
 		return nil, nil, NewArgError("groupID", "must be set")
 	}
 
-	path := fmt.Sprintf(ldapConfigurationPath, groupID)
+	path := fmt.Sprintf(ldapConfigurationPath + "/ldap/userToDNMapping", groupID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {

--- a/mongodbatlas/ldap_configurations.go
+++ b/mongodbatlas/ldap_configurations.go
@@ -19,7 +19,7 @@ type LDAPConfigurationsService interface {
 	Verify(context.Context, string, *LDAP) (*LDAPConfiguration, *Response, error)
 	Get(context.Context, string) (*LDAPConfiguration, *Response, error)
 	GetStatus(context.Context, string, string) (*LDAPConfiguration, *Response, error)
-	Save(context.Context, string, *LDAP) (*LDAPConfiguration, *Response, error)
+	Save(context.Context, string, *LDAPConfiguration) (*LDAPConfiguration, *Response, error)
 	Delete(context.Context, string) (*LDAPConfiguration, *Response, error)
 }
 
@@ -131,7 +131,7 @@ func (s *LDAPConfigurationsServiceOp) GetStatus(ctx context.Context, groupID, re
 // Save saves an LDAP configuration for a Atlas project.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/ldaps-configuration-save/
-func (s *LDAPConfigurationsServiceOp) Save(ctx context.Context, groupID string, configuration *LDAP) (*LDAPConfiguration, *Response, error) {
+func (s *LDAPConfigurationsServiceOp) Save(ctx context.Context, groupID string, configuration *LDAPConfiguration) (*LDAPConfiguration, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}

--- a/mongodbatlas/ldap_configurations.go
+++ b/mongodbatlas/ldap_configurations.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	ldapConfigurationPath       = "groups/%s/userSecurity"
-	ldapVerifyConfigurationPath = ldapConfigurationPath + "/ldap/verify"
+	ldapConfigurationPath                = "groups/%s/userSecurity"
+	ldapConfigurationPathuserToDNMapping = ldapConfigurationPath + "/ldap/userToDNMapping"
+	ldapVerifyConfigurationPath          = ldapConfigurationPath + "/ldap/verify"
 )
 
 // LDAPConfigurationsService is an interface of the LDAP Configuration
@@ -188,7 +189,7 @@ func (s *LDAPConfigurationsServiceOp) Delete(ctx context.Context, groupID string
 		return nil, nil, NewArgError("groupID", "must be set")
 	}
 
-	path := fmt.Sprintf(ldapConfigurationPath + "/ldap/userToDNMapping", groupID)
+	path := fmt.Sprintf(ldapConfigurationPathuserToDNMapping, groupID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {

--- a/mongodbatlas/ldap_configurations_test.go
+++ b/mongodbatlas/ldap_configurations_test.go
@@ -133,7 +133,7 @@ func TestLDAPConfigurations_Save(t *testing.T) {
 		}`)
 	})
 
-	request := &LDAP{}
+	request := &LDAPConfiguration{}
 	ldap, _, err := client.LDAPConfigurations.Save(ctx, groupID, request)
 	if err != nil {
 		t.Fatalf("LDAPConfigurations.Save returned error: %v", err)

--- a/mongodbatlas/ldap_configurations_test.go
+++ b/mongodbatlas/ldap_configurations_test.go
@@ -258,7 +258,7 @@ func TestLDAPConfigurations_Delete(t *testing.T) {
 			Hostname:              "atlas-ldaps-01.ldap.myteam.com",
 			Port:                  636,
 			BindUsername:          "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
-			AuthzQueryTemplate: "{USER}?memberOf?base",
+			AuthzQueryTemplate:    "{USER}?memberOf?base",
 		},
 	}
 

--- a/mongodbatlas/ldap_configurations_test.go
+++ b/mongodbatlas/ldap_configurations_test.go
@@ -28,7 +28,12 @@ func TestLDAPConfigurations_Verify(t *testing.T) {
 		}`)
 	})
 
-	request := &LDAP{}
+	request := &LDAP{
+		Hostname:     "atlas-ldaps-01.ldap.myteam.com",
+		Port:         636,
+		BindUsername: "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
+		BindPassword: "admin",
+	}
 	ldap, _, err := client.LDAPConfigurations.Verify(ctx, groupID, request)
 	if err != nil {
 		t.Fatalf("LDAPConfigurations.Verify returned error: %v", err)
@@ -133,7 +138,16 @@ func TestLDAPConfigurations_Save(t *testing.T) {
 		}`)
 	})
 
-	request := &LDAPConfiguration{}
+	request := &LDAPConfiguration{
+		LDAP: &LDAP{
+			AuthenticationEnabled: true,
+			AuthorizationEnabled:  true,
+			Hostname:              "atlas-ldaps-01.ldap.myteam.com",
+			Port:                  636,
+			BindUsername:          "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
+			BindPassword:          "admin",
+		},
+	}
 	ldap, _, err := client.LDAPConfigurations.Save(ctx, groupID, request)
 	if err != nil {
 		t.Fatalf("LDAPConfigurations.Save returned error: %v", err)

--- a/mongodbatlas/ldap_configurations_test.go
+++ b/mongodbatlas/ldap_configurations_test.go
@@ -232,7 +232,7 @@ func TestLDAPConfigurations_Delete(t *testing.T) {
 
 	groupID := "535683b3794d371327b"
 
-	mux.HandleFunc(fmt.Sprintf("/groups/%s/userSecurity", groupID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/userSecurity/ldap/userToDNMapping", groupID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 		fmt.Fprint(w, `{
 			  "ldap" : {
@@ -241,11 +241,7 @@ func TestLDAPConfigurations_Delete(t *testing.T) {
 				"authzQueryTemplate" : "{USER}?memberOf?base",
 				"bindUsername" : "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
 				"hostname" : "atlas-ldaps-01.ldap.myteam.com",
-				"port" : 636,
-				"userToDNMapping" : [ {
-				  "match" : "(.*)",
-				  "substitution" : "CN={0},CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"
-				} ]
+				"port" : 636
 			  }
 		}`)
 	})
@@ -262,12 +258,6 @@ func TestLDAPConfigurations_Delete(t *testing.T) {
 			Hostname:              "atlas-ldaps-01.ldap.myteam.com",
 			Port:                  636,
 			BindUsername:          "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
-			UserToDNMapping: []*UserToDNMapping{
-				{
-					Match:        "(.*)",
-					Substitution: "CN={0},CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
-				},
-			},
 			AuthzQueryTemplate: "{USER}?memberOf?base",
 		},
 	}


### PR DESCRIPTION
## Description
I discovered bugs in the implementation of the LDAP configuration api call https://github.com/mongodb/go-client-mongodb-atlas/pull/135#pullrequestreview-486081262 https://github.com/mongodb/go-client-mongodb-atlas/commit/346af62096340db047f8b37362d1b886868f454d:

1. `LDAPConfigurationsService.Save`  was using the struct `LDAP` instead of `LDAPConfiguration`
2. The path of the `LDAPConfigurationsService.Delete` was not correct


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

