### PR TITLE
Fixed Invite New User endpoints for organizations and projects

### DIFF
--- a/mongodbatlas/organization_invitations.go
+++ b/mongodbatlas/organization_invitations.go
@@ -102,12 +102,12 @@ func (s *OrganizationsServiceOp) Invitation(ctx context.Context, orgID, invitati
 // InviteUser invites one user to the Atlas organization that you specify.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organization-create-one-invitation/
-func (s *OrganizationsServiceOp) InviteUser(ctx context.Context, invitation *Invitation) (*Invitation, *Response, error) {
-	if invitation.OrgID == "" {
+func (s *OrganizationsServiceOp) InviteUser(ctx context.Context, orgID string, invitation *Invitation) (*Invitation, *Response, error) {
+	if orgID == "" {
 		return nil, nil, NewArgError("orgID", "must be set")
 	}
 
-	path := fmt.Sprintf(invitationBasePath, invitation.OrgID)
+	path := fmt.Sprintf(invitationBasePath, orgID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, invitation)
 	if err != nil {

--- a/mongodbatlas/organization_invitations.go
+++ b/mongodbatlas/organization_invitations.go
@@ -126,19 +126,19 @@ func (s *OrganizationsServiceOp) InviteUser(ctx context.Context, orgID string, i
 // UpdateInvitation updates one pending invitation to the Atlas organization that you specify.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organization-update-one-invitation/
-func (s *OrganizationsServiceOp) UpdateInvitation(ctx context.Context, invitation *Invitation) (*Invitation, *Response, error) {
-	if invitation.OrgID == "" {
+func (s *OrganizationsServiceOp) UpdateInvitation(ctx context.Context, orgID string, invitation *Invitation) (*Invitation, *Response, error) {
+	if orgID == "" {
 		return nil, nil, NewArgError("orgID", "must be set")
 	}
 
-	return s.updateInvitation(ctx, invitation)
+	return s.updateInvitation(ctx, orgID, "", invitation)
 }
 
 // UpdateInvitationByID updates one invitation to the Atlas organization.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organization-update-one-invitation-by-id/
-func (s *OrganizationsServiceOp) UpdateInvitationByID(ctx context.Context, invitationID string, invitation *Invitation) (*Invitation, *Response, error) {
-	if invitation.OrgID == "" {
+func (s *OrganizationsServiceOp) UpdateInvitationByID(ctx context.Context, orgID, invitationID string, invitation *Invitation) (*Invitation, *Response, error) {
+	if orgID == "" {
 		return nil, nil, NewArgError("orgID", "must be set")
 	}
 
@@ -146,9 +146,7 @@ func (s *OrganizationsServiceOp) UpdateInvitationByID(ctx context.Context, invit
 		return nil, nil, NewArgError("invitationID", "must be set")
 	}
 
-	invitation.ID = invitationID
-
-	return s.updateInvitation(ctx, invitation)
+	return s.updateInvitation(ctx, orgID, invitationID, invitation)
 }
 
 // DeleteInvitation deletes one unaccepted invitation to the specified Atlas organization. You can't delete an invitation that a user has accepted.
@@ -176,11 +174,11 @@ func (s *OrganizationsServiceOp) DeleteInvitation(ctx context.Context, orgID, in
 	return resp, err
 }
 
-func (s *OrganizationsServiceOp) updateInvitation(ctx context.Context, invitation *Invitation) (*Invitation, *Response, error) {
-	path := fmt.Sprintf(invitationBasePath, invitation.OrgID)
+func (s *OrganizationsServiceOp) updateInvitation(ctx context.Context, orgID, invitationID string, invitation *Invitation) (*Invitation, *Response, error) {
+	path := fmt.Sprintf(invitationBasePath, orgID)
 
-	if invitation.ID != "" {
-		path = fmt.Sprintf("%s/%s", path, invitation.ID)
+	if invitationID != "" {
+		path = fmt.Sprintf("%s/%s", path, invitationID)
 	}
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, invitation)

--- a/mongodbatlas/organization_invitations_test.go
+++ b/mongodbatlas/organization_invitations_test.go
@@ -160,7 +160,7 @@ func TestOrganizations_InviteUser(t *testing.T) {
 		Roles:           []string{"ORG_OWNER"},
 	}
 
-	invitation, _, err := client.Organizations.InviteUser(ctx, body)
+	invitation, _, err := client.Organizations.InviteUser(ctx, orgID, body)
 	if err != nil {
 		t.Fatalf("Organizations.InviteUser returned error: %v", err)
 	}

--- a/mongodbatlas/organization_invitations_test.go
+++ b/mongodbatlas/organization_invitations_test.go
@@ -211,7 +211,7 @@ func TestOrganizations_UpdateInvitation(t *testing.T) {
 		Roles:           []string{"ORG_OWNER"},
 	}
 
-	invitation, _, err := client.Organizations.UpdateInvitation(ctx, body)
+	invitation, _, err := client.Organizations.UpdateInvitation(ctx, orgID, body)
 	if err != nil {
 		t.Fatalf("Organizations.UpdateInvitation returned error: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestOrganizations_UpdateInvitationByID(t *testing.T) {
 		Roles:           []string{"ORG_OWNER"},
 	}
 
-	invitation, _, err := client.Organizations.UpdateInvitationByID(ctx, invitationID, body)
+	invitation, _, err := client.Organizations.UpdateInvitationByID(ctx, orgID, invitationID, body)
 	if err != nil {
 		t.Fatalf("Organizations.UpdateInvitationByID returned error: %v", err)
 	}

--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -33,7 +33,7 @@ type OrganizationsService interface {
 	Projects(context.Context, string, *ListOptions) (*Projects, *Response, error)
 	Users(context.Context, string, *ListOptions) (*AtlasUsersResponse, *Response, error)
 	Delete(context.Context, string) (*Response, error)
-	InviteUser(context.Context, *Invitation) (*Invitation, *Response, error)
+	InviteUser(context.Context, string, *Invitation) (*Invitation, *Response, error)
 	UpdateInvitation(context.Context, *Invitation) (*Invitation, *Response, error)
 	UpdateInvitationByID(context.Context, string, *Invitation) (*Invitation, *Response, error)
 	DeleteInvitation(context.Context, string, string) (*Response, error)

--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -34,8 +34,8 @@ type OrganizationsService interface {
 	Users(context.Context, string, *ListOptions) (*AtlasUsersResponse, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	InviteUser(context.Context, string, *Invitation) (*Invitation, *Response, error)
-	UpdateInvitation(context.Context, *Invitation) (*Invitation, *Response, error)
-	UpdateInvitationByID(context.Context, string, *Invitation) (*Invitation, *Response, error)
+	UpdateInvitation(context.Context, string, *Invitation) (*Invitation, *Response, error)
+	UpdateInvitationByID(context.Context, string, string, *Invitation) (*Invitation, *Response, error)
 	DeleteInvitation(context.Context, string, string) (*Response, error)
 }
 

--- a/mongodbatlas/project_invitations.go
+++ b/mongodbatlas/project_invitations.go
@@ -104,19 +104,19 @@ func (s *ProjectsServiceOp) InviteUser(ctx context.Context, groupID string, invi
 // UpdateInvitation updates one pending invitation to the Atlas project that you specify.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/project-update-one-invitation/
-func (s *ProjectsServiceOp) UpdateInvitation(ctx context.Context, invitation *Invitation) (*Invitation, *Response, error) {
-	if invitation.GroupID == "" {
+func (s *ProjectsServiceOp) UpdateInvitation(ctx context.Context, groupID string, invitation *Invitation) (*Invitation, *Response, error) {
+	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}
 
-	return s.updateInvitation(ctx, invitation)
+	return s.updateInvitation(ctx, groupID, "", invitation)
 }
 
 // UpdateInvitationByID updates one invitation to the Atlas project.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/project-update-one-invitation-by-id/
-func (s *ProjectsServiceOp) UpdateInvitationByID(ctx context.Context, invitationID string, invitation *Invitation) (*Invitation, *Response, error) {
-	if invitation.GroupID == "" {
+func (s *ProjectsServiceOp) UpdateInvitationByID(ctx context.Context, groupID, invitationID string, invitation *Invitation) (*Invitation, *Response, error) {
+	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}
 
@@ -126,7 +126,7 @@ func (s *ProjectsServiceOp) UpdateInvitationByID(ctx context.Context, invitation
 
 	invitation.ID = invitationID
 
-	return s.updateInvitation(ctx, invitation)
+	return s.updateInvitation(ctx, groupID, invitationID, invitation)
 }
 
 // DeleteInvitation deletes one unaccepted invitation to the specified Atlas project. You can't delete an invitation that a user has accepted.
@@ -154,11 +154,11 @@ func (s *ProjectsServiceOp) DeleteInvitation(ctx context.Context, groupID, invit
 	return resp, err
 }
 
-func (s *ProjectsServiceOp) updateInvitation(ctx context.Context, invitation *Invitation) (*Invitation, *Response, error) {
-	path := fmt.Sprintf(projectInvitationBasePath, invitation.GroupID)
+func (s *ProjectsServiceOp) updateInvitation(ctx context.Context, groupID, invitationID string, invitation *Invitation) (*Invitation, *Response, error) {
+	path := fmt.Sprintf(projectInvitationBasePath, groupID)
 
-	if invitation.ID != "" {
-		path = fmt.Sprintf("%s/%s", path, invitation.ID)
+	if invitationID != "" {
+		path = fmt.Sprintf("%s/%s", path, invitationID)
 	}
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, invitation)

--- a/mongodbatlas/project_invitations.go
+++ b/mongodbatlas/project_invitations.go
@@ -80,12 +80,12 @@ func (s *ProjectsServiceOp) Invitation(ctx context.Context, groupID, invitationI
 }
 
 // InviteUser invites one user to the Atlas project that you specify.
-func (s *ProjectsServiceOp) InviteUser(ctx context.Context, invitation *Invitation) (*Invitation, *Response, error) {
-	if invitation.GroupID == "" {
+func (s *ProjectsServiceOp) InviteUser(ctx context.Context, groupID string, invitation *Invitation) (*Invitation, *Response, error) {
+	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}
 
-	path := fmt.Sprintf(projectInvitationBasePath, invitation.GroupID)
+	path := fmt.Sprintf(projectInvitationBasePath, groupID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, invitation)
 	if err != nil {

--- a/mongodbatlas/project_invitations_test.go
+++ b/mongodbatlas/project_invitations_test.go
@@ -158,7 +158,7 @@ func TestProjects_InviteUser(t *testing.T) {
 		Roles:           []string{"ORG_OWNER"},
 	}
 
-	invitation, _, err := client.Projects.InviteUser(ctx, body)
+	invitation, _, err := client.Projects.InviteUser(ctx, groupID, body)
 	if err != nil {
 		t.Fatalf("Projects.InviteUser returned error: %v", err)
 	}

--- a/mongodbatlas/project_invitations_test.go
+++ b/mongodbatlas/project_invitations_test.go
@@ -209,7 +209,7 @@ func TestProjects_UpdateInvitation(t *testing.T) {
 		Roles:           []string{"ORG_OWNER"},
 	}
 
-	invitation, _, err := client.Projects.UpdateInvitation(ctx, body)
+	invitation, _, err := client.Projects.UpdateInvitation(ctx, groupID, body)
 	if err != nil {
 		t.Fatalf("Projects.UpdateInvitation returned error: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestProjects_UpdateInvitationByID(t *testing.T) {
 		Roles:           []string{"ORG_OWNER"},
 	}
 
-	invitation, _, err := client.Projects.UpdateInvitationByID(ctx, invitationID, body)
+	invitation, _, err := client.Projects.UpdateInvitationByID(ctx, groupID, invitationID, body)
 	if err != nil {
 		t.Fatalf("Projects.UpdateInvitationByID returned error: %v", err)
 	}

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -49,7 +49,7 @@ type ProjectsService interface {
 	RemoveUserFromProject(context.Context, string, string) (*Response, error)
 	Invitations(context.Context, string, *InvitationOptions) ([]*Invitation, *Response, error)
 	Invitation(context.Context, string, string) (*Invitation, *Response, error)
-	InviteUser(context.Context, *Invitation) (*Invitation, *Response, error)
+	InviteUser(context.Context, string, *Invitation) (*Invitation, *Response, error)
 	UpdateInvitation(context.Context, *Invitation) (*Invitation, *Response, error)
 	UpdateInvitationByID(context.Context, string, *Invitation) (*Invitation, *Response, error)
 	DeleteInvitation(context.Context, string, string) (*Response, error)

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -50,8 +50,8 @@ type ProjectsService interface {
 	Invitations(context.Context, string, *InvitationOptions) ([]*Invitation, *Response, error)
 	Invitation(context.Context, string, string) (*Invitation, *Response, error)
 	InviteUser(context.Context, string, *Invitation) (*Invitation, *Response, error)
-	UpdateInvitation(context.Context, *Invitation) (*Invitation, *Response, error)
-	UpdateInvitationByID(context.Context, string, *Invitation) (*Invitation, *Response, error)
+	UpdateInvitation(context.Context, string, *Invitation) (*Invitation, *Response, error)
+	UpdateInvitationByID(context.Context, string, string, *Invitation) (*Invitation, *Response, error)
 	DeleteInvitation(context.Context, string, string) (*Response, error)
 }
 


### PR DESCRIPTION
## Description

Bug: The Request Body Parameters `ID`, `OrgID`, `GroupID` must be blank when using `POST`, `PATCH` endpoints

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

