### PR TITLE
CLOUDP-98424: Allow upload of json in atlas search

### DIFF
--- a/mongodbatlas/search.go
+++ b/mongodbatlas/search.go
@@ -31,6 +31,7 @@ type SearchService interface {
 	ListIndexes(ctx context.Context, groupID string, clusterName string, databaseName string, collectionName string, opts *ListOptions) ([]*SearchIndex, *Response, error)
 	GetIndex(ctx context.Context, groupID, clusterName, indexID string) (*SearchIndex, *Response, error)
 	CreateIndex(ctx context.Context, projectID, clusterName string, r *SearchIndex) (*SearchIndex, *Response, error)
+	CreateIndexWithJson(ctx context.Context, projectID, clusterName string, body interface{}) (*SearchIndex, *Response, error)
 	UpdateIndex(ctx context.Context, projectID, clusterName, indexID string, r *SearchIndex) (*SearchIndex, *Response, error)
 	DeleteIndex(ctx context.Context, projectID, clusterName, indexID string) (*Response, error)
 	ListAnalyzers(ctx context.Context, groupID, clusterName string, listOptions *ListOptions) ([]*SearchAnalyzer, *Response, error)
@@ -110,6 +111,17 @@ func (s *SearchServiceOp) GetIndex(ctx context.Context, groupID, clusterName, in
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/fts-indexes-create-one/
 func (s *SearchServiceOp) CreateIndex(ctx context.Context, projectID, clusterName string, r *SearchIndex) (*SearchIndex, *Response, error) {
+	return s.createIndex(ctx, projectID, clusterName, r)
+}
+
+// CreateIndex creates an Atlas Search index.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/fts-indexes-create-one/
+func (s *SearchServiceOp) CreateIndexWithJson(ctx context.Context, projectID, clusterName string, body interface{}) (*SearchIndex, *Response, error) {
+	return s.createIndex(ctx, projectID, clusterName, body)
+}
+
+func (s *SearchServiceOp) createIndex(ctx context.Context, projectID, clusterName string, r interface{}) (*SearchIndex, *Response, error) {
 	if projectID == "" {
 		return nil, nil, NewArgError("projectID", "must be set")
 	}


### PR DESCRIPTION
## Description

The team that owns atlas search suggested uploading JSON data instead of passing flags in our CLI experience to be inline with their efforts in the UI.

Link to any related issue(s): [CLOUDP-98424](https://jira.mongodb.org/browse/CLOUDP-98424)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

