### PR TITLE
CLOUDP-85933: Add service to get the public ip to the atlas go client

### DIFF
--- a/mongodbatlas/ip_info.go
+++ b/mongodbatlas/ip_info.go
@@ -1,0 +1,57 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"net/http"
+)
+
+const ipInfoPath = "api/private/ipinfo"
+
+// IPInfoService is used to determine the public ip address of the client
+//
+// We currently make no promise to support or document this service or endpoint
+// beyond what can be seen here.
+type IPInfoService interface {
+	Get(context.Context) (*IPInfo, *Response, error)
+}
+
+// IPInfoService is an implementation of IPInfoService
+type IPInfoServiceOp struct {
+	Client PlainRequestDoer
+}
+
+var _ IPInfoService = &IPInfoServiceOp{}
+
+type IPInfo struct {
+	CurrentIPv4Address string `json:"currentIpv4Address"`
+}
+
+// Get gets the public ip address of the client
+func (s *IPInfoServiceOp) Get(ctx context.Context) (*IPInfo, *Response, error) {
+	req, err := s.Client.NewPlainRequest(ctx, http.MethodGet, ipInfoPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(IPInfo)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, nil
+}

--- a/mongodbatlas/ip_info.go
+++ b/mongodbatlas/ip_info.go
@@ -30,9 +30,7 @@ type IPInfoService interface {
 }
 
 // IPInfoService is an implementation of IPInfoService
-type IPInfoServiceOp struct {
-	Client PlainRequestDoer
-}
+type IPInfoServiceOp service
 
 var _ IPInfoService = &IPInfoServiceOp{}
 
@@ -42,7 +40,7 @@ type IPInfo struct {
 
 // Get gets the public ip address of the client
 func (s *IPInfoServiceOp) Get(ctx context.Context) (*IPInfo, *Response, error) {
-	req, err := s.Client.NewPlainRequest(ctx, http.MethodGet, ipInfoPath)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, ipInfoPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mongodbatlas/ip_info_test.go
+++ b/mongodbatlas/ip_info_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestIPInfoOp_Get(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/api/private/ipinfo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+				"currentIpv4Address": "127.0.0.1"
+		}`)
+	})
+
+	result, _, err := client.IPInfo.Get(ctx)
+	if err != nil {
+		t.Fatalf("IPInfo.Get returned error: %v", err)
+	}
+	expected := &IPInfo{CurrentIPv4Address: "127.0.0.1"}
+
+	if diff := deep.Equal(result, expected); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -137,6 +137,7 @@ type Client struct {
 	CloudProviderAccess                 CloudProviderAccessService
 	DefaultMongoDBMajorVersion          DefaultMongoDBMajorVersionService
 	CloudProviderRegions                CloudProviderRegionsService
+	IPInfo                              IPInfoService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -288,6 +289,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.CloudProviderAccess = &CloudProviderAccessServiceOp{Client: c}
 	c.DefaultMongoDBMajorVersion = &DefaultMongoDBMajorVersionServiceOp{Client: c}
 	c.CloudProviderRegions = &CloudProviderRegionsServiceOp{Client: c}
+	c.IPInfo = &IPInfoServiceOp{Client: c}
 
 	return c
 }


### PR DESCRIPTION
## Description

I have added the service to handle the endpoint `GET api/private/ipinfo`



Link to any related issue(s):

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

