### PR TITLE
ldap group is admin db

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -83,7 +83,8 @@ func (user *DatabaseUser) GetAuthDB() (name string) {
 	_, isX509 := adminX509Type[user.X509Type]
 	_, isIAM := awsIAMType[user.AWSIAMType]
 
-	isLDAP := len(user.LDAPAuthType) > 0 && user.LDAPAuthType != "NONE"
+	// just USER is external
+	isLDAP := len(user.LDAPAuthType) > 0 && user.LDAPAuthType == "USER"
 
 	if isX509 || isIAM || isLDAP {
 		name = "$external"


### PR DESCRIPTION
## Description

Hello just modifying the logic to set the auth db to admin for LDAP Group. 

Link to any related issue(s): 

https://github.com/mongodb/terraform-provider-mongodbatlas/issues/447

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

