### PR TITLE
CLOUDP-149874: export jobs should use exportID as per docs

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_export_jobs.go
+++ b/mongodbatlas/cloud_provider_snapshot_export_jobs.go
@@ -76,18 +76,18 @@ func (c CloudProviderSnapshotExportJobsServiceOp) List(ctx context.Context, proj
 // Get Allows you to retrieve one export job specified by the export job ID.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/cloud-backup/export/get-one-export-job/
-func (c CloudProviderSnapshotExportJobsServiceOp) Get(ctx context.Context, projectID, clusterName, exportJobID string) (*CloudProviderSnapshotExportJob, *Response, error) {
+func (c CloudProviderSnapshotExportJobsServiceOp) Get(ctx context.Context, projectID, clusterName, exportID string) (*CloudProviderSnapshotExportJob, *Response, error) {
 	if projectID == "" {
 		return nil, nil, NewArgError("projectID", "must be set")
 	}
 	if clusterName == "" {
 		return nil, nil, NewArgError("clusterName", "must be set")
 	}
-	if exportJobID == "" {
-		return nil, nil, NewArgError("exportJobID", "must be set")
+	if exportID == "" {
+		return nil, nil, NewArgError("exportID", "must be set")
 	}
 
-	path := fmt.Sprintf("api/atlas/v1.0/groups/%s/clusters/%s/backup/exports/%s", projectID, clusterName, exportJobID)
+	path := fmt.Sprintf("api/atlas/v1.0/groups/%s/clusters/%s/backup/exports/%s", projectID, clusterName, exportID)
 
 	req, err := c.Client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {

--- a/mongodbatlas/cloud_provider_snapshot_export_jobs_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_export_jobs_test.go
@@ -150,9 +150,9 @@ func TestCloudProviderSnapshotExportJobs_Get(t *testing.T) {
 
 	projectID := "test-project-id"
 	clusterName := "test-cluster-name"
-	exportJobID := "job-id-test"
+	exportID := "job-id-test"
 
-	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/backup/exports/%s", projectID, clusterName, exportJobID)
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/backup/exports/%s", projectID, clusterName, exportID)
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -167,7 +167,7 @@ func TestCloudProviderSnapshotExportJobs_Get(t *testing.T) {
 }`)
 	})
 
-	cloudProviderSnapshotBucket, _, err := client.CloudProviderSnapshotExportJobs.Get(ctx, projectID, clusterName, exportJobID)
+	cloudProviderSnapshotBucket, _, err := client.CloudProviderSnapshotExportJobs.Get(ctx, projectID, clusterName, exportID)
 	if err != nil {
 		t.Fatalf("CloudProviderSnapshotExportJobs.Get returned error: %v", err)
 	}


### PR DESCRIPTION
## Description

_Jira ticket:_  [CLOUDP-149874](https://jira.mongodb.org/browse/CLOUDP-149874)

Updated `exportJobId` to `exportId` based on [this comment](https://github.com/mongodb/mongodb-atlas-cli/pull/1558#pullrequestreview-1219897594) and the appropriate docs

> Thanks for this work! I think you referenced our deprecated API docs for the copy (we're taking these down soon!) and so I've updated the descriptions to match the [OpenAPI generated ones](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Cloud-Backup-Export/operation/returnOneCloudBackupSnapshotExportJob).

> With that in mind, do you think the flag name should be exportId instead of exportJobId to match the API parameter in the docs?

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code


