### PR TITLE
INTMDB-144: deleted omitempty for scopes of database users

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -53,7 +53,7 @@ type DatabaseUser struct {
 	AWSIAMType      string  `json:"awsIAMType,omitempty"`
 	GroupID         string  `json:"groupId,omitempty"`
 	Roles           []Role  `json:"roles,omitempty"`
-	Scopes          []Scope `json:"scopes,omitempty"`
+	Scopes          []Scope `json:"scopes"`
 	Password        string  `json:"password,omitempty"`
 	Username        string  `json:"username,omitempty"`
 }

--- a/mongodbatlas/database_users_test.go
+++ b/mongodbatlas/database_users_test.go
@@ -154,6 +154,7 @@ func TestDatabaseUsers_CreateWithX509Type(t *testing.T) {
 			DatabaseName: "admin",
 			RoleName:     "readWriteAnyDatabase",
 		}},
+		Scopes: []Scope{},
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/groups/%s/databaseUsers", groupID), func(w http.ResponseWriter, r *http.Request) {
@@ -167,6 +168,7 @@ func TestDatabaseUsers_CreateWithX509Type(t *testing.T) {
 				"databaseName": "admin",
 				"roleName":     "readWriteAnyDatabase",
 			}},
+			"scopes": []interface{}{},
 		}
 
 		var v map[string]interface{}
@@ -189,7 +191,8 @@ func TestDatabaseUsers_CreateWithX509Type(t *testing.T) {
 					"databaseName": "admin",
 					"roleName": "readWriteAnyDatabase"
 				}
-			]
+			],
+			"scopes" : []
 		}`)
 	})
 
@@ -220,6 +223,7 @@ func TestDatabaseUsers_CreateWithAWSIAMType(t *testing.T) {
 			DatabaseName: "admin",
 			RoleName:     "readWriteAnyDatabase",
 		}},
+		Scopes: []Scope{},
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/groups/%s/databaseUsers", groupID), func(w http.ResponseWriter, r *http.Request) {
@@ -233,6 +237,7 @@ func TestDatabaseUsers_CreateWithAWSIAMType(t *testing.T) {
 				"databaseName": "admin",
 				"roleName":     "readWriteAnyDatabase",
 			}},
+			"scopes": []interface{}{},
 		}
 
 		var v map[string]interface{}
@@ -255,7 +260,8 @@ func TestDatabaseUsers_CreateWithAWSIAMType(t *testing.T) {
 					"databaseName": "admin",
 					"roleName": "readWriteAnyDatabase"
 				}
-			]
+			],
+			"scopes" : []
 		}`)
 	})
 
@@ -287,6 +293,7 @@ func TestDatabaseUsers_Create(t *testing.T) {
 			CollectionName: "test-collection-name",
 			RoleName:       "test-role-name",
 		}},
+		Scopes: []Scope{},
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/groups/%s/databaseUsers", groupID), func(w http.ResponseWriter, r *http.Request) {
@@ -300,6 +307,7 @@ func TestDatabaseUsers_Create(t *testing.T) {
 				"collectionName": "test-collection-name",
 				"roleName":       "test-role-name",
 			}},
+			"scopes": []interface{}{},
 		}
 
 		jsonBlob := `
@@ -314,7 +322,8 @@ func TestDatabaseUsers_Create(t *testing.T) {
 					"collectionName": "test-collection-name",
 					"roleName": "test-role-name"
 				}
-			]
+			],
+			"scopes": []
 		}
 		`
 
@@ -471,6 +480,7 @@ func TestDatabaseUsers_Update(t *testing.T) {
 			CollectionName: "test-collection-name",
 			RoleName:       "test-role-name",
 		}},
+		Scopes: []Scope{},
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/groups/%s/databaseUsers/admin/%s", groupID, "test-username"), func(w http.ResponseWriter, r *http.Request) {
@@ -484,6 +494,7 @@ func TestDatabaseUsers_Update(t *testing.T) {
 				"collectionName": "test-collection-name",
 				"roleName":       "test-role-name",
 			}},
+			"scopes": []interface{}{},
 		}
 
 		jsonBlob := `
@@ -498,7 +509,8 @@ func TestDatabaseUsers_Update(t *testing.T) {
 					"collectionName": "test-collection-name",
 					"roleName": "test-role-name"
 				}
-			]
+			],
+			"scopes" : []
 		}
 		`
 


### PR DESCRIPTION
## Description

Delete the omitempty for scopes parameter so it can send an empty array of scopes in json request.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

