### PR TITLE
Renamed AdvancedRegionSpec to AdvancedReplicationSpec

### DIFF
--- a/mongodbatlas/advanced_clusters.go
+++ b/mongodbatlas/advanced_clusters.go
@@ -43,27 +43,27 @@ var _ AdvancedClustersService = &AdvancedClustersServiceOp{}
 
 // AdvancedCluster represents MongoDB cluster.
 type AdvancedCluster struct {
-	BackupEnabled            *bool                 `json:"backupEnabled,omitempty"`
-	BiConnector              *BiConnector          `json:"biConnector,omitempty"`
-	ClusterType              string                `json:"clusterType,omitempty"`
-	ConnectionStrings        *ConnectionStrings    `json:"connectionStrings,omitempty"`
-	DiskSizeGB               *float64              `json:"diskSizeGB,omitempty"`
-	EncryptionAtRestProvider string                `json:"encryptionAtRestProvider,omitempty"`
-	GroupID                  string                `json:"groupId,omitempty"`
-	ID                       string                `json:"id,omitempty"`
-	Labels                   []Label               `json:"labels,omitempty"`
-	MongoDBMajorVersion      string                `json:"mongoDBMajorVersion,omitempty"`
-	MongoDBVersion           string                `json:"mongoDBVersion,omitempty"`
-	Name                     string                `json:"name,omitempty"`
-	Paused                   *bool                 `json:"paused,omitempty"`
-	PitEnabled               *bool                 `json:"pitEnabled,omitempty"`
-	StateName                string                `json:"stateName,omitempty"`
-	ReplicationSpecs         []*AdvancedRegionSpec `json:"replicationSpecs,omitempty"`
-	CreateDate               string                `json:"createDate,omitempty"`
-	RootCertType             string                `json:"rootCertType,omitempty"`
+	BackupEnabled            *bool                      `json:"backupEnabled,omitempty"`
+	BiConnector              *BiConnector               `json:"biConnector,omitempty"`
+	ClusterType              string                     `json:"clusterType,omitempty"`
+	ConnectionStrings        *ConnectionStrings         `json:"connectionStrings,omitempty"`
+	DiskSizeGB               *float64                   `json:"diskSizeGB,omitempty"`
+	EncryptionAtRestProvider string                     `json:"encryptionAtRestProvider,omitempty"`
+	GroupID                  string                     `json:"groupId,omitempty"`
+	ID                       string                     `json:"id,omitempty"`
+	Labels                   []Label                    `json:"labels,omitempty"`
+	MongoDBMajorVersion      string                     `json:"mongoDBMajorVersion,omitempty"`
+	MongoDBVersion           string                     `json:"mongoDBVersion,omitempty"`
+	Name                     string                     `json:"name,omitempty"`
+	Paused                   *bool                      `json:"paused,omitempty"`
+	PitEnabled               *bool                      `json:"pitEnabled,omitempty"`
+	StateName                string                     `json:"stateName,omitempty"`
+	ReplicationSpecs         []*AdvancedReplicationSpec `json:"replicationSpecs,omitempty"`
+	CreateDate               string                     `json:"createDate,omitempty"`
+	RootCertType             string                     `json:"rootCertType,omitempty"`
 }
 
-type AdvancedRegionSpec struct {
+type AdvancedReplicationSpec struct {
 	NumShards     int    `json:"numShards,omitempty"`
 	ID            string `json:"id,omitempty"`
 	ZoneName      string `json:"zoneName,omitempty"`

--- a/mongodbatlas/advanced_clusters.go
+++ b/mongodbatlas/advanced_clusters.go
@@ -64,10 +64,10 @@ type AdvancedCluster struct {
 }
 
 type AdvancedReplicationSpec struct {
-	NumShards     int    `json:"numShards,omitempty"`
-	ID            string `json:"id,omitempty"`
-	ZoneName      string `json:"zoneName,omitempty"`
-	RegionConfigs []*AdvancedRegionConfig
+	NumShards     int                     `json:"numShards,omitempty"`
+	ID            string                  `json:"id,omitempty"`
+	ZoneName      string                  `json:"zoneName,omitempty"`
+	RegionConfigs []*AdvancedRegionConfig `json:"regionConfigs,omitempty"`
 }
 
 type AdvancedRegionConfig struct {

--- a/mongodbatlas/advanced_clusters_test.go
+++ b/mongodbatlas/advanced_clusters_test.go
@@ -233,7 +233,7 @@ func TestAdvancedClusters_List(t *testing.T) {
 				PitEnabled:               &pitEnabled,
 				StateName:                "CREATING",
 
-				ReplicationSpecs: []*AdvancedRegionSpec{
+				ReplicationSpecs: []*AdvancedReplicationSpec{
 					{
 						ID:        "1",
 						NumShards: 1,
@@ -285,7 +285,7 @@ func TestAdvancedClusters_List(t *testing.T) {
 				Paused:                   &paused,
 				PitEnabled:               &pitEnabled,
 				StateName:                "CREATING",
-				ReplicationSpecs: []*AdvancedRegionSpec{
+				ReplicationSpecs: []*AdvancedReplicationSpec{
 					{
 						ID:        "2",
 						NumShards: 1,
@@ -501,7 +501,7 @@ func TestAdvancedClusters_Get(t *testing.T) {
 		Paused:                   &paused,
 		PitEnabled:               &pitEnabled,
 		StateName:                "CREATING",
-		ReplicationSpecs: []*AdvancedRegionSpec{
+		ReplicationSpecs: []*AdvancedReplicationSpec{
 			{
 				ID:        "2",
 				NumShards: 1,
@@ -711,7 +711,7 @@ func TestAdvancedClusters_Create(t *testing.T) {
 		Paused:                   &paused,
 		PitEnabled:               &pitEnabled,
 		StateName:                "CREATING",
-		ReplicationSpecs: []*AdvancedRegionSpec{
+		ReplicationSpecs: []*AdvancedReplicationSpec{
 			{
 				ID:        "2",
 				NumShards: 1,
@@ -810,7 +810,7 @@ func TestAdvancedClusters_Create(t *testing.T) {
 		Paused:                   &paused,
 		PitEnabled:               &pitEnabled,
 		StateName:                "CREATING",
-		ReplicationSpecs: []*AdvancedRegionSpec{
+		ReplicationSpecs: []*AdvancedReplicationSpec{
 			{
 				ID:        "2",
 				NumShards: 1,
@@ -1020,7 +1020,7 @@ func TestAdvancedClusters_Update(t *testing.T) {
 		Paused:                   &paused,
 		PitEnabled:               &pitEnabled,
 		StateName:                "CREATING",
-		ReplicationSpecs: []*AdvancedRegionSpec{
+		ReplicationSpecs: []*AdvancedReplicationSpec{
 			{
 				ID:        "2",
 				NumShards: 1,
@@ -1119,7 +1119,7 @@ func TestAdvancedClusters_Update(t *testing.T) {
 		Paused:                   &paused,
 		PitEnabled:               &pitEnabled,
 		StateName:                "CREATING",
-		ReplicationSpecs: []*AdvancedRegionSpec{
+		ReplicationSpecs: []*AdvancedReplicationSpec{
 			{
 				ID:        "2",
 				NumShards: 1,


### PR DESCRIPTION
## Description

Renamed AdvancedRegionSpec to AdvancedReplicationSpec and added missing json string for `RegionConfigs`

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

