### PR TITLE
fix: make org owner optional

### DIFF
--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -77,7 +77,7 @@ type Organizations struct {
 type CreateOrganizationRequest struct {
 	APIKey     *APIKeyInput `json:"apiKey,omitempty"`
 	Name       string       `json:"name"`
-	OrgOwnerID string       `json:"orgOwnerId"`
+	OrgOwnerID *string      `json:"orgOwnerId,omitempty"`
 }
 
 // CreateOrganizationResponse struct for CreateOrganizationResponse.


### PR DESCRIPTION
## Description

After some manual QA the ownerID needs to be a pointer or it will fail when using OAuth as auth mechnism 