### PR TITLE
INTMDB-211: Added shard keys properties to Managed Namespace in global configurat…

### DIFF
--- a/mongodbatlas/global_clusters.go
+++ b/mongodbatlas/global_clusters.go
@@ -48,9 +48,11 @@ type GlobalCluster struct {
 
 // ManagedNamespace represents the information about managed namespace configuration.
 type ManagedNamespace struct {
-	Db             string `json:"db"` //nolint:stylecheck // not changing this as is a breaking change
-	Collection     string `json:"collection"`
-	CustomShardKey string `json:"customShardKey,omitempty"`
+	Db                     string `json:"db"` //nolint:stylecheck // not changing this as is a breaking change
+	Collection             string `json:"collection"`
+	CustomShardKey         string `json:"customShardKey,omitempty"`
+	IsCustomShardKeyHashed *bool  `json:"isCustomShardKeyHashed,omitempty"` // Flag that specifies whether the custom shard key for the collection is hashed.
+	IsShardKeyUnique       *bool  `json:"isShardKeyUnique,omitempty"`       // Flag that specifies whether the underlying index enforces a unique constraint.
 }
 
 // CustomZoneMappingsRequest represents the request related to add custom zone mappings to a global cluster.

--- a/mongodbatlas/global_clusters_test.go
+++ b/mongodbatlas/global_clusters_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/openlyinc/pointy"
 )
 
 func TestGlobalClusters_Get(t *testing.T) {
@@ -50,7 +51,9 @@ func TestGlobalClusters_Get(t *testing.T) {
 			"managedNamespaces" : [ {
 			  "collection" : "zips",
 			  "customShardKey" : "city",
-			  "db" : "mydata"
+			  "db" : "mydata",
+			  "isCustomShardKeyHashed" : true,
+			  "isShardKeyUnique" : true
 			},{
 			  "collection" : "stores",
 			  "customShardKey" : "store_number",
@@ -81,9 +84,11 @@ func TestGlobalClusters_Get(t *testing.T) {
 		},
 		ManagedNamespaces: []ManagedNamespace{
 			{
-				Collection:     "zips",
-				CustomShardKey: "city",
-				Db:             "mydata",
+				Collection:             "zips",
+				CustomShardKey:         "city",
+				Db:                     "mydata",
+				IsCustomShardKeyHashed: pointy.Bool(true),
+				IsShardKeyUnique:       pointy.Bool(true),
 			}, {
 				Collection:     "stores",
 				CustomShardKey: "store_number",
@@ -105,16 +110,20 @@ func TestGlobalClusters_AddManagedNamespace(t *testing.T) {
 	clusterName := "appData"
 
 	createRequest := &ManagedNamespace{
-		Db:             "mydata",
-		Collection:     "publishers",
-		CustomShardKey: "city",
+		Db:                     "mydata",
+		Collection:             "publishers",
+		CustomShardKey:         "city",
+		IsCustomShardKeyHashed: pointy.Bool(true),
+		IsShardKeyUnique:       pointy.Bool(true),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/globalWrites/managedNamespaces", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
 		expectedRequest := map[string]interface{}{
-			"db":             "mydata",
-			"collection":     "publishers",
-			"customShardKey": "city",
+			"db":                     "mydata",
+			"collection":             "publishers",
+			"customShardKey":         "city",
+			"isCustomShardKeyHashed": true,
+			"isShardKeyUnique":       true,
 		}
 
 		jsonBlob := `
@@ -136,7 +145,9 @@ func TestGlobalClusters_AddManagedNamespace(t *testing.T) {
 			"managedNamespaces" : [ {
 			  "collection" : "publishers",
 			  "customShardKey" : "city",
-			  "db" : "mydata"
+			  "db" : "mydata",
+			  "isCustomShardKeyHashed" : true,
+			  "isShardKeyUnique" : true
 			},{
 			  "collection" : "stores",
 			  "customShardKey" : "store_number",


### PR DESCRIPTION
## Description

Added shard keys properties to Managed Namespace struct

Link to any related issue(s): [INTMDB-211](https://jira.mongodb.org/browse/INTMDB-211)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

