### PR TITLE
task: drop support for 1.17

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.17
           - 1.18
           - 1.19
     steps:


### PR DESCRIPTION
## Description

Drops support for go1.17, this is inline with our support policy we kept it because it wasn't affecting us but it now block updating a test lib which requires 1.18+

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


