### PR TITLE
add OrganizationsListOptions for filtering organization list results

### DIFF
--- a/mongodbatlas/mongodbatlas_test.go
+++ b/mongodbatlas/mongodbatlas_test.go
@@ -494,3 +494,55 @@ func checkCurrentPage(t *testing.T, resp *Response, expectedPage int) { //nolint
 		t.Fatalf("expected current page to be '%d', was '%d'", expectedPage, p)
 	}
 }
+
+func TestSetListOptions_EmptyBoolPtr(t *testing.T) {
+	type testListOptions struct {
+		Exists *bool `url:"exists,omitempty"`
+	}
+
+	boolPtr := func(b bool) *bool {
+		return &b
+	}
+	testBaseUrl := "www.example.com"
+
+	tests := []struct {
+		testName string
+		arg      *testListOptions
+		expected string
+	}{
+		{
+			testName: "true value",
+			arg: &testListOptions{
+				Exists: boolPtr(true),
+			},
+			expected: testBaseUrl + "?exists=true",
+		},
+		{
+			testName: "false value",
+			arg: &testListOptions{
+				Exists: boolPtr(false),
+			},
+			expected: testBaseUrl + "?exists=false",
+		},
+		{
+			testName: "omitted null value",
+			arg:      &testListOptions{},
+			expected: testBaseUrl,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Helper()
+			t.Log(tt.testName)
+
+			actual, err := setListOptions(testBaseUrl, tt.arg)
+			if err != nil {
+				t.Errorf("setListOptions() error = %v", err)
+			}
+			if actual != tt.expected {
+				t.Errorf("setListOptions() actual = %s, expected = %s", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/mongodbatlas/mongodbatlas_test.go
+++ b/mongodbatlas/mongodbatlas_test.go
@@ -503,7 +503,7 @@ func TestSetListOptions_EmptyBoolPtr(t *testing.T) {
 	boolPtr := func(b bool) *bool {
 		return &b
 	}
-	testBaseUrl := "www.example.com"
+	testBaseURL := "www.example.com"
 
 	tests := []struct {
 		testName string
@@ -515,19 +515,19 @@ func TestSetListOptions_EmptyBoolPtr(t *testing.T) {
 			arg: &testListOptions{
 				Exists: boolPtr(true),
 			},
-			expected: testBaseUrl + "?exists=true",
+			expected: testBaseURL + "?exists=true",
 		},
 		{
 			testName: "false value",
 			arg: &testListOptions{
 				Exists: boolPtr(false),
 			},
-			expected: testBaseUrl + "?exists=false",
+			expected: testBaseURL + "?exists=false",
 		},
 		{
 			testName: "omitted null value",
 			arg:      &testListOptions{},
-			expected: testBaseUrl,
+			expected: testBaseURL,
 		},
 	}
 
@@ -536,7 +536,7 @@ func TestSetListOptions_EmptyBoolPtr(t *testing.T) {
 			t.Helper()
 			t.Log(tt.testName)
 
-			actual, err := setListOptions(testBaseUrl, tt.arg)
+			actual, err := setListOptions(testBaseURL, tt.arg)
 			if err != nil {
 				t.Errorf("setListOptions() error = %v", err)
 			}

--- a/mongodbatlas/mongodbatlas_test.go
+++ b/mongodbatlas/mongodbatlas_test.go
@@ -532,6 +532,7 @@ func TestSetListOptions_EmptyBoolPtr(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
 			t.Helper()
 			t.Log(tt.testName)

--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -42,7 +42,8 @@ var _ OrganizationsService = &OrganizationsServiceOp{}
 
 // OrganizationsListOptions filtering options for organizations
 type OrganizationsListOptions struct {
-	Name string `url:"name,omitempty"`
+	Name               string `url:"name,omitempty"`
+	IncludeDeletedOrgs *bool  `url:"includeDeletedOrgs,omitempty"`
 	ListOptions
 }
 

--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -28,7 +28,7 @@ const (
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organizations/
 type OrganizationsService interface {
-	List(context.Context, *ListOptions) (*Organizations, *Response, error)
+	List(context.Context, *OrganizationsListOptions) (*Organizations, *Response, error)
 	Get(context.Context, string) (*Organization, *Response, error)
 	Projects(context.Context, string, *ListOptions) (*Projects, *Response, error)
 	Users(context.Context, string, *ListOptions) (*AtlasUsersResponse, *Response, error)
@@ -39,6 +39,12 @@ type OrganizationsService interface {
 type OrganizationsServiceOp service
 
 var _ OrganizationsService = &OrganizationsServiceOp{}
+
+// OrganizationsListOptions filtering options for organizations
+type OrganizationsListOptions struct {
+	Name string `url:"name,omitempty"`
+	ListOptions
+}
 
 // Organization represents the structure of an organization.
 type Organization struct {
@@ -58,7 +64,7 @@ type Organizations struct {
 // List gets all organizations.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organization-get-all/
-func (s *OrganizationsServiceOp) List(ctx context.Context, opts *ListOptions) (*Organizations, *Response, error) {
+func (s *OrganizationsServiceOp) List(ctx context.Context, opts *OrganizationsListOptions) (*Organizations, *Response, error) {
 	path, err := setListOptions(orgsBasePath, opts)
 	if err != nil {
 		return nil, nil, err

--- a/mongodbatlas/organizations_test.go
+++ b/mongodbatlas/organizations_test.go
@@ -23,75 +23,151 @@ import (
 )
 
 func TestOrganizationsServiceOp_List(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	t.Run("default", func(t *testing.T) {
+		client, mux, teardown := setup()
+		defer teardown()
 
-	mux.HandleFunc("/orgs", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-		_, _ = fmt.Fprint(w, `{
-			"links": [{
-				"href": "https://cloud.mongodb.com/api/public/v1.0/orgs",
-				"rel": "self"
-			}],
-			"results": [{
-				"id": "56a10a80e4b0fd3b9a9bb0c2",
+		mux.HandleFunc("/orgs", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			_, _ = fmt.Fprint(w, `{
 				"links": [{
-					"href": "https://cloud.mongodb.com/api/public/v1.0/orgs/56a10a80e4b0fd3b9a9bb0c2",
+					"href": "https://cloud.mongodb.com/api/public/v1.0/orgs",
 					"rel": "self"
 				}],
-				"name": "012i3091203jioawjioej"
-			}, {
-				"id": "56aa691ce4b0a0e8c4be51f7",
-				"links": [{
-					"href": "https://cloud.mongodb.com/api/public/v1.0/orgs/56aa691ce4b0a0e8c4be51f7",
-					"rel": "self"
+				"results": [{
+					"id": "56a10a80e4b0fd3b9a9bb0c2",
+					"links": [{
+						"href": "https://cloud.mongodb.com/api/public/v1.0/orgs/56a10a80e4b0fd3b9a9bb0c2",
+						"rel": "self"
+					}],
+					"name": "012i3091203jioawjioej"
+				}, {
+					"id": "56aa691ce4b0a0e8c4be51f7",
+					"links": [{
+						"href": "https://cloud.mongodb.com/api/public/v1.0/orgs/56aa691ce4b0a0e8c4be51f7",
+						"rel": "self"
+					}],
+					"name": "1454008603036"
 				}],
-				"name": "1454008603036"
-			}],
-			"totalCount": 2
-		}`)
+				"totalCount": 2
+			}`)
+		})
+
+		orgs, _, err := client.Organizations.List(ctx, nil)
+		if err != nil {
+			t.Fatalf("Organizations.List returned error: %v", err)
+		}
+
+		expected := &Organizations{
+			Links: []*Link{
+				{
+					Href: "https://cloud.mongodb.com/api/public/v1.0/orgs",
+					Rel:  "self",
+				},
+			},
+			Results: []*Organization{
+				{
+					ID: "56a10a80e4b0fd3b9a9bb0c2",
+					Links: []*Link{
+						{
+							Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/56a10a80e4b0fd3b9a9bb0c2",
+							Rel:  "self",
+						},
+					},
+					Name: "012i3091203jioawjioej",
+				},
+				{
+					ID: "56aa691ce4b0a0e8c4be51f7",
+					Links: []*Link{
+						{
+							Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/56aa691ce4b0a0e8c4be51f7",
+							Rel:  "self",
+						},
+					},
+					Name: "1454008603036",
+				},
+			},
+			TotalCount: 2,
+		}
+
+		if diff := deep.Equal(orgs, expected); diff != nil {
+			t.Error(diff)
+		}
 	})
+	t.Run("by page number", func(t *testing.T) {
+		client, mux, teardown := setup()
+		defer teardown()
 
-	orgs, _, err := client.Organizations.List(ctx, nil)
-	if err != nil {
-		t.Fatalf("Organizations.List returned error: %v", err)
-	}
-
-	expected := &Organizations{
-		Links: []*Link{
-			{
-				Href: "https://cloud.mongodb.com/api/public/v1.0/orgs",
-				Rel:  "self",
-			},
-		},
-		Results: []*Organization{
-			{
-				ID: "56a10a80e4b0fd3b9a9bb0c2",
-				Links: []*Link{
+		mux.HandleFunc("/orgs", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			_, _ = fmt.Fprint(w, `{
+				"links": [
 					{
-						Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/56a10a80e4b0fd3b9a9bb0c2",
-						Rel:  "self",
+						"href": "https://cloud.mongodb.com/api/public/v1.0/orgs?pageNum=1&itemsPerPage=1",
+						"rel": "previous"
 					},
-				},
-				Name: "012i3091203jioawjioej",
-			},
-			{
-				ID: "56aa691ce4b0a0e8c4be51f7",
-				Links: []*Link{
 					{
-						Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/56aa691ce4b0a0e8c4be51f7",
-						Rel:  "self",
+						"href": "https://cloud.mongodb.com/api/public/v1.0/orgs?pageNum=2&itemsPerPage=1",
+						"rel": "self"
 					},
-				},
-				Name: "1454008603036",
-			},
-		},
-		TotalCount: 2,
-	}
+					{
+						"href": "https://cloud.mongodb.com/api/public/v1.0/orgs?itemsPerPage=3&pageNum=2",
+						"rel": "next"
+					}
+				],
+				"results": [{
+					"id": "56a10a80e4b0fd3b9a9bb0c2",
+					"links": [{
+						"href": "https://cloud.mongodb.com/api/public/v1.0/orgs/56a10a80e4b0fd3b9a9bb0c2",
+						"rel": "self"
+					}],
+					"name": "FooBar"
+				}],
+				"totalCount": 3
+			}`)
+		})
 
-	if diff := deep.Equal(orgs, expected); diff != nil {
-		t.Error(diff)
-	}
+		opt := &OrganizationsListOptions{ListOptions: ListOptions{PageNum: 2}, Name: "FooBar"}
+
+		orgs, _, err := client.Organizations.List(ctx, opt)
+		if err != nil {
+			t.Fatalf("Organizations.List returned error: %v", err)
+		}
+
+		expected := &Organizations{
+			Links: []*Link{
+				{
+					Href: "https://cloud.mongodb.com/api/public/v1.0/orgs?pageNum=1&itemsPerPage=1",
+					Rel:  "previous",
+				},
+				{
+					Href: "https://cloud.mongodb.com/api/public/v1.0/orgs?pageNum=2&itemsPerPage=1",
+					Rel:  "self",
+				},
+				{
+					Href: "https://cloud.mongodb.com/api/public/v1.0/orgs?itemsPerPage=3&pageNum=2",
+					Rel:  "next",
+				},
+			},
+			Results: []*Organization{
+				{
+					ID: "56a10a80e4b0fd3b9a9bb0c2",
+					Links: []*Link{
+						{
+							Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/56a10a80e4b0fd3b9a9bb0c2",
+							Rel:  "self",
+						},
+					},
+					Name: "FooBar",
+				},
+			},
+			TotalCount: 3,
+		}
+
+		if diff := deep.Equal(orgs, expected); diff != nil {
+			t.Error(diff)
+		}
+	})
 }
 
 func TestOrganizationsServiceOp_Get(t *testing.T) {


### PR DESCRIPTION
## Description

Addresses #143 

The Ops Manager and Atlas API supports filtering Organization list results by the name, however this Go client does not support that at the moment. This PR would add that functionality and adds a test to help ensure it works.

I recognize this is a breaking change to the interface so I'm open to discussion on a better way to do it. Though I saw this pattern in `ContainersListOptions` which is where I adopted it from.

https://github.com/mongodb/go-client-mongodb-atlas/blob/d1f10b2b037bf8a783bada68f9c40f9d56a05a1f/mongodbatlas/containers.go#L30-L33

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

