### PR TITLE
Adding missing args to do a custom online archive

### DIFF
--- a/mongodbatlas/online_archives.go
+++ b/mongodbatlas/online_archives.go
@@ -196,11 +196,11 @@ type OnlineArchive struct {
 
 // OnlineArchiveCriteria criteria to use for archiving data.
 type OnlineArchiveCriteria struct {
-	DateField       string   `json:"dateField,omitempty"`
+	DateField       string   `json:"dateField,omitempty"` // DateField is mandatory when Type is DATE
 	DateFormat      string   `json:"dateFormat,omitempty"`
 	ExpireAfterDays *float64 `json:"expireAfterDays,omitempty"`
+	Query           string `json:"query,omitempty"` // Query is mandatory when Type is CUSTOM
 	Type            string   `json:"type,omitempty"`
-	Query           string   `json:"query,omitempty"`
 }
 
 // PartitionFields fields to use to partition data

--- a/mongodbatlas/online_archives.go
+++ b/mongodbatlas/online_archives.go
@@ -196,10 +196,11 @@ type OnlineArchive struct {
 
 // OnlineArchiveCriteria criteria to use for archiving data.
 type OnlineArchiveCriteria struct {
-	DateField       string  `json:"dateField,omitempty"`
-	DateFormat      string  `json:"dateFormat,omitempty"`
-	ExpireAfterDays float64 `json:"expireAfterDays"`
-	Type            string  `json:"type,omitempty"`
+	DateField       string   `json:"dateField,omitempty"`
+	DateFormat      string   `json:"dateFormat,omitempty"`
+	ExpireAfterDays *float64 `json:"expireAfterDays,omitempty"`
+	Type            string   `json:"type,omitempty"`
+	Query           string   `json:"query,omitempty"`
 }
 
 // PartitionFields fields to use to partition data

--- a/mongodbatlas/online_archives.go
+++ b/mongodbatlas/online_archives.go
@@ -199,7 +199,7 @@ type OnlineArchiveCriteria struct {
 	DateField       string   `json:"dateField,omitempty"` // DateField is mandatory when Type is DATE
 	DateFormat      string   `json:"dateFormat,omitempty"`
 	ExpireAfterDays *float64 `json:"expireAfterDays,omitempty"`
-	Query           string `json:"query,omitempty"` // Query is mandatory when Type is CUSTOM
+	Query           string   `json:"query,omitempty"` // Query is mandatory when Type is CUSTOM
 	Type            string   `json:"type,omitempty"`
 }
 

--- a/mongodbatlas/online_archives_test.go
+++ b/mongodbatlas/online_archives_test.go
@@ -120,7 +120,7 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 				CollName:    "employees",
 				Criteria: &OnlineArchiveCriteria{
 					DateField:       "created",
-					ExpireAfterDays: 5,
+					ExpireAfterDays: pointy.Float64(5),
 				},
 				DBName:  "people",
 				GroupID: groupID,
@@ -149,7 +149,7 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 				CollName:    "invoices",
 				Criteria: &OnlineArchiveCriteria{
 					DateField:       "year",
-					ExpireAfterDays: 5,
+					ExpireAfterDays: pointy.Float64(5),
 				},
 				DBName:  "accounting",
 				GroupID: groupID,
@@ -231,7 +231,7 @@ func TestOnlineArchiveServiceOp_Get(t *testing.T) {
 		CollName:    "employees",
 		Criteria: &OnlineArchiveCriteria{
 			DateField:       "created",
-			ExpireAfterDays: 5,
+			ExpireAfterDays: pointy.Float64(5),
 		},
 		DBName:  "people",
 		GroupID: groupID,
@@ -271,7 +271,7 @@ func TestOnlineArchiveServiceOp_Create(t *testing.T) {
 		CollName: "employees",
 		Criteria: &OnlineArchiveCriteria{
 			DateField:       "created",
-			ExpireAfterDays: 5,
+			ExpireAfterDays: pointy.Float64(5),
 		},
 		DBName: "people",
 		PartitionFields: []*PartitionFields{
@@ -358,7 +358,7 @@ func TestOnlineArchiveServiceOp_Update(t *testing.T) {
 
 	updateRequest := &OnlineArchive{
 		Criteria: &OnlineArchiveCriteria{
-			ExpireAfterDays: 6,
+			ExpireAfterDays: pointy.Float64(6),
 		},
 	}
 
@@ -402,9 +402,9 @@ func TestOnlineArchiveServiceOp_Update(t *testing.T) {
 		t.Fatalf("OnlineArchives.Update returned error: %v", err)
 	}
 
-	expectedExpireAfterDays := float64(6)
+	expectedExpireAfterDays := pointy.Float64(6)
 	if archive.Criteria.ExpireAfterDays != expectedExpireAfterDays {
-		t.Errorf("expected name '%f', received '%s'", expectedExpireAfterDays, archive.DBName)
+		t.Errorf("expected name '%f', received '%s'", *expectedExpireAfterDays, archive.DBName)
 	}
 }
 

--- a/mongodbatlas/online_archives_test.go
+++ b/mongodbatlas/online_archives_test.go
@@ -403,8 +403,8 @@ func TestOnlineArchiveServiceOp_Update(t *testing.T) {
 	}
 
 	expectedExpireAfterDays := pointy.Float64(6)
-	if archive.Criteria.ExpireAfterDays != expectedExpireAfterDays {
-		t.Errorf("expected name '%f', received '%s'", *expectedExpireAfterDays, archive.DBName)
+	if *(archive.Criteria.ExpireAfterDays) != *expectedExpireAfterDays {
+		t.Errorf("expected expireAfterDays '%f', received '%f'", *expectedExpireAfterDays, *archive.Criteria.ExpireAfterDays)
 	}
 }
 


### PR DESCRIPTION
## Description

Hello @gssbzn , @andreaangiolillo , adding missing attributes required to do a custom type archive log.
- added the query parameter in criteria
- changed from float64 to *float64 to avoid sending  expireAfterDays when it's `custom` type.

```
│ Error: error creating MongoDB Atlas Online Archive:: POST https://cloud.mongodb.com/api/atlas/v1.0/groups/5cf5a45a9ccf6400e60981b6/clusters/test-angel-cloud-backup1/onlineArchives: 400 (request "INVALID_ATTRIBUTE") Invalid attribute expireAfterDays specified.
│
│   with mongodbatlas_online_archive.users_archive_query,
│   on main.tf line 25, in resource "mongodbatlas_online_archive" "users_archive_query":
│   25: resource "mongodbatlas_online_archive" "users_archive_query" {
```

required in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/413

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

