### PR TITLE
CLOUDP-155908: set v2 as base branch for automation PRs

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -1,9 +1,5 @@
 name: Generate Client
 on:
- ## For verification only
- push:
-   branches:
-     - v2
  workflow_dispatch:
  schedule:
    - cron: "0 8 * * MON-FRI"
@@ -33,8 +29,10 @@ jobs:
       - uses: peter-evans/create-pull-request@v4
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
-          title: "OpenAPI Client Update"
-          commit-message: "OpenAPI Client Update"
+          title: "OpenAPI client update"
+          commit-message: "automatic client update"
+          delete-branch: true
+          base: v2
           branch: client
           body: |
             Automatic update for MongoDB Atlas Go Client.
@@ -43,7 +41,9 @@ jobs:
             
             ## Review procedure
             
-            1. Compare changes in the OpenAPI file
-            2. Review if there was a new platform version introduced 
-            3. Review client changes. 
+            1. Review changes in the OpenAPI file
+            2. Check for new versions in versions.yaml file
+            3. Review go client changes 
+            
+
             

--- a/v2/.gitignore
+++ b/v2/.gitignore
@@ -1,0 +1,3 @@
+/api/api
+/api/.openapi-generator
+/openapi/atlas-api-transformed.yaml


### PR DESCRIPTION
## Description

When the workflow is triggered manually or by the schedule, we need to set v2 as the base branch for automation PRs. 


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

