### PR TITLE
feat: add the ability to revoke tokens

### DIFF
--- a/auth/device_flow.go
+++ b/auth/device_flow.go
@@ -109,3 +109,19 @@ func (c Config) PollToken(ctx context.Context, code *DeviceCode) (*Token, *atlas
 		return token, resp, nil
 	}
 }
+
+// Revoke takes an access or refresh token and revokes it.
+func (c Config) Revoke(ctx context.Context, token, tokenTypeHint string) (*atlas.Response, error) {
+	req, err := c.NewRequest(ctx, http.MethodPost, deviceBasePath+"/revoke",
+		url.Values{
+			"client_id":       {c.ClientID},
+			"token":           {token},
+			"token_type_hint": {tokenTypeHint},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(ctx, req, nil)
+}

--- a/auth/device_flow_test.go
+++ b/auth/device_flow_test.go
@@ -132,3 +132,17 @@ func TestConfig_PollToken(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+func TestConfig_Revoke(t *testing.T) {
+	config, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/private/unauth/account/device/revoke", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+	})
+
+	_, err := config.Revoke(ctx, "a", "refresh_token")
+	if err != nil {
+		t.Fatalf("RequestCode returned error: %v", err)
+	}
+}

--- a/auth/device_flow_test.go
+++ b/auth/device_flow_test.go
@@ -27,7 +27,7 @@ func TestConfig_RequestCode(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/private/unauth/account/device/authorize", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPost)
+		testMethod(t, r)
 		fmt.Fprintf(w, `{
 		  "user_code": "QW3PYV7R",
 		  "verification_uri": "%s/account/connect",
@@ -60,7 +60,7 @@ func TestConfig_GetToken(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/private/unauth/account/device/token", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPost)
+		testMethod(t, r)
 		fmt.Fprint(w, `{
 		  "access_token": "secret1",
 		  "refresh_token": "secret2",
@@ -99,7 +99,7 @@ func TestConfig_PollToken(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/private/unauth/account/device/token", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPost)
+		testMethod(t, r)
 		fmt.Fprint(w, `{
 		  "access_token": "secret1",
 		  "refresh_token": "secret2",
@@ -138,7 +138,7 @@ func TestConfig_Revoke(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/private/unauth/account/device/revoke", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPost)
+		testMethod(t, r)
 	})
 
 	_, err := config.Revoke(ctx, "a", "refresh_token")

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -70,10 +70,10 @@ func setup() (config *Config, mux *http.ServeMux, teardown func()) {
 	return config, mux, server.Close
 }
 
-func testMethod(t *testing.T, r *http.Request, expected string) {
+func testMethod(t *testing.T, r *http.Request) {
 	t.Helper()
-	if expected != r.Method {
-		t.Errorf("Request method = %v, expected %v", r.Method, expected)
+	if http.MethodPost != r.Method {
+		t.Errorf("Request method = %v, expected %v", r.Method, http.MethodPost)
 	}
 }
 


### PR DESCRIPTION
## Description

Adds a method to revoke access or refresh tokens

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

