### PR TITLE
INTMDB-454: Add support for root query to get org_id from API Key used in Terraform

### DIFF
--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -102,6 +102,7 @@ type Client struct {
 	Clusters                            ClustersService
 	CloudProviderSnapshots              CloudProviderSnapshotsService
 	APIKeys                             APIKeysService
+	Root                                RootService
 	ProjectAPIKeys                      ProjectAPIKeysService
 	CloudProviderSnapshotRestoreJobs    CloudProviderSnapshotRestoreJobsService
 	Peers                               PeersService
@@ -242,6 +243,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 
 	c.APIKeys = &APIKeysServiceOp{Client: c}
+	c.Root = &RootServiceOp{Client: c}
 	c.CloudProviderSnapshots = &CloudProviderSnapshotsServiceOp{Client: c}
 	c.ContinuousSnapshots = &ContinuousSnapshotsServiceOp{Client: c}
 	c.CloudProviderSnapshotRestoreJobs = &CloudProviderSnapshotRestoreJobsServiceOp{Client: c}

--- a/mongodbatlas/root.go
+++ b/mongodbatlas/root.go
@@ -32,13 +32,6 @@ type RootService interface {
 // RootServiceOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API.
 type RootServiceOp service
-
-/*type Root struct {
-	Links      []*Link  `json:"links"`
-	Results    []APIKey `json:"results,omitempty"`
-	TotalCount int      `json:"totalCount"`
-}*/
-
 type Root struct {
 	APIKey struct {
 		AccessList []struct {

--- a/mongodbatlas/root.go
+++ b/mongodbatlas/root.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 )
 
-const rootPath = "api/atlas/v1.0" //nolint:gosec // This is a path
+const rootPath = "api/atlas/v1.0"
 
 // RootService is an interface for interfacing with the Root
 // endpoints of the MongoDB Atlas API.

--- a/mongodbatlas/root.go
+++ b/mongodbatlas/root.go
@@ -26,7 +26,7 @@ const rootPath = "api/atlas/v1.0" //nolint:gosec // This is a path
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/root
 type RootService interface {
-	List(context.Context, *ListOptions) ([]APIKey, *Response, error)
+	List(context.Context, *ListOptions) (*Root, *Response, error)
 }
 
 // RootServiceOp handles communication with the APIKey related methods
@@ -34,22 +34,9 @@ type RootService interface {
 type RootServiceOp service
 
 type Root struct {
-	Links []struct {
-		Href string `json:"href"`
-		Rel  string `json:"rel"`
-	} `json:"links"`
-	Results []struct {
-		Desc  string `json:"desc"`
-		ID    string `json:"id"`
-		Links []struct {
-			Href string `json:"href"`
-			Rel  string `json:"rel"`
-		} `json:"links"`
-		PrivateKey string      `json:"privateKey"`
-		PublicKey  string      `json:"publicKey"`
-		Roles      []AtlasRole `json:"roles,omitempty"`
-	} `json:"results"`
-	TotalCount int `json:"totalCount"`
+	Links      []*Link  `json:"links"`
+	Results    []APIKey `json:"results,omitempty"`
+	TotalCount int      `json:"totalCount"`
 }
 
 var _ RootService = &RootServiceOp{}
@@ -57,7 +44,7 @@ var _ RootService = &RootServiceOp{}
 // List all API-KEY related data
 //
 // See more: https://www.mongodb.com/docs/atlas/reference/api/root/
-func (s *RootServiceOp) List(ctx context.Context, listOptions *ListOptions) ([]APIKey, *Response, error) {
+func (s *RootServiceOp) List(ctx context.Context, listOptions *ListOptions) (*Root, *Response, error) {
 	path := rootPath
 
 	// Add query params from listOptions
@@ -71,15 +58,11 @@ func (s *RootServiceOp) List(ctx context.Context, listOptions *ListOptions) ([]A
 		return nil, nil, err
 	}
 
-	root := new(apiKeysResponse)
+	root := new(Root)
 	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	if l := root.Links; l != nil {
-		resp.Links = l
-	}
-
-	return root.Results, resp, nil
+	return root, resp, nil
 }

--- a/mongodbatlas/root.go
+++ b/mongodbatlas/root.go
@@ -33,6 +33,25 @@ type RootService interface {
 // of the MongoDB Atlas API.
 type RootServiceOp service
 
+type Root struct {
+	Links []struct {
+		Href string `json:"href"`
+		Rel  string `json:"rel"`
+	} `json:"links"`
+	Results []struct {
+		Desc  string `json:"desc"`
+		ID    string `json:"id"`
+		Links []struct {
+			Href string `json:"href"`
+			Rel  string `json:"rel"`
+		} `json:"links"`
+		PrivateKey string      `json:"privateKey"`
+		PublicKey  string      `json:"publicKey"`
+		Roles      []AtlasRole `json:"roles,omitempty"`
+	} `json:"results"`
+	TotalCount int `json:"totalCount"`
+}
+
 var _ RootService = &RootServiceOp{}
 
 // List all API-KEY related data

--- a/mongodbatlas/root.go
+++ b/mongodbatlas/root.go
@@ -1,0 +1,66 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"net/http"
+)
+
+const rootPath = "api/atlas/v1.0" //nolint:gosec // This is a path
+
+// RootService is an interface for interfacing with the Root
+// endpoints of the MongoDB Atlas API.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/root
+type RootService interface {
+	List(context.Context, *ListOptions) ([]APIKey, *Response, error)
+}
+
+// RootServiceOp handles communication with the APIKey related methods
+// of the MongoDB Atlas API.
+type RootServiceOp service
+
+var _ RootService = &RootServiceOp{}
+
+// List all API-KEY related data
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api/root/
+func (s *RootServiceOp) List(ctx context.Context, listOptions *ListOptions) ([]APIKey, *Response, error) {
+	path := rootPath
+
+	// Add query params from listOptions
+	path, err := setListOptions(path, listOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(apiKeysResponse)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Results, resp, nil
+}

--- a/mongodbatlas/root.go
+++ b/mongodbatlas/root.go
@@ -33,10 +33,26 @@ type RootService interface {
 // of the MongoDB Atlas API.
 type RootServiceOp service
 
-type Root struct {
+/*type Root struct {
 	Links      []*Link  `json:"links"`
 	Results    []APIKey `json:"results,omitempty"`
 	TotalCount int      `json:"totalCount"`
+}*/
+
+type Root struct {
+	APIKey struct {
+		AccessList []struct {
+			CIDRBlock string `json:"cidrBlock"`
+			IPAddress string `json:"ipAddress"`
+		} `json:"accessList"`
+		ID        string      `json:"id"`
+		PublicKey string      `json:"publicKey"`
+		Roles     []AtlasRole `json:"roles,omitempty"`
+	} `json:"apiKey"`
+	AppName    string  `json:"appName"`
+	Build      string  `json:"build"`
+	Links      []*Link `json:"links"`
+	Throttling bool    `json:"throttling"`
 }
 
 var _ RootService = &RootServiceOp{}

--- a/mongodbatlas/root.go
+++ b/mongodbatlas/root.go
@@ -24,7 +24,7 @@ const rootPath = "api/atlas/v1.0"
 // RootService is an interface for interfacing with the Root
 // endpoints of the MongoDB Atlas API.
 //
-// See more: https://docs.atlas.mongodb.com/reference/api/root
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Root/operation/getSystemStatus
 type RootService interface {
 	List(context.Context, *ListOptions) (*Root, *Response, error)
 }
@@ -52,7 +52,7 @@ var _ RootService = &RootServiceOp{}
 
 // List all API-KEY related data
 //
-// See more: https://www.mongodb.com/docs/atlas/reference/api/root/
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Root/operation/getSystemStatus
 func (s *RootServiceOp) List(ctx context.Context, listOptions *ListOptions) (*Root, *Response, error) {
 	path := rootPath
 

--- a/mongodbatlas/root_test.go
+++ b/mongodbatlas/root_test.go
@@ -1,0 +1,113 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestRoot_ListRoot(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/atlas/v1.0", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"results": [
+				{
+					"desc": "test-apikey",
+					"id": "5c47503320eef5699e1cce8d",
+					"privateKey": "********-****-****-db2c132ca78d",
+					"publicKey": "ewmaqvdo",
+					"roles": [
+						{
+							"groupId": "1",
+							"roleName": "GROUP_OWNER"
+						},
+						{
+							"orgId": "1",
+							"roleName": "ORG_MEMBER"
+						}
+					]
+				},
+				{
+					"desc": "test-apikey-2",
+					"id": "5c47503320eef5699e1cce8f",
+					"privateKey": "********-****-****-db2c132ca78f",
+					"publicKey": "ewmaqvde",
+					"roles": [
+						{
+							"groupId": "1",
+							"roleName": "GROUP_OWNER"
+						},
+						{
+							"orgId": "1",
+							"roleName": "ORG_MEMBER"
+						}
+					]
+				}
+			],
+			"totalCount": 2
+		}`)
+	})
+
+	apiKeys, _, err := client.Root.List(ctx, nil)
+
+	if err != nil {
+		t.Fatalf("APIKeys.List returned error: %v", err)
+	}
+
+	expected := []APIKey{
+		{
+			ID:         "5c47503320eef5699e1cce8d",
+			Desc:       "test-apikey",
+			PrivateKey: "********-****-****-db2c132ca78d",
+			PublicKey:  "ewmaqvdo",
+			Roles: []AtlasRole{
+				{
+					GroupID:  "1",
+					RoleName: "GROUP_OWNER",
+				},
+				{
+					OrgID:    "1",
+					RoleName: "ORG_MEMBER",
+				},
+			},
+		},
+		{
+			ID:         "5c47503320eef5699e1cce8f",
+			Desc:       "test-apikey-2",
+			PrivateKey: "********-****-****-db2c132ca78f",
+			PublicKey:  "ewmaqvde",
+			Roles: []AtlasRole{
+				{
+					GroupID:  "1",
+					RoleName: "GROUP_OWNER",
+				},
+				{
+					OrgID:    "1",
+					RoleName: "ORG_MEMBER",
+				},
+			},
+		},
+	}
+	if diff := deep.Equal(apiKeys, expected); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/mongodbatlas/root_test.go
+++ b/mongodbatlas/root_test.go
@@ -29,6 +29,10 @@ func TestRoot_ListRoot(t *testing.T) {
 	mux.HandleFunc("/api/atlas/v1.0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
+			"links" : [ {
+				"href" : "https://cloud.mongodb.com/api/atlas/v1.0",
+				"rel" : "self"
+			} ],
 			"results": [
 				{
 					"desc": "test-apikey",
@@ -73,39 +77,48 @@ func TestRoot_ListRoot(t *testing.T) {
 		t.Fatalf("APIKeys.List returned error: %v", err)
 	}
 
-	expected := []APIKey{
-		{
-			ID:         "5c47503320eef5699e1cce8d",
-			Desc:       "test-apikey",
-			PrivateKey: "********-****-****-db2c132ca78d",
-			PublicKey:  "ewmaqvdo",
-			Roles: []AtlasRole{
-				{
-					GroupID:  "1",
-					RoleName: "GROUP_OWNER",
+	expected := &Root{
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0",
+				Rel:  "self",
+			},
+		},
+		Results: []APIKey{
+			{
+				ID:         "5c47503320eef5699e1cce8d",
+				Desc:       "test-apikey",
+				PrivateKey: "********-****-****-db2c132ca78d",
+				PublicKey:  "ewmaqvdo",
+				Roles: []AtlasRole{
+					{
+						GroupID:  "1",
+						RoleName: "GROUP_OWNER",
+					},
+					{
+						OrgID:    "1",
+						RoleName: "ORG_MEMBER",
+					},
 				},
-				{
-					OrgID:    "1",
-					RoleName: "ORG_MEMBER",
+			},
+			{
+				ID:         "5c47503320eef5699e1cce8f",
+				Desc:       "test-apikey-2",
+				PrivateKey: "********-****-****-db2c132ca78f",
+				PublicKey:  "ewmaqvde",
+				Roles: []AtlasRole{
+					{
+						GroupID:  "1",
+						RoleName: "GROUP_OWNER",
+					},
+					{
+						OrgID:    "1",
+						RoleName: "ORG_MEMBER",
+					},
 				},
 			},
 		},
-		{
-			ID:         "5c47503320eef5699e1cce8f",
-			Desc:       "test-apikey-2",
-			PrivateKey: "********-****-****-db2c132ca78f",
-			PublicKey:  "ewmaqvde",
-			Roles: []AtlasRole{
-				{
-					GroupID:  "1",
-					RoleName: "GROUP_OWNER",
-				},
-				{
-					OrgID:    "1",
-					RoleName: "ORG_MEMBER",
-				},
-			},
-		},
+		TotalCount: 2,
 	}
 	if diff := deep.Equal(apiKeys, expected); diff != nil {
 		t.Error(diff)

--- a/mongodbatlas/root_test.go
+++ b/mongodbatlas/root_test.go
@@ -86,19 +86,20 @@ func TestRoot_ListRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("APIKeys.List returned error: %v", err)
 	}
+
 	expected := &Root{
 		APIKey: struct {
 			AccessList []struct {
-				CIDRBlock string "json:\"cidrBlock\""
-				IPAddress string "json:\"ipAddress\""
-			} "json:\"accessList\""
-			ID        string      "json:\"id\""
-			PublicKey string      "json:\"publicKey\""
-			Roles     []AtlasRole "json:\"roles,omitempty\""
+				CIDRBlock string `json:"cidrBlock"`
+				IPAddress string `json:"ipAddress"`
+			} `json:"accessList"`
+			ID        string      `json:"id"`
+			PublicKey string      `json:"publicKey"`
+			Roles     []AtlasRole `json:"roles,omitempty"`
 		}{
 			AccessList: []struct {
-				CIDRBlock string "json:\"cidrBlock\""
-				IPAddress string "json:\"ipAddress\""
+				CIDRBlock string `json:"cidrBlock"`
+				IPAddress string `json:"ipAddress"`
 			}{
 				{IPAddress: "", CIDRBlock: "0.0.0.0/1"},
 				{IPAddress: "", CIDRBlock: "128.0.0.0/1"},

--- a/mongodbatlas/root_test.go
+++ b/mongodbatlas/root_test.go
@@ -29,46 +29,56 @@ func TestRoot_ListRoot(t *testing.T) {
 	mux.HandleFunc("/api/atlas/v1.0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
-			"links" : [ {
-				"href" : "https://cloud.mongodb.com/api/atlas/v1.0",
-				"rel" : "self"
-			} ],
-			"results": [
+			"apiKey": {
+			  "accessList": [
 				{
-					"desc": "test-apikey",
-					"id": "5c47503320eef5699e1cce8d",
-					"privateKey": "********-****-****-db2c132ca78d",
-					"publicKey": "ewmaqvdo",
-					"roles": [
-						{
-							"groupId": "1",
-							"roleName": "GROUP_OWNER"
-						},
-						{
-							"orgId": "1",
-							"roleName": "ORG_MEMBER"
-						}
-					]
+				  "cidrBlock": "0.0.0.0/1",
+				  "ipAddress": null
 				},
 				{
-					"desc": "test-apikey-2",
-					"id": "5c47503320eef5699e1cce8f",
-					"privateKey": "********-****-****-db2c132ca78f",
-					"publicKey": "ewmaqvde",
-					"roles": [
-						{
-							"groupId": "1",
-							"roleName": "GROUP_OWNER"
-						},
-						{
-							"orgId": "1",
-							"roleName": "ORG_MEMBER"
-						}
-					]
+				  "cidrBlock": "128.0.0.0/1",
+				  "ipAddress": null
+				},
+				{
+				  "cidrBlock": "47.225.212.178/32",
+				  "ipAddress": "47.225.212.178"
 				}
+			  ],
+			  "id": "5c47503320eef5699e1cce8f",
+			  "publicKey": "ewmaqvde",
+			  "roles": [
+				{
+				  "orgId": "5c47503320eef5699e1cce8f",
+				  "roleName": "ORG_OWNER"
+				},
+				{
+				  "orgId": "5c47503320eef5699e1cce8f",
+				  "roleName": "ORG_MEMBER"
+				},
+				{
+				  "orgId": "5c47503320eef5699e1cce8f",
+				  "roleName": "ORG_GROUP_CREATOR"
+				},
+				{
+				  "groupId": "5c47503320eef5699e1cce8f",
+				  "roleName": "GROUP_OWNER"
+				}
+			  ]
+			},
+			"appName": "MongoDB Atlas",
+			"build": "a646b0cf64fe70b213d206768900eb5e4982a476",
+			"links": [
+			  {
+				"href": "https://cloud.mongodb.com/api/atlas/v1.0",
+				"rel": "self"
+			  },
+			  {
+				"href": "https://cloud.mongodb.com/api/atlas/v1.0/orgs/5c47503320eef5699e1cce8f/apiKeys/5c47503320eef5699e1cce8f",
+				"rel": "https://cloud.mongodb.com/apiKeys"
+			  }
 			],
-			"totalCount": 2
-		}`)
+			"throttling": false
+		  }`)
 	})
 
 	apiKeys, _, err := client.Root.List(ctx, nil)
@@ -76,50 +86,60 @@ func TestRoot_ListRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("APIKeys.List returned error: %v", err)
 	}
-
 	expected := &Root{
+		APIKey: struct {
+			AccessList []struct {
+				CIDRBlock string "json:\"cidrBlock\""
+				IPAddress string "json:\"ipAddress\""
+			} "json:\"accessList\""
+			ID        string      "json:\"id\""
+			PublicKey string      "json:\"publicKey\""
+			Roles     []AtlasRole "json:\"roles,omitempty\""
+		}{
+			AccessList: []struct {
+				CIDRBlock string "json:\"cidrBlock\""
+				IPAddress string "json:\"ipAddress\""
+			}{
+				{IPAddress: "", CIDRBlock: "0.0.0.0/1"},
+				{IPAddress: "", CIDRBlock: "128.0.0.0/1"},
+				{IPAddress: "47.225.212.178", CIDRBlock: "47.225.212.178/32"},
+			},
+			ID:        "5c47503320eef5699e1cce8f",
+			PublicKey: "ewmaqvde",
+			Roles: []AtlasRole{
+				{
+					OrgID:    "5c47503320eef5699e1cce8f",
+					RoleName: "ORG_OWNER",
+				},
+				{
+					OrgID:    "5c47503320eef5699e1cce8f",
+					RoleName: "ORG_MEMBER",
+				},
+				{
+					OrgID:    "5c47503320eef5699e1cce8f",
+					RoleName: "ORG_GROUP_CREATOR",
+				},
+				{
+					GroupID:  "5c47503320eef5699e1cce8f",
+					RoleName: "GROUP_OWNER",
+				},
+			},
+		},
+		AppName: "MongoDB Atlas",
+		Build:   "a646b0cf64fe70b213d206768900eb5e4982a476",
 		Links: []*Link{
 			{
 				Href: "https://cloud.mongodb.com/api/atlas/v1.0",
 				Rel:  "self",
 			},
-		},
-		Results: []APIKey{
 			{
-				ID:         "5c47503320eef5699e1cce8d",
-				Desc:       "test-apikey",
-				PrivateKey: "********-****-****-db2c132ca78d",
-				PublicKey:  "ewmaqvdo",
-				Roles: []AtlasRole{
-					{
-						GroupID:  "1",
-						RoleName: "GROUP_OWNER",
-					},
-					{
-						OrgID:    "1",
-						RoleName: "ORG_MEMBER",
-					},
-				},
-			},
-			{
-				ID:         "5c47503320eef5699e1cce8f",
-				Desc:       "test-apikey-2",
-				PrivateKey: "********-****-****-db2c132ca78f",
-				PublicKey:  "ewmaqvde",
-				Roles: []AtlasRole{
-					{
-						GroupID:  "1",
-						RoleName: "GROUP_OWNER",
-					},
-					{
-						OrgID:    "1",
-						RoleName: "ORG_MEMBER",
-					},
-				},
+				Href: "https://cloud.mongodb.com/api/atlas/v1.0/orgs/5c47503320eef5699e1cce8f/apiKeys/5c47503320eef5699e1cce8f",
+				Rel:  "https://cloud.mongodb.com/apiKeys",
 			},
 		},
-		TotalCount: 2,
+		Throttling: false,
 	}
+
 	if diff := deep.Equal(apiKeys, expected); diff != nil {
 		t.Error(diff)
 	}


### PR DESCRIPTION
## Description

INTMDB-454: Add support for root query to get org_id from API Key used in Terraform

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

