### PR TITLE
CLOUDP-127482: Add filter by name on list all groups by org

### DIFF
--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -30,7 +30,7 @@ type OrganizationsService interface {
 	Invitations(context.Context, string, *InvitationOptions) ([]*Invitation, *Response, error)
 	Get(context.Context, string) (*Organization, *Response, error)
 	Invitation(context.Context, string, string) (*Invitation, *Response, error)
-	Projects(context.Context, string, *ListOptions) (*Projects, *Response, error)
+	Projects(context.Context, string, *ProjectsListOptions) (*Projects, *Response, error)
 	Users(context.Context, string, *ListOptions) (*AtlasUsersResponse, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	InviteUser(context.Context, string, *Invitation) (*Invitation, *Response, error)
@@ -48,6 +48,12 @@ var _ OrganizationsService = &OrganizationsServiceOp{}
 type OrganizationsListOptions struct {
 	Name               string `url:"name,omitempty"`
 	IncludeDeletedOrgs *bool  `url:"includeDeletedOrgs,omitempty"`
+	ListOptions
+}
+
+// ProjectsListOptions filtering options for projects.
+type ProjectsListOptions struct {
+	Name string `url:"name,omitempty"`
 	ListOptions
 }
 
@@ -120,7 +126,7 @@ func (s *OrganizationsServiceOp) Get(ctx context.Context, orgID string) (*Organi
 // Projects gets all projects for the given organization ID.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organization-get-all-projects/
-func (s *OrganizationsServiceOp) Projects(ctx context.Context, orgID string, opts *ListOptions) (*Projects, *Response, error) {
+func (s *OrganizationsServiceOp) Projects(ctx context.Context, orgID string, opts *ProjectsListOptions) (*Projects, *Response, error) {
 	if orgID == "" {
 		return nil, nil, NewArgError("orgID", "must be set")
 	}

--- a/mongodbatlas/organizations_test.go
+++ b/mongodbatlas/organizations_test.go
@@ -234,7 +234,7 @@ func TestOrganizationsServiceOp_Projects(t *testing.T) {
 		}`)
 	})
 
-	projects, _, err := client.Organizations.Projects(ctx, orgID, nil)
+	projects, _, err := client.Organizations.Projects(ctx, orgID, &ProjectsListOptions{Name: "FooBar"})
 	if err != nil {
 		t.Fatalf("Organizations.GetProjects returned error: %v", err)
 	}


### PR DESCRIPTION
## Description

Add filter by name on list all groups by org

Link to any related issue(s): CLOUDP-127482

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

