### PR TITLE
CLOUDP-155911: unify make calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ node_modules
 # Output of the go coverage tool
 *.out
 openapi/atlas-api-transformed.yaml
+example_cluster_aws

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,17 +52,16 @@ TAG=$(patsubst v%,%,$(shell git describe --tags --dirty --always))
 check-version:
 	scripts/check-version.sh "$(TAG)"
 
-.PHONY: v2-verify
-v2-verify: tools
-	echo "Running client cleanup"
+.PHONY: openapi-pipeline
+openapi-pipeline: tools
+	echo "Running OpenAPI Generation and Validation process"
 	$(MAKE) -C tools clean_client
 	echo "Running client generation"
 	$(MAKE) -C tools generate_client
-	echo "Checking end user examples"
-	$(MAKE) -C tools generate_client
+	echo "Validating generated SDK"
+	$(MAKE) v2-examples-build
 	$(MAKE) v2-lint
 	$(MAKE) v2-test
-	$(MAKE) v2-examples-build
 
 .PHONY: v2-lint
 v2-lint:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -16,7 +16,5 @@ fetch_openapi:
 generate_client:
 	./scripts/generate.sh
 
-.PHONY: verify_client
-verify_client: clean_client generate_client
 
 

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -12,8 +12,12 @@
       },
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "2.5.2",
-        "jest": "^29.4.2",
+        "jest": "29.4.2",
         "prettier": "2.8.4"
+      },
+      "engines": {
+        "node": ">= 14",
+        "npm": ">= 5"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## Description

We should use a single call (make, etc.) for each SDK repository as a standard.
This PR introduces:

```
make openapi-pipeline
```

target that can be triggered to perform end to end open API generation and validation. 