### PR TITLE
CLOUDP-83026: support for cluster status endpoint

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -420,18 +420,14 @@ func (s *ClustersServiceOp) Status(ctx context.Context, groupID, clusterName str
 	escapedEntry := url.PathEscape(clusterName)
 	path := fmt.Sprintf("%s/%s/status", basePath, escapedEntry)
 
+	var root ClusterStatus
 	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return ClusterStatus{}, nil, err
+		return root, nil, err
 	}
 
-	root := new(ClusterStatus)
-	resp, err := s.Client.Do(ctx, req, root)
-	if err != nil {
-		return ClusterStatus{}, resp, err
-	}
-
-	return *root, resp, err
+	resp, err := s.Client.Do(ctx, req, &root)
+	return root, resp, err
 }
 
 func checkClusterNameParam(clusterName string) error {

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -409,6 +409,7 @@ func (s *ClustersServiceOp) GetProcessArgs(ctx context.Context, groupID, cluster
 }
 
 // Status gets the status of the operation on the Cluster.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/clusters-check-operation-status/
 func (s *ClustersServiceOp) Status(ctx context.Context, groupID, clusterName string) (ClusterStatus, *Response, error) {
 	if err := checkClusterNameParam(clusterName); err != nil {

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -977,3 +977,27 @@ func TestClusters_Get(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+func TestClusters_Status(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "1"
+	clusterName := "appData"
+
+	mux.HandleFunc(fmt.Sprintf("/groups/%s/clusters/%s/status", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{ "changeStatus": "PENDING" }`)
+	})
+
+	status, _, err := client.Clusters.Status(ctx, groupID, clusterName)
+	if err != nil {
+		t.Fatalf("Clusters.Status returned error: %v", err)
+	}
+
+	expected := ClusterStatus{ChangeStatus: ChangeStatusPending}
+
+	if status != expected {
+		t.Errorf("Expected %v but got %v", expected, status)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds support for https://docs.atlas.mongodb.com/reference/api/clusters-check-operation-status/ endpoint to clusters.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

