### PR TITLE
CLOUDP-118028: [atlascli] Allow to list and edit project settings

### DIFF
--- a/mongodbatlas/project_settings.go
+++ b/mongodbatlas/project_settings.go
@@ -27,7 +27,7 @@ type ProjectSettings struct {
 	IsDataExplorerEnabled                       *bool `url:"isDataExplorerEnabled,omitempty"`
 	IsPerformanceAdvisorEnabled                 *bool `url:"isPerformanceAdvisorEnabled,omitempty"`
 	IsRealtimePerformancePanelEnabled           *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
-	IsSchemaAdvisorEnabled                      *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
+	IsSchemaAdvisorEnabled                      *bool `url:"isSchemaAdvisorEnabled,omitempty"`
 }
 
 // GetProjectSettings gets details about the settings for specified project.

--- a/mongodbatlas/project_settings.go
+++ b/mongodbatlas/project_settings.go
@@ -24,10 +24,10 @@ const projectSettingsBasePath = projectBasePath + "/%s/settings"
 
 type ProjectSettings struct {
 	IsCollectDatabaseSpecificsStatisticsEnabled *bool `url:"isCollectDatabaseSpecificsStatisticsEnabled,omitempty"`
-	IsDataExplorerEnabled                       *bool `url:"IsDataExplorerEnabled,omitempty"`
-	IsPerformanceAdvisorEnabled                 *bool `url:"IsPerformanceAdvisorEnabled,omitempty"`
-	IsRealtimePerformancePanelEnabled           *bool `url:"IsRealtimePerformancePanelEnabled,omitempty"`
-	IsSchemaAdvisorEnabled                      *bool `url:"IsRealtimePerformancePanelEnabled,omitempty"`
+	IsDataExplorerEnabled                       *bool `url:"isDataExplorerEnabled,omitempty"`
+	IsPerformanceAdvisorEnabled                 *bool `url:"isPerformanceAdvisorEnabled,omitempty"`
+	IsRealtimePerformancePanelEnabled           *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
+	IsSchemaAdvisorEnabled                      *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
 }
 
 // GetProjectSettings gets details about the settings for specified project.

--- a/mongodbatlas/project_settings.go
+++ b/mongodbatlas/project_settings.go
@@ -24,12 +24,11 @@ const projectSettingsBasePath = projectBasePath + "/%s/settings"
 
 type ProjectSettings struct {
 	IsCollectDatabaseSpecificsStatisticsEnabled *bool `url:"isCollectDatabaseSpecificsStatisticsEnabled,omitempty"`
-	isDataExplorerEnabled *bool `url:"isDataExplorerEnabled,omitempty"`
-	isPerformanceAdvisorEnabled *bool `url:"isPerformanceAdvisorEnabled,omitempty"`
-	isRealtimePerformancePanelEnabled *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
-	isSchemaAdvisorEnabled *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
+	IsDataExplorerEnabled                       *bool `url:"IsDataExplorerEnabled,omitempty"`
+	IsPerformanceAdvisorEnabled                 *bool `url:"IsPerformanceAdvisorEnabled,omitempty"`
+	IsRealtimePerformancePanelEnabled           *bool `url:"IsRealtimePerformancePanelEnabled,omitempty"`
+	IsSchemaAdvisorEnabled                      *bool `url:"IsRealtimePerformancePanelEnabled,omitempty"`
 }
-
 
 // GetProjectSettings gets details about the settings for specified project.
 //
@@ -76,5 +75,3 @@ func (s *ProjectsServiceOp) UpdateProjectSettings(ctx context.Context, groupID s
 
 	return root, resp, nil
 }
-
-

