### PR TITLE
CLOUDP-114669: Automatically add trailing slash to the URL

### DIFF
--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -392,7 +392,7 @@ func (c *Client) NewPlainRequest(ctx context.Context, method, urlStr string) (*h
 
 func (c *Client) newRequest(ctx context.Context, urlStr, method string, body interface{}) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
-		return nil, fmt.Errorf("base URL must have a trailing slash, but %q does not", c.BaseURL)
+		c.BaseURL.Path += "/"
 	}
 	rel, err := url.Parse(urlStr)
 	if err != nil {

--- a/mongodbatlas/mongodbatlas_test.go
+++ b/mongodbatlas/mongodbatlas_test.go
@@ -199,12 +199,12 @@ func TestNewRequest_withCustomUserAgent(t *testing.T) {
 	}
 }
 
-func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
+func TestNewRequest_noErrorForNoTrailingSlash(t *testing.T) {
 	tests := []struct {
 		rawurl    string
 		wantError bool
 	}{
-		{rawurl: "https://example.com/api/v1", wantError: true},
+		{rawurl: "https://example.com/api/v1", wantError: false},
 		{rawurl: "https://example.com/api/v1/", wantError: false},
 	}
 	c := NewClient(nil)
@@ -218,6 +218,32 @@ func TestNewRequest_errorForNoTrailingSlash(t *testing.T) {
 			t.Fatalf("Expected error to be returned.")
 		} else if !test.wantError && err != nil {
 			t.Fatalf("NewRequest returned unexpected error: %v.", err)
+		}
+	}
+}
+
+func TestNewRequest_correctURLWithNoTrailingSlash(t *testing.T) {
+	tests := []struct {
+		rawURL      string
+		expectedURL string
+	}{
+		{rawURL: "http://test.com", expectedURL: "http://test.com/"},
+		{rawURL: "http://home.base.com/", expectedURL: "http://home.base.com/"},
+	}
+
+	c := NewClient(nil)
+	for _, test := range tests {
+		u, err := url.Parse(test.rawURL)
+		if err != nil {
+			t.Fatalf("url.Parse returned unexpected error: %v.", err)
+		}
+		c.BaseURL = u
+		req, err := c.NewRequest(ctx, http.MethodGet, "", nil)
+		if err != nil {
+			t.Fatalf("NewRequest return unexpected error: %v.", err)
+		}
+		if req.URL.String() != test.expectedURL {
+			t.Fatalf("Incorrectly added trailing slash. Expected: %v; Got: %v.", test.expectedURL, req.URL.String())
 		}
 	}
 }


### PR DESCRIPTION
## Description

This PR adds an ability for the `Client` to automatically add trailing slash (`/`) to the end of the provided URL. The motivation behind this is that some internal tools use this library and it is easier to assume that the library handles both cases: with, and without trailing slash.

cc: @jamesbroadhead 

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-114669

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

