### PR TITLE
CLOUDP-110989: Capture Raw response body

### DIFF
--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -85,6 +85,9 @@ type Client struct {
 	BaseURL   *url.URL
 	UserAgent string
 
+	// copy raw server response to the Response struct
+	withRaw bool
+
 	// Services used for communicating with the API
 	CustomDBRoles                       CustomDBRolesService
 	DatabaseUsers                       DatabaseUsersService
@@ -328,6 +331,14 @@ func SetBaseURL(bu string) ClientOpt {
 	}
 }
 
+// SetWithRaw is a client option for getting raw atlas server response within Response structure.
+func SetWithRaw() ClientOpt {
+	return func(c *Client) error {
+		c.withRaw = true
+		return nil
+	}
+}
+
 // SetUserAgent is a client option for setting the user agent.
 func SetUserAgent(ua string) ClientOpt {
 	return func(c *Client) error {
@@ -451,14 +462,27 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		return response, err
 	}
 
+	body := resp.Body
+
+	if c.withRaw {
+		raw := new(bytes.Buffer)
+		_, err = io.Copy(raw, body)
+		if err != nil {
+			return response, err
+		}
+
+		response.Raw = raw.Bytes()
+		body = io.NopCloser(raw)
+	}
+
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {
-			_, err = io.Copy(w, resp.Body)
+			_, err = io.Copy(w, body)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			decErr := json.NewDecoder(resp.Body).Decode(v)
+			decErr := json.NewDecoder(body).Decode(v)
 			if errors.Is(decErr, io.EOF) {
 				decErr = nil // ignore EOF errors caused by empty response body
 			}


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

We are adding a `WithRaw()` option to allow copying body responses.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

based on https://github.com/mongodb/go-client-mongodb-ops-manager/pull/72