### PR TITLE
CLOUDP-139997: added OplogMinRetentionHours to ProcessArgs

### DIFF
--- a/mongodbatlas/advanced_clusters.go
+++ b/mongodbatlas/advanced_clusters.go
@@ -43,66 +43,66 @@ var _ AdvancedClustersService = &AdvancedClustersServiceOp{}
 
 // AdvancedCluster represents MongoDB cluster.
 type AdvancedCluster struct {
-	BackupEnabled            *bool                      `json:"backupEnabled,omitempty"`
-	BiConnector              *BiConnector               `json:"biConnector,omitempty"`
-	ClusterType              string                     `json:"clusterType,omitempty"`
-	ConnectionStrings        *ConnectionStrings         `json:"connectionStrings,omitempty"`
-	DiskSizeGB               *float64                   `json:"diskSizeGB,omitempty"`
-	EncryptionAtRestProvider string                     `json:"encryptionAtRestProvider,omitempty"`
-	GroupID                  string                     `json:"groupId,omitempty"`
-	ID                       string                     `json:"id,omitempty"`
-	Labels                   []Label                    `json:"labels,omitempty"`
-	MongoDBMajorVersion      string                     `json:"mongoDBMajorVersion,omitempty"`
-	MongoDBVersion           string                     `json:"mongoDBVersion,omitempty"`
-	Name                     string                     `json:"name,omitempty"`
-	Paused                   *bool                      `json:"paused,omitempty"`
-	PitEnabled               *bool                      `json:"pitEnabled,omitempty"`
-	StateName                string                     `json:"stateName,omitempty"`
-	ReplicationSpecs         []*AdvancedReplicationSpec `json:"replicationSpecs,omitempty"`
-	CreateDate               string                     `json:"createDate,omitempty"`
-	RootCertType             string                     `json:"rootCertType,omitempty"`
-	VersionReleaseSystem     string                     `json:"versionReleaseSystem,omitempty"`
+	BackupEnabled            *bool                      `yaml:"backupEnabled,omitempty" json:"backupEnabled,omitempty"`
+	BiConnector              *BiConnector               `yaml:"biConnector,omitempty" json:"biConnector,omitempty"`
+	ClusterType              string                     `yaml:"clusterType,omitempty" json:"clusterType,omitempty"`
+	ConnectionStrings        *ConnectionStrings         `yaml:"connectionStrings,omitempty" json:"connectionStrings,omitempty"`
+	DiskSizeGB               *float64                   `yaml:"diskSizeGB,omitempty" json:"diskSizeGB,omitempty"`
+	EncryptionAtRestProvider string                     `yaml:"encryptionAtRestProvider,omitempty" json:"encryptionAtRestProvider,omitempty"`
+	GroupID                  string                     `yaml:"groupId,omitempty" json:"groupId,omitempty"`
+	ID                       string                     `yaml:"id,omitempty" json:"id,omitempty"`
+	Labels                   []Label                    `yaml:"labels,omitempty" json:"labels,omitempty"`
+	MongoDBMajorVersion      string                     `yaml:"mongoDBMajorVersion,omitempty" json:"mongoDBMajorVersion,omitempty"`
+	MongoDBVersion           string                     `yaml:"mongoDBVersion,omitempty" json:"mongoDBVersion,omitempty"`
+	Name                     string                     `yaml:"name,omitempty" json:"name,omitempty"`
+	Paused                   *bool                      `yaml:"paused,omitempty" json:"paused,omitempty"`
+	PitEnabled               *bool                      `yaml:"pitEnabled,omitempty" json:"pitEnabled,omitempty"`
+	StateName                string                     `yaml:"stateName,omitempty" json:"stateName,omitempty"`
+	ReplicationSpecs         []*AdvancedReplicationSpec `yaml:"replicationSpecs,omitempty" json:"replicationSpecs,omitempty"`
+	CreateDate               string                     `yaml:"createDate,omitempty" json:"createDate,omitempty"`
+	RootCertType             string                     `yaml:"rootCertType,omitempty" json:"rootCertType,omitempty"`
+	VersionReleaseSystem     string                     `yaml:"versionReleaseSystem,omitempty" json:"versionReleaseSystem,omitempty"`
 }
 
 type AdvancedReplicationSpec struct {
-	NumShards     int                     `json:"numShards,omitempty"`
-	ID            string                  `json:"id,omitempty"`
-	ZoneName      string                  `json:"zoneName,omitempty"`
-	RegionConfigs []*AdvancedRegionConfig `json:"regionConfigs,omitempty"`
+	NumShards     int                     `yaml:"numShards,omitempty" json:"numShards,omitempty"`
+	ID            string                  `yaml:"id,omitempty" json:"id,omitempty"`
+	ZoneName      string                  `yaml:"zoneName,omitempty" json:"zoneName,omitempty"`
+	RegionConfigs []*AdvancedRegionConfig `yaml:"regionConfigs,omitempty" json:"regionConfigs,omitempty"`
 }
 
 type AdvancedRegionConfig struct {
-	AnalyticsSpecs      *Specs               `json:"analyticsSpecs,omitempty"`
-	ElectableSpecs      *Specs               `json:"electableSpecs,omitempty"`
-	ReadOnlySpecs       *Specs               `json:"readOnlySpecs,omitempty"`
-	AutoScaling         *AdvancedAutoScaling `json:"autoScaling,omitempty"`
-	BackingProviderName string               `json:"backingProviderName,omitempty"`
-	Priority            *int                 `json:"priority,omitempty"`
-	ProviderName        string               `json:"providerName,omitempty"`
-	RegionName          string               `json:"regionName,omitempty"`
+	AnalyticsSpecs      *Specs               `yaml:"analyticsSpecs,omitempty" json:"analyticsSpecs,omitempty"`
+	ElectableSpecs      *Specs               `yaml:"electableSpecs,omitempty" json:"electableSpecs,omitempty"`
+	ReadOnlySpecs       *Specs               `yaml:"readOnlySpecs,omitempty" json:"readOnlySpecs,omitempty"`
+	AutoScaling         *AdvancedAutoScaling `yaml:"autoScaling,omitempty" json:"autoScaling,omitempty"`
+	BackingProviderName string               `yaml:"backingProviderName,omitempty" json:"backingProviderName,omitempty"`
+	Priority            *int                 `yaml:"priority,omitempty" json:"priority,omitempty"`
+	ProviderName        string               `yaml:"providerName,omitempty" json:"providerName,omitempty"`
+	RegionName          string               `yaml:"regionName,omitempty" json:"regionName,omitempty"`
 }
 
 type AdvancedAutoScaling struct {
-	DiskGB  *DiskGB  `json:"diskGB,omitempty"`
-	Compute *Compute `json:"compute,omitempty"`
+	DiskGB  *DiskGB  `yaml:"diskGB,omitempty" json:"diskGB,omitempty"`
+	Compute *Compute `yaml:"compute,omitempty" json:"compute,omitempty"`
 }
 
 type DiskGB struct {
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 }
 
 type Specs struct {
-	DiskIOPS      *int64 `json:"diskIOPS,omitempty"`
-	EbsVolumeType string `json:"ebsVolumeType,omitempty"`
-	InstanceSize  string `json:"instanceSize,omitempty"`
-	NodeCount     *int   `json:"nodeCount,omitempty"`
+	DiskIOPS      *int64 `yaml:"diskIOPS,omitempty" json:"diskIOPS,omitempty"`
+	EbsVolumeType string `yaml:"ebsVolumeType,omitempty" json:"ebsVolumeType,omitempty"`
+	InstanceSize  string `yaml:"instanceSize,omitempty" json:"instanceSize,omitempty"`
+	NodeCount     *int   `yaml:"nodeCount,omitempty" json:"nodeCount,omitempty"`
 }
 
 // AdvancedClustersResponse is the response from the AdvancedClustersService.List.
 type AdvancedClustersResponse struct {
-	Links      []*Link            `json:"links,omitempty"`
-	Results    []*AdvancedCluster `json:"results,omitempty"`
-	TotalCount int                `json:"totalCount,omitempty"`
+	Links      []*Link            `yaml:"links,omitempty" json:"links,omitempty"`
+	Results    []*AdvancedCluster `yaml:"results,omitempty" json:"results,omitempty"`
+	TotalCount int                `yaml:"totalCount,omitempty" json:"totalCount,omitempty"`
 }
 
 // List all clusters in the project associated to {GROUP-ID}.

