### PR TITLE
NOREF: Include userAlias for processes

### DIFF
--- a/mongodbatlas/processes.go
+++ b/mongodbatlas/processes.go
@@ -34,6 +34,7 @@ type Process struct {
 	ReplicaSetName string  `json:"replicaSetName"`
 	TypeName       string  `json:"typeName"`
 	Version        string  `json:"version"`
+	UserAlias      string  `json:"userAlias"`
 }
 
 // processesResponse is the response from Processes.List.

--- a/mongodbatlas/processes_test.go
+++ b/mongodbatlas/processes_test.go
@@ -54,7 +54,7 @@ func TestProcesses_ListProcesses(t *testing.T) {
 						"shardName": "shard-0",
 						"typeName": "REPLICA_PRIMARY",
 						"version": "3.6.7",
-						"userAlias": "zuul",
+						"userAlias": "zuul"
 					}
 				],
 				"totalCount": 2

--- a/mongodbatlas/processes_test.go
+++ b/mongodbatlas/processes_test.go
@@ -35,7 +35,7 @@ func TestProcesses_ListProcesses(t *testing.T) {
 						"shardName": "shard-0",
 						"typeName": "REPLICA_PRIMARY",
 						"version": "3.6.7",
-						"userAlias": "zuul",
+						"userAlias": "zuul"
 					},
 					{
 						"created": "2017-08-22T15:14:06Z",

--- a/mongodbatlas/processes_test.go
+++ b/mongodbatlas/processes_test.go
@@ -34,7 +34,8 @@ func TestProcesses_ListProcesses(t *testing.T) {
 						"replicaSetName": "replica-set-0",
 						"shardName": "shard-0",
 						"typeName": "REPLICA_PRIMARY",
-						"version": "3.6.7"
+						"version": "3.6.7",
+						"userAlias": "zuul",
 					},
 					{
 						"created": "2017-08-22T15:14:06Z",
@@ -52,7 +53,8 @@ func TestProcesses_ListProcesses(t *testing.T) {
 						"replicaSetName": "replica-set-0",
 						"shardName": "shard-0",
 						"typeName": "REPLICA_PRIMARY",
-						"version": "3.6.7"
+						"version": "3.6.7",
+						"userAlias": "zuul",
 					}
 				],
 				"totalCount": 2
@@ -82,6 +84,7 @@ func TestProcesses_ListProcesses(t *testing.T) {
 		ReplicaSetName: "replica-set-0",
 		TypeName:       "REPLICA_PRIMARY",
 		Version:        "3.6.7",
+		UserAlias:      "zuul",
 	}
 
 	expected := []*Process{&process, &process}
@@ -116,6 +119,7 @@ func TestProcesses_ListProcessesMultiplePages(t *testing.T) {
 					ReplicaSetName: "replica-set-0",
 					TypeName:       "REPLICA_PRIMARY",
 					Version:        "3.6.7",
+					UserAlias:      "zuul",
 				},
 				{
 					Created:  "2017-08-22T15:14:06Z",
@@ -134,6 +138,7 @@ func TestProcesses_ListProcessesMultiplePages(t *testing.T) {
 					ReplicaSetName: "replica-set-0",
 					TypeName:       "REPLICA_PRIMARY",
 					Version:        "3.6.7",
+					UserAlias:      "zuul",
 				},
 			},
 			Links: []*Link{
@@ -194,7 +199,8 @@ func TestProcesses_RetrievePageByNumber(t *testing.T) {
 					"replicaSetName": "replica-set-0",
 					"shardName": "shard-0",
 					"typeName": "REPLICA_PRIMARY",
-					"version": "3.6.7"
+					"version": "3.6.7",
+					"userAlias": "zuul"
 				}
 			],
 			"totalCount": 1


### PR DESCRIPTION
## Description

The Atlas API has support for returning the `userAlias` as part of the response body for listing all the processes under a project.

Documentation reference: https://docs.atlas.mongodb.com/reference/api/processes-get-all/

This PR makes sure that field is returned as part of the processes `List` function.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

