### PR TITLE
Add a helper method to group client options

### DIFF
--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -276,8 +276,20 @@ func NewClient(httpClient *http.Client) *Client {
 	return c
 }
 
-// ClientOpt are options for New.
+// ClientOpt configures a Client.
 type ClientOpt func(*Client) error
+
+// Options turns a list of ClientOpt instances into a ClientOpt.
+func Options(opts ...ClientOpt) ClientOpt {
+	return func(c *Client) error {
+		for _, opt := range opts {
+			if err := opt(c); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
 
 // New returns a new MongoDBAtlas API client instance.
 func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {


### PR DESCRIPTION
## Description

I'm planning a bit of a refactor on how we set up our client in the cli and this helper would be useful

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

