### PR TITLE
Fix broken link in api documentation for CloudProviderSnapshotRestoreJobsService.

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -12,7 +12,7 @@ const (
 
 // CloudProviderSnapshotRestoreJobsService is an interface for interfacing with the CloudProviderSnapshotRestoreJobs
 // endpoints of the MongoDB Atlas API.
-// See more: https://docs.atlas.mongodb.com/reference/api/cloudProviderSnapshotRestoreJobs/
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs/
 type CloudProviderSnapshotRestoreJobsService interface {
 	List(context.Context, *SnapshotReqPathParameters, *ListOptions) (*CloudProviderSnapshotRestoreJobs, *Response, error)
 	Get(context.Context, *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJob, *Response, error)


### PR DESCRIPTION
## Description

I noticed that this link was broken. Changed to be the same format as other API links in the documentation & verified it goes to the correct documentation page.

This seems to be the only such broken link in documentation for these interfaces.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works (NA)
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code