### PR TITLE
INTMDB-5: added parameter team name for alert configurations

### DIFF
--- a/mongodbatlas/alert_configurations.go
+++ b/mongodbatlas/alert_configurations.go
@@ -117,6 +117,7 @@ type Notification struct {
 	ServiceKey          string   `json:"serviceKey,omitempty"`          // PagerDuty service key. Populated for the PAGER_DUTY notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
 	SMSEnabled          *bool    `json:"smsEnabled,omitempty"`          // Flag indicating if text message notifications should be sent. Populated for ORG, GROUP, and USER notifications types.
 	TeamID              string   `json:"teamId,omitempty"`              // Unique identifier of a team.
+	TeamName            string   `json:"teamName,omitempty"`            // Label for the team that receives this notification.
 	TypeName            string   `json:"typeName,omitempty"`            // Type of alert notification.
 	Username            string   `json:"username,omitempty"`            // Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Populated for the USER notifications type.
 	VictorOpsAPIKey     string   `json:"victorOpsApiKey,omitempty"`     // VictorOps API key. Populated for the VICTOR_OPS notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.


### PR DESCRIPTION
## Description

Added new parameter `teamName` for alert configurations

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

