### PR TITLE
INTMDB-400: Empty struct to delete backup distribution configuration

### DIFF
--- a/mongodbatlas/cloud_provider_snapshot_backup_policies.go
+++ b/mongodbatlas/cloud_provider_snapshot_backup_policies.go
@@ -54,7 +54,7 @@ type CloudProviderSnapshotBackupPolicy struct {
 	Export                            *Export              `json:"export,omitempty"`                            // Export struct that represents a policy for automatically exporting cloud backup snapshots to AWS bucket.
 	UseOrgAndGroupNamesInExportPrefix *bool                `json:"useOrgAndGroupNamesInExportPrefix,omitempty"` // Specifies whether to use organization and project names instead of organization and project UUIDs in the path to the metadata files that Atlas uploads to your S3 bucket after it finishes exporting the snapshots
 	Links                             []*Link              `json:"links,omitempty"`                             // One or more links to sub-resources and/or related resources.
-	CopySettings                      []CopySetting        `json:"copySettings,omitempty"`                      // List that contains a document for each copy setting item in the desired backup policy.
+	CopySettings                      []CopySetting        `json:"copySettings"`                                // List that contains a document for each copy setting item in the desired backup policy.
 	DeleteCopiedBackups               []DeleteCopiedBackup `json:"deleteCopiedBackups,omitempty"`               // List that contains a document for each deleted copy setting whose backup copies you want to delete.
 }
 


### PR DESCRIPTION
## Description

Empty struct to delete backup distribution configuration
Need a way to emit empty copySettings array this to PATCH API call to remove distribution configuration

```
{
  "clusterId":"63a32ba4zzz3dcaa7eaf",
"clusterName":"test-backups",
"copySettings":[]
}
```

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

