### PR TITLE
Adding projectOwnerId to Projects.Create

### DIFF
--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -42,7 +42,7 @@ type ProjectsService interface {
 	GetAllProjects(context.Context, *ListOptions) (*Projects, *Response, error)
 	GetOneProject(context.Context, string) (*Project, *Response, error)
 	GetOneProjectByName(context.Context, string) (*Project, *Response, error)
-	Create(context.Context, *Project) (*Project, *Response, error)
+	Create(context.Context, *ProjectOptions, *Project) (*Project, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	GetProjectTeamsAssigned(context.Context, string) (*TeamsAssigned, *Response, error)
 	AddTeamsToProject(context.Context, string, []*ProjectTeam) (*TeamsAssigned, *Response, error)
@@ -97,6 +97,10 @@ type TeamsAssigned struct {
 	Links      []*Link   `json:"links"`
 	Results    []*Result `json:"results"`
 	TotalCount int       `json:"totalCount"`
+}
+
+type ProjectOptions struct {
+	ProjectOwnerId      string `url:"projectOwnerId,omitempty"`      // Unique 24-hexadecimal digit string that identifies the Atlas user account to be granted the Project Owner role on the specified project.
 }
 
 // GetAllProjects gets all project.
@@ -177,12 +181,17 @@ func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName
 // Create creates a project.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/project-create-one/
-func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project) (*Project, *Response, error) {
+func (s *ProjectsServiceOp) Create(ctx context.Context, opts *ProjectOptions,  createRequest *Project) (*Project, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.Client.NewRequest(ctx, http.MethodPost, projectBasePath, createRequest)
+	path, err := setListOptions(projectBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -42,7 +42,7 @@ type ProjectsService interface {
 	GetAllProjects(context.Context, *ListOptions) (*Projects, *Response, error)
 	GetOneProject(context.Context, string) (*Project, *Response, error)
 	GetOneProjectByName(context.Context, string) (*Project, *Response, error)
-	Create(context.Context, *ProjectOptions, *Project) (*Project, *Response, error)
+	Create(context.Context, *Project, *ProjectOptions) (*Project, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	GetProjectTeamsAssigned(context.Context, string) (*TeamsAssigned, *Response, error)
 	AddTeamsToProject(context.Context, string, []*ProjectTeam) (*TeamsAssigned, *Response, error)
@@ -100,7 +100,7 @@ type TeamsAssigned struct {
 }
 
 type ProjectOptions struct {
-	ProjectOwnerId      string `url:"projectOwnerId,omitempty"`      // Unique 24-hexadecimal digit string that identifies the Atlas user account to be granted the Project Owner role on the specified project.
+	ProjectOwnerID string `url:"projectOwnerId,omitempty"` // Unique 24-hexadecimal digit string that identifies the Atlas user account to be granted the Project Owner role on the specified project.
 }
 
 // GetAllProjects gets all project.
@@ -181,7 +181,7 @@ func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName
 // Create creates a project.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/project-create-one/
-func (s *ProjectsServiceOp) Create(ctx context.Context, opts *ProjectOptions,  createRequest *Project) (*Project, *Response, error) {
+func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project, opts *ProjectOptions) (*Project, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -42,7 +42,7 @@ type ProjectsService interface {
 	GetAllProjects(context.Context, *ListOptions) (*Projects, *Response, error)
 	GetOneProject(context.Context, string) (*Project, *Response, error)
 	GetOneProjectByName(context.Context, string) (*Project, *Response, error)
-	Create(context.Context, *Project, *ProjectOptions) (*Project, *Response, error)
+	Create(context.Context, *Project, *CreateProjectOptions) (*Project, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	GetProjectTeamsAssigned(context.Context, string) (*TeamsAssigned, *Response, error)
 	AddTeamsToProject(context.Context, string, []*ProjectTeam) (*TeamsAssigned, *Response, error)
@@ -99,7 +99,7 @@ type TeamsAssigned struct {
 	TotalCount int       `json:"totalCount"`
 }
 
-type ProjectOptions struct {
+type CreateProjectOptions struct {
 	ProjectOwnerID string `url:"projectOwnerId,omitempty"` // Unique 24-hexadecimal digit string that identifies the Atlas user account to be granted the Project Owner role on the specified project.
 }
 
@@ -181,7 +181,7 @@ func (s *ProjectsServiceOp) GetOneProjectByName(ctx context.Context, projectName
 // Create creates a project.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/project-create-one/
-func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project, opts *ProjectOptions) (*Project, *Response, error) {
+func (s *ProjectsServiceOp) Create(ctx context.Context, createRequest *Project, opts *CreateProjectOptions) (*Project, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -219,9 +219,9 @@ func TestProject_Create(t *testing.T) {
 		}`)
 	})
 
-	opts:= &ProjectOptions{ProjectOwnerId:"1"}
+	opts := &ProjectOptions{ProjectOwnerID: "1"}
 
-	project, _, err := client.Projects.Create(ctx, opts, createRequest)
+	project, _, err := client.Projects.Create(ctx, createRequest, opts)
 	if err != nil {
 		t.Fatalf("Projects.Create returned error: %v", err)
 	}

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -219,7 +219,7 @@ func TestProject_Create(t *testing.T) {
 		}`)
 	})
 
-	opts := &ProjectOptions{ProjectOwnerID: "1"}
+	opts := &CreateProjectOptions{ProjectOwnerID: "1"}
 
 	project, _, err := client.Projects.Create(ctx, createRequest, opts)
 	if err != nil {

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -219,7 +219,9 @@ func TestProject_Create(t *testing.T) {
 		}`)
 	})
 
-	project, _, err := client.Projects.Create(ctx, createRequest)
+	opts:= &ProjectOptions{ProjectOwnerId:"1"}
+
+	project, _, err := client.Projects.Create(ctx, opts, createRequest)
 	if err != nil {
 		t.Fatalf("Projects.Create returned error: %v", err)
 	}

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -245,6 +245,53 @@ func TestProject_Create(t *testing.T) {
 	}
 }
 
+func TestProject_Create_without_opts(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	createRequest := &Project{
+		OrgID: "5a0a1e7e0f2912c554080adc",
+		Name:  "ProjectFoobar",
+	}
+
+	mux.HandleFunc("/api/atlas/v1.0/groups", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{
+			"clusterCount": 2,
+			"created": "2016-07-14T14:19:33Z",
+			"id": "5a0a1e7e0f2912c554080ae6",
+			"links": [{
+				"href": "https://cloud.mongodb.com/api/atlas/v1.0/groups/5a0a1e7e0f2912c554080ae6",
+				"rel": "self"
+			}],
+			"name": "ProjectFoobar",
+			"orgId": "5a0a1e7e0f2912c554080adc"
+		}`)
+	})
+
+	project, _, err := client.Projects.Create(ctx, createRequest, nil)
+	if err != nil {
+		t.Fatalf("Projects.Create returned error: %v", err)
+	}
+
+	expected := &Project{
+		ClusterCount: 2,
+		Created:      "2016-07-14T14:19:33Z",
+		ID:           "5a0a1e7e0f2912c554080ae6",
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/groups/5a0a1e7e0f2912c554080ae6",
+				Rel:  "self",
+			},
+		},
+		Name:  "ProjectFoobar",
+		OrgID: "5a0a1e7e0f2912c554080adc",
+	}
+
+	if diff := deep.Equal(project, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
 func TestProject_Delete(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
## Description
[CLOUDP-95603: [Mongocli - Atlas] Add support for projectOwnerId flag with project creation/modification](https://jira.mongodb.org/browse/CLOUDP-95603)

Description:
Added query param [projectOwnerId](https://docs.atlas.mongodb.com/reference/api/project-create-one/#request-query-parameters) to `Projects.Create`

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments


