### PR TITLE
Adding AutoDefer method to automatically defer any maintenance

### DIFF
--- a/mongodbatlas/maintenance.go
+++ b/mongodbatlas/maintenance.go
@@ -46,6 +46,7 @@ type MaintenanceWindowsService interface {
 	Get(context.Context, string) (*MaintenanceWindow, *Response, error)
 	Update(context.Context, string, *MaintenanceWindow) (*Response, error)
 	Defer(context.Context, string) (*Response, error)
+	AutoDefer(context.Context, string) (*Response, error)
 	Reset(context.Context, string) (*Response, error)
 }
 
@@ -121,6 +122,26 @@ func (s *MaintenanceWindowsServiceOp) Defer(ctx context.Context, groupID string)
 	}
 
 	path := fmt.Sprintf(maintenanceWindowsPath+"/defer", groupID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// AutoDefer any scheduled maintenance for the given project for one week.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/maintenance-window-auto-defer/
+func (s *MaintenanceWindowsServiceOp) AutoDefer(ctx context.Context, groupID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(maintenanceWindowsPath+"/autoDefer", groupID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {

--- a/mongodbatlas/maintenance_test.go
+++ b/mongodbatlas/maintenance_test.go
@@ -148,6 +148,23 @@ func TestMaintenanceWindows_Defer(t *testing.T) {
 	}
 }
 
+func TestMaintenanceWindows_AutoDefer(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6d2065c687d9d64ae7acdg41"
+
+	mux.HandleFunc(fmt.Sprintf("/"+maintenanceWindowsPath+"/autoDefer", groupID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{}`)
+	})
+
+	_, err := client.MaintenanceWindows.AutoDefer(ctx, groupID)
+	if err != nil {
+		t.Errorf("MaintenanceWindows.AutoDefer returned error: %v", err)
+	}
+}
+
 func TestMaintenanceWindows_Delete(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
## Description

This PR includes the AutoDefer method to automatically defer any maintenance as explained here https://docs.atlas.mongodb.com/reference/api/maintenance-window-auto-defer/

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