--- a/mongodbatlas/project_settings.go
+++ b/mongodbatlas/project_settings.go
@@ -1,0 +1,80 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const projectSettingsBasePath = projectBasePath + "/%s/settings"
+
+type ProjectSettings struct {
+	IsCollectDatabaseSpecificsStatisticsEnabled *bool `url:"isCollectDatabaseSpecificsStatisticsEnabled,omitempty"`
+	isDataExplorerEnabled *bool `url:"isDataExplorerEnabled,omitempty"`
+	isPerformanceAdvisorEnabled *bool `url:"isPerformanceAdvisorEnabled,omitempty"`
+	isRealtimePerformancePanelEnabled *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
+	isSchemaAdvisorEnabled *bool `url:"isRealtimePerformancePanelEnabled,omitempty"`
+}
+
+
+// GetProjectSettings gets details about the settings for specified project.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api/project-settings-get-one/
+func (s *ProjectsServiceOp) GetProjectSettings(ctx context.Context, groupID string) (*ProjectSettings, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(projectSettingsBasePath, groupID)
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var root *ProjectSettings
+	resp, err := s.Client.Do(ctx, req, &root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, nil
+}
+
+// UpdateProjectSettings updates the settings for the specified project.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api/project-settings-update-one/
+func (s *ProjectsServiceOp) UpdateProjectSettings(ctx context.Context, groupID string, projectSettings *ProjectSettings) (*ProjectSettings, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(projectSettingsBasePath, groupID)
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, projectSettings)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var root *ProjectSettings
+	resp, err := s.Client.Do(ctx, req, &root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, nil
+}
+
+

--- a/mongodbatlas/project_settings_test.go
+++ b/mongodbatlas/project_settings_test.go
@@ -31,10 +31,10 @@ func TestProjects_GetProjectSettings(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		_, _ = fmt.Fprint(w, `{
                "isCollectDatabaseSpecificsStatisticsEnabled": true,
-			   "IsDataExplorerEnabled": true,
-			   "IsPerformanceAdvisorEnabled": true,
-			   "IsRealtimePerformancePanelEnabled": true,
-			   "IsSchemaAdvisorEnabled": true
+			   "isDataExplorerEnabled": true,
+			   "isPerformanceAdvisorEnabled": true,
+			   "isRealtimePerformancePanelEnabled": true,
+			   "isSchemaAdvisorEnabled": true
 }`)
 	})
 
@@ -64,10 +64,10 @@ func TestProjects_UpdateProjectSettings(t *testing.T) {
 		testMethod(t, r, http.MethodPatch)
 		_, _ = fmt.Fprint(w, `{
                "isCollectDatabaseSpecificsStatisticsEnabled": true,
-			   "IsDataExplorerEnabled": true,
-			   "IsPerformanceAdvisorEnabled": true,
-			   "IsRealtimePerformancePanelEnabled": true,
-			   "IsSchemaAdvisorEnabled": true
+			   "isDataExplorerEnabled": true,
+			   "isPerformanceAdvisorEnabled": true,
+			   "isRealtimePerformancePanelEnabled": true,
+			   "isSchemaAdvisorEnabled": true
 }`)
 	})
 

--- a/mongodbatlas/project_settings_test.go
+++ b/mongodbatlas/project_settings_test.go
@@ -19,9 +19,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/openlyinc/pointy"
-
 	"github.com/go-test/deep"
