### PR TITLE
CLOUDP-149874: export jobs should use exportJobID

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_export_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_export_jobs.go
@@ -73,21 +73,21 @@ func (c CloudProviderSnapshotExportJobsServiceOp) List(ctx context.Context, proj
 	return root, resp, nil
 }
 
-// Get Allows you to retrieve one export job specified by the bucket ID.
+// Get Allows you to retrieve one export job specified by the export job ID.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/cloud-backup/export/get-one-export-job/
-func (c CloudProviderSnapshotExportJobsServiceOp) Get(ctx context.Context, projectID, clusterName, bucketID string) (*CloudProviderSnapshotExportJob, *Response, error) {
+func (c CloudProviderSnapshotExportJobsServiceOp) Get(ctx context.Context, projectID, clusterName, exportJobID string) (*CloudProviderSnapshotExportJob, *Response, error) {
 	if projectID == "" {
 		return nil, nil, NewArgError("projectID", "must be set")
 	}
 	if clusterName == "" {
 		return nil, nil, NewArgError("clusterName", "must be set")
 	}
-	if bucketID == "" {
-		return nil, nil, NewArgError("bucketID", "must be set")
+	if exportJobID == "" {
+		return nil, nil, NewArgError("exportJobID", "must be set")
 	}
 
-	path := fmt.Sprintf("api/atlas/v1.0/groups/%s/clusters/%s/backup/exports/%s", projectID, clusterName, bucketID)
+	path := fmt.Sprintf("api/atlas/v1.0/groups/%s/clusters/%s/backup/exports/%s", projectID, clusterName, exportJobID)
 
 	req, err := c.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {


### PR DESCRIPTION
## Description

Updated backup export jobs to take jobId flag as opposed to bucketId

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

