### PR TITLE
Add support for components in `CloudProviderSnapshotRestoreJob`

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -28,22 +28,23 @@ var _ CloudProviderSnapshotRestoreJobsService = &CloudProviderSnapshotRestoreJob
 
 // CloudProviderSnapshotRestoreJob represents the structure of a cloudProviderSnapshotRestoreJob.
 type CloudProviderSnapshotRestoreJob struct {
-	ID                    string   `json:"id,omitempty"`                    // The unique identifier of the restore job.
-	SnapshotID            string   `json:"snapshotId,omitempty"`            // Unique identifier of the snapshot to restore.
-	DeliveryType          string   `json:"deliveryType,omitempty"`          // Type of restore job to create. Possible values are: automated or download or pointInTime
-	DeliveryURL           []string `json:"deliveryUrl,omitempty"`           // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
-	TargetClusterName     string   `json:"targetClusterName,omitempty"`     // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
-	TargetGroupID         string   `json:"targetGroupId,omitempty"`         // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
-	Cancelled             bool     `json:"cancelled,omitempty"`             // Indicates whether the restore job was canceled.
-	CreatedAt             string   `json:"createdAt,omitempty"`             // UTC ISO 8601 formatted point in time when Atlas created the restore job.
-	Expired               bool     `json:"expired,omitempty"`               // Indicates whether the restore job expired.
-	ExpiresAt             string   `json:"expiresAt,omitempty"`             // UTC ISO 8601 formatted point in time when the restore job expires.
-	FinishedAt            string   `json:"finishedAt,omitempty"`            // UTC ISO 8601 formatted point in time when the restore job completed.
-	Links                 []*Link  `json:"links,omitempty"`                 // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
-	Timestamp             string   `json:"timestamp,omitempty"`             // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
-	OplogTs               int64    `json:"oplogTs,omitempty"`               //nolint:stylecheck // not changing this // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot. This is the first part of an Oplog timestamp.
-	OplogInc              int64    `json:"oplogInc,omitempty"`              // Oplog operation number from which to you want to restore this snapshot. This is the second part of an Oplog timestamp.
-	PointInTimeUTCSeconds int64    `json:"pointInTimeUTCSeconds,omitempty"` // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which you want to restore this snapshot.
+	ID                    string       `json:"id,omitempty"`                    // The unique identifier of the restore job.
+	SnapshotID            string       `json:"snapshotId,omitempty"`            // Unique identifier of the snapshot to restore.
+	Components            []*Component `json:"components,omitempty"`            // Collection of clusters to be downloaded. Atlas returns this parameter when restoring a sharded cluster and "deliveryType" : "download".
+	DeliveryType          string       `json:"deliveryType,omitempty"`          // Type of restore job to create. Possible values are: automated or download or pointInTime
+	DeliveryURL           []string     `json:"deliveryUrl,omitempty"`           // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
+	TargetClusterName     string       `json:"targetClusterName,omitempty"`     // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
+	TargetGroupID         string       `json:"targetGroupId,omitempty"`         // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
+	Cancelled             bool         `json:"cancelled,omitempty"`             // Indicates whether the restore job was canceled.
+	CreatedAt             string       `json:"createdAt,omitempty"`             // UTC ISO 8601 formatted point in time when Atlas created the restore job.
+	Expired               bool         `json:"expired,omitempty"`               // Indicates whether the restore job expired.
+	ExpiresAt             string       `json:"expiresAt,omitempty"`             // UTC ISO 8601 formatted point in time when the restore job expires.
+	FinishedAt            string       `json:"finishedAt,omitempty"`            // UTC ISO 8601 formatted point in time when the restore job completed.
+	Links                 []*Link      `json:"links,omitempty"`                 // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
+	Timestamp             string       `json:"timestamp,omitempty"`             // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
+	OplogTs               int64        `json:"oplogTs,omitempty"`               //nolint:stylecheck // not changing this // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot. This is the first part of an Oplog timestamp.
+	OplogInc              int64        `json:"oplogInc,omitempty"`              // Oplog operation number from which to you want to restore this snapshot. This is the second part of an Oplog timestamp.
+	PointInTimeUTCSeconds int64        `json:"pointInTimeUTCSeconds,omitempty"` // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which you want to restore this snapshot.
 }
 
 // CloudProviderSnapshotRestoreJobs represents an array of cloudProviderSnapshotRestoreJob
@@ -51,6 +52,11 @@ type CloudProviderSnapshotRestoreJobs struct {
 	Links      []*Link                            `json:"links"`
 	Results    []*CloudProviderSnapshotRestoreJob `json:"results"`
 	TotalCount int                                `json:"totalCount"`
+}
+
+type Component struct {
+	DownloadURL    string `json:"downloadUrl"`    // URL from which the snapshot of the components.replicaSetName should be downloaded. Atlas returns null for this parameter if the download URL has expired, has been used, or hasn't been created.
+	ReplicaSetName string `json:"replicaSetName"` // Name of the shard or config server included in the snapshot.
 }
 
 // List gets all cloud provider snapshot restore jobs for the specified cluster.

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs_test.go
@@ -62,6 +62,16 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 				{
 					"cancelled": false,
 					"createdAt": "2018-08-01T22:05:41Z",
+					"components": [
+						{
+							"downloadUrl": "https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f-config.tar.gz",
+							"replicaSetName": "atlas-abcdef-config-0"
+						},
+						{
+							"downloadUrl": "https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f.tar.gz",
+							"replicaSetName": "atlas-abcdef-shard-0"
+						}
+					],
 					"deliveryType": "download",
 					"deliveryUrl": ["https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f.tar.gz"],
 					"expired": false,
@@ -90,6 +100,7 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 					"oplogTs":	1583753751,
 					"oplogInc":	1
 				}
+
 			],
 			"totalCount": 2
 		}`)
@@ -138,8 +149,18 @@ func TestCloudProviderSnapshotRestoreJobs_List(t *testing.T) {
 				Timestamp:         "2018-08-01T20:02:07Z",
 			},
 			{
-				Cancelled:    false,
-				CreatedAt:    "2018-08-01T22:05:41Z",
+				Cancelled: false,
+				CreatedAt: "2018-08-01T22:05:41Z",
+				Components: []*Component{
+					{
+						DownloadURL:    "https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f-config.tar.gz",
+						ReplicaSetName: "atlas-abcdef-config-0",
+					},
+					{
+						DownloadURL:    "https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f.tar.gz",
+						ReplicaSetName: "atlas-abcdef-shard-0",
+					},
+				},
 				DeliveryType: "download",
 				DeliveryURL:  []string{"https://restore.mongodb.net:27017/restore-5b622e3587d9d6039faf713f.tar.gz"},
 				Expired:      false,


### PR DESCRIPTION
## Description

Adds the Components array to the struct `CloudProviderSnapshotRestoreJob`.

Link to any related issue(s): #171 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code