### PR TITLE
CLOUDP-81043: add Regionalized Private Endpoint Status to atlas go client

### DIFF
--- a/mongodbatlas/private_endpoints.go
+++ b/mongodbatlas/private_endpoints.go
@@ -6,7 +6,10 @@ import (
 	"net/http"
 )
 
-const privateEndpointsPath = "groups/%s/privateEndpoint"
+const (
+	privateEndpointsPath = "groups/%s/privateEndpoint"
+	regionalModePath     = privateEndpointsPath + "/regionalMode"
+)
 
 // PrivateEndpointsService is an interface for interfacing with the Private Endpoints
 // of the MongoDB Atlas API.
@@ -20,6 +23,8 @@ type PrivateEndpointsService interface {
 	AddOnePrivateEndpoint(context.Context, string, string, string, *InterfaceEndpointConnection) (*InterfaceEndpointConnection, *Response, error)
 	GetOnePrivateEndpoint(context.Context, string, string, string, string) (*InterfaceEndpointConnection, *Response, error)
 	DeleteOnePrivateEndpoint(context.Context, string, string, string, string) (*Response, error)
+	UpdateRegionalizedPrivateEndpointSetting(context.Context, string, bool) (*RegionalizedPrivateEndpointSetting, *Response, error)
+	GetRegionalizedPrivateEndpointSetting(context.Context, string) (*RegionalizedPrivateEndpointSetting, *Response, error)
 }
 
 // PrivateEndpointsServiceOp handles communication with the PrivateEndpoints related methods
@@ -52,6 +57,11 @@ type InterfaceEndpointConnection struct {
 	DeleteRequested               *bool  `json:"deleteRequested,omitempty"`               // Indicates if Atlas received a request to remove the interface endpoint from the private endpoint connection.
 	ErrorMessage                  string `json:"errorMessage,omitempty"`                  // Error message pertaining to the interface endpoint. Returns null if there are no errors.
 	ConnectionStatus              string `json:"connectionStatus,omitempty"`              // Status of the interface endpoint: NONE, PENDING_ACCEPTANCE, PENDING, AVAILABLE, REJECTED, DELETING.
+}
+
+// RegionalizedPrivateEndpointSetting represents MongoDB Regionalized private Endpoint Setting.
+type RegionalizedPrivateEndpointSetting struct {
+	Enabled bool `json:"enabled"` // Flag that indicates whether the regionalized private endpoint setting is enabled for one Atlas project.
 }
 
 // Create one private endpoint service for AWS or Azure in an Atlas project.
@@ -266,4 +276,50 @@ func (s *PrivateEndpointsServiceOp) DeleteOnePrivateEndpoint(ctx context.Context
 	}
 
 	return s.Client.Do(ctx, req, nil)
+}
+
+// UpdateRegionalizedPrivateEndpointSetting updates the regionalized private endpoint setting for one Atlas project.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoints-update-regional-mode
+func (s *PrivateEndpointsServiceOp) UpdateRegionalizedPrivateEndpointSetting(ctx context.Context, groupID string, enabled bool) (*RegionalizedPrivateEndpointSetting, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(regionalModePath, groupID)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, enabled)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(RegionalizedPrivateEndpointSetting)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// GetRegionalizedPrivateEndpointSetting updates the regionalized private endpoint setting for one Atlas project.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoints-get-regional-mode
+func (s *PrivateEndpointsServiceOp) GetRegionalizedPrivateEndpointSetting(ctx context.Context, groupID string) (*RegionalizedPrivateEndpointSetting, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(regionalModePath, groupID)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(RegionalizedPrivateEndpointSetting)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
 }

--- a/mongodbatlas/private_endpoints_test.go
+++ b/mongodbatlas/private_endpoints_test.go
@@ -541,3 +541,57 @@ func TestPrivateEndpoints_DeleteOneInterfaceEndpointAzure(t *testing.T) {
 		t.Errorf("PrivateEndpoints.DeleteOnePrivateEndpoint returned error: %v", err)
 	}
 }
+
+func TestPrivateEndpoints_UpdateRegionalizedPrivateEndpointSetting(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/privateEndpoint/regionalMode", groupID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		fmt.Fprint(w, `{
+			"enabled" : true
+		}`)
+	})
+
+	interfaceEndpoint, _, err := client.PrivateEndpoints.UpdateRegionalizedPrivateEndpointSetting(ctx, groupID, true)
+	if err != nil {
+		t.Errorf("PrivateEndpoints.UpdateRegionalizedPrivateEndpointSetting returned error: %v", err)
+	}
+
+	expected := &RegionalizedPrivateEndpointSetting{
+		Enabled: true,
+	}
+
+	if !reflect.DeepEqual(interfaceEndpoint, expected) {
+		t.Errorf("PrivateEndpoints.UpdateRegionalizedPrivateEndpointSetting\n got=%#v\nwant=%#v", interfaceEndpoint, expected)
+	}
+}
+
+func TestPrivateEndpoints_GetRegionalizedPrivateEndpointSetting(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "1"
+
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/privateEndpoint/regionalMode", groupID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"enabled" : true
+		}`)
+	})
+
+	interfaceEndpoint, _, err := client.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(ctx, groupID)
+	if err != nil {
+		t.Errorf("PrivateEndpoints.UpdateRegionalizedPrivateEndpointSetting returned error: %v", err)
+	}
+
+	expected := &RegionalizedPrivateEndpointSetting{
+		Enabled: true,
+	}
+
+	if !reflect.DeepEqual(interfaceEndpoint, expected) {
+		t.Errorf("PrivateEndpoints.UpdateRegionalizedPrivateEndpointSetting\n got=%#v\nwant=%#v", interfaceEndpoint, expected)
+	}
+}


### PR DESCRIPTION
add Regionalized Private Endpoint Status to atlas go client

- https://docs.atlas.mongodb.com/reference/api/private-endpoints-update-regional-mode
- https://docs.atlas.mongodb.com/reference/api/private-endpoints-get-regional-mode

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

