### PR TITLE
CLOUDP-141434: Add RootCertType to the atlas go client

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -169,6 +169,7 @@ type Cluster struct {
 	ConnectionStrings        *ConnectionStrings       `json:"connectionStrings,omitempty"`
 	Links                    []*Link                  `json:"links,omitempty"`
 	VersionReleaseSystem     string                   `json:"versionReleaseSystem,omitempty"`
+	RootCertType             string                   `json:"rootCertType,omitempty"`
 }
 
 // ProcessArgs represents the advanced configuration options for the cluster.

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -390,6 +390,7 @@ func TestClusters_Create(t *testing.T) {
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
 		StateName:            "IDLE",
 		VersionReleaseSystem: "LTS",
+		RootCertType:         "ISRGROOTX1",
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters", groupID), func(w http.ResponseWriter, r *http.Request) {
@@ -442,6 +443,7 @@ func TestClusters_Create(t *testing.T) {
 			"srvAddress":           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
 			"stateName":            "IDLE",
 			"versionReleaseSystem": "LTS",
+			"rootCertType":         "ISRGROOTX1",
 		}
 
 		jsonBlob := `


### PR DESCRIPTION
## Description

The cluster struct is missing  the `RootCertType` parameter. ([API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/createOneCluster))

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

