### PR TITLE
CLOUDP-155226: include versioned API version in requests

### DIFF
--- a/v2/api/atlas_client.go
+++ b/v2/api/atlas_client.go
@@ -12,7 +12,7 @@ const (
 	// CloudURL is default base URL for the services.
 	DefaultCloudURL = "https://cloud.mongodb.com/"
 	// Version the version of the current API client. Should be set to the next version planned to be released.
-	Version    = "1.230201.0-dev1"
+	Version    = "1.20230201.0-dev1"
 	ClientName = "go-mongodbatlas-versioned"
 )
 

--- a/v2/api/atlas_client.go
+++ b/v2/api/atlas_client.go
@@ -12,7 +12,7 @@ const (
 	// CloudURL is default base URL for the services.
 	DefaultCloudURL = "https://cloud.mongodb.com/"
 	// Version the version of the current API client. Should be set to the next version planned to be released.
-	Version    = "2.0.0-dev1"
+	Version    = "1.230201.0-dev1"
 	ClientName = "go-mongodbatlas-versioned"
 )
 

--- a/v2/tools/config/go-templates/atlas_client.mustache
+++ b/v2/tools/config/go-templates/atlas_client.mustache
@@ -12,7 +12,7 @@ const (
 	// CloudURL is default base URL for the services.
 	DefaultCloudURL = "https://cloud.mongodb.com/"
 	// Version the version of the current API client. Should be set to the next version planned to be released.
-	Version    = "1.{{xgenResourceVersion}}.0-dev1"
+	Version    = "{{xgenClientVersion}}"
 	ClientName = "go-mongodbatlas-versioned"
 )
 

--- a/v2/tools/config/go-templates/atlas_client.mustache
+++ b/v2/tools/config/go-templates/atlas_client.mustache
@@ -12,7 +12,7 @@ const (
 	// CloudURL is default base URL for the services.
 	DefaultCloudURL = "https://cloud.mongodb.com/"
 	// Version the version of the current API client. Should be set to the next version planned to be released.
-	Version    = "2.0.0-dev1"
+	Version    = "1.{{xgenResourceVersion}}.0-dev1"
 	ClientName = "go-mongodbatlas-versioned"
 )
 

--- a/v2/tools/scripts/generate.sh
+++ b/v2/tools/scripts/generate.sh
@@ -4,6 +4,8 @@ set -e
 OPENAPI_FOLDER=${OPENAPI_FOLDER:-"./openapi"}
 OPENAPI_FILE="$OPENAPI_FOLDER/atlas-api.yaml"
 TRANSFORMED_FILE="$OPENAPI_FOLDER/atlas-api-transformed.yaml"
+## Version of the versioned API
+CURRENT_REVISION=${CURRENT_REVISION:-"230201"}
 
 ## go package containing rolling updates for all recent versions 
 LATEST_PACKAGE=${LATEST_PACKAGE:-"api"}
@@ -20,4 +22,6 @@ npm run sdk:transform -- "$TRANSFORMED_FILE"
 npm exec openapi-generator-cli -- generate \
     -c "./config/go.yaml" -i "$TRANSFORMED_FILE" -o "$SDK_ROOT$LATEST_PACKAGE" \
     --package-name="$LATEST_PACKAGE" \
-    --ignore-file-override=config/.go-ignore 
+    --ignore-file-override=config/.go-ignore \
+    --additional-properties=xgenResourceVersion="$CURRENT_REVISION"
+

--- a/v2/tools/scripts/generate.sh
+++ b/v2/tools/scripts/generate.sh
@@ -5,7 +5,7 @@ OPENAPI_FOLDER=${OPENAPI_FOLDER:-"./openapi"}
 OPENAPI_FILE="$OPENAPI_FOLDER/atlas-api.yaml"
 TRANSFORMED_FILE="$OPENAPI_FOLDER/atlas-api-transformed.yaml"
 ## Version of the versioned API
-CLIENT_VERSION=${CLIENT_VERSION:-"1.230201.0-dev1"}
+CLIENT_VERSION=${CLIENT_VERSION:-"1.20230201.0-dev1"}
 
 ## go package containing rolling updates for all recent versions 
 LATEST_PACKAGE=${LATEST_PACKAGE:-"api"}

--- a/v2/tools/scripts/generate.sh
+++ b/v2/tools/scripts/generate.sh
@@ -5,7 +5,7 @@ OPENAPI_FOLDER=${OPENAPI_FOLDER:-"./openapi"}
 OPENAPI_FILE="$OPENAPI_FOLDER/atlas-api.yaml"
 TRANSFORMED_FILE="$OPENAPI_FOLDER/atlas-api-transformed.yaml"
 ## Version of the versioned API
-CURRENT_REVISION=${CURRENT_REVISION:-"230201"}
+CLIENT_VERSION=${CLIENT_VERSION:-"1.230201.0-dev1"}
 
 ## go package containing rolling updates for all recent versions 
 LATEST_PACKAGE=${LATEST_PACKAGE:-"api"}
@@ -23,5 +23,5 @@ npm exec openapi-generator-cli -- generate \
     -c "./config/go.yaml" -i "$TRANSFORMED_FILE" -o "$SDK_ROOT$LATEST_PACKAGE" \
     --package-name="$LATEST_PACKAGE" \
     --ignore-file-override=config/.go-ignore \
-    --additional-properties=xgenResourceVersion="$CURRENT_REVISION"
+    --additional-properties=xgenClientVersion="$CLIENT_VERSION"
 


### PR DESCRIPTION
## What

Use env var provided version when running generator job.

## Why

To fully automate generation we need to supply all input arguments from CI/CD job.
The current version matches the proposal in the specification and it is likely to change.