+	"github.com/openlyinc/pointy"
 )
 
 func TestProjects_GetProjectSettings(t *testing.T) {

--- a/mongodbatlas/project_settings_test.go
+++ b/mongodbatlas/project_settings_test.go
@@ -1,0 +1,98 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"fmt"
+	"github.com/openlyinc/pointy"
+	"net/http"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestProjects_GetProjectSettings(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/settings", groupID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		_, _ = fmt.Fprint(w, `{
+               "isCollectDatabaseSpecificsStatisticsEnabled": true,
+			   "isDataExplorerEnabled": true,
+			   "isPerformanceAdvisorEnabled": true,
+			   "isRealtimePerformancePanelEnabled": true,
+			   "isSchemaAdvisorEnabled": true
+}`)
+	})
+
+	projectSettings, _, err := client.Projects.GetProjectSettings(ctx, groupID)
+	if err != nil {
+		t.Fatalf("Projects.GetProjectSettings returned error: %v", err)
+	}
+
+	expected := &ProjectSettings{
+		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
+		isDataExplorerEnabled:                       pointy.Bool(true),
+		isPerformanceAdvisorEnabled:                 pointy.Bool(true),
+		isRealtimePerformancePanelEnabled:           pointy.Bool(true),
+		isSchemaAdvisorEnabled:                      pointy.Bool(true),
+	}
+
+	if diff := deep.Equal(projectSettings, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestProjects_UpdateProjectSettings(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/settings", groupID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		_, _ = fmt.Fprint(w, `{
+               "isCollectDatabaseSpecificsStatisticsEnabled": true,
+			   "isDataExplorerEnabled": true,
+			   "isPerformanceAdvisorEnabled": true,
+			   "isRealtimePerformancePanelEnabled": true,
+			   "isSchemaAdvisorEnabled": true
+}`)
+	})
+
+	body := &ProjectSettings{
+		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
+		isDataExplorerEnabled:                       pointy.Bool(true),
+		isPerformanceAdvisorEnabled:                 pointy.Bool(true),
+		isRealtimePerformancePanelEnabled:           pointy.Bool(true),
+		isSchemaAdvisorEnabled:                      pointy.Bool(true),
+	}
+
+	response, _, err := client.Projects.UpdateProjectSettings(ctx, groupID, body)
+	if err != nil {
+		t.Fatalf("Projects.UpdateProjectSettings returned error: %v", err)
+	}
+
+	expected := &ProjectSettings{
+		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
+		isDataExplorerEnabled:                       pointy.Bool(true),
+		isPerformanceAdvisorEnabled:                 pointy.Bool(true),
+		isRealtimePerformancePanelEnabled:           pointy.Bool(true),
+		isSchemaAdvisorEnabled:                      pointy.Bool(true),
+	}
+
+	if diff := deep.Equal(response, expected); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/mongodbatlas/project_settings_test.go
+++ b/mongodbatlas/project_settings_test.go
@@ -16,9 +16,10 @@ package mongodbatlas
 
 import (
 	"fmt"
-	"github.com/openlyinc/pointy"
 	"net/http"
 	"testing"
+
+	"github.com/openlyinc/pointy"
 
 	"github.com/go-test/deep"
 )
@@ -31,10 +32,10 @@ func TestProjects_GetProjectSettings(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		_, _ = fmt.Fprint(w, `{
                "isCollectDatabaseSpecificsStatisticsEnabled": true,
-			   "isDataExplorerEnabled": true,
-			   "isPerformanceAdvisorEnabled": true,
-			   "isRealtimePerformancePanelEnabled": true,
-			   "isSchemaAdvisorEnabled": true
+			   "IsDataExplorerEnabled": true,
+			   "IsPerformanceAdvisorEnabled": true,
+			   "IsRealtimePerformancePanelEnabled": true,
+			   "IsSchemaAdvisorEnabled": true
 }`)
 	})
 
@@ -45,10 +46,10 @@ func TestProjects_GetProjectSettings(t *testing.T) {
 
 	expected := &ProjectSettings{
 		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
-		isDataExplorerEnabled:                       pointy.Bool(true),
-		isPerformanceAdvisorEnabled:                 pointy.Bool(true),
-		isRealtimePerformancePanelEnabled:           pointy.Bool(true),
-		isSchemaAdvisorEnabled:                      pointy.Bool(true),
+		IsDataExplorerEnabled:                       pointy.Bool(true),
+		IsPerformanceAdvisorEnabled:                 pointy.Bool(true),
+		IsRealtimePerformancePanelEnabled:           pointy.Bool(true),
+		IsSchemaAdvisorEnabled:                      pointy.Bool(true),
 	}
 
 	if diff := deep.Equal(projectSettings, expected); diff != nil {
@@ -64,19 +65,19 @@ func TestProjects_UpdateProjectSettings(t *testing.T) {
 		testMethod(t, r, http.MethodPatch)
 		_, _ = fmt.Fprint(w, `{
                "isCollectDatabaseSpecificsStatisticsEnabled": true,
-			   "isDataExplorerEnabled": true,
-			   "isPerformanceAdvisorEnabled": true,
-			   "isRealtimePerformancePanelEnabled": true,
-			   "isSchemaAdvisorEnabled": true
+			   "IsDataExplorerEnabled": true,
+			   "IsPerformanceAdvisorEnabled": true,
+			   "IsRealtimePerformancePanelEnabled": true,
+			   "IsSchemaAdvisorEnabled": true
 }`)
 	})
 
 	body := &ProjectSettings{
 		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
-		isDataExplorerEnabled:                       pointy.Bool(true),
-		isPerformanceAdvisorEnabled:                 pointy.Bool(true),
-		isRealtimePerformancePanelEnabled:           pointy.Bool(true),
-		isSchemaAdvisorEnabled:                      pointy.Bool(true),
+		IsDataExplorerEnabled:                       pointy.Bool(true),
+		IsPerformanceAdvisorEnabled:                 pointy.Bool(true),
+		IsRealtimePerformancePanelEnabled:           pointy.Bool(true),
+		IsSchemaAdvisorEnabled:                      pointy.Bool(true),
 	}
 
 	response, _, err := client.Projects.UpdateProjectSettings(ctx, groupID, body)
@@ -86,10 +87,10 @@ func TestProjects_UpdateProjectSettings(t *testing.T) {
 
 	expected := &ProjectSettings{
 		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
-		isDataExplorerEnabled:                       pointy.Bool(true),
-		isPerformanceAdvisorEnabled:                 pointy.Bool(true),
-		isRealtimePerformancePanelEnabled:           pointy.Bool(true),
-		isSchemaAdvisorEnabled:                      pointy.Bool(true),
+		IsDataExplorerEnabled:                       pointy.Bool(true),
+		IsPerformanceAdvisorEnabled:                 pointy.Bool(true),
+		IsRealtimePerformancePanelEnabled:           pointy.Bool(true),
+		IsSchemaAdvisorEnabled:                      pointy.Bool(true),
 	}
 
 	if diff := deep.Equal(response, expected); diff != nil {

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -53,7 +53,7 @@ type ProjectsService interface {
 	UpdateInvitation(context.Context, string, *Invitation) (*Invitation, *Response, error)
 	UpdateInvitationByID(context.Context, string, string, *Invitation) (*Invitation, *Response, error)
 	DeleteInvitation(context.Context, string, string) (*Response, error)
-	GetProjectSettings(context.Context, string)(*ProjectSettings, *Response, error)
+	GetProjectSettings(context.Context, string) (*ProjectSettings, *Response, error)
 	UpdateProjectSettings(context.Context, string, *ProjectSettings) (*ProjectSettings, *Response, error)
 }
 

--- a/mongodbatlas/projects.go
+++ b/mongodbatlas/projects.go
@@ -53,6 +53,8 @@ type ProjectsService interface {
 	UpdateInvitation(context.Context, string, *Invitation) (*Invitation, *Response, error)
 	UpdateInvitationByID(context.Context, string, string, *Invitation) (*Invitation, *Response, error)
 	DeleteInvitation(context.Context, string, string) (*Response, error)
+	GetProjectSettings(context.Context, string)(*ProjectSettings, *Response, error)
+	UpdateProjectSettings(context.Context, string, *ProjectSettings) (*ProjectSettings, *Response, error)
 }
 
 // ProjectsServiceOp handles communication with the Projects related methods of the


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Atlas customers can now manage project settings and all cluster resizing via the Admin API, rather than shifting to the UI for certain operations. This improves operational workflows, allowing customers to manage their deployments more programmatically.

[Get Product Settings](https://www.mongodb.com/docs/atlas/reference/api/project-settings-get-one/), [Update Project Settings](https://www.mongodb.com/docs/atlas/reference/api/project-settings-update-one/)