--- a/mongodbatlas/advanced_clusters.go
+++ b/mongodbatlas/advanced_clusters.go
@@ -43,66 +43,66 @@ var _ AdvancedClustersService = &AdvancedClustersServiceOp{}
 
 // AdvancedCluster represents MongoDB cluster.
 type AdvancedCluster struct {
-	BackupEnabled            *bool                      `yaml:"backupEnabled,omitempty" json:"backupEnabled,omitempty"`
-	BiConnector              *BiConnector               `yaml:"biConnector,omitempty" json:"biConnector,omitempty"`
-	ClusterType              string                     `yaml:"clusterType,omitempty" json:"clusterType,omitempty"`
-	ConnectionStrings        *ConnectionStrings         `yaml:"connectionStrings,omitempty" json:"connectionStrings,omitempty"`
-	DiskSizeGB               *float64                   `yaml:"diskSizeGB,omitempty" json:"diskSizeGB,omitempty"`
-	EncryptionAtRestProvider string                     `yaml:"encryptionAtRestProvider,omitempty" json:"encryptionAtRestProvider,omitempty"`
-	GroupID                  string                     `yaml:"groupId,omitempty" json:"groupId,omitempty"`
-	ID                       string                     `yaml:"id,omitempty" json:"id,omitempty"`
-	Labels                   []Label                    `yaml:"labels,omitempty" json:"labels,omitempty"`
-	MongoDBMajorVersion      string                     `yaml:"mongoDBMajorVersion,omitempty" json:"mongoDBMajorVersion,omitempty"`
-	MongoDBVersion           string                     `yaml:"mongoDBVersion,omitempty" json:"mongoDBVersion,omitempty"`
-	Name                     string                     `yaml:"name,omitempty" json:"name,omitempty"`
-	Paused                   *bool                      `yaml:"paused,omitempty" json:"paused,omitempty"`
-	PitEnabled               *bool                      `yaml:"pitEnabled,omitempty" json:"pitEnabled,omitempty"`
-	StateName                string                     `yaml:"stateName,omitempty" json:"stateName,omitempty"`
-	ReplicationSpecs         []*AdvancedReplicationSpec `yaml:"replicationSpecs,omitempty" json:"replicationSpecs,omitempty"`
-	CreateDate               string                     `yaml:"createDate,omitempty" json:"createDate,omitempty"`
-	RootCertType             string                     `yaml:"rootCertType,omitempty" json:"rootCertType,omitempty"`
-	VersionReleaseSystem     string                     `yaml:"versionReleaseSystem,omitempty" json:"versionReleaseSystem,omitempty"`
+	BackupEnabled            *bool                      `json:"backupEnabled,omitempty"`
+	BiConnector              *BiConnector               `json:"biConnector,omitempty"`
+	ClusterType              string                     `json:"clusterType,omitempty"`
+	ConnectionStrings        *ConnectionStrings         `json:"connectionStrings,omitempty"`
+	DiskSizeGB               *float64                   `json:"diskSizeGB,omitempty"`
+	EncryptionAtRestProvider string                     `json:"encryptionAtRestProvider,omitempty"`
+	GroupID                  string                     `json:"groupId,omitempty"`
+	ID                       string                     `json:"id,omitempty"`
+	Labels                   []Label                    `json:"labels,omitempty"`
+	MongoDBMajorVersion      string                     `json:"mongoDBMajorVersion,omitempty"`
+	MongoDBVersion           string                     `json:"mongoDBVersion,omitempty"`
+	Name                     string                     `json:"name,omitempty"`
+	Paused                   *bool                      `json:"paused,omitempty"`
+	PitEnabled               *bool                      `json:"pitEnabled,omitempty"`
+	StateName                string                     `json:"stateName,omitempty"`
+	ReplicationSpecs         []*AdvancedReplicationSpec `json:"replicationSpecs,omitempty"`
+	CreateDate               string                     `json:"createDate,omitempty"`
+	RootCertType             string                     `json:"rootCertType,omitempty"`
+	VersionReleaseSystem     string                     `json:"versionReleaseSystem,omitempty"`
 }
 
 type AdvancedReplicationSpec struct {
-	NumShards     int                     `yaml:"numShards,omitempty" json:"numShards,omitempty"`
-	ID            string                  `yaml:"id,omitempty" json:"id,omitempty"`
-	ZoneName      string                  `yaml:"zoneName,omitempty" json:"zoneName,omitempty"`
-	RegionConfigs []*AdvancedRegionConfig `yaml:"regionConfigs,omitempty" json:"regionConfigs,omitempty"`
+	NumShards     int                     `json:"numShards,omitempty"`
+	ID            string                  `json:"id,omitempty"`
+	ZoneName      string                  `json:"zoneName,omitempty"`
+	RegionConfigs []*AdvancedRegionConfig `json:"regionConfigs,omitempty"`
 }
 
 type AdvancedRegionConfig struct {
-	AnalyticsSpecs      *Specs               `yaml:"analyticsSpecs,omitempty" json:"analyticsSpecs,omitempty"`
-	ElectableSpecs      *Specs               `yaml:"electableSpecs,omitempty" json:"electableSpecs,omitempty"`
-	ReadOnlySpecs       *Specs               `yaml:"readOnlySpecs,omitempty" json:"readOnlySpecs,omitempty"`
-	AutoScaling         *AdvancedAutoScaling `yaml:"autoScaling,omitempty" json:"autoScaling,omitempty"`
-	BackingProviderName string               `yaml:"backingProviderName,omitempty" json:"backingProviderName,omitempty"`
-	Priority            *int                 `yaml:"priority,omitempty" json:"priority,omitempty"`
-	ProviderName        string               `yaml:"providerName,omitempty" json:"providerName,omitempty"`
-	RegionName          string               `yaml:"regionName,omitempty" json:"regionName,omitempty"`
+	AnalyticsSpecs      *Specs               `json:"analyticsSpecs,omitempty"`
+	ElectableSpecs      *Specs               `json:"electableSpecs,omitempty"`
+	ReadOnlySpecs       *Specs               `json:"readOnlySpecs,omitempty"`
+	AutoScaling         *AdvancedAutoScaling `json:"autoScaling,omitempty"`
+	BackingProviderName string               `json:"backingProviderName,omitempty"`
+	Priority            *int                 `json:"priority,omitempty"`
+	ProviderName        string               `json:"providerName,omitempty"`
+	RegionName          string               `json:"regionName,omitempty"`
 }
 
 type AdvancedAutoScaling struct {
-	DiskGB  *DiskGB  `yaml:"diskGB,omitempty" json:"diskGB,omitempty"`
-	Compute *Compute `yaml:"compute,omitempty" json:"compute,omitempty"`
+	DiskGB  *DiskGB  `json:"diskGB,omitempty"`
+	Compute *Compute `json:"compute,omitempty"`
 }
 
 type DiskGB struct {
-	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 type Specs struct {
-	DiskIOPS      *int64 `yaml:"diskIOPS,omitempty" json:"diskIOPS,omitempty"`
-	EbsVolumeType string `yaml:"ebsVolumeType,omitempty" json:"ebsVolumeType,omitempty"`
-	InstanceSize  string `yaml:"instanceSize,omitempty" json:"instanceSize,omitempty"`
-	NodeCount     *int   `yaml:"nodeCount,omitempty" json:"nodeCount,omitempty"`
+	DiskIOPS      *int64 `json:"diskIOPS,omitempty"`
+	EbsVolumeType string `json:"ebsVolumeType,omitempty"`
+	InstanceSize  string `json:"instanceSize,omitempty"`
+	NodeCount     *int   `json:"nodeCount,omitempty"`
 }
 
 // AdvancedClustersResponse is the response from the AdvancedClustersService.List.
 type AdvancedClustersResponse struct {
-	Links      []*Link            `yaml:"links,omitempty" json:"links,omitempty"`
-	Results    []*AdvancedCluster `yaml:"results,omitempty" json:"results,omitempty"`
-	TotalCount int                `yaml:"totalCount,omitempty" json:"totalCount,omitempty"`
+	Links      []*Link            `json:"links,omitempty"`
+	Results    []*AdvancedCluster `json:"results,omitempty"`
+	TotalCount int                `json:"totalCount,omitempty"`
 }
 
 // List all clusters in the project associated to {GROUP-ID}.

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -173,15 +173,16 @@ type Cluster struct {
 
 // ProcessArgs represents the advanced configuration options for the cluster.
 type ProcessArgs struct {
-	DefaultReadConcern               string `json:"defaultReadConcern,omitempty"`
-	DefaultWriteConcern              string `json:"defaultWriteConcern,omitempty"`
-	FailIndexKeyTooLong              *bool  `json:"failIndexKeyTooLong,omitempty"`
-	JavascriptEnabled                *bool  `json:"javascriptEnabled,omitempty"`
-	MinimumEnabledTLSProtocol        string `json:"minimumEnabledTlsProtocol,omitempty"`
-	NoTableScan                      *bool  `json:"noTableScan,omitempty"`
-	OplogSizeMB                      *int64 `json:"oplogSizeMB,omitempty"`
-	SampleSizeBIConnector            *int64 `json:"sampleSizeBIConnector,omitempty"`
-	SampleRefreshIntervalBIConnector *int64 `json:"sampleRefreshIntervalBIConnector,omitempty"`
+	DefaultReadConcern               string   `json:"defaultReadConcern,omitempty"`
+	DefaultWriteConcern              string   `json:"defaultWriteConcern,omitempty"`
+	MinimumEnabledTLSProtocol        string   `json:"minimumEnabledTlsProtocol,omitempty"`
+	FailIndexKeyTooLong              *bool    `json:"failIndexKeyTooLong,omitempty"`
+	JavascriptEnabled                *bool    `json:"javascriptEnabled,omitempty"`
+	NoTableScan                      *bool    `json:"noTableScan,omitempty"`
+	OplogSizeMB                      *int64   `json:"oplogSizeMB,omitempty"`
+	SampleSizeBIConnector            *int64   `json:"sampleSizeBIConnector,omitempty"`
+	SampleRefreshIntervalBIConnector *int64   `json:"sampleRefreshIntervalBIConnector,omitempty"`
+	OplogMinRetentionHours           *float64 `json:"oplogMinRetentionHours,omitempty"`
 }
 
 // ClusterStatus is the status of the operations on the cluster.
@@ -436,7 +437,7 @@ func (s *ClustersServiceOp) Delete(ctx context.Context, groupID, clusterName str
 
 // UpdateProcessArgs Modifies Advanced Configuration Options for One Cluster
 //
-// See more: https://docs.atlas.mongodb.com/reference/api/clusters-modify-advanced-configuration-options/
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/updateAdvancedConfigurationOptionsForOneCluster
 func (s *ClustersServiceOp) UpdateProcessArgs(ctx context.Context, groupID, clusterName string, updateRequest *ProcessArgs) (*ProcessArgs, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupId", "must be set")
@@ -464,7 +465,7 @@ func (s *ClustersServiceOp) UpdateProcessArgs(ctx context.Context, groupID, clus
 
 // GetProcessArgs gets the Advanced Configuration Options for One Cluster
 //
-// See more: https://docs.atlas.mongodb.com/reference/api/clusters-get-advanced-configuration-options/#get-advanced-configuration-options-for-one-cluster
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/returnOneAdvancedConfigurationOptionsForOneCluster
 func (s *ClustersServiceOp) GetProcessArgs(ctx context.Context, groupID, clusterName string) (*ProcessArgs, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupId", "must be set")

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -743,6 +743,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		MinimumEnabledTLSProtocol:        tlsProtocol,
 		NoTableScan:                      pointy.Bool(true),
 		OplogSizeMB:                      pointy.Int64(2000),
+		OplogMinRetentionHours:           pointy.Float64(100),
 		SampleSizeBIConnector:            pointy.Int64(5000),
 		SampleRefreshIntervalBIConnector: pointy.Int64(300),
 	}
@@ -756,6 +757,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 			"minimumEnabledTlsProtocol":        tlsProtocol,
 			"noTableScan":                      true,
 			"oplogSizeMB":                      float64(2000),
+			"oplogMinRetentionHours":           float64(100),
 			"sampleSizeBIConnector":            float64(5000),
 			"sampleRefreshIntervalBIConnector": float64(300),
 		}
@@ -769,6 +771,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 			"minimumEnabledTlsProtocol": "TLS1_2",
 			"noTableScan": true,
 			"oplogSizeMB": 2000,
+            "oplogMinRetentionHours": 100,
 			"sampleSizeBIConnector": 5000,
 			"sampleRefreshIntervalBIConnector": 300
 		}


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments
The ProcessArgs is missing `OplogMinRetentionHours` property. See [Update Advanced Configuration Options for One Cluster](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/upgradeOneTenantCluster)

