### PR TITLE
INTMDB-167: URL encode private enpoint ID

### DIFF
--- a/mongodbatlas/private_endpoints.go
+++ b/mongodbatlas/private_endpoints.go
@@ -259,7 +259,7 @@ func (s *PrivateEndpointsServiceOp) DeleteOnePrivateEndpoint(ctx context.Context
 	}
 
 	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
-	path := fmt.Sprintf("%s/%s/endpointService/%s/endpoint/%s", basePath, cloudProvider, endpointServiceID, privateEndpointID)
+	path := fmt.Sprintf("%s/%s/endpointService/%s/endpoint/%s", basePath, cloudProvider, endpointServiceID, url.PathEscape(privateEndpointID))
 
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {

--- a/mongodbatlas/private_endpoints.go
+++ b/mongodbatlas/private_endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 const privateEndpointsPath = "groups/%s/privateEndpoint"
@@ -224,7 +225,7 @@ func (s *PrivateEndpointsServiceOp) GetOnePrivateEndpoint(ctx context.Context, g
 	}
 
 	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
-	path := fmt.Sprintf("%s/%s/endpointService/%s/endpoint/%s", basePath, cloudProvider, endpointServiceID, privateEndpointID)
+	path := fmt.Sprintf("%s/%s/endpointService/%s/endpoint/%s", basePath, cloudProvider, endpointServiceID, url.PathEscape(privateEndpointID))
 
 	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {

--- a/mongodbatlas/private_endpoints_test.go
+++ b/mongodbatlas/private_endpoints_test.go
@@ -532,7 +532,7 @@ func TestPrivateEndpoints_DeleteOneInterfaceEndpointAzure(t *testing.T) {
 
 	groupID := "1"
 	privateLinkID := "5df264b8f10fab7d2cad2f0d"
-	interfaceEndpointID := "vpce-0b9c5701325cb15dd"
+	interfaceEndpointID := "subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test"
 
 	mux.HandleFunc(fmt.Sprintf("/groups/%s/privateEndpoint/%s/endpointService/%s/endpoint/%s", groupID, "AZURE", privateLinkID, interfaceEndpointID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/mongodbatlas/private_endpoints_test.go
+++ b/mongodbatlas/private_endpoints_test.go
@@ -479,7 +479,8 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointAzure(t *testing.T) {
 	privateLinkID := "5df264b8f10fab7d2cad2f0d"
 	interfaceEndpointID := "/subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test"
 
-	path := fmt.Sprintf("/groups/%s/privateEndpoint/%s/endpointService/%s/endpoint/%s", groupID, "AZURE", privateLinkID, "%2Fsubscriptions%2F19265c27-b60e-4c3b-9426-ae3f507300b5%2FresourceGroups%2Ftest%2Fproviders%2FMicrosoft.Network%2FprivateEndpoints%2Ftest")
+	path :=fmt.Sprintf("/groups/%s/privateEndpoint/%s/endpointService/%s/endpoint%s", groupID, "AZURE", privateLinkID, interfaceEndpointID)
+
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
@@ -497,7 +498,7 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointAzure(t *testing.T) {
 
 	expected := &InterfaceEndpointConnection{
 		PrivateEndpointIPAddress:  "10.0.0.4",
-		PrivateEndpointResourceID: "/subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test",
+		PrivateEndpointResourceID: interfaceEndpointID,
 		ConnectionStatus:          "INITIATING",
 		DeleteRequested:           pointy.Bool(false),
 	}

--- a/mongodbatlas/private_endpoints_test.go
+++ b/mongodbatlas/private_endpoints_test.go
@@ -477,12 +477,13 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointAzure(t *testing.T) {
 
 	groupID := "1"
 	privateLinkID := "5df264b8f10fab7d2cad2f0d"
-	interfaceEndpointID := "vpce-0b9c5701325cb15dd"
+	interfaceEndpointID := "/subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test"
 
-	mux.HandleFunc(fmt.Sprintf("/groups/%s/privateEndpoint/%s/endpointService/%s/endpoint/%s", groupID, "AZURE", privateLinkID, interfaceEndpointID), func(w http.ResponseWriter, r *http.Request) {
+	path := fmt.Sprintf("/groups/%s/privateEndpoint/%s/endpointService/%s/endpoint/%s", groupID, "AZURE", privateLinkID, "%2Fsubscriptions%2F19265c27-b60e-4c3b-9426-ae3f507300b5%2FresourceGroups%2Ftest%2Fproviders%2FMicrosoft.Network%2FprivateEndpoints%2Ftest")
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
-			"privateEndpointResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/privatelink/providers/Microsoft.Network/privateEndpoints/test",
+			"privateEndpointResourceId": "/subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test",
 			"privateEndpointIPAddress": "10.0.0.4",
 			"connectionStatus": "INITIATING",
 			"deleteRequested": false
@@ -496,7 +497,7 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointAzure(t *testing.T) {
 
 	expected := &InterfaceEndpointConnection{
 		PrivateEndpointIPAddress:  "10.0.0.4",
-		PrivateEndpointResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/privatelink/providers/Microsoft.Network/privateEndpoints/test",
+		PrivateEndpointResourceID: "/subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test",
 		ConnectionStatus:          "INITIATING",
 		DeleteRequested:           pointy.Bool(false),
 	}

--- a/mongodbatlas/private_endpoints_test.go
+++ b/mongodbatlas/private_endpoints_test.go
@@ -479,7 +479,7 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointAzure(t *testing.T) {
 	privateLinkID := "5df264b8f10fab7d2cad2f0d"
 	interfaceEndpointID := "/subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test"
 
-	path :=fmt.Sprintf("/groups/%s/privateEndpoint/%s/endpointService/%s/endpoint%s", groupID, "AZURE", privateLinkID, interfaceEndpointID)
+	path := fmt.Sprintf("/groups/%s/privateEndpoint/%s/endpointService/%s/endpoint%s", groupID, "AZURE", privateLinkID, interfaceEndpointID)
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)


### PR DESCRIPTION
## Description

[Get one private endpoint](https://docs.atlas.mongodb.com/reference/api/private-endpoints-endpoint-get-one) needs url encoding for `ENDPOINT-ID` when used with azure.

[Delete one private endpoint](https://docs.atlas.mongodb.com/reference/api/private-endpoints-endpoint-delete-one) needs url encoding for `ENDPOINT-ID` when used with azure.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments
Tested with mongocli

```
./bin/mongocli atlas privateendpoint azure interface describe 6009a7a62cde816e1914b656 --privateEndpointId /subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test

ID                                                                                                                          IP ADDRESS   STATUS   ERROR
/subscriptions/19265c27-b60e-4c3b-9426-ae3f507300b5/resourceGroups/test/providers/Microsoft.Network/privateEndpoints/test   10.0.0.4

```
