### PR TITLE
CLOUDP-85749: Add new available region endpoint to the atlas go client

### DIFF
--- a/mongodbatlas/cloud_provider_regions.go
+++ b/mongodbatlas/cloud_provider_regions.go
@@ -1,0 +1,96 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	cloudProviderRegionsBasePath = "groups/%s/clusters/provider/regions"
+)
+
+// CloudProviderRegionsService is an interface for interfacing with the Cloud Provider Regions
+// endpoints of the MongoDB Atlas API.
+type CloudProviderRegionsService interface {
+	Get(context.Context, string, *CloudProviderRegionsOptions) (*CloudProviders, *Response, error)
+}
+
+// CloudProviderRegionsServiceOp handles communication with the CloudProviderRegionsService related methods of the
+// MongoDB Atlas API
+type CloudProviderRegionsServiceOp service
+
+var _ CloudProviderRegionsService = &CloudProviderRegionsServiceOp{}
+
+// CloudProvider represents a cloud provider of the MongoDB Atlas API
+type CloudProvider struct{
+	Provider string `json:"provider,omitempty"`
+	InstanceSizes []*InstanceSize `json:"instanceSizes,omitempty"`
+}
+
+// InstanceSize represents an instance size of the MongoDB Atlas API
+type InstanceSize struct{
+	Name string `json:"name,omitempty"`
+	AvailableRegions []*AvailableRegion `json:"availableRegions,omitempty"`
+}
+
+// AvailableRegion represents an available region of the MongoDB Atlas API
+type AvailableRegion struct{
+	Name string `json:"name,omitempty"`
+	Default bool `json:"default,omitempty"`
+}
+
+// CloudProviders represents the response from CloudProviderRegionsService.Get
+type CloudProviders struct{
+	Links      []*Link   `json:"links,omitempty"`
+	Results    []*CloudProvider `json:"results,omitempty"`
+	TotalCount int       `json:"totalCount,omitempty"`
+}
+
+// CloudProviderRegionsOptions specifies the optional parameters to the CloudProviderRegions Get method.
+type CloudProviderRegionsOptions struct {
+	Provider string `url:"provider,omitempty"`
+	Tier   string   `url:"tier,omitempty"`
+	CrossCloudProvider   bool   `url:"maxDate"`
+}
+
+// Get gets the available regions for each cloud provider
+func (s *CloudProviderRegionsServiceOp) Get(ctx context.Context, groupID string , options *CloudProviderRegionsOptions) (*CloudProviders, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupId", "must be set")
+	}
+
+	path := fmt.Sprintf(cloudProviderRegionsBasePath, groupID)
+
+	path, err := setListOptions(path, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CloudProviders)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}

