### PR TITLE
CLOUDP-156539: notifications only for v0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Maintained by the API experience team
-*       @mongodb/apix
+mongodbatlas/*       @mongodb/apix
+auth/*               @mongodb/apix


### PR DESCRIPTION
## Description

Reducing the amount of noise happening in the new SDK. 
We need apix to still receive useful notifications to manually written client.
More context in the jira.