### PR TITLE
custom_db_role resource use *string

### DIFF
--- a/mongodbatlas/convert.go
+++ b/mongodbatlas/convert.go
@@ -1,0 +1,5 @@
+package mongodbatlas
+
+func StrPtr(s string) *string {
+	return &s
+}

--- a/mongodbatlas/convert.go
+++ b/mongodbatlas/convert.go
@@ -1,5 +1,0 @@
-package mongodbatlas
-
-func StrPtr(s string) *string {
-	return &s
-}

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -41,9 +41,9 @@ var _ CustomDBRolesService = &CustomDBRolesServiceOp{}
 
 // A Resource describes a specific resource the Role will allow operating on.
 type Resource struct {
-	Collection string `json:"collection,omitempty"`
-	Db         string `json:"db,omitempty"` //nolint:stylecheck // not changing this as is a breaking change
-	Cluster    *bool  `json:"cluster,omitempty"`
+	Collection *string `json:"collection,omitempty"`
+	Db         *string `json:"db,omitempty"` //nolint:stylecheck // not changing this as is a breaking change
+	Cluster    *bool   `json:"cluster,omitempty"`
 }
 
 // An Action describes the operation the role will include, for a specific set of Resources.

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -42,7 +42,7 @@ var _ CustomDBRolesService = &CustomDBRolesServiceOp{}
 // A Resource describes a specific resource the Role will allow operating on.
 type Resource struct {
 	Collection *string `json:"collection,omitempty"`
-	Db         *string `json:"db,omitempty"` //nolint:stylecheck // not changing this as is a breaking change
+	Db         *string `json:"db,omitempty"`
 	Cluster    *bool   `json:"cluster,omitempty"`
 }
 

--- a/mongodbatlas/custom_db_roles.go
+++ b/mongodbatlas/custom_db_roles.go
@@ -42,7 +42,7 @@ var _ CustomDBRolesService = &CustomDBRolesServiceOp{}
 // A Resource describes a specific resource the Role will allow operating on.
 type Resource struct {
 	Collection *string `json:"collection,omitempty"`
-	Db         *string `json:"db,omitempty"`
+	DB         *string `json:"db,omitempty"`
 	Cluster    *bool   `json:"cluster,omitempty"`
 }
 

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -128,6 +128,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 				"roleName": "test-role-name",
 			},
 		},
