### PR TITLE
letting 0 be as value in the threshold

### DIFF
--- a/mongodbatlas/alert_configurations.go
+++ b/mongodbatlas/alert_configurations.go
@@ -69,7 +69,7 @@ type Matcher struct {
 type MetricThreshold struct {
 	MetricName string  `json:"metricName,omitempty"` // Name of the metric to check.
 	Operator   string  `json:"operator,omitempty"`   // Operator to apply when checking the current metric value against the threshold value.
-	Threshold  float64 `json:"threshold,omitempty"`  // Threshold value outside of which an alert will be triggered.
+	Threshold  float64 `json:"threshold"`            // Threshold value outside of which an alert will be triggered.
 	Units      string  `json:"units,omitempty"`      // The units for the threshold value.
 	Mode       string  `json:"mode,omitempty"`       // This must be set to AVERAGE. Atlas computes the current metric value as an average.
 }


### PR DESCRIPTION
## Description

This is to fix for the case where the threshold is equal to 0 https://github.com/mongodb/terraform-provider-mongodbatlas/issues/311. that gets ignored when bypassing to the client.

Link to any related issue(s): 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code

## Further comments

