### PR TITLE
INTMDB-252: Added two parameters for Process args

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -170,6 +170,8 @@ type Cluster struct {
 
 // ProcessArgs represents the advanced configuration options for the cluster.
 type ProcessArgs struct {
+	DefaultReadConcern               string `json:"defaultReadConcern,omitempty"`
+	DefaultWriteConcern              string `json:"defaultWriteConcern,omitempty"`
 	FailIndexKeyTooLong              *bool  `json:"failIndexKeyTooLong,omitempty"`
 	JavascriptEnabled                *bool  `json:"javascriptEnabled,omitempty"`
 	MinimumEnabledTLSProtocol        string `json:"minimumEnabledTlsProtocol,omitempty"`

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -723,8 +723,12 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 	groupID := "1"
 	clusterName := "AppData"
 	tlsProtocol := "TLS1_2"
+	defaultReadConcern := "available"
+	defaultWriteConcern := "1"
 
 	updateRequest := &ProcessArgs{
+		DefaultReadConcern:               defaultReadConcern,
+		DefaultWriteConcern:              defaultWriteConcern,
 		FailIndexKeyTooLong:              pointy.Bool(false),
 		JavascriptEnabled:                pointy.Bool(false),
 		MinimumEnabledTLSProtocol:        tlsProtocol,
@@ -736,6 +740,8 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/processArgs", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
+			"defaultReadConcern":               defaultReadConcern,
+			"defaultWriteConcern":              defaultWriteConcern,
 			"failIndexKeyTooLong":              false,
 			"javascriptEnabled":                false,
 			"minimumEnabledTlsProtocol":        tlsProtocol,
@@ -747,6 +753,8 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 
 		jsonBlob := `
 		{
+			"defaultReadConcern": "available",
+			"defaultWriteConcern": "1",
 			"failIndexKeyTooLong": false,
 			"javascriptEnabled": false,
 			"minimumEnabledTlsProtocol": "TLS1_2",
@@ -796,6 +804,8 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/processArgs", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
+			"defaultReadConcern": "available",
+			"defaultWriteConcern": "1",
 			"failIndexKeyTooLong": false,
 			"javascriptEnabled": false,
 			"minimumEnabledTlsProtocol": "TLS1_2",
@@ -812,6 +822,8 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 	}
 
 	expected := &ProcessArgs{
+		DefaultReadConcern:               "available",
+		DefaultWriteConcern:              "1",
 		FailIndexKeyTooLong:              pointy.Bool(false),
 		JavascriptEnabled:                pointy.Bool(false),
 		MinimumEnabledTLSProtocol:        "TLS1_2",


### PR DESCRIPTION
## Description

- Added two parameters `defaultReadConcern` and `defaultWriteConcern` for process args

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

