### PR TITLE
CLOUDP-163493 - ci/cd cleanup

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -24,4 +24,10 @@ jobs:
       - name: Fail when generate introducing diff
         run: |
           (( $(git status --porcelain | wc -l) > 0 )) &&  exit 1
+      - name: Make sure that no breaking changes were introduced
+        run: | 
+          make v2-lint && make v2-test
+
+
+
         

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -23,6 +23,7 @@ jobs:
           make clean_and_generate
       - name: Fail when generate introducing diff
         run: |
+          git diff | cat
           (( $(git status --porcelain | wc -l) > 0 )) &&  exit 1
       - name: Make sure that no breaking changes were introduced
         run: | 

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -23,8 +23,7 @@ jobs:
           make clean_and_generate
       - name: Fail when generate introducing diff
         run: |
-          git diff | cat
-          (( $(git status --porcelain | wc -l) > 0 )) &&  exit 1
+          git diff --exit-code
       - name: Make sure that no breaking changes were introduced
         run: | 
           make v2-lint && make v2-test

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -18,3 +18,10 @@ jobs:
         run: |
           npm install
           npm run ci
+      - working-directory: ./tools
+        run: |
+          make clean_and_generate
+      - name: Fail when generate introducing diff
+        run: |
+          (( $(git status --porcelain | wc -l) > 0 )) &&  exit 1
+        

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -26,7 +26,7 @@ jobs:
           git diff --exit-code
       - name: Make sure that no breaking changes were introduced
         run: | 
-          make v2-lint && make v2-test
+          make tools v2-lint v2-test
 
 
 

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -24,10 +24,4 @@ jobs:
       - name: Fail when generate introducing diff
         run: |
           git diff --exit-code
-      - name: Make sure that no breaking changes were introduced
-        run: | 
-          make tools v2-lint v2-test
-
-
-
-        
+          

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -59,8 +59,6 @@ openapi-pipeline: tools
 	echo "Running client generation"
 	$(MAKE) -C tools generate_client
 	echo "Validating generated SDK"
-	$(MAKE) v2-lint
-	$(MAKE) v2-test
 	$(MAKE) v2-examples-build
 
 .PHONY: v2-lint

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -61,14 +61,6 @@ openapi-pipeline:
 	echo "Validating generated SDK"
 	$(MAKE) v2-examples-build
 
-.PHONY: v2-lint
-v2-lint:
-	golangci-lint run "$(APIV2_FOLDER)/$(SOURCE_FILES)"
-
 .PHONY: v2-examples-build
 v2-examples-build:
 	go build "$(APIV2_FOLDER)/examples/example_cluster_aws.go"
-
-.PHONY: v2-test
-v2-test:
-	go test "$(APIV2_FOLDER)/$(SOURCE_FILES)" -coverprofile $(COVERAGE) -timeout=30s -parallel=4 -cover -race

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -53,7 +53,7 @@ check-version:
 	scripts/check-version.sh "$(TAG)"
 
 .PHONY: openapi-pipeline
-openapi-pipeline: tools
+openapi-pipeline:
 	echo "Running OpenAPI Generation and Validation process"
 	$(MAKE) -C tools clean_client
 	echo "Running client generation"

--- a/api/test/regression/multi_cloud_clusters.go
+++ b/api/test/regression/multi_cloud_clusters.go
@@ -128,8 +128,6 @@ func TestMultiCloudClustersModelRegression() {
 			Standard:          _string,
 			StandardSrv:       _string,
 		},
-		// TODO this should be removed as they are part of the response body.
-		// See: https://jira.mongodb.org/browse/CLOUDP-151153
 		CreateDate: nil,
 		Paused:     nil,
 		Links:      nil,

--- a/api/v1alpha/README.md
+++ b/api/v1alpha/README.md
@@ -1,4 +1,4 @@
-# Go API client	
+# Go API client
 ## Documentation for API Endpoints
 
 All URIs are relative to *https://cloud.mongodb.com*

--- a/api/v1alpha/README.md
+++ b/api/v1alpha/README.md
@@ -1,4 +1,4 @@
-# Go API client
+# Go API client	
 ## Documentation for API Endpoints
 
 All URIs are relative to *https://cloud.mongodb.com*

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -22,6 +22,3 @@ generate_client:
 
 .PHONY: clean_and_generate
 clean_and_generate: clean_client generate_client
-
-
-

--- a/tools/README.md
+++ b/tools/README.md
@@ -39,15 +39,8 @@ We use mustache comments to mark templates as modified:
 
 #### Contributing
 
-1. After making change validate correctness of your changes by running
-
-```
-(cd .. && make v2-lint v2-test)
-```
-
-> NOTE: We need to regenerate our SDK if changes in tools will affect the generated clients.
-> PR jobs will verify if changes are up to date.
-> To regenerate run:
+We need to regenerate our SDK if changes in tools will affect the generated clients.
+PR based checks will verify if changes are up to date.
 
 ```
 make clean_and_generate

--- a/tools/README.md
+++ b/tools/README.md
@@ -36,3 +36,19 @@ We use mustache comments to mark templates as modified:
 
 - `{{! X-XGEN-CUSTOM }}` - usually present at the top of the file - means that the whole file is currently customized.
 - `{{! X-XGEN-MODIFIED }}` - is put into existing templates to note areas in the code that were customized.
+
+#### Contributing
+
+1. After making change validate correctness of your changes by running
+
+```
+(cd .. && make v2-lint v2-test)
+```
+
+> NOTE: We need to regenerate our SDK if changes in tools will affect the generated clients.
+> PR jobs will verify if changes are up to date.
+> To regenerate run:
+
+```
+make clean_and_generate
+```

--- a/tools/config/go-templates/README.mustache
+++ b/tools/config/go-templates/README.mustache
@@ -1,4 +1,4 @@
-{{! X-XGEN-CUSTOM }}# Go API client	
+{{! X-XGEN-CUSTOM }}# Go API client
 ## Documentation for API Endpoints
 
 All URIs are relative to *{{basePath}}*

--- a/tools/config/go-templates/README.mustache
+++ b/tools/config/go-templates/README.mustache
@@ -1,4 +1,4 @@
-{{! X-XGEN-CUSTOM }}# Go API client 	
+{{! X-XGEN-CUSTOM }}# Go API client	
 ## Documentation for API Endpoints
 
 All URIs are relative to *{{basePath}}*


### PR DESCRIPTION
## Description

Changes

- [x] Require SDK changes with each ./tools PRs. those might be breaking SDK or introducing an invalid open API file)
- [x] Run lint and unit tests for tooling changes (as we did them to validate the correctness of the transformations) and templates
- [x] Minor cleanup - removing redundant checks from the Open API validator path
   - linting - generally templates proving our ability for passing lint errors,
   - compatibility tests - used for tooling but will be breaking/blocking jobs when a new version of that API is introduced. 
- [x] README updates explaining those changes