+		//the following case verifies https://github.com/mongodb/go-client-mongodb-atlas/issues/263
 		{
 			input: CustomDBRole{
 				Actions: []Action{

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/openlyinc/pointy"
 )
 
 func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
@@ -42,8 +43,8 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: StrPtr("test-collection"),
-				Db:         StrPtr("test-db"),
+				Collection: pointy.String("test-collection"),
+				Db:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -76,8 +77,8 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: StrPtr("test-collection"),
-				Db:         StrPtr("test-db"),
+				Collection: pointy.String("test-collection"),
+				Db:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -99,8 +100,8 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: StrPtr("test-collection"),
-				Db:         StrPtr("test-db"),
+				Collection: pointy.String("test-collection"),
+				Db:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -180,8 +181,8 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: StrPtr("test-collection"),
-				Db:         StrPtr("test-db"),
+				Collection: pointy.String("test-collection"),
+				Db:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -278,8 +279,8 @@ func TestCustomDBRoles_DeleteInheritedRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: StrPtr("test-collection"),
-				Db:         StrPtr("test-db"),
+				Collection: pointy.String("test-collection"),
+				Db:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{},

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -42,8 +42,8 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: "test-collection",
-				Db:         "test-db",
+				Collection: StrPtr("test-collection"),
+				Db:         StrPtr("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -76,8 +76,8 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: "test-collection",
-				Db:         "test-db",
+				Collection: StrPtr("test-collection"),
+				Db:         StrPtr("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -99,8 +99,8 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: "test-collection",
-				Db:         "test-db",
+				Collection: StrPtr("test-collection"),
+				Db:         StrPtr("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -180,8 +180,8 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: "test-collection",
-				Db:         "test-db",
+				Collection: StrPtr("test-collection"),
+				Db:         StrPtr("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -278,8 +278,8 @@ func TestCustomDBRoles_DeleteInheritedRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: "test-collection",
-				Db:         "test-db",
+				Collection: StrPtr("test-collection"),
+				Db:         StrPtr("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{},

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -44,7 +44,7 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
 				Collection: pointy.String("test-collection"),
-				Db:         pointy.String("test-db"),
+				DB:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -78,7 +78,7 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
 				Collection: pointy.String("test-collection"),
-				Db:         pointy.String("test-db"),
+				DB:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -104,7 +104,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 					Action: "CREATE_INDEX",
 					Resources: []Resource{{
 						Collection: pointy.String("test-collection"),
-						Db:         pointy.String("test-db"),
+						DB:         pointy.String("test-db"),
 					}},
 				}},
 				InheritedRoles: []InheritedRole{{
@@ -137,7 +137,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 						Resources: []Resource{
 							{
 								Collection: pointy.String(""),
-								Db:         pointy.String("admin"),
+								DB:         pointy.String("admin"),
 							},
 						},
 					},
@@ -253,7 +253,7 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
 				Collection: pointy.String("test-collection"),
-				Db:         pointy.String("test-db"),
+				DB:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -351,7 +351,7 @@ func TestCustomDBRoles_DeleteInheritedRole(t *testing.T) {
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
 				Collection: pointy.String("test-collection"),
-				Db:         pointy.String("test-db"),
+				DB:         pointy.String("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{},

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -171,6 +171,36 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: CustomDBRole{
+				RoleName: "just-cluster-action",
+				Actions: []Action{
+					{
+						Action: "CONN_POOL_STATS",
+						Resources: []Resource{
+							{
+								Cluster: pointy.Bool(true),
+							},
+						},
+					},
+				},
+				InheritedRoles: []InheritedRole{},
+			},
+			expected: map[string]interface{}{
+				"roleName": "just-cluster-action",
+				"actions": []interface{}{
+					map[string]interface{}{
+						"action": "CONN_POOL_STATS",
+						"resources": []interface{}{
+							map[string]interface{}{
+								"cluster": true,
+							},
+						},
+					},
+				},
+				"inheritedRoles": []interface{}{},
+			},
+		},
 	}
 
 	//keep the mux creation outside of the loop to avoid allocations.

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -128,7 +128,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 				"roleName": "test-role-name",
 			},
 		},
-		//the following case verifies https://github.com/mongodb/go-client-mongodb-atlas/issues/263
+		// the following case verifies https://github.com/mongodb/go-client-mongodb-atlas/issues/263
 		{
 			input: CustomDBRole{
 				Actions: []Action{
@@ -203,11 +203,11 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 		},
 	}
 
-	//keep the mux creation outside of the loop to avoid allocations.
+	// keep the mux creation outside of the loop to avoid allocations.
 	client, mux, teardown := setup()
 	defer teardown()
 
-	//allows mux to expect different values at each iteration.
+	// allows mux to expect different values at each iteration.
 	var muxExpected map[string]interface{}
 
 	mux.HandleFunc("/api/atlas/v1.0/groups/1/customDBRoles/roles", func(w http.ResponseWriter, r *http.Request) {
@@ -225,11 +225,9 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 		if err := json.NewEncoder(w).Encode(v); err != nil {
 			t.Error(err)
 		}
-
 	})
 
 	for _, example := range createExamples {
-
 		muxExpected = example.expected
 
 		customDBRole, _, err := client.CustomDBRoles.Create(ctx, "1", &example.input)
@@ -241,7 +239,6 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 			t.Errorf("expected roleName '%s', received '%s'", example.expected["roleName"], roleName)
 		}
 	}
-
 }
 
 func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes https://github.com/mongodb/go-client-mongodb-atlas/issues/263

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

Just posting this here to streamline any fix on this. If further doc/tests/etc. are needed let me know. Didn't want to run the tests in case they were integration and not just unit tests.

I did use a `replace` in the `go.mod` to use my fork and this fixes my issue, but you have to wrap all strings as pointers. Therefore, this is a breaking change.