### PR TITLE
lint: replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,12 +10,39 @@ linters-settings:
       - octalLiteral
   gocyclo:
     min-complexity: 15
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
   maligned:
     suggest-new: true
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
   tagliatelle:
     # check the struck tag name case
     case:
@@ -42,7 +69,6 @@ linters:
     - godot # Check if comments end in a period [fast: true, auto-fix: true]
     - gofmt
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
@@ -51,6 +77,7 @@ linters:
     - misspell
     - nakedret
     - nolintlint
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
     - rowserrcheck
     - staticcheck
     - structcheck

--- a/mongodbatlas/cloud_provider_access.go
+++ b/mongodbatlas/cloud_provider_access.go
@@ -32,7 +32,7 @@ type CloudProviderAccessService interface {
 	DeauthorizeRole(context.Context, *CloudProviderDeauthorizationRequest) (*Response, error)
 }
 
-// ProjectIPAccessListServiceOp provides an implementation of the CloudProviderAccessService interface.
+// CloudProviderAccessServiceOp provides an implementation of the CloudProviderAccessService interface.
 type CloudProviderAccessServiceOp service
 
 var _ CloudProviderAccessService = &CloudProviderAccessServiceOp{}
@@ -42,7 +42,7 @@ type CloudProviderAccessRoles struct {
 	AWSIAMRoles []AWSIAMRole `json:"awsIamRoles,omitempty"` // Unique identifier of AWS security group in this access list entry.
 }
 
-// ProjectIPAccessLists is the response from the ProjectIPAccessListService.List.
+// AWSIAMRole is the response from the CloudProviderAccessService.ListRoles.
 type AWSIAMRole struct {
 	AtlasAWSAccountARN         string          `json:"atlasAWSAccountArn,omitempty"`         // ARN associated with the Atlas AWS account used to assume IAM roles in your AWS account.
 	AtlasAssumedRoleExternalID string          `json:"atlasAssumedRoleExternalId,omitempty"` // Unique external ID Atlas uses when assuming the IAM role in your AWS account.
@@ -71,7 +71,7 @@ type CloudProviderAuthorizationRequest struct {
 	IAMAssumedRoleARN string `json:"iamAssumedRoleArn"`
 }
 
-// CloudProviderAuthorizationRequest.
+// CloudProviderDeauthorizationRequest represents a request to remove authorization.
 type CloudProviderDeauthorizationRequest struct {
 	ProviderName string
 	GroupID      string
@@ -98,7 +98,7 @@ func (s *CloudProviderAccessServiceOp) ListRoles(ctx context.Context, groupID st
 	return root, resp, nil
 }
 
-// Create creates an AWS IAM role.
+// CreateRole creates an AWS IAM role.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-create-one-role/
 func (s *CloudProviderAccessServiceOp) CreateRole(ctx context.Context, groupID string, request *CloudProviderAccessRoleRequest) (*AWSIAMRole, *Response, error) {

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -24,7 +24,9 @@ import (
 type ChangeStatus string
 
 const (
-	ChangeStatusApplied          ChangeStatus = "APPLIED"
+	// ChangeStatusApplied signals when changes to the deployments have completed.
+	ChangeStatusApplied ChangeStatus = "APPLIED"
+	// ChangeStatusPending signals when changes to the deployments are still pending.
 	ChangeStatusPending          ChangeStatus = "PENDING"
 	clustersPath                              = "api/atlas/v1.0/groups/%s/clusters"
 	sampleDatasetLoadPath                     = "api/atlas/v1.0/groups/%s/sampleDatasetLoad"

--- a/mongodbatlas/ip_info.go
+++ b/mongodbatlas/ip_info.go
@@ -29,7 +29,7 @@ type IPInfoService interface {
 	Get(context.Context) (*IPInfo, *Response, error)
 }
 
-// IPInfoService is an implementation of IPInfoService.
+// IPInfoServiceOp is an implementation of IPInfoService.
 type IPInfoServiceOp service
 
 var _ IPInfoService = &IPInfoServiceOp{}

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -343,21 +343,7 @@ func SetUserAgent(ua string) ClientOpt {
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
 func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
-	if !strings.HasSuffix(c.BaseURL.Path, "/") {
-		return nil, fmt.Errorf("base URL must have a trailing slash, but %q does not", c.BaseURL)
-	}
-	u, err := c.BaseURL.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	var buf io.Reader
-	if body != nil {
-		if buf, err = c.newEncodedBody(body); err != nil {
-			return nil, err
-		}
-	}
-
-	req, err := http.NewRequest(method, u.String(), buf)
+	req, err := c.newRequest(ctx, urlStr, method, body)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +371,7 @@ func (c *Client) newEncodedBody(body interface{}) (io.Reader, error) {
 // A relative URL can be provided in urlStr, which will be resolved to the
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash.
 func (c *Client) NewGZipRequest(ctx context.Context, method, urlStr string) (*http.Request, error) {
-	req, err := c.newRequest(urlStr, method)
+	req, err := c.newRequest(ctx, urlStr, method, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +384,7 @@ func (c *Client) NewGZipRequest(ctx context.Context, method, urlStr string) (*ht
 // A relative URL can be provided in urlStr, which will be resolved to the
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash.
 func (c *Client) NewPlainRequest(ctx context.Context, method, urlStr string) (*http.Request, error) {
-	req, err := c.newRequest(urlStr, method)
+	req, err := c.newRequest(ctx, urlStr, method, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +393,7 @@ func (c *Client) NewPlainRequest(ctx context.Context, method, urlStr string) (*h
 	return req, nil
 }
 
-func (c *Client) newRequest(urlStr, method string) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, urlStr, method string, body interface{}) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("base URL must have a trailing slash, but %q does not", c.BaseURL)
 	}
@@ -418,7 +404,13 @@ func (c *Client) newRequest(urlStr, method string) (*http.Request, error) {
 
 	u := c.BaseURL.ResolveReference(rel)
 
-	req, err := http.NewRequest(method, u.String(), nil)
+	var buf io.Reader
+	if body != nil {
+		if buf, err = c.newEncodedBody(body); err != nil {
+			return nil, err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
 	if err != nil {
 		return nil, err
 	}

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -34,6 +34,7 @@ import (
 )
 
 const (
+	// CloudURL is default base URL for the services
 	CloudURL       = "https://cloud.mongodb.com/"
 	defaultBaseURL = CloudURL
 	jsonMediaType  = "application/json"

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	// CloudURL is default base URL for the services
+	// CloudURL is default base URL for the services.
 	CloudURL       = "https://cloud.mongodb.com/"
 	defaultBaseURL = CloudURL
 	jsonMediaType  = "application/json"


### PR DESCRIPTION
## Description

`golint` has been archived and it's now deprecated on golangci-lint, they recommend to replace with revive 