### PR TITLE
CLOUDP-97442: update performance advisor with new endpoints -> atlas go client

### DIFF
--- a/mongodbatlas/performance_advisor.go
+++ b/mongodbatlas/performance_advisor.go
@@ -25,6 +25,7 @@ const (
 	performanceAdvisorNamespacesPath           = performanceAdvisorPath + "/namespaces"
 	performanceAdvisorSlowQueryLogsPath        = performanceAdvisorPath + "/slowQueryLogs"
 	performanceAdvisorSuggestedIndexesLogsPath = performanceAdvisorPath + "/suggestedIndexes"
+	performanceAdvisorManagedSlowMs            = "api/atlas/v1.0/groups/%s/managedSlowMs"
 )
 
 // PerformanceAdvisorService is an interface of the Performance Advisor
@@ -35,6 +36,8 @@ type PerformanceAdvisorService interface {
 	GetNamespaces(context.Context, string, string, *NamespaceOptions) (*Namespaces, *Response, error)
 	GetSlowQueries(context.Context, string, string, *SlowQueryOptions) (*SlowQueries, *Response, error)
 	GetSuggestedIndexes(context.Context, string, string, *SuggestedIndexOptions) (*SuggestedIndexes, *Response, error)
+	EnableManagedSlowOperationThreshold(context.Context, string) (*Response, error)
+	DisableManagedSlowOperationThreshold(context.Context, string) (*Response, error)
 }
 
 // PerformanceAdvisorServiceOp handles communication with the Performance Advisor related methods of the MongoDB Atlas API.
@@ -220,4 +223,52 @@ func (s *PerformanceAdvisorServiceOp) GetSuggestedIndexes(ctx context.Context, g
 	}
 
 	return root, resp, err
+}
+
+// EnableManagedSlowOperationThreshold enables the Atlas managed slow operation threshold for your project.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/pa-managed-slow-ms-enable/
+func (s *PerformanceAdvisorServiceOp) EnableManagedSlowOperationThreshold(ctx context.Context, groupID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(performanceAdvisorManagedSlowMs, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, "enable")
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+// DisableManagedSlowOperationThreshold disables the Atlas managed slow operation threshold for your project.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/pa-managed-slow-ms-disable/
+func (s *PerformanceAdvisorServiceOp) DisableManagedSlowOperationThreshold(ctx context.Context, groupID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(performanceAdvisorManagedSlowMs, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, "disable")
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
 }

--- a/mongodbatlas/performance_advisor_test.go
+++ b/mongodbatlas/performance_advisor_test.go
@@ -241,3 +241,31 @@ func TestPerformanceAdvisor_GetSuggestedIndexes(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+func TestPerformanceAdvisor_EnableManagedSlowOperationThreshold(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/"+performanceAdvisorManagedSlowMs+"/enable", projectID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+	})
+
+	_, err := client.PerformanceAdvisor.EnableManagedSlowOperationThreshold(ctx, projectID)
+	if err != nil {
+		t.Fatalf("PerformanceAdvisor.EnableManagedSlowOperationThreshold returned error: %v", err)
+	}
+}
+
+func TestPerformanceAdvisor_DisableManagedSlowOperationThreshold(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/"+performanceAdvisorManagedSlowMs+"/disable", projectID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.PerformanceAdvisor.DisableManagedSlowOperationThreshold(ctx, projectID)
+	if err != nil {
+		t.Fatalf("PerformanceAdvisor.DisableManagedSlowOperationThreshold returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

I have added the following performance advisor endpoints:

- [Enable Managed Slow Operation Threshold](https://docs.atlas.mongodb.com/reference/api/pa-managed-slow-ms-enable/)
- [Disable Managed Slow Operation Threshold](https://docs.atlas.mongodb.com/reference/api/pa-managed-slow-ms-disable/)


Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

