### PR TITLE
feat: update golancgci and enable tagliatelle

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.39.0
+          version: v1.40.0
 
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.40.0
+          version: v1.40.1
 
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,13 @@ linters-settings:
     check-shadowing: true
   maligned:
     suggest-new: true
+  tagliatelle:
+    # check the struck tag name case
+    case:
+      use-field-name: true
+      rules:
+        json: camel
+        yaml: camel
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 SOURCE_FILES?=./...
 PKG_NAME=mongodbatlas
-GOLANGCI_VERSION=v1.39.0
+GOLANGCI_VERSION=v1.40.0
 COVERAGE=coverage.out
 
 export GO111MODULE := on

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 SOURCE_FILES?=./...
 PKG_NAME=mongodbatlas
-GOLANGCI_VERSION=v1.40.0
+GOLANGCI_VERSION=v1.40.1
 COVERAGE=coverage.out
 
 export GO111MODULE := on

--- a/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -68,8 +68,8 @@ type CloudProviderSnapshotRestoreJobs struct {
 }
 
 type Component struct {
-	DownloadURL    string `json:"downloadUrl"`    // URL from which the snapshot of the components.replicaSetName should be downloaded. Atlas returns null for this parameter if the download URL has expired, has been used, or hasn't been created.
-	ReplicaSetName string `json:"replicaSetName"` // Name of the shard or config server included in the snapshot.
+	DownloadURL    string `json:"downloadUrl"`    // DownloadURL from which the snapshot of the components.replicaSetName should be downloaded. Atlas returns null for this parameter if the download URL has expired, has been used, or hasn't been created.
+	ReplicaSetName string `json:"replicaSetName"` // ReplicaSetName of the shard or config server included in the snapshot.
 }
 
 // List gets all cloud provider snapshot restore jobs for the specified cluster.


### PR DESCRIPTION
## Description

Update golangci and enable a new linter for json tags, this may be handy to prevent copy past errors, we had those before and it caught one on the ops manager version of this lib

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

