### PR TITLE
CLOUDP-78002: adds support for Atlas Error codes

### DIFF
--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -151,7 +151,7 @@ type ErrorResponse struct {
 	ErrorCode string `json:"errorCode"`
 
 	// HTTP status code.
-	HttpError int `json:"error"`
+	HTTPCode int `json:"error"`
 
 	// A short description of the error, which is simply the HTTP status phrase.
 	Reason string `json:"reason"`

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -146,8 +146,12 @@ type ListOptions struct {
 type ErrorResponse struct {
 	// HTTP response that caused this error
 	Response *http.Response
-	// The error code, which is simply the HTTP status code.
-	ErrorCode int `json:"Error"`
+
+	// The error code as specified in https://docs.atlas.mongodb.com/reference/api/api-errors/
+	ErrorCode string `json:"errorCode"`
+
+	// HTTP status code.
+	HttpError int `json:"error"`
 
 	// A short description of the error, which is simply the HTTP status phrase.
 	Reason string `json:"reason"`
@@ -421,7 +425,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 
 func (r *ErrorResponse) Error() string {
 	return fmt.Sprintf("%v %v: %d (request %q) %v",
-		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Reason, r.Detail)
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.ErrorCode, r.Detail)
 }
 
 // CheckResponse checks the API response for errors, and returns them if present. A response is considered an

--- a/mongodbatlas/mongodbatlas_test.go
+++ b/mongodbatlas/mongodbatlas_test.go
@@ -360,7 +360,11 @@ func TestCheckResponse(t *testing.T) {
 	res := &http.Response{
 		Request:    &http.Request{},
 		StatusCode: http.StatusBadRequest,
-		Body:       ioutil.NopCloser(strings.NewReader(`{"error":400, "reason":"r", "detail":"d"}`)),
+		Body: ioutil.NopCloser(
+			strings.NewReader(
+				`{"error":409, "errorCode": "GROUP_ALREADY_EXISTS", "reason":"Conflict", "detail":"A group with name \"Test\" already exists"}`,
+			),
+		),
 	}
 	err := CheckResponse(res).(*ErrorResponse)
 
@@ -370,9 +374,10 @@ func TestCheckResponse(t *testing.T) {
 
 	expected := &ErrorResponse{
 		Response:  res,
-		ErrorCode: 400,
-		Reason:    "r",
-		Detail:    "d",
+		HttpError: 409,
+		ErrorCode: "GROUP_ALREADY_EXISTS",
+		Reason:    "Conflict",
+		Detail:    `A group with name "Test" already exists`,
 	}
 	if !reflect.DeepEqual(err, expected) {
 		t.Errorf("Error = %#v, expected %#v", err, expected)

--- a/mongodbatlas/mongodbatlas_test.go
+++ b/mongodbatlas/mongodbatlas_test.go
@@ -374,7 +374,7 @@ func TestCheckResponse(t *testing.T) {
 
 	expected := &ErrorResponse{
 		Response:  res,
-		HttpError: 409,
+		HTTPCode:  409,
 		ErrorCode: "GROUP_ALREADY_EXISTS",
 		Reason:    "Conflict",
 		Detail:    `A group with name "Test" already exists`,


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-78002

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This is a fix adding the support for `errorCode` (https://docs.atlas.mongodb.com/reference/api/api-errors/).

**Important!** This is a breaking change as changes the type of the field `ErrorCode` from `int` to `string` and all the clients will have to change their codebase after using the new version of the library. This needs to be mentioned in the release notes.
(as discussed with the team we can afford to break this as the main clients don't use this object much - but will appreciate the alternative opinions)