--- a/mongodbatlas/cloud_provider_regions.go
+++ b/mongodbatlas/cloud_provider_regions.go
@@ -27,7 +27,7 @@ const (
 // CloudProviderRegionsService is an interface for interfacing with the Cloud Provider Regions
 // endpoints of the MongoDB Atlas API.
 type CloudProviderRegionsService interface {
-	Get(context.Context, string, *CloudProviderRegionsOptions) (*CloudProviders, *Response, error)
+	List(context.Context, string, *CloudProviderRegionsOptions) (*CloudProviders, *Response, error)
 }
 
 // CloudProviderRegionsServiceOp handles communication with the CloudProviderRegionsService related methods of the
@@ -68,8 +68,8 @@ type CloudProviderRegionsOptions struct {
 	CrossCloudProvider bool   `url:"maxDate"`
 }
 
-// Get gets the available regions for each cloud provider
-func (s *CloudProviderRegionsServiceOp) Get(ctx context.Context, groupID string, options *CloudProviderRegionsOptions) (*CloudProviders, *Response, error) {
+// List gets the available regions for each cloud provider
+func (s *CloudProviderRegionsServiceOp) List(ctx context.Context, groupID string, options *CloudProviderRegionsOptions) (*CloudProviders, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupId", "must be set")
 	}

--- a/mongodbatlas/cloud_provider_regions.go
+++ b/mongodbatlas/cloud_provider_regions.go
@@ -65,7 +65,7 @@ type CloudProviders struct {
 type CloudProviderRegionsOptions struct {
 	Provider           string `url:"provider,omitempty"`
 	Tier               string `url:"tier,omitempty"`
-	CrossCloudProvider bool   `url:"maxDate"`
+	CrossCloudProvider bool   `url:"crossCloudProvider"`
 }
 
 // List gets the available regions for each cloud provider

--- a/mongodbatlas/cloud_provider_regions.go
+++ b/mongodbatlas/cloud_provider_regions.go
@@ -37,39 +37,39 @@ type CloudProviderRegionsServiceOp service
 var _ CloudProviderRegionsService = &CloudProviderRegionsServiceOp{}
 
 // CloudProvider represents a cloud provider of the MongoDB Atlas API
-type CloudProvider struct{
-	Provider string `json:"provider,omitempty"`
+type CloudProvider struct {
+	Provider      string          `json:"provider,omitempty"`
 	InstanceSizes []*InstanceSize `json:"instanceSizes,omitempty"`
 }
 
 // InstanceSize represents an instance size of the MongoDB Atlas API
-type InstanceSize struct{
-	Name string `json:"name,omitempty"`
+type InstanceSize struct {
+	Name             string             `json:"name,omitempty"`
 	AvailableRegions []*AvailableRegion `json:"availableRegions,omitempty"`
 }
 
 // AvailableRegion represents an available region of the MongoDB Atlas API
-type AvailableRegion struct{
-	Name string `json:"name,omitempty"`
-	Default bool `json:"default,omitempty"`
+type AvailableRegion struct {
+	Name    string `json:"name,omitempty"`
+	Default bool   `json:"default,omitempty"`
 }
 
 // CloudProviders represents the response from CloudProviderRegionsService.Get
-type CloudProviders struct{
-	Links      []*Link   `json:"links,omitempty"`
+type CloudProviders struct {
+	Links      []*Link          `json:"links,omitempty"`
 	Results    []*CloudProvider `json:"results,omitempty"`
-	TotalCount int       `json:"totalCount,omitempty"`
+	TotalCount int              `json:"totalCount,omitempty"`
 }
 
 // CloudProviderRegionsOptions specifies the optional parameters to the CloudProviderRegions Get method.
 type CloudProviderRegionsOptions struct {
-	Provider string `url:"provider,omitempty"`
-	Tier   string   `url:"tier,omitempty"`
-	CrossCloudProvider   bool   `url:"maxDate"`
+	Provider           string `url:"provider,omitempty"`
+	Tier               string `url:"tier,omitempty"`
+	CrossCloudProvider bool   `url:"maxDate"`
 }
 
 // Get gets the available regions for each cloud provider
-func (s *CloudProviderRegionsServiceOp) Get(ctx context.Context, groupID string , options *CloudProviderRegionsOptions) (*CloudProviders, *Response, error) {
+func (s *CloudProviderRegionsServiceOp) Get(ctx context.Context, groupID string, options *CloudProviderRegionsOptions) (*CloudProviders, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupId", "must be set")
 	}

--- a/mongodbatlas/cloud_provider_regions_test.go
+++ b/mongodbatlas/cloud_provider_regions_test.go
@@ -16,9 +16,10 @@ package mongodbatlas
 
 import (
 	"fmt"
-	"github.com/go-test/deep"
 	"net/http"
 	"testing"
+
+	"github.com/go-test/deep"
 )
 
 func TestCloudProviderRegions_Get(t *testing.T) {
@@ -131,18 +132,18 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 	}
 
 	expected := &CloudProviders{
-		Links:      []*Link{
+		Links: []*Link{
 			{
 				Rel:  "self",
 				Href: "http://mongodb-cloud.com/api/atlas/v1.0/groups/60585bf86e35cb1e7fbe739f/clusters/provider/regions",
 			},
 		},
-		Results:    []*CloudProvider{
+		Results: []*CloudProvider{
 			{
-				Provider:      "AWS",
+				Provider: "AWS",
 				InstanceSizes: []*InstanceSize{
 					{
-						Name:             "R50",
+						Name: "R50",
 						AvailableRegions: []*AvailableRegion{
 							{
 								Name:    "US_EAST_1",
@@ -155,7 +156,7 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 						},
 					},
 					{
-						Name:             "M0",
+						Name: "M0",
 						AvailableRegions: []*AvailableRegion{
 							{
 								Name:    "US_EAST_1",
@@ -166,10 +167,10 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 				},
 			},
 			{
-				Provider:      "AZURE",
+				Provider: "AZURE",
 				InstanceSizes: []*InstanceSize{
 					{
-						Name:             "R50",
+						Name: "R50",
 						AvailableRegions: []*AvailableRegion{
 							{
 								Name:    "US_WEST_2",
@@ -182,7 +183,7 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 						},
 					},
 					{
-						Name:             "M0",
+						Name: "M0",
 						AvailableRegions: []*AvailableRegion{
 							{
 								Name:    "US_WEST_2",
@@ -193,10 +194,10 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 				},
 			},
 			{
-				Provider:      "GCP",
+				Provider: "GCP",
 				InstanceSizes: []*InstanceSize{
 					{
-						Name:             "R50",
+						Name: "R50",
 						AvailableRegions: []*AvailableRegion{
 							{
 								Name:    "CENTRAL_US",
@@ -209,7 +210,7 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 						},
 					},
 					{
-						Name:             "M0",
+						Name: "M0",
 						AvailableRegions: []*AvailableRegion{
 							{
 								Name:    "CENTRAL_US",
@@ -219,11 +220,10 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 					},
 				},
 			},
-
 		},
 		TotalCount: 3,
 	}
-	
+
 	if diff := deep.Equal(availableRegions, expected); diff != nil {
 		t.Error(diff)
 	}

--- a/mongodbatlas/cloud_provider_regions_test.go
+++ b/mongodbatlas/cloud_provider_regions_test.go
@@ -126,7 +126,7 @@ func TestCloudProviderRegions_Get(t *testing.T) {
 					}`)
 	})
 
-	availableRegions, _, err := client.CloudProviderRegions.Get(ctx, groupID, nil)
+	availableRegions, _, err := client.CloudProviderRegions.List(ctx, groupID, nil)
 	if err != nil {
 		t.Fatalf("CloudProviderRegions.Get returned error: %v", err)
 	}

--- a/mongodbatlas/cloud_provider_regions_test.go
+++ b/mongodbatlas/cloud_provider_regions_test.go
@@ -1,0 +1,230 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"fmt"
+	"github.com/go-test/deep"
+	"net/http"
+	"testing"
+)
+
+func TestCloudProviderRegions_Get(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "5b6212af90dc76637950a2c6"
+
+	path := fmt.Sprintf("/groups/%s/clusters/provider/regions", groupID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+						   "links":[
+							  {
+								 "href":"http://mongodb-cloud.com/api/atlas/v1.0/groups/60585bf86e35cb1e7fbe739f/clusters/provider/regions",
+								 "rel":"self"
+							  }
+						   ],
+						   "results":[
+							  {
+								 "instanceSizes":[
+									{
+									   "availableRegions":[
+										  {
+											 "default":true,
+											 "name":"US_EAST_1"
+										  },
+										  {
+											 "default":false,
+											 "name":"US_EAST_2"
+										  }
+									   ],
+									   "name":"R50"
+									},
+									{
+									   "availableRegions":[
+										  {
+											 "default":true,
+											 "name":"US_EAST_1"
+										  }
+									   ],
+									   "name":"M0"
+									}
+								 ],
+								 "provider":"AWS"
+							  },
+							  {
+								 "instanceSizes":[
+									{
+									   "availableRegions":[
+										  {
+											 "default":true,
+											 "name":"US_WEST_2"
+										  },
+										  {
+											 "default":false,
+											 "name":"US_CENTRAL"
+										  }
+									   ],
+									   "name":"R50"
+									},
+									{
+									   "availableRegions":[
+										  {
+											 "default":true,
+											 "name":"US_WEST_2"
+										  }
+									   ],
+									   "name":"M0"
+									}
+								 ],
+								 "provider":"AZURE"
+							  },
+							  {
+								 "instanceSizes":[
+									{
+									   "availableRegions":[
+										  {
+											 "default":true,
+											 "name":"CENTRAL_US"
+										  },
+										  {
+											 "default":false,
+											 "name":"EASTERN_US"
+										  }
+									   ],
+									   "name":"R50"
+									},
+									{
+									   "availableRegions":[
+										  {
+											 "default":true,
+											 "name":"CENTRAL_US"
+										  }
+									   ],
+									   "name":"M0"
+									}
+								 ],
+								 "provider":"GCP"
+							  }
+						   ],
+						   "totalCount":3
+					}`)
+	})
+
+	availableRegions, _, err := client.CloudProviderRegions.Get(ctx, groupID, nil)
+	if err != nil {
+		t.Fatalf("CloudProviderRegions.Get returned error: %v", err)
+	}
+
+	expected := &CloudProviders{
+		Links:      []*Link{
+			{
+				Rel:  "self",
+				Href: "http://mongodb-cloud.com/api/atlas/v1.0/groups/60585bf86e35cb1e7fbe739f/clusters/provider/regions",
+			},
+		},
+		Results:    []*CloudProvider{
+			{
+				Provider:      "AWS",
+				InstanceSizes: []*InstanceSize{
+					{
+						Name:             "R50",
+						AvailableRegions: []*AvailableRegion{
+							{
+								Name:    "US_EAST_1",
+								Default: true,
+							},
+							{
+								Name:    "US_EAST_2",
+								Default: false,
+							},
+						},
+					},
+					{
+						Name:             "M0",
+						AvailableRegions: []*AvailableRegion{
+							{
+								Name:    "US_EAST_1",
+								Default: true,
+							},
+						},
+					},
+				},
+			},
+			{
+				Provider:      "AZURE",
+				InstanceSizes: []*InstanceSize{
+					{
+						Name:             "R50",
+						AvailableRegions: []*AvailableRegion{
+							{
+								Name:    "US_WEST_2",
+								Default: true,
+							},
+							{
+								Name:    "US_CENTRAL",
+								Default: false,
+							},
+						},
+					},
+					{
+						Name:             "M0",
+						AvailableRegions: []*AvailableRegion{
+							{
+								Name:    "US_WEST_2",
+								Default: true,
+							},
+						},
+					},
+				},
+			},
+			{
+				Provider:      "GCP",
+				InstanceSizes: []*InstanceSize{
+					{
+						Name:             "R50",
+						AvailableRegions: []*AvailableRegion{
+							{
+								Name:    "CENTRAL_US",
+								Default: true,
+							},
+							{
+								Name:    "EASTERN_US",
+								Default: false,
+							},
+						},
+					},
+					{
+						Name:             "M0",
+						AvailableRegions: []*AvailableRegion{
+							{
+								Name:    "CENTRAL_US",
+								Default: true,
+							},
+						},
+					},
+				},
+			},
+
+		},
+		TotalCount: 3,
+	}
+	
+	if diff := deep.Equal(availableRegions, expected); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -136,6 +136,7 @@ type Client struct {
 	PerformanceAdvisor                  PerformanceAdvisorService
 	CloudProviderAccess                 CloudProviderAccessService
 	DefaultMongoDBMajorVersion          DefaultMongoDBMajorVersionService
+	CloudProviderRegions				CloudProviderRegionsService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -286,6 +287,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.PerformanceAdvisor = &PerformanceAdvisorServiceOp{Client: c}
 	c.CloudProviderAccess = &CloudProviderAccessServiceOp{Client: c}
 	c.DefaultMongoDBMajorVersion = &DefaultMongoDBMajorVersionServiceOp{Client: c}
+	c.CloudProviderRegions = &CloudProviderRegionsServiceOp{Client:c}
 
 	return c
 }

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -136,7 +136,7 @@ type Client struct {
 	PerformanceAdvisor                  PerformanceAdvisorService
 	CloudProviderAccess                 CloudProviderAccessService
 	DefaultMongoDBMajorVersion          DefaultMongoDBMajorVersionService
-	CloudProviderRegions				CloudProviderRegionsService
+	CloudProviderRegions                CloudProviderRegionsService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -287,7 +287,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.PerformanceAdvisor = &PerformanceAdvisorServiceOp{Client: c}
 	c.CloudProviderAccess = &CloudProviderAccessServiceOp{Client: c}
 	c.DefaultMongoDBMajorVersion = &DefaultMongoDBMajorVersionServiceOp{Client: c}
-	c.CloudProviderRegions = &CloudProviderRegionsServiceOp{Client:c}
+	c.CloudProviderRegions = &CloudProviderRegionsServiceOp{Client: c}
 
 	return c
 }


### PR DESCRIPTION
## Description

I have added the service to handle the endpoint `GET /api/atlas/v1.0/groups/{GROUP-ID}/clusters/provider/regions`


Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

