### PR TITLE
feat: add support to export snapshots on backup policies

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_backup_policies.go
+++ b/mongodbatlas/cloud_provider_snapshot_backup_policies.go
@@ -50,6 +50,8 @@ type CloudProviderSnapshotBackupPolicy struct {
 	UpdateSnapshots       *bool    `json:"updateSnapshots,omitempty"`       // Specify true to apply the retention changes in the updated backup policy to snapshots that Atlas took previously.
 	NextSnapshot          string   `json:"nextSnapshot,omitempty"`          // UTC ISO 8601 formatted point in time when Atlas will take the next snapshot.
 	Policies              []Policy `json:"policies,omitempty"`              // A list of policy definitions for the cluster.
+	AutoExportEnabled     *bool    `json:"autoExportEnabled,omitempty"`     // Specify true to enable automatic export of cloud backup snapshots to the AWS bucket. You must also define the export policy using export. Specify false to disable automatic export.
+	Export                *Export  `json:"export,omitempty"`                // Export struct that represents a policy for automatically exporting cloud backup snapshots to AWS bucket.
 }
 
 // Policy represents for the snapshot and an array of backup policy items.
@@ -65,6 +67,12 @@ type PolicyItem struct {
 	FrequencyType     string `json:"frequencyType,omitempty"`     // Frequency associated with the backup policy item. One of the following values: hourly, daily, weekly or monthly.
 	RetentionUnit     string `json:"retentionUnit,omitempty"`     // Metric of duration of the backup policy item: days, weeks, or months.
 	RetentionValue    int    `json:"retentionValue,omitempty"`    // Duration for which the backup is kept. Associated with retentionUnit.
+}
+
+// Export represents a policy for automatically exporting cloud backup snapshots to AWS bucket.
+type Export struct {
+	ExportBucketID string `json:"exportBucketId,omitempty"` // Unique identifier of the AWS bucket to export the cloud backup snapshot to.
+	FrequencyType  string `json:"frequencyType,omitempty"`  // Frequency associated with the export policy.
 }
 
 // Get gets the current snapshot schedule and retention settings for the cluster with {CLUSTER-NAME}.

--- a/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
@@ -86,7 +86,12 @@ func TestCloudProviderSnapshotBackupPolicies_Get(t *testing.T) {
 			],
 			"referenceHourOfDay": 17,
 			"referenceMinuteOfHour": 24,
-			"restoreWindowDays": 7
+			"restoreWindowDays": 7,
+			"autoExportEnabled" : true,
+			"export": {
+			  "frequencyType": "monthly",
+			  "exportBucketId": "604f6322dc786a5341d4f7fb"
+			}
 		}`)
 	})
 
@@ -137,6 +142,11 @@ func TestCloudProviderSnapshotBackupPolicies_Get(t *testing.T) {
 		ReferenceHourOfDay:    pointy.Int64(17),
 		ReferenceMinuteOfHour: pointy.Int64(24),
 		RestoreWindowDays:     pointy.Int64(7),
+		AutoExportEnabled:     pointy.Bool(true),
+		Export: &Export{
+			ExportBucketID: "604f6322dc786a5341d4f7fb",
+			FrequencyType:  "monthly",
+		},
 	}
 
 	if diff := deep.Equal(snapshotBackupPolicy, expected); diff != nil {
@@ -178,7 +188,12 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 					},
 				},
 			},
-			"updateSnapshots": true,
+			"updateSnapshots":   true,
+			"autoExportEnabled": true,
+			"export": map[string]interface{}{
+				"frequencyType":  "monthly",
+				"exportBucketId": "604f6322dc786a5341d4f7fb",
+			},
 		}
 
 		var v map[string]interface{}
@@ -227,7 +242,12 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 				}
 			],
 			"referenceHourOfDay": 12,
-			"referenceMinuteOfHour": 30
+			"referenceMinuteOfHour": 30,
+			"autoExportEnabled" : true,
+			"export": {
+			  "frequencyType": "monthly",
+			  "exportBucketId": "604f6322dc786a5341d4f7fb"
+			}
 		}`)
 	})
 
@@ -255,7 +275,12 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 				},
 			},
 		},
-		UpdateSnapshots: pointy.Bool(true),
+		UpdateSnapshots:   pointy.Bool(true),
+		AutoExportEnabled: pointy.Bool(true),
+		Export: &Export{
+			ExportBucketID: "604f6322dc786a5341d4f7fb",
+			FrequencyType:  "monthly",
+		},
 	}
 
 	cloudProviderSnapshot, _, err := client.CloudProviderSnapshotBackupPolicies.Update(ctx, groupID, clusterName, updateRequest)
@@ -290,6 +315,11 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 		},
 		ReferenceHourOfDay:    pointy.Int64(12),
 		ReferenceMinuteOfHour: pointy.Int64(30),
+		AutoExportEnabled:     pointy.Bool(true),
+		Export: &Export{
+			ExportBucketID: "604f6322dc786a5341d4f7fb",
+			FrequencyType:  "monthly",
+		},
 	}
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {
@@ -331,7 +361,12 @@ func TestCloudProviderSnapshotBackupPolicies_Delete(t *testing.T) {
 			],
 			"referenceHourOfDay": 17,
 			"referenceMinuteOfHour": 24,
-			"restoreWindowDays": 7
+			"restoreWindowDays": 7,
+			"autoExportEnabled" : true,
+			"export": {
+			  "frequencyType": "monthly",
+			  "exportBucketId": "604f6322dc786a5341d4f7fb"
+			}
 		}`)
 	})
 
@@ -353,6 +388,11 @@ func TestCloudProviderSnapshotBackupPolicies_Delete(t *testing.T) {
 		ReferenceHourOfDay:    pointy.Int64(17),
 		ReferenceMinuteOfHour: pointy.Int64(24),
 		RestoreWindowDays:     pointy.Int64(7),
+		AutoExportEnabled:     pointy.Bool(true),
+		Export: &Export{
+			ExportBucketID: "604f6322dc786a5341d4f7fb",
+			FrequencyType:  "monthly",
+		},
 	}
 
 	if diff := deep.Equal(cloudProviderSnapshot, expected); diff != nil {


### PR DESCRIPTION
## Description

This is a needed feature to implement export snapshot possibility on terraform module.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

