### PR TITLE
task: drop pointy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.18
 require (
 	github.com/go-test/deep v1.1.0
 	github.com/google/go-querystring v1.1.0
-	github.com/openlyinc/pointy v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,7 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
-github.com/openlyinc/pointy v1.2.0 h1:vbb/WoPbshyTH8j3/XYu3enlZfv+NHxAD15qTm1zbk0=
-github.com/openlyinc/pointy v1.2.0/go.mod h1:JodZOTJoBNaAQHeU0F/SwA4PL0lg4pKF7fYFpX291P0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/mongodbatlas/advanced_clusters_test.go
+++ b/mongodbatlas/advanced_clusters_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 const (
@@ -254,11 +253,11 @@ func TestAdvancedClusters_List(t *testing.T) {
 							{
 								AnalyticsAutoScaling: &AdvancedAutoScaling{
 									DiskGB: &DiskGB{
-										Enabled: pointy.Bool(true),
+										Enabled: pointer(true),
 									},
 									Compute: &Compute{
-										Enabled:          pointy.Bool(true),
-										ScaleDownEnabled: pointy.Bool(false),
+										Enabled:          pointer(true),
+										ScaleDownEnabled: pointer(false),
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M20",
 									},
@@ -527,7 +526,7 @@ func TestAdvancedClusters_Get(t *testing.T) {
 		Paused:                       &paused,
 		PitEnabled:                   &pitEnabled,
 		StateName:                    "CREATING",
-		TerminationProtectionEnabled: pointy.Bool(false),
+		TerminationProtectionEnabled: pointer(false),
 		VersionReleaseSystem:         "LTS",
 		ReplicationSpecs: []*AdvancedReplicationSpec{
 			{

--- a/mongodbatlas/alert_configurations_test.go
+++ b/mongodbatlas/alert_configurations_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestAlertConfiguration_Create(t *testing.T) {
@@ -79,14 +78,14 @@ func TestAlertConfiguration_Create(t *testing.T) {
 
 	alertReq := &AlertConfiguration{
 		EventTypeName: "NO_PRIMARY",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		Notifications: []Notification{
 			{
 				TypeName:     "GROUP",
 				IntervalMin:  5,
-				DelayMin:     pointy.Int(0),
-				SMSEnabled:   pointy.Bool(false),
-				EmailEnabled: pointy.Bool(true),
+				DelayMin:     pointer(0),
+				SMSEnabled:   pointer(false),
+				EmailEnabled: pointer(true),
 				Roles:        []string{"GROUP_CHARTS_ADMIN", "GROUP_CLUSTER_MANAGER"},
 			},
 		},
@@ -101,16 +100,16 @@ func TestAlertConfiguration_Create(t *testing.T) {
 	expected := &AlertConfiguration{
 		ID:            "57b76ddc96e8215c017ceafb",
 		Created:       "2016-08-19T20:36:44Z",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		EventTypeName: "NO_PRIMARY",
 		GroupID:       "535683b3794d371327b",
 		Matchers:      []Matcher{},
 		Notifications: []Notification{
 			{
-				DelayMin:     pointy.Int(0),
-				EmailEnabled: pointy.Bool(true),
+				DelayMin:     pointer(0),
+				EmailEnabled: pointer(true),
 				IntervalMin:  5,
-				SMSEnabled:   pointy.Bool(false),
+				SMSEnabled:   pointer(false),
 				TypeName:     "GROUP",
 				Roles:        []string{"GROUP_CHARTS_ADMIN", "GROUP_CLUSTER_MANAGER"},
 			},
@@ -166,24 +165,24 @@ func TestAlertConfiguration_EnableAnAlertConfig(t *testing.T) {
 		}`)
 	})
 
-	alertConfiguration, _, err := client.AlertConfigurations.EnableAnAlertConfig(ctx, groupID, alertConfigID, pointy.Bool(true))
+	alertConfiguration, _, err := client.AlertConfigurations.EnableAnAlertConfig(ctx, groupID, alertConfigID, pointer(true))
 	if err != nil {
 		t.Fatalf("AlertConfiguration.EnableAnAlertConfig returned error: %v", err)
 	}
 
 	expected := &AlertConfiguration{
 		Created:       "2016-08-19T20:45:29Z",
-		Enabled:       pointy.Bool(false),
+		Enabled:       pointer(false),
 		EventTypeName: "NO_PRIMARY",
 		GroupID:       "535683b3794d371327b",
 		ID:            "57b76ddc96e8215c017ceafb",
 		Matchers:      []Matcher{},
 		Notifications: []Notification{
 			{
-				DelayMin:     pointy.Int(5),
-				EmailEnabled: pointy.Bool(false),
+				DelayMin:     pointer(5),
+				EmailEnabled: pointer(false),
 				IntervalMin:  5,
-				SMSEnabled:   pointy.Bool(true),
+				SMSEnabled:   pointer(true),
 				TypeName:     "GROUP",
 			},
 		},
@@ -248,7 +247,7 @@ func TestAlertConfiguration_GetAnAlertConfig(t *testing.T) {
 		EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 		Created:       "2016-08-23T20:26:50Z",
 		Updated:       "2016-08-23T20:26:50Z",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		Matchers: []Matcher{
 			{
 				FieldName: "HOSTNAME_AND_PORT",
@@ -260,7 +259,7 @@ func TestAlertConfiguration_GetAnAlertConfig(t *testing.T) {
 			{
 				TypeName:     "SMS",
 				IntervalMin:  5,
-				DelayMin:     pointy.Int(0),
+				DelayMin:     pointer(0),
 				MobileNumber: "2343454567",
 				Roles:        []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_DATA_ACCESS_READ_ONLY"},
 			},
@@ -341,7 +340,7 @@ func TestAlertConfiguration_GetOpenAlertsConfig(t *testing.T) {
 			LastNotified:      "2016-08-22T15:57:24.126Z",
 			MetricName:        "ASSERT_REGULAR",
 			CurrentValue: &CurrentValue{
-				Number: pointy.Float64(0.0),
+				Number: pointer(0.0),
 				Units:  "RAW",
 			},
 		},
@@ -355,7 +354,7 @@ func TestAlertConfiguration_GetOpenAlertsConfig(t *testing.T) {
 			LastNotified:  "2016-08-22T20:14:19.313Z",
 			MetricName:    "ASSERT_REGULAR",
 			CurrentValue: &CurrentValue{
-				Number: pointy.Float64(0.0),
+				Number: pointer(0.0),
 				Units:  "RAW",
 			},
 		},
@@ -455,7 +454,7 @@ func TestAlertConfiguration_List(t *testing.T) {
 			EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 			Created:       "2016-08-23T20:26:50Z",
 			Updated:       "2016-08-23T20:26:50Z",
-			Enabled:       pointy.Bool(true),
+			Enabled:       pointer(true),
 			Matchers: []Matcher{
 				{
 					FieldName: "HOSTNAME_AND_PORT",
@@ -467,7 +466,7 @@ func TestAlertConfiguration_List(t *testing.T) {
 				{
 					TypeName:     "SMS",
 					IntervalMin:  5,
-					DelayMin:     pointy.Int(0),
+					DelayMin:     pointer(0),
 					MobileNumber: "2343454567",
 					Roles:        []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_DATA_ACCESS_READ_ONLY"},
 				},
@@ -486,7 +485,7 @@ func TestAlertConfiguration_List(t *testing.T) {
 			EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 			Created:       "2016-08-23T20:26:50Z",
 			Updated:       "2016-08-23T20:26:50Z",
-			Enabled:       pointy.Bool(true),
+			Enabled:       pointer(true),
 			Matchers: []Matcher{
 				{
 					FieldName: "HOSTNAME_AND_PORT",
@@ -498,7 +497,7 @@ func TestAlertConfiguration_List(t *testing.T) {
 				{
 					TypeName:     "SMS",
 					IntervalMin:  5,
-					DelayMin:     pointy.Int(0),
+					DelayMin:     pointer(0),
 					MobileNumber: "2343454567",
 					Roles:        []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_DATA_ACCESS_READ_ONLY"},
 				},
@@ -575,14 +574,14 @@ func TestAlertConfiguration_Update(t *testing.T) {
 
 	alertReq := &AlertConfiguration{
 		EventTypeName: "NO_PRIMARY",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		Notifications: []Notification{
 			{
 				TypeName:     "GROUP",
 				IntervalMin:  5,
-				DelayMin:     pointy.Int(5),
-				SMSEnabled:   pointy.Bool(true),
-				EmailEnabled: pointy.Bool(false),
+				DelayMin:     pointer(5),
+				SMSEnabled:   pointer(true),
+				EmailEnabled: pointer(false),
 				Roles:        []string{"GROUP_CHARTS_ADMIN", "GROUP_CLUSTER_MANAGER"},
 			},
 		},
@@ -596,7 +595,7 @@ func TestAlertConfiguration_Update(t *testing.T) {
 
 	expected := &AlertConfiguration{
 		Created:       "2016-08-19T20:45:29Z",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		EventTypeName: "NO_PRIMARY",
 		GroupID:       "535683b3794d371327b",
 		ID:            "57b76ddc96e8215c017ceafb",
@@ -604,9 +603,9 @@ func TestAlertConfiguration_Update(t *testing.T) {
 			{
 				TypeName:     "GROUP",
 				IntervalMin:  5,
-				DelayMin:     pointy.Int(5),
-				SMSEnabled:   pointy.Bool(true),
-				EmailEnabled: pointy.Bool(false),
+				DelayMin:     pointer(5),
+				SMSEnabled:   pointer(true),
+				EmailEnabled: pointer(false),
 				Roles:        []string{"GROUP_CHARTS_ADMIN", "GROUP_CLUSTER_MANAGER"},
 			},
 		},
@@ -728,7 +727,7 @@ func TestAlertConfiguration_GetAnAlertConfigTeams(t *testing.T) {
 		EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 		Created:       "2016-08-23T20:26:50Z",
 		Updated:       "2016-08-23T20:26:50Z",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		Matchers: []Matcher{
 			{
 				FieldName: "HOSTNAME_AND_PORT",
@@ -740,7 +739,7 @@ func TestAlertConfiguration_GetAnAlertConfigTeams(t *testing.T) {
 			{
 				TypeName:                 "MICROSOFT_TEAMS",
 				IntervalMin:              5,
-				DelayMin:                 pointy.Int(0),
+				DelayMin:                 pointer(0),
 				MicrosoftTeamsWebhookURL: "http://941a-47-225-212-178.ngrok.io",
 				Roles:                    []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_DATA_ACCESS_READ_ONLY"},
 			},
@@ -813,7 +812,7 @@ func TestAlertConfiguration_GetAnAlertConfigWebhook(t *testing.T) {
 		EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 		Created:       "2016-08-23T20:26:50Z",
 		Updated:       "2016-08-23T20:26:50Z",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		Matchers: []Matcher{
 			{
 				FieldName: "HOSTNAME_AND_PORT",
@@ -825,7 +824,7 @@ func TestAlertConfiguration_GetAnAlertConfigWebhook(t *testing.T) {
 			{
 				TypeName:      "WEBHOOK",
 				IntervalMin:   5,
-				DelayMin:      pointy.Int(0),
+				DelayMin:      pointer(0),
 				WebhookSecret: "SECRET",
 				WebhookURL:    "http://941a-47-225-212-178.ngrok.io",
 				Roles:         []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_DATA_ACCESS_READ_ONLY"},

--- a/mongodbatlas/alerts_test.go
+++ b/mongodbatlas/alerts_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestAlert_Get(t *testing.T) {
@@ -74,7 +73,7 @@ func TestAlert_Get(t *testing.T) {
 		EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 		Created:       "2016-08-23T20:26:50Z",
 		Updated:       "2016-08-23T20:26:50Z",
-		Enabled:       pointy.Bool(true),
+		Enabled:       pointer(true),
 		Matchers: []Matcher{
 			{
 				FieldName: "HOSTNAME_AND_PORT",
@@ -86,7 +85,7 @@ func TestAlert_Get(t *testing.T) {
 			{
 				TypeName:     "SMS",
 				IntervalMin:  5,
-				DelayMin:     pointy.Int(0),
+				DelayMin:     pointer(0),
 				MobileNumber: "2343454567",
 			},
 		},
@@ -193,7 +192,7 @@ func TestAlerts_List(t *testing.T) {
 				EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 				Created:       "2016-08-23T20:26:50Z",
 				Updated:       "2016-08-23T20:26:50Z",
-				Enabled:       pointy.Bool(true),
+				Enabled:       pointer(true),
 				Matchers: []Matcher{
 					{
 						FieldName: "HOSTNAME_AND_PORT",
@@ -205,7 +204,7 @@ func TestAlerts_List(t *testing.T) {
 					{
 						TypeName:     "SMS",
 						IntervalMin:  5,
-						DelayMin:     pointy.Int(0),
+						DelayMin:     pointer(0),
 						MobileNumber: "2343454567",
 					},
 				},
@@ -223,7 +222,7 @@ func TestAlerts_List(t *testing.T) {
 				EventTypeName: "OUTSIDE_METRIC_THRESHOLD",
 				Created:       "2016-08-23T20:26:50Z",
 				Updated:       "2016-08-23T20:26:50Z",
-				Enabled:       pointy.Bool(true),
+				Enabled:       pointer(true),
 				Matchers: []Matcher{
 					{
 						FieldName: "HOSTNAME_AND_PORT",
@@ -235,7 +234,7 @@ func TestAlerts_List(t *testing.T) {
 					{
 						TypeName:     "SMS",
 						IntervalMin:  5,
-						DelayMin:     pointy.Int(0),
+						DelayMin:     pointer(0),
 						MobileNumber: "2343454567",
 					},
 				},
@@ -307,7 +306,7 @@ func TestAlert_Acknowledge(t *testing.T) {
 		LastNotified:           "2016-08-23T20:33:23Z",
 		MetricName:             "ASSERTS_REGULAR",
 		CurrentValue: &CurrentValue{
-			Number: pointy.Float64(0.0),
+			Number: pointer(0.0),
 			Units:  "RAW",
 		},
 	}

--- a/mongodbatlas/auditing_test.go
+++ b/mongodbatlas/auditing_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestConfigureAuditing(t *testing.T) {
@@ -56,9 +55,9 @@ func TestConfigureAuditing(t *testing.T) {
 	})
 
 	auditingRequest := &Auditing{
-		AuditAuthorizationSuccess: pointy.Bool(false),
+		AuditAuthorizationSuccess: pointer(false),
 		AuditFilter:               "{\n  \"atype\": \"authenticate\",\n  \"param\": {\n    \"user\": \"auditAdmin\",\n    \"db\": \"admin\",\n    \"mechanism\": \"SCRAM-SHA-1\"\n  }\n}",
-		Enabled:                   pointy.Bool(true),
+		Enabled:                   pointer(true),
 	}
 
 	auditingResponse, _, err := client.Auditing.Configure(ctx, groupID, auditingRequest)
@@ -67,10 +66,10 @@ func TestConfigureAuditing(t *testing.T) {
 	}
 
 	expected := &Auditing{
-		AuditAuthorizationSuccess: pointy.Bool(false),
+		AuditAuthorizationSuccess: pointer(false),
 		AuditFilter:               "{\n  \"atype\": \"authenticate\",\n  \"param\": {\n    \"user\": \"auditAdmin\",\n    \"db\": \"admin\",\n    \"mechanism\": \"SCRAM-SHA-1\"\n  }\n}",
 		ConfigurationType:         "FILTER_JSON",
-		Enabled:                   pointy.Bool(true),
+		Enabled:                   pointer(true),
 	}
 
 	if diff := deep.Equal(auditingResponse, expected); diff != nil {
@@ -100,10 +99,10 @@ func TestAuditing_Get(t *testing.T) {
 	}
 
 	expected := &Auditing{
-		AuditAuthorizationSuccess: pointy.Bool(false),
+		AuditAuthorizationSuccess: pointer(false),
 		AuditFilter:               "{\n  \"atype\": \"authenticate\",\n  \"param\": {\n    \"user\": \"auditAdmin\",\n    \"db\": \"admin\",\n    \"mechanism\": \"SCRAM-SHA-1\"\n  }\n}",
 		ConfigurationType:         "FILTER_JSON",
-		Enabled:                   pointy.Bool(true),
+		Enabled:                   pointer(true),
 	}
 
 	if diff := deep.Equal(auditing, expected); diff != nil {

--- a/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestCloudProviderSnapshotBackupPolicies_Get(t *testing.T) {
@@ -176,15 +175,15 @@ func TestCloudProviderSnapshotBackupPolicies_Get(t *testing.T) {
 				},
 			},
 		},
-		ReferenceHourOfDay:    pointy.Int64(17),
-		ReferenceMinuteOfHour: pointy.Int64(24),
-		RestoreWindowDays:     pointy.Int64(7),
-		AutoExportEnabled:     pointy.Bool(true),
+		ReferenceHourOfDay:    pointer64(17),
+		ReferenceMinuteOfHour: pointer64(24),
+		RestoreWindowDays:     pointer64(7),
+		AutoExportEnabled:     pointer(true),
 		Export: &Export{
 			ExportBucketID: "604f6322dc786a5341d4f7fb",
 			FrequencyType:  "monthly",
 		},
-		UseOrgAndGroupNamesInExportPrefix: pointy.Bool(false),
+		UseOrgAndGroupNamesInExportPrefix: pointer(false),
 	}
 
 	if diff := deep.Equal(snapshotBackupPolicy, expected); diff != nil {
@@ -346,8 +345,8 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 	})
 
 	updateRequest := &CloudProviderSnapshotBackupPolicy{
-		ReferenceHourOfDay:    pointy.Int64(12),
-		ReferenceMinuteOfHour: pointy.Int64(30),
+		ReferenceHourOfDay:    pointer64(12),
+		ReferenceMinuteOfHour: pointer64(30),
 		Policies: []Policy{
 			{
 				ID: "5c95242c87d9d636e70c28ef",
@@ -369,8 +368,8 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 				},
 			},
 		},
-		UpdateSnapshots:   pointy.Bool(true),
-		AutoExportEnabled: pointy.Bool(true),
+		UpdateSnapshots:   pointer(true),
+		AutoExportEnabled: pointer(true),
 		Export: &Export{
 			ExportBucketID: "604f6322dc786a5341d4f7fb",
 			FrequencyType:  "monthly",
@@ -423,9 +422,9 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 				},
 			},
 		},
-		ReferenceHourOfDay:    pointy.Int64(12),
-		ReferenceMinuteOfHour: pointy.Int64(30),
-		AutoExportEnabled:     pointy.Bool(true),
+		ReferenceHourOfDay:    pointer64(12),
+		ReferenceMinuteOfHour: pointer64(30),
+		AutoExportEnabled:     pointer(true),
 		Export: &Export{
 			ExportBucketID: "604f6322dc786a5341d4f7fb",
 			FrequencyType:  "monthly",
@@ -534,10 +533,10 @@ func TestCloudProviderSnapshotBackupPolicies_Delete(t *testing.T) {
 				PolicyItems: []PolicyItem{},
 			},
 		},
-		ReferenceHourOfDay:    pointy.Int64(17),
-		ReferenceMinuteOfHour: pointy.Int64(24),
-		RestoreWindowDays:     pointy.Int64(7),
-		AutoExportEnabled:     pointy.Bool(true),
+		ReferenceHourOfDay:    pointer64(17),
+		ReferenceMinuteOfHour: pointer64(24),
+		RestoreWindowDays:     pointer64(7),
+		AutoExportEnabled:     pointer(true),
 		Export: &Export{
 			ExportBucketID: "604f6322dc786a5341d4f7fb",
 			FrequencyType:  "monthly",

--- a/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
+++ b/mongodbatlas/cloud_provider_snapshot_backup_policies_test.go
@@ -175,9 +175,9 @@ func TestCloudProviderSnapshotBackupPolicies_Get(t *testing.T) {
 				},
 			},
 		},
-		ReferenceHourOfDay:    pointer64(17),
-		ReferenceMinuteOfHour: pointer64(24),
-		RestoreWindowDays:     pointer64(7),
+		ReferenceHourOfDay:    pointer(int64(17)),
+		ReferenceMinuteOfHour: pointer(int64(24)),
+		RestoreWindowDays:     pointer(int64(7)),
 		AutoExportEnabled:     pointer(true),
 		Export: &Export{
 			ExportBucketID: "604f6322dc786a5341d4f7fb",
@@ -345,8 +345,8 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 	})
 
 	updateRequest := &CloudProviderSnapshotBackupPolicy{
-		ReferenceHourOfDay:    pointer64(12),
-		ReferenceMinuteOfHour: pointer64(30),
+		ReferenceHourOfDay:    pointer(int64(12)),
+		ReferenceMinuteOfHour: pointer(int64(30)),
 		Policies: []Policy{
 			{
 				ID: "5c95242c87d9d636e70c28ef",
@@ -422,8 +422,8 @@ func TestCloudProviderSnapshotBackupPolicies_Update(t *testing.T) {
 				},
 			},
 		},
-		ReferenceHourOfDay:    pointer64(12),
-		ReferenceMinuteOfHour: pointer64(30),
+		ReferenceHourOfDay:    pointer(int64(12)),
+		ReferenceMinuteOfHour: pointer(int64(30)),
 		AutoExportEnabled:     pointer(true),
 		Export: &Export{
 			ExportBucketID: "604f6322dc786a5341d4f7fb",
@@ -533,9 +533,9 @@ func TestCloudProviderSnapshotBackupPolicies_Delete(t *testing.T) {
 				PolicyItems: []PolicyItem{},
 			},
 		},
-		ReferenceHourOfDay:    pointer64(17),
-		ReferenceMinuteOfHour: pointer64(24),
-		RestoreWindowDays:     pointer64(7),
+		ReferenceHourOfDay:    pointer(int64(17)),
+		ReferenceMinuteOfHour: pointer(int64(24)),
+		RestoreWindowDays:     pointer(int64(7)),
 		AutoExportEnabled:     pointer(true),
 		Export: &Export{
 			ExportBucketID: "604f6322dc786a5341d4f7fb",

--- a/mongodbatlas/cluster_outage_simulation_test.go
+++ b/mongodbatlas/cluster_outage_simulation_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestClusterOutageSimulationServiceOp_GetOutageSimulation(t *testing.T) {
@@ -54,18 +53,18 @@ func TestClusterOutageSimulationServiceOp_GetOutageSimulation(t *testing.T) {
 	}
 
 	expected := &ClusterOutageSimulation{
-		ClusterName: pointy.String(clusterName),
-		GroupID:     pointy.String(groupID),
-		ID:          pointy.String("63599c987d469e386156afcb"),
+		ClusterName: pointer(clusterName),
+		GroupID:     pointer(groupID),
+		ID:          pointer("63599c987d469e386156afcb"),
 		OutageFilters: []ClusterOutageSimulationOutageFilter{
 			{
-				CloudProvider: pointy.String("AWS"),
-				RegionName:    pointy.String("string"),
-				Type:          pointy.String("REGION"),
+				CloudProvider: pointer("AWS"),
+				RegionName:    pointer("string"),
+				Type:          pointer("REGION"),
 			},
 		},
-		StartRequestDate: pointy.String("2022-01-01T00:00:00Z"),
-		State:            pointy.String("START_REQUESTED"),
+		StartRequestDate: pointer("2022-01-01T00:00:00Z"),
+		State:            pointer("START_REQUESTED"),
 	}
 
 	if diff := deep.Equal(simulation, expected); diff != nil {
@@ -103,18 +102,18 @@ func TestClusterOutageSimulationServiceOp_EndOutageSimulation(t *testing.T) {
 	}
 
 	expected := &ClusterOutageSimulation{
-		ClusterName: pointy.String(clusterName),
-		GroupID:     pointy.String(groupID),
-		ID:          pointy.String("63599c987d469e386156afcb"),
+		ClusterName: pointer(clusterName),
+		GroupID:     pointer(groupID),
+		ID:          pointer("63599c987d469e386156afcb"),
 		OutageFilters: []ClusterOutageSimulationOutageFilter{
 			{
-				CloudProvider: pointy.String("AWS"),
-				RegionName:    pointy.String("string"),
-				Type:          pointy.String("REGION"),
+				CloudProvider: pointer("AWS"),
+				RegionName:    pointer("string"),
+				Type:          pointer("REGION"),
 			},
 		},
-		StartRequestDate: pointy.String("2022-01-01T00:00:00Z"),
-		State:            pointy.String("START_REQUESTED"),
+		StartRequestDate: pointer("2022-01-01T00:00:00Z"),
+		State:            pointer("START_REQUESTED"),
 	}
 
 	if diff := deep.Equal(simulation, expected); diff != nil {
@@ -131,9 +130,9 @@ func TestClusterOutageSimulationServiceOp_StartOutageSimulation(t *testing.T) {
 	createRequest := &ClusterOutageSimulationRequest{
 		OutageFilters: []ClusterOutageSimulationOutageFilter{
 			{
-				CloudProvider: pointy.String("AWS"),
-				RegionName:    pointy.String("string"),
-				Type:          pointy.String("REGION"),
+				CloudProvider: pointer("AWS"),
+				RegionName:    pointer("string"),
+				Type:          pointer("REGION"),
 			},
 		},
 	}
@@ -181,18 +180,18 @@ func TestClusterOutageSimulationServiceOp_StartOutageSimulation(t *testing.T) {
 	}
 
 	expected := &ClusterOutageSimulation{
-		ClusterName: pointy.String(clusterName),
-		GroupID:     pointy.String(groupID),
-		ID:          pointy.String("63599c987d469e386156afcb"),
+		ClusterName: pointer(clusterName),
+		GroupID:     pointer(groupID),
+		ID:          pointer("63599c987d469e386156afcb"),
 		OutageFilters: []ClusterOutageSimulationOutageFilter{
 			{
-				CloudProvider: pointy.String("AWS"),
-				RegionName:    pointy.String("string"),
-				Type:          pointy.String("REGION"),
+				CloudProvider: pointer("AWS"),
+				RegionName:    pointer("string"),
+				Type:          pointer("REGION"),
 			},
 		},
-		StartRequestDate: pointy.String("2022-01-01T00:00:00Z"),
-		State:            pointy.String("START_REQUESTED"),
+		StartRequestDate: pointer("2022-01-01T00:00:00Z"),
+		State:            pointer("START_REQUESTED"),
 	}
 
 	if diff := deep.Equal(simulation, expected); diff != nil {

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestClusters_ListClusters(t *testing.T) {
@@ -194,14 +193,14 @@ func TestClusters_ListClusters(t *testing.T) {
 
 	cluster1 := Cluster{
 		AutoScaling: &AutoScaling{
-			DiskGBEnabled: pointy.Bool(true),
+			DiskGBEnabled: pointer(true),
 			Compute: &Compute{
-				Enabled:          pointy.Bool(true),
-				ScaleDownEnabled: pointy.Bool(true),
+				Enabled:          pointer(true),
+				ScaleDownEnabled: pointer(true),
 			},
 		},
-		BackupEnabled: pointy.Bool(true),
-		BiConnector:   &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		BackupEnabled: pointer(true),
+		BiConnector:   &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:   "REPLICASET",
 		ConnectionStrings: &ConnectionStrings{
 			Standard:          "mongodb://cluster0-shard-00-00-auylw.mongodb.net:27017,cluster0-shard-00-01-auylw.mongodb.net:27017,cluster0-shard-00-02-auylw.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0",
@@ -226,7 +225,7 @@ func TestClusters_ListClusters(t *testing.T) {
 			},
 		},
 
-		DiskSizeGB:               pointy.Float64(160),
+		DiskSizeGB:               pointer(160),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  "5356823b3794de37132bb7b",
 		MongoDBVersion:           "3.4.9",
@@ -234,12 +233,12 @@ func TestClusters_ListClusters(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     "AppData",
-		NumShards:                pointy.Int64(1),
-		Paused:                   pointy.Bool(false),
+		NumShards:                pointer64(1),
+		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointy.Int64(1320),
-			EncryptEBSVolume: pointy.Bool(false),
+			DiskIOPS:         pointer64(1320),
+			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 			AutoScaling: &AutoScaling{
@@ -249,13 +248,13 @@ func TestClusters_ListClusters(t *testing.T) {
 				},
 			},
 		},
-		ReplicationFactor: pointy.Int64(3),
+		ReplicationFactor: pointer64(3),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointy.Int64(3),
-				Priority:       pointy.Int64(7),
-				ReadOnlyNodes:  pointy.Int64(0),
+				ElectableNodes: pointer64(3),
+				Priority:       pointer64(7),
+				ReadOnlyNodes:  pointer64(0),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
@@ -353,12 +352,12 @@ func TestClusters_Create(t *testing.T) {
 
 	createRequest := &Cluster{
 		ID: "1",
-		AutoScaling: &AutoScaling{DiskGBEnabled: pointy.Bool(true),
-			Compute: &Compute{Enabled: pointy.Bool(true), ScaleDownEnabled: pointy.Bool(true)}},
-		BackupEnabled:            pointy.Bool(true),
-		BiConnector:              &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
+			Compute: &Compute{Enabled: pointer(true), ScaleDownEnabled: pointer(true)}},
+		BackupEnabled:            pointer(true),
+		BiConnector:              &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
-		DiskSizeGB:               pointy.Float64(160),
+		DiskSizeGB:               pointer(160),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -366,23 +365,23 @@ func TestClusters_Create(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     "AppData",
-		NumShards:                pointy.Int64(1),
-		Paused:                   pointy.Bool(false),
+		NumShards:                pointer64(1),
+		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointy.Int64(1320),
-			EncryptEBSVolume: pointy.Bool(false),
+			DiskIOPS:         pointer64(1320),
+			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 			AutoScaling:      &AutoScaling{Compute: &Compute{MinInstanceSize: "M10", MaxInstanceSize: "M60"}},
 		},
-		ReplicationFactor: pointy.Int64(3),
+		ReplicationFactor: pointer64(3),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointy.Int64(3),
-				Priority:       pointy.Int64(7),
-				ReadOnlyNodes:  pointy.Int64(0),
+				ElectableNodes: pointer64(3),
+				Priority:       pointer64(7),
+				ReadOnlyNodes:  pointer64(0),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
@@ -536,12 +535,12 @@ func TestClusters_Update(t *testing.T) {
 
 	updateRequest := &Cluster{
 		ID: "1",
-		AutoScaling: &AutoScaling{DiskGBEnabled: pointy.Bool(true),
-			Compute: &Compute{Enabled: pointy.Bool(true), ScaleDownEnabled: pointy.Bool(true)}},
-		BackupEnabled:            pointy.Bool(true),
-		BiConnector:              &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
+			Compute: &Compute{Enabled: pointer(true), ScaleDownEnabled: pointer(true)}},
+		BackupEnabled:            pointer(true),
+		BiConnector:              &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
-		DiskSizeGB:               pointy.Float64(160),
+		DiskSizeGB:               pointer(160),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -549,23 +548,23 @@ func TestClusters_Update(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     clusterName,
-		NumShards:                pointy.Int64(1),
-		Paused:                   pointy.Bool(false),
+		NumShards:                pointer64(1),
+		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointy.Int64(1320),
-			EncryptEBSVolume: pointy.Bool(false),
+			DiskIOPS:         pointer64(1320),
+			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 			AutoScaling:      &AutoScaling{Compute: &Compute{MinInstanceSize: "M20", MaxInstanceSize: "M80"}},
 		},
-		ReplicationFactor: pointy.Int64(3),
+		ReplicationFactor: pointer64(3),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointy.Int64(3),
-				Priority:       pointy.Int64(7),
-				ReadOnlyNodes:  pointy.Int64(0),
+				ElectableNodes: pointer64(3),
+				Priority:       pointer64(7),
+				ReadOnlyNodes:  pointer64(0),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
@@ -733,14 +732,14 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 	updateRequest := &ProcessArgs{
 		DefaultReadConcern:               defaultReadConcern,
 		DefaultWriteConcern:              defaultWriteConcern,
-		FailIndexKeyTooLong:              pointy.Bool(false),
-		JavascriptEnabled:                pointy.Bool(false),
+		FailIndexKeyTooLong:              pointer(false),
+		JavascriptEnabled:                pointer(false),
 		MinimumEnabledTLSProtocol:        tlsProtocol,
-		NoTableScan:                      pointy.Bool(true),
-		OplogSizeMB:                      pointy.Int64(2000),
-		OplogMinRetentionHours:           pointy.Float64(100),
-		SampleSizeBIConnector:            pointy.Int64(5000),
-		SampleRefreshIntervalBIConnector: pointy.Int64(300),
+		NoTableScan:                      pointer(true),
+		OplogSizeMB:                      pointer64(2000),
+		OplogMinRetentionHours:           pointer(100),
+		SampleSizeBIConnector:            pointer64(5000),
+		SampleRefreshIntervalBIConnector: pointer64(300),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/processArgs", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
@@ -796,8 +795,8 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		t.Errorf("expected tlsProtocol '%s', received '%s'", tlsProtocol, tls)
 	}
 
-	if jsEnabled := processArgs.JavascriptEnabled; pointy.BoolValue(jsEnabled, false) != false {
-		t.Errorf("expected javascriptEnabled '%t', received '%t'", pointy.BoolValue(jsEnabled, false), false)
+	if jsEnabled := processArgs.JavascriptEnabled; pointerValue(jsEnabled, false) != false {
+		t.Errorf("expected javascriptEnabled '%t', received '%t'", pointerValue(jsEnabled, false), false)
 	}
 }
 
@@ -828,13 +827,13 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 	expected := &ProcessArgs{
 		DefaultReadConcern:               "available",
 		DefaultWriteConcern:              "1",
-		FailIndexKeyTooLong:              pointy.Bool(false),
-		JavascriptEnabled:                pointy.Bool(false),
+		FailIndexKeyTooLong:              pointer(false),
+		JavascriptEnabled:                pointer(false),
 		MinimumEnabledTLSProtocol:        "TLS1_2",
-		NoTableScan:                      pointy.Bool(true),
-		OplogSizeMB:                      pointy.Int64(2000),
-		SampleSizeBIConnector:            pointy.Int64(5000),
-		SampleRefreshIntervalBIConnector: pointy.Int64(300),
+		NoTableScan:                      pointer(true),
+		OplogSizeMB:                      pointer64(2000),
+		SampleSizeBIConnector:            pointer64(5000),
+		SampleRefreshIntervalBIConnector: pointer64(300),
 	}
 
 	if diff := deep.Equal(processArgs, expected); diff != nil {
@@ -931,9 +930,9 @@ func TestClusters_Get(t *testing.T) {
 
 	expected := &Cluster{
 		ID:            "1",
-		AutoScaling:   &AutoScaling{DiskGBEnabled: pointy.Bool(true)},
-		BackupEnabled: pointy.Bool(true),
-		BiConnector:   &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		AutoScaling:   &AutoScaling{DiskGBEnabled: pointer(true)},
+		BackupEnabled: pointer(true),
+		BiConnector:   &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:   "REPLICASET",
 		ConnectionStrings: &ConnectionStrings{
 			Standard:          "mongodb://cluster0-shard-00-00-auylw.mongodb.net:27017,cluster0-shard-00-01-auylw.mongodb.net:27017,cluster0-shard-00-02-auylw.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0",
@@ -957,7 +956,7 @@ func TestClusters_Get(t *testing.T) {
 				},
 			},
 		},
-		DiskSizeGB:               pointy.Float64(160),
+		DiskSizeGB:               pointer(160),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -965,28 +964,28 @@ func TestClusters_Get(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     clusterName,
-		NumShards:                pointy.Int64(1),
-		Paused:                   pointy.Bool(false),
-		PitEnabled:               pointy.Bool(false),
+		NumShards:                pointer64(1),
+		Paused:                   pointer(false),
+		PitEnabled:               pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointy.Int64(1320),
-			EncryptEBSVolume: pointy.Bool(false),
+			DiskIOPS:         pointer64(1320),
+			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 		},
-		ReplicationFactor: pointy.Int64(3),
+		ReplicationFactor: pointer64(3),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointy.Int64(3),
-				Priority:       pointy.Int64(7),
-				ReadOnlyNodes:  pointy.Int64(0),
+				ElectableNodes: pointer64(3),
+				Priority:       pointer64(7),
+				ReadOnlyNodes:  pointer64(0),
 			},
 		},
 		SrvAddress:                   "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
 		StateName:                    "IDLE",
-		TerminationProtectionEnabled: pointy.Bool(false),
+		TerminationProtectionEnabled: pointer(false),
 		VersionReleaseSystem:         "LTS",
 	}
 
@@ -1293,12 +1292,12 @@ func TestClusters_Upgrade(t *testing.T) {
 
 	upgradeRequest := &Cluster{
 		ID: "1",
-		AutoScaling: &AutoScaling{DiskGBEnabled: pointy.Bool(true),
-			Compute: &Compute{Enabled: pointy.Bool(true), ScaleDownEnabled: pointy.Bool(true)}},
-		BackupEnabled:            pointy.Bool(true),
-		BiConnector:              &BiConnector{Enabled: pointy.Bool(false), ReadPreference: "secondary"},
+		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
+			Compute: &Compute{Enabled: pointer(true), ScaleDownEnabled: pointer(true)}},
+		BackupEnabled:            pointer(true),
+		BiConnector:              &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
-		DiskSizeGB:               pointy.Float64(160),
+		DiskSizeGB:               pointer(160),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -1306,23 +1305,23 @@ func TestClusters_Upgrade(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     clusterName,
-		NumShards:                pointy.Int64(1),
-		Paused:                   pointy.Bool(false),
+		NumShards:                pointer64(1),
+		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointy.Int64(1320),
-			EncryptEBSVolume: pointy.Bool(false),
+			DiskIOPS:         pointer64(1320),
+			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 			AutoScaling:      &AutoScaling{Compute: &Compute{MinInstanceSize: "M20", MaxInstanceSize: "M80"}},
 		},
-		ReplicationFactor: pointy.Int64(3),
+		ReplicationFactor: pointer64(3),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointy.Int64(3),
-				Priority:       pointy.Int64(7),
-				ReadOnlyNodes:  pointy.Int64(0),
+				ElectableNodes: pointer64(3),
+				Priority:       pointer64(7),
+				ReadOnlyNodes:  pointer64(0),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -225,7 +225,7 @@ func TestClusters_ListClusters(t *testing.T) {
 			},
 		},
 
-		DiskSizeGB:               pointer(160),
+		DiskSizeGB:               pointer(160.0),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  "5356823b3794de37132bb7b",
 		MongoDBVersion:           "3.4.9",
@@ -233,11 +233,11 @@ func TestClusters_ListClusters(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     "AppData",
-		NumShards:                pointer64(1),
+		NumShards:                pointer(int64(1)),
 		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointer64(1320),
+			DiskIOPS:         pointer(int64(1320)),
 			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
@@ -248,13 +248,13 @@ func TestClusters_ListClusters(t *testing.T) {
 				},
 			},
 		},
-		ReplicationFactor: pointer64(3),
+		ReplicationFactor: pointer(int64(3)),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointer64(3),
-				Priority:       pointer64(7),
-				ReadOnlyNodes:  pointer64(0),
+				ElectableNodes: pointer(int64(3)),
+				Priority:       pointer(int64(7)),
+				ReadOnlyNodes:  pointer(int64(0)),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
@@ -357,7 +357,7 @@ func TestClusters_Create(t *testing.T) {
 		BackupEnabled:            pointer(true),
 		BiConnector:              &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
-		DiskSizeGB:               pointer(160),
+		DiskSizeGB:               pointer(160.0),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -365,23 +365,23 @@ func TestClusters_Create(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     "AppData",
-		NumShards:                pointer64(1),
+		NumShards:                pointer(int64(1)),
 		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointer64(1320),
+			DiskIOPS:         pointer(int64(1320)),
 			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 			AutoScaling:      &AutoScaling{Compute: &Compute{MinInstanceSize: "M10", MaxInstanceSize: "M60"}},
 		},
-		ReplicationFactor: pointer64(3),
+		ReplicationFactor: pointer(int64(3)),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointer64(3),
-				Priority:       pointer64(7),
-				ReadOnlyNodes:  pointer64(0),
+				ElectableNodes: pointer(int64(3)),
+				Priority:       pointer(int64(7)),
+				ReadOnlyNodes:  pointer(int64(0)),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
@@ -540,7 +540,7 @@ func TestClusters_Update(t *testing.T) {
 		BackupEnabled:            pointer(true),
 		BiConnector:              &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
-		DiskSizeGB:               pointer(160),
+		DiskSizeGB:               pointer(160.0),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -548,23 +548,23 @@ func TestClusters_Update(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     clusterName,
-		NumShards:                pointer64(1),
+		NumShards:                pointer(int64(1)),
 		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointer64(1320),
+			DiskIOPS:         pointer(int64(1320)),
 			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 			AutoScaling:      &AutoScaling{Compute: &Compute{MinInstanceSize: "M20", MaxInstanceSize: "M80"}},
 		},
-		ReplicationFactor: pointer64(3),
+		ReplicationFactor: pointer(int64(3)),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointer64(3),
-				Priority:       pointer64(7),
-				ReadOnlyNodes:  pointer64(0),
+				ElectableNodes: pointer(int64(3)),
+				Priority:       pointer(int64(7)),
+				ReadOnlyNodes:  pointer(int64(0)),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
@@ -736,10 +736,10 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		JavascriptEnabled:                pointer(false),
 		MinimumEnabledTLSProtocol:        tlsProtocol,
 		NoTableScan:                      pointer(true),
-		OplogSizeMB:                      pointer64(2000),
-		OplogMinRetentionHours:           pointer(100),
-		SampleSizeBIConnector:            pointer64(5000),
-		SampleRefreshIntervalBIConnector: pointer64(300),
+		OplogSizeMB:                      pointer(int64(2000)),
+		OplogMinRetentionHours:           pointer(100.0),
+		SampleSizeBIConnector:            pointer(int64(5000)),
+		SampleRefreshIntervalBIConnector: pointer(int64(300)),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/processArgs", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
@@ -795,8 +795,8 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		t.Errorf("expected tlsProtocol '%s', received '%s'", tlsProtocol, tls)
 	}
 
-	if jsEnabled := processArgs.JavascriptEnabled; pointerValue(jsEnabled, false) != false {
-		t.Errorf("expected javascriptEnabled '%t', received '%t'", pointerValue(jsEnabled, false), false)
+	if jsEnabled := processArgs.JavascriptEnabled; *jsEnabled != false {
+		t.Errorf("expected javascriptEnabled '%t', received '%t'", *jsEnabled, false)
 	}
 }
 
@@ -831,9 +831,9 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 		JavascriptEnabled:                pointer(false),
 		MinimumEnabledTLSProtocol:        "TLS1_2",
 		NoTableScan:                      pointer(true),
-		OplogSizeMB:                      pointer64(2000),
-		SampleSizeBIConnector:            pointer64(5000),
-		SampleRefreshIntervalBIConnector: pointer64(300),
+		OplogSizeMB:                      pointer(int64(2000)),
+		SampleSizeBIConnector:            pointer(int64(5000)),
+		SampleRefreshIntervalBIConnector: pointer(int64(300)),
 	}
 
 	if diff := deep.Equal(processArgs, expected); diff != nil {
@@ -956,7 +956,7 @@ func TestClusters_Get(t *testing.T) {
 				},
 			},
 		},
-		DiskSizeGB:               pointer(160),
+		DiskSizeGB:               pointer(160.0),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -964,23 +964,23 @@ func TestClusters_Get(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     clusterName,
-		NumShards:                pointer64(1),
+		NumShards:                pointer(int64(1)),
 		Paused:                   pointer(false),
 		PitEnabled:               pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointer64(1320),
+			DiskIOPS:         pointer(int64(1320)),
 			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 		},
-		ReplicationFactor: pointer64(3),
+		ReplicationFactor: pointer(int64(3)),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointer64(3),
-				Priority:       pointer64(7),
-				ReadOnlyNodes:  pointer64(0),
+				ElectableNodes: pointer(int64(3)),
+				Priority:       pointer(int64(7)),
+				ReadOnlyNodes:  pointer(int64(0)),
 			},
 		},
 		SrvAddress:                   "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",
@@ -1297,7 +1297,7 @@ func TestClusters_Upgrade(t *testing.T) {
 		BackupEnabled:            pointer(true),
 		BiConnector:              &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
 		ClusterType:              "REPLICASET",
-		DiskSizeGB:               pointer(160),
+		DiskSizeGB:               pointer(160.0),
 		EncryptionAtRestProvider: "AWS",
 		GroupID:                  groupID,
 		MongoDBVersion:           "3.4.9",
@@ -1305,23 +1305,23 @@ func TestClusters_Upgrade(t *testing.T) {
 		MongoURIUpdated:          "2017-10-23T21:26:17Z",
 		MongoURIWithOptions:      "mongodb://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=mongo-shard-0",
 		Name:                     clusterName,
-		NumShards:                pointer64(1),
+		NumShards:                pointer(int64(1)),
 		Paused:                   pointer(false),
 		ProviderSettings: &ProviderSettings{
 			ProviderName:     "AWS",
-			DiskIOPS:         pointer64(1320),
+			DiskIOPS:         pointer(int64(1320)),
 			EncryptEBSVolume: pointer(false),
 			InstanceSizeName: "M40",
 			RegionName:       "US_WEST_2",
 			AutoScaling:      &AutoScaling{Compute: &Compute{MinInstanceSize: "M20", MaxInstanceSize: "M80"}},
 		},
-		ReplicationFactor: pointer64(3),
+		ReplicationFactor: pointer(int64(3)),
 
 		ReplicationSpec: map[string]RegionsConfig{
 			"US_EAST_1": {
-				ElectableNodes: pointer64(3),
-				Priority:       pointer64(7),
-				ReadOnlyNodes:  pointer64(0),
+				ElectableNodes: pointer(int64(3)),
+				Priority:       pointer(int64(7)),
+				ReadOnlyNodes:  pointer(int64(0)),
 			},
 		},
 		SrvAddress:           "mongodb+srv://mongo-shard-00-00.mongodb.net:27017,mongo-shard-00-01.mongodb.net:27017,mongo-shard-00-02.mongodb.net:27017",

--- a/mongodbatlas/containers_test.go
+++ b/mongodbatlas/containers_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestContainers_List(t *testing.T) {
@@ -64,14 +63,14 @@ func TestContainers_List(t *testing.T) {
 			GCPProjectID:   "my-sample-project-191923",
 			NetworkName:    "test1",
 			ProviderName:   "GCP",
-			Provisioned:    pointy.Bool(true),
+			Provisioned:    pointer(true),
 		}
 
 		AWSContainer := Container{
 			AtlasCIDRBlock: "10.8.0.0/21",
 			ID:             "1112269b3bf99403840e8934",
 			ProviderName:   "AWS",
-			Provisioned:    pointy.Bool(true),
+			Provisioned:    pointer(true),
 			RegionName:     "US_EAST_1",
 			VPCID:          "vpc-zz0zzzzz",
 		}
@@ -97,13 +96,13 @@ func TestContainers_List(t *testing.T) {
 						GCPProjectID:   "my-sample-project-191923",
 						NetworkName:    "test1",
 						ProviderName:   "GCP",
-						Provisioned:    pointy.Bool(true),
+						Provisioned:    pointer(true),
 					},
 					{
 						AtlasCIDRBlock: "10.8.0.0/21",
 						ID:             "1112269b3bf99403840e8934",
 						ProviderName:   "AWS",
-						Provisioned:    pointy.Bool(true),
+						Provisioned:    pointer(true),
 						RegionName:     "US_EAST_1",
 						VPCID:          "vpc-zz0zzzzz",
 					},
@@ -216,14 +215,14 @@ func TestContainers_ListAll(t *testing.T) {
 		GCPProjectID:   "my-sample-project-191923",
 		NetworkName:    "test1",
 		ProviderName:   "GCP",
-		Provisioned:    pointy.Bool(true),
+		Provisioned:    pointer(true),
 	}
 
 	AWSContainer := Container{
 		AtlasCIDRBlock: "10.8.0.0/21",
 		ID:             "1112269b3bf99403840e8934",
 		ProviderName:   "AWS",
-		Provisioned:    pointy.Bool(true),
+		Provisioned:    pointer(true),
 		RegionName:     "US_EAST_1",
 		VPCID:          "vpc-zz0zzzzz",
 	}
@@ -407,7 +406,7 @@ func TestContainersServiceOp_Create(t *testing.T) {
 			expectedResponse: &Container{
 				AtlasCIDRBlock: "10.8.0.0/21",
 				ID:             "1112269b3bf99403840e8934",
-				Provisioned:    pointy.Bool(true),
+				Provisioned:    pointer(true),
 				RegionName:     "US_EAST_1",
 				VPCID:          "vpc-zz0zzzzz",
 			},
@@ -436,7 +435,7 @@ func TestContainersServiceOp_Create(t *testing.T) {
 				AtlasCIDRBlock:      "10.8.0.0/21",
 				AzureSubscriptionID: "602336d43d098d433845971g",
 				ID:                  "5cbf563d87d9d67253be590a",
-				Provisioned:         pointy.Bool(false),
+				Provisioned:         pointer(false),
 				ProviderName:        "AZURE",
 				Region:              "US_EAST_2",
 			},
@@ -460,7 +459,7 @@ func TestContainersServiceOp_Create(t *testing.T) {
 			expectedResponse: &Container{
 				AtlasCIDRBlock: "10.8.0.0/18",
 				ID:             "1112269b3bf99403840e8934",
-				Provisioned:    pointy.Bool(true),
+				Provisioned:    pointer(true),
 				NetworkName:    "null",
 				GCPProjectID:   "null",
 			},

--- a/mongodbatlas/continuous_snapshots_test.go
+++ b/mongodbatlas/continuous_snapshots_test.go
@@ -20,8 +20,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/openlyinc/pointy"
-
 	"github.com/go-test/deep"
 )
 
@@ -96,7 +94,7 @@ func TestContinuousSnapshots_List(t *testing.T) {
 					Date:      "2017-12-26T16:32:16Z",
 					Increment: 1,
 				},
-				DoNotDelete: pointy.Bool(false),
+				DoNotDelete: pointer(false),
 				Expires:     "2018-12-25T16:32:16Z",
 				GroupID:     "6c7498dg87d9e6526801572b",
 				ID:          "5a4279d4fcc178500596745a",
@@ -190,7 +188,7 @@ func TestContinuousSnapshots_Get(t *testing.T) {
 			Date:      "2017-12-26T16:32:16Z",
 			Increment: 1,
 		},
-		DoNotDelete: pointy.Bool(false),
+		DoNotDelete: pointer(false),
 		Expires:     "2018-12-25T16:32:16Z",
 		GroupID:     "6c7498dg87d9e6526801572b",
 		ID:          "6b5380e6jvn128560506942b",
@@ -303,7 +301,7 @@ func TestContinuousSnapshots_ChangeExpiry(t *testing.T) {
 			Date:      "2017-12-26T16:32:16Z",
 			Increment: 1,
 		},
-		DoNotDelete: pointy.Bool(false),
+		DoNotDelete: pointer(false),
 		Expires:     "2018-12-01T00:00:00Z",
 		GroupID:     "6c7498dg87d9e6526801572b",
 		ID:          "6b5380e6jvn128560506942b",

--- a/mongodbatlas/custom_db_roles_test.go
+++ b/mongodbatlas/custom_db_roles_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
@@ -43,8 +42,8 @@ func TestCustomDBRoles_ListCustomDBRoles(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: pointy.String("test-collection"),
-				DB:         pointy.String("test-db"),
+				Collection: pointer("test-collection"),
+				DB:         pointer("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -77,8 +76,8 @@ func TestCustomDBRoles_GetCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: pointy.String("test-collection"),
-				DB:         pointy.String("test-db"),
+				Collection: pointer("test-collection"),
+				DB:         pointer("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -103,8 +102,8 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 				Actions: []Action{{
 					Action: "CREATE_INDEX",
 					Resources: []Resource{{
-						Collection: pointy.String("test-collection"),
-						DB:         pointy.String("test-db"),
+						Collection: pointer("test-collection"),
+						DB:         pointer("test-db"),
 					}},
 				}},
 				InheritedRoles: []InheritedRole{{
@@ -136,8 +135,8 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 						Action: "CREATE_INDEX",
 						Resources: []Resource{
 							{
-								Collection: pointy.String(""),
-								DB:         pointy.String("admin"),
+								Collection: pointer(""),
+								DB:         pointer("admin"),
 							},
 						},
 					},
@@ -179,7 +178,7 @@ func TestCustomDBRoles_CreateCustomDBRole(t *testing.T) {
 						Action: "CONN_POOL_STATS",
 						Resources: []Resource{
 							{
-								Cluster: pointy.Bool(true),
+								Cluster: pointer(true),
 							},
 						},
 					},
@@ -249,8 +248,8 @@ func TestCustomDBRoles_UpdateCustomDBRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: pointy.String("test-collection"),
-				DB:         pointy.String("test-db"),
+				Collection: pointer("test-collection"),
+				DB:         pointer("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{{
@@ -347,8 +346,8 @@ func TestCustomDBRoles_DeleteInheritedRole(t *testing.T) {
 		Actions: []Action{{
 			Action: "CREATE_INDEX",
 			Resources: []Resource{{
-				Collection: pointy.String("test-collection"),
-				DB:         pointy.String("test-db"),
+				Collection: pointer("test-collection"),
+				DB:         pointer("test-db"),
 			}},
 		}},
 		InheritedRoles: []InheritedRole{},

--- a/mongodbatlas/data_lakes_test.go
+++ b/mongodbatlas/data_lakes_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestDataLakes_List(t *testing.T) {
@@ -139,7 +138,7 @@ func TestDataLakes_List(t *testing.T) {
 								Pipeline: "my.pipeline",
 							},
 						},
-						MaxWildcardCollections: pointy.Int64(92),
+						MaxWildcardCollections: pointer(int64(92)),
 					},
 				},
 				Stores: []DataLakeStore{
@@ -150,7 +149,7 @@ func TestDataLakes_List(t *testing.T) {
 						Bucket:                   "datacenter-alpha",
 						Prefix:                   "/metrics",
 						Delimiter:                "/",
-						IncludeTags:              pointy.Bool(false),
+						IncludeTags:              pointer(false),
 						AdditionalStorageClasses: []string{"STANDARD_IA"},
 					},
 				},

--- a/mongodbatlas/encryptions_at_rest.go
+++ b/mongodbatlas/encryptions_at_rest.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/openlyinc/pointy"
 )
 
 const (
@@ -179,9 +177,9 @@ func (s *EncryptionsAtRestServiceOp) Delete(ctx context.Context, groupID string)
 	}
 
 	createRequest := EncryptionAtRest{
-		AwsKms:         AwsKms{Enabled: pointy.Bool(false)},
-		AzureKeyVault:  AzureKeyVault{Enabled: pointy.Bool(false)},
-		GoogleCloudKms: GoogleCloudKms{Enabled: pointy.Bool(false)},
+		AwsKms:         AwsKms{Enabled: pointer(false)},
+		AzureKeyVault:  AzureKeyVault{Enabled: pointer(false)},
+		GoogleCloudKms: GoogleCloudKms{Enabled: pointer(false)},
 	}
 
 	path := fmt.Sprintf(encryptionsAtRestBasePath, groupID)

--- a/mongodbatlas/encryptions_at_rest_test.go
+++ b/mongodbatlas/encryptions_at_rest_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestEncryptionsAtRest_Create(t *testing.T) {
@@ -31,7 +30,7 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 	createRequest := &EncryptionAtRest{
 		GroupID: "6d2065c687d9d64ae7acdg41",
 		AwsKms: AwsKms{
-			Enabled:             pointy.Bool(true),
+			Enabled:             pointer(true),
 			AccessKeyID:         "AKIAIOSFODNN7EXAMPLE",
 			SecretAccessKey:     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 			CustomerMasterKeyID: "030gce02-586d-48d2-a966-05ea954fde0g",
@@ -39,7 +38,7 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 			RoleID:              "5f232b94af0a6b41747bcc2d",
 		},
 		AzureKeyVault: AzureKeyVault{
-			Enabled:           pointy.Bool(true),
+			Enabled:           pointer(true),
 			ClientID:          "g54f9e2-89e3-40fd-8188-EXAMPLEID",
 			AzureEnvironment:  Azure,
 			SubscriptionID:    "0ec944e3-g725-44f9-a147-EXAMPLEID",
@@ -50,7 +49,7 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 			TenantID:          "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID",
 		},
 		GoogleCloudKms: GoogleCloudKms{
-			Enabled:              pointy.Bool(true),
+			Enabled:              pointer(true),
 			ServiceAccountKey:    "{\"type\": \"service_account\",\"project_id\": \"my-project-common-0\",\"private_key_id\": \"e120598ea4f88249469fcdd75a9a785c1bb3\",\"private_key\": \"-----BEGIN PRIVATE KEY-----\\nMIIEuwIBA(truncated)SfecnS0mT94D9\\n-----END PRIVATE KEY-----\\n\",\"client_email\": \"my-email-kms-0@my-project-common-0.iam.gserviceaccount.com\",\"client_id\": \"10180967717292066\",\"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",\"token_uri\": \"https://accounts.google.com/o/oauth2/token\",\"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",\"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/my-email-kms-0%40my-project-common-0.iam.gserviceaccount.com\"}",
 			KeyVersionResourceID: "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1",
 		},
@@ -127,15 +126,15 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 
 	expected := &EncryptionAtRest{
 		AwsKms: AwsKms{
-			Enabled:             pointy.Bool(true),
+			Enabled:             pointer(true),
 			AccessKeyID:         "AKIAIOSFODNN7EXAMPLE",
 			CustomerMasterKeyID: "030gce02-586d-48d2-a966-05ea954fde0g",
 			Region:              "US_EAST_1",
 			RoleID:              "5f232b94af0a6b41747bcc2d",
-			Valid:               pointy.Bool(true),
+			Valid:               pointer(true),
 		},
 		AzureKeyVault: AzureKeyVault{
-			Enabled:           pointy.Bool(true),
+			Enabled:           pointer(true),
 			ClientID:          "g54f9e2-89e3-40fd-8188-EXAMPLEID",
 			AzureEnvironment:  "AZURE",
 			SubscriptionID:    "0ec944e3-g725-44f9-a147-EXAMPLEID",
@@ -145,7 +144,7 @@ func TestEncryptionsAtRest_Create(t *testing.T) {
 			TenantID:          "e8e4b6ba-ff32-4c88-a9af-dc17efegdf63",
 		},
 		GoogleCloudKms: GoogleCloudKms{
-			Enabled:              pointy.Bool(true),
+			Enabled:              pointer(true),
 			KeyVersionResourceID: "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1",
 		},
 	}
@@ -196,15 +195,15 @@ func TestEncryptionsAtRest_Get(t *testing.T) {
 
 	expected := &EncryptionAtRest{
 		AwsKms: AwsKms{
-			Enabled:             pointy.Bool(true),
+			Enabled:             pointer(true),
 			AccessKeyID:         "AKIAIOSFODNN7EXAMPLE",
 			CustomerMasterKeyID: "030gce02-586d-48d2-a966-05ea954fde0g",
 			Region:              "US_EAST_1",
 			RoleID:              "5f232b94af0a6b41747bcc2d",
-			Valid:               pointy.Bool(true),
+			Valid:               pointer(true),
 		},
 		AzureKeyVault: AzureKeyVault{
-			Enabled:           pointy.Bool(true),
+			Enabled:           pointer(true),
 			AzureEnvironment:  "AZURE",
 			ClientID:          "g54f9e2-89e3-40fd-8188-EXAMPLEID",
 			KeyIdentifier:     "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86",
@@ -214,7 +213,7 @@ func TestEncryptionsAtRest_Get(t *testing.T) {
 			TenantID:          "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID",
 		},
 		GoogleCloudKms: GoogleCloudKms{
-			Enabled:              pointy.Bool(true),
+			Enabled:              pointer(true),
 			KeyVersionResourceID: "projects/my-project/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1",
 		},
 	}

--- a/mongodbatlas/federation_settings_connected_org_config_test.go
+++ b/mongodbatlas/federation_settings_connected_org_config_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 const connectedOrgID = "627a9683eafda674de306d14"
@@ -153,7 +152,7 @@ func TestFederatedSettingsConnectedOrganizationOp_Get(t *testing.T) {
 
 	expected := &FederatedSettingsConnectedOrganization{
 		DomainAllowList:          []string{"reorganizeyourworld.com"},
-		DomainRestrictionEnabled: pointy.Bool(false),
+		DomainRestrictionEnabled: pointer(false),
 		IdentityProviderID:       "0oad0iizxh30vuyr5297",
 		OrgID:                    "627a9683eafda674de306f14",
 		PostAuthRoleGrants:       []string{},
@@ -210,7 +209,7 @@ func TestFederatedSettingsConnectedOrganizationOp_Update(t *testing.T) {
 
 	updated := &FederatedSettingsConnectedOrganization{
 		DomainAllowList:          []string{"reorganizeyourworld.com"},
-		DomainRestrictionEnabled: pointy.Bool(false),
+		DomainRestrictionEnabled: pointer(false),
 		IdentityProviderID:       "0oad0iizxh30vuyr5297",
 		OrgID:                    "627a9683eafda674de306d14",
 		PostAuthRoleGrants:       []string{},
@@ -235,7 +234,7 @@ func TestFederatedSettingsConnectedOrganizationOp_Update(t *testing.T) {
 
 	expected := &FederatedSettingsConnectedOrganization{
 		DomainAllowList:          []string{"reorganizeyourworld.com"},
-		DomainRestrictionEnabled: pointy.Bool(false),
+		DomainRestrictionEnabled: pointer(false),
 		IdentityProviderID:       "0oad0iizxh30vuyr5297",
 		OrgID:                    "627a9683eafda674de306f14",
 		PostAuthRoleGrants:       []string{},

--- a/mongodbatlas/federation_settings_identity_provider_test.go
+++ b/mongodbatlas/federation_settings_identity_provider_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 const ipOrgID = "1234567890abcdefghij"
@@ -93,7 +92,7 @@ func TestFederatedSettingsIdentityProviderOp_List(t *testing.T) {
 				},
 				RequestBinding:             "HTTP-POST",
 				ResponseSignatureAlgorithm: "SHA-256",
-				SsoDebugEnabled:            pointy.Bool(true),
+				SsoDebugEnabled:            pointer(true),
 				SsoURL:                     "https://123456789000.us.provider.com/samlp/12345678901234567890123456789012",
 				Status:                     "INACTIVE"},
 		}
@@ -157,7 +156,7 @@ func TestFederatedSettingsIdentityProviderOp_Get(t *testing.T) {
 		OktaIdpID:                  "1234567890abcdefghij",
 		RequestBinding:             "HTTP-POST",
 		ResponseSignatureAlgorithm: "SHA-256",
-		SsoDebugEnabled:            pointy.Bool(true),
+		SsoDebugEnabled:            pointer(true),
 		SsoURL:                     "https://123456789000.us.provider.com/samlp/12345678901234567890123456789012",
 		Status:                     "INACTIVE",
 	}

--- a/mongodbatlas/global_clusters_test.go
+++ b/mongodbatlas/global_clusters_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestGlobalClusters_Get(t *testing.T) {
@@ -89,10 +88,10 @@ func TestGlobalClusters_Get(t *testing.T) {
 				Collection:             "zips",
 				CustomShardKey:         "city",
 				Db:                     "mydata",
-				IsCustomShardKeyHashed: pointy.Bool(true),
-				IsShardKeyUnique:       pointy.Bool(true),
+				IsCustomShardKeyHashed: pointer(true),
+				IsShardKeyUnique:       pointer(true),
 				NumInitialChunks:       4,
-				PresplitHashedZones:    pointy.Bool(true),
+				PresplitHashedZones:    pointer(true),
 			}, {
 				Collection:     "stores",
 				CustomShardKey: "store_number",
@@ -117,10 +116,10 @@ func TestGlobalClusters_AddManagedNamespace(t *testing.T) {
 		Db:                     "mydata",
 		Collection:             "publishers",
 		CustomShardKey:         "city",
-		IsCustomShardKeyHashed: pointy.Bool(true),
-		IsShardKeyUnique:       pointy.Bool(true),
+		IsCustomShardKeyHashed: pointer(true),
+		IsShardKeyUnique:       pointer(true),
 		NumInitialChunks:       4,
-		PresplitHashedZones:    pointy.Bool(true),
+		PresplitHashedZones:    pointer(true),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.5/groups/%s/clusters/%s/globalWrites/managedNamespaces", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {

--- a/mongodbatlas/ldap_configurations_test.go
+++ b/mongodbatlas/ldap_configurations_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestLDAPConfigurations_Verify(t *testing.T) {
@@ -44,10 +43,10 @@ func TestLDAPConfigurations_Verify(t *testing.T) {
 	})
 
 	request := &LDAP{
-		Hostname:     pointy.String("atlas-ldaps-01.ldap.myteam.com"),
-		Port:         pointy.Int(636),
-		BindUsername: pointy.String("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
-		BindPassword: pointy.String("admin"),
+		Hostname:     pointer("atlas-ldaps-01.ldap.myteam.com"),
+		Port:         pointer(636),
+		BindUsername: pointer("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
+		BindPassword: pointer("admin"),
 	}
 	ldap, _, err := client.LDAPConfigurations.Verify(ctx, groupID, request)
 	if err != nil {
@@ -155,12 +154,12 @@ func TestLDAPConfigurations_Save(t *testing.T) {
 
 	request := &LDAPConfiguration{
 		LDAP: &LDAP{
-			AuthenticationEnabled: pointy.Bool(true),
-			AuthorizationEnabled:  pointy.Bool(true),
-			Hostname:              pointy.String("atlas-ldaps-01.ldap.myteam.com"),
-			Port:                  pointy.Int(636),
-			BindUsername:          pointy.String("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
-			BindPassword:          pointy.String("admin"),
+			AuthenticationEnabled: pointer(true),
+			AuthorizationEnabled:  pointer(true),
+			Hostname:              pointer("atlas-ldaps-01.ldap.myteam.com"),
+			Port:                  pointer(636),
+			BindUsername:          pointer("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
+			BindPassword:          pointer("admin"),
 		},
 	}
 	ldap, _, err := client.LDAPConfigurations.Save(ctx, groupID, request)
@@ -170,18 +169,18 @@ func TestLDAPConfigurations_Save(t *testing.T) {
 
 	expected := &LDAPConfiguration{
 		LDAP: &LDAP{
-			AuthenticationEnabled: pointy.Bool(true),
-			AuthorizationEnabled:  pointy.Bool(true),
-			Hostname:              pointy.String("atlas-ldaps-01.ldap.myteam.com"),
-			Port:                  pointy.Int(636),
-			BindUsername:          pointy.String("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
+			AuthenticationEnabled: pointer(true),
+			AuthorizationEnabled:  pointer(true),
+			Hostname:              pointer("atlas-ldaps-01.ldap.myteam.com"),
+			Port:                  pointer(636),
+			BindUsername:          pointer("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
 			UserToDNMapping: []*UserToDNMapping{
 				{
 					Match:        "(.*)",
 					Substitution: "CN={0},CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
 				},
 			},
-			AuthzQueryTemplate: pointy.String("{USER}?memberOf?base"),
+			AuthzQueryTemplate: pointer("{USER}?memberOf?base"),
 		},
 	}
 
@@ -221,18 +220,18 @@ func TestLDAPConfigurations_Get(t *testing.T) {
 
 	expected := &LDAPConfiguration{
 		LDAP: &LDAP{
-			AuthenticationEnabled: pointy.Bool(true),
-			AuthorizationEnabled:  pointy.Bool(true),
-			Hostname:              pointy.String("atlas-ldaps-01.ldap.myteam.com"),
-			Port:                  pointy.Int(636),
-			BindUsername:          pointy.String("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
+			AuthenticationEnabled: pointer(true),
+			AuthorizationEnabled:  pointer(true),
+			Hostname:              pointer("atlas-ldaps-01.ldap.myteam.com"),
+			Port:                  pointer(636),
+			BindUsername:          pointer("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
 			UserToDNMapping: []*UserToDNMapping{
 				{
 					Match:        "(.*)",
 					Substitution: "CN={0},CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com",
 				},
 			},
-			AuthzQueryTemplate: pointy.String("{USER}?memberOf?base"),
+			AuthzQueryTemplate: pointer("{USER}?memberOf?base"),
 		},
 	}
 
@@ -268,12 +267,12 @@ func TestLDAPConfigurations_Delete(t *testing.T) {
 
 	expected := &LDAPConfiguration{
 		LDAP: &LDAP{
-			AuthenticationEnabled: pointy.Bool(true),
-			AuthorizationEnabled:  pointy.Bool(true),
-			Hostname:              pointy.String("atlas-ldaps-01.ldap.myteam.com"),
-			Port:                  pointy.Int(636),
-			BindUsername:          pointy.String("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
-			AuthzQueryTemplate:    pointy.String("{USER}?memberOf?base"),
+			AuthenticationEnabled: pointer(true),
+			AuthorizationEnabled:  pointer(true),
+			Hostname:              pointer("atlas-ldaps-01.ldap.myteam.com"),
+			Port:                  pointer(636),
+			BindUsername:          pointer("CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com"),
+			AuthzQueryTemplate:    pointer("{USER}?memberOf?base"),
 		},
 	}
 

--- a/mongodbatlas/live_migration_test.go
+++ b/mongodbatlas/live_migration_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestLiveMigration_CreateLinkToken(t *testing.T) {
@@ -86,13 +85,13 @@ func TestLiveMigration_CreateValidation(t *testing.T) {
 			GroupID:               "9b43a5b329223c3a1591a678",
 			Username:              "example",
 			Password:              "string",
-			SSL:                   pointy.Bool(true),
+			SSL:                   pointer(true),
 			CACertificatePath:     "/path/to/ca",
-			ManagedAuthentication: pointy.Bool(false),
+			ManagedAuthentication: pointer(false),
 		},
 		Destination:    &Destination{ClusterName: "exampleClusterB", GroupID: "e01c9427f054fe80745f3f6c"},
 		MigrationHosts: []string{"vm001.example.com"},
-		DropEnabled:    pointy.Bool(true),
+		DropEnabled:    pointer(true),
 	}
 
 	response, _, err := client.LiveMigration.CreateValidation(ctx, groupID, body)
@@ -162,13 +161,13 @@ func TestLiveMigration_Create(t *testing.T) {
 			GroupID:               "9b43a5b329223c3a1591a678",
 			Username:              "example",
 			Password:              "string",
-			SSL:                   pointy.Bool(true),
+			SSL:                   pointer(true),
 			CACertificatePath:     "/path/to/ca",
-			ManagedAuthentication: pointy.Bool(false),
+			ManagedAuthentication: pointer(false),
 		},
 		Destination:    &Destination{ClusterName: "exampleClusterB", GroupID: "e01c9427f054fe80745f3f6c"},
 		MigrationHosts: []string{"vm001.example.com"},
-		DropEnabled:    pointy.Bool(true),
+		DropEnabled:    pointer(true),
 	}
 
 	response, _, err := client.LiveMigration.Create(ctx, groupID, body)
@@ -210,7 +209,7 @@ func TestLiveMigration_Get(t *testing.T) {
 		ID:              "a659ce44c03ca1e348b1e992",
 		Status:          "PENDING",
 		MigrationHosts:  []string{"vm001.example.com"},
-		ReadyForCutover: pointy.Bool(false),
+		ReadyForCutover: pointer(false),
 	}
 
 	if diff := deep.Equal(response, expected); diff != nil {

--- a/mongodbatlas/maintenance_test.go
+++ b/mongodbatlas/maintenance_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestMaintenanceWindows_UpdateWithSheduleTime(t *testing.T) {
@@ -53,9 +52,9 @@ func TestMaintenanceWindows_UpdateWithSheduleTime(t *testing.T) {
 
 	maintenanceRequest := &MaintenanceWindow{
 		DayOfWeek:         2,
-		HourOfDay:         pointy.Int(3),
+		HourOfDay:         pointer(3),
 		NumberOfDeferrals: 4,
-		StartASAP:         pointy.Bool(false),
+		StartASAP:         pointer(false),
 	}
 
 	_, err := client.MaintenanceWindows.Update(ctx, groupID, maintenanceRequest)
@@ -90,7 +89,7 @@ func TestMaintenanceWindows_UpdateWithStartNow(t *testing.T) {
 	})
 
 	maintenanceRequest := &MaintenanceWindow{
-		StartASAP: pointy.Bool(true),
+		StartASAP: pointer(true),
 	}
 
 	_, err := client.MaintenanceWindows.Update(ctx, groupID, maintenanceRequest)
@@ -122,7 +121,7 @@ func TestMaintenanceWindows_Get(t *testing.T) {
 
 	expected := &MaintenanceWindow{
 		DayOfWeek:         2,
-		HourOfDay:         pointy.Int(3),
+		HourOfDay:         pointer(3),
 		NumberOfDeferrals: 4,
 	}
 

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -640,3 +640,7 @@ func parseVersionInfo(s string) *ServiceVersion {
 func (resp *Response) ServiceVersion() *ServiceVersion {
 	return parseVersionInfo(resp.Header.Get("X-MongoDB-Service-Version"))
 }
+
+func pointer[T any](x T) *T {
+	return &x
+}

--- a/mongodbatlas/online_archives_test.go
+++ b/mongodbatlas/online_archives_test.go
@@ -120,7 +120,7 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 				CollName:    "employees",
 				Criteria: &OnlineArchiveCriteria{
 					DateField:       "created",
-					ExpireAfterDays: pointer(5),
+					ExpireAfterDays: pointer(5.0),
 				},
 				DBName:  "people",
 				GroupID: groupID,
@@ -128,17 +128,17 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 					{
 						FieldName: "firstName",
 						FieldType: "string",
-						Order:     pointer(0),
+						Order:     pointer(0.0),
 					},
 					{
 						FieldName: "lastName",
 						FieldType: "string",
-						Order:     pointer(1),
+						Order:     pointer(1.0),
 					},
 					{
 						FieldName: "created",
 						FieldType: "date",
-						Order:     pointer(2),
+						Order:     pointer(2.0),
 					},
 				},
 				Paused: pointer(false),
@@ -149,7 +149,7 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 				CollName:    "invoices",
 				Criteria: &OnlineArchiveCriteria{
 					DateField:       "year",
-					ExpireAfterDays: pointer(5),
+					ExpireAfterDays: pointer(5.0),
 				},
 				DBName:  "accounting",
 				GroupID: groupID,
@@ -157,17 +157,17 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 					{
 						FieldName: "year",
 						FieldType: "date",
-						Order:     pointer(0),
+						Order:     pointer(0.0),
 					},
 					{
 						FieldName: "month",
 						FieldType: "string",
-						Order:     pointer(1),
+						Order:     pointer(1.0),
 					},
 					{
 						FieldName: "invoiceNumber",
 						FieldType: "int",
-						Order:     pointer(2),
+						Order:     pointer(2.0),
 					},
 				},
 				Paused: pointer(false),
@@ -231,7 +231,7 @@ func TestOnlineArchiveServiceOp_Get(t *testing.T) {
 		CollName:    "employees",
 		Criteria: &OnlineArchiveCriteria{
 			DateField:       "created",
-			ExpireAfterDays: pointer(5),
+			ExpireAfterDays: pointer(5.0),
 		},
 		DBName:  "people",
 		GroupID: groupID,
@@ -239,17 +239,17 @@ func TestOnlineArchiveServiceOp_Get(t *testing.T) {
 			{
 				FieldName: "firstName",
 				FieldType: "string",
-				Order:     pointer(0),
+				Order:     pointer(0.0),
 			},
 			{
 				FieldName: "lastName",
 				FieldType: "string",
-				Order:     pointer(1),
+				Order:     pointer(1.0),
 			},
 			{
 				FieldName: "created",
 				FieldType: "date",
-				Order:     pointer(2),
+				Order:     pointer(2.0),
 			},
 		},
 		Paused: pointer(false),
@@ -271,14 +271,14 @@ func TestOnlineArchiveServiceOp_Create(t *testing.T) {
 		CollName: "employees",
 		Criteria: &OnlineArchiveCriteria{
 			DateField:       "created",
-			ExpireAfterDays: pointer(5),
+			ExpireAfterDays: pointer(5.0),
 		},
 		DBName: "people",
 		PartitionFields: []*PartitionFields{
 			{
 				FieldName: "created",
 				FieldType: "date",
-				Order:     pointer(0),
+				Order:     pointer(0.0),
 			},
 		},
 	}
@@ -358,7 +358,7 @@ func TestOnlineArchiveServiceOp_Update(t *testing.T) {
 
 	updateRequest := &OnlineArchive{
 		Criteria: &OnlineArchiveCriteria{
-			ExpireAfterDays: pointer(6),
+			ExpireAfterDays: pointer(6.0),
 		},
 	}
 
@@ -402,7 +402,7 @@ func TestOnlineArchiveServiceOp_Update(t *testing.T) {
 		t.Fatalf("OnlineArchives.Update returned error: %v", err)
 	}
 
-	expectedExpireAfterDays := pointer(6)
+	expectedExpireAfterDays := pointer(6.0)
 	if *(archive.Criteria.ExpireAfterDays) != *expectedExpireAfterDays {
 		t.Errorf("expected expireAfterDays '%f', received '%f'", *expectedExpireAfterDays, *archive.Criteria.ExpireAfterDays)
 	}

--- a/mongodbatlas/online_archives_test.go
+++ b/mongodbatlas/online_archives_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestOnlineArchiveServiceOp_List(t *testing.T) {
@@ -121,7 +120,7 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 				CollName:    "employees",
 				Criteria: &OnlineArchiveCriteria{
 					DateField:       "created",
-					ExpireAfterDays: pointy.Float64(5),
+					ExpireAfterDays: pointer(5),
 				},
 				DBName:  "people",
 				GroupID: groupID,
@@ -129,20 +128,20 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 					{
 						FieldName: "firstName",
 						FieldType: "string",
-						Order:     pointy.Float64(0),
+						Order:     pointer(0),
 					},
 					{
 						FieldName: "lastName",
 						FieldType: "string",
-						Order:     pointy.Float64(1),
+						Order:     pointer(1),
 					},
 					{
 						FieldName: "created",
 						FieldType: "date",
-						Order:     pointy.Float64(2),
+						Order:     pointer(2),
 					},
 				},
-				Paused: pointy.Bool(false),
+				Paused: pointer(false),
 			},
 			{
 				ID:          "5ebc2789fe9c0ab8d33b96cd",
@@ -150,7 +149,7 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 				CollName:    "invoices",
 				Criteria: &OnlineArchiveCriteria{
 					DateField:       "year",
-					ExpireAfterDays: pointy.Float64(5),
+					ExpireAfterDays: pointer(5),
 				},
 				DBName:  "accounting",
 				GroupID: groupID,
@@ -158,20 +157,20 @@ func TestOnlineArchiveServiceOp_List(t *testing.T) {
 					{
 						FieldName: "year",
 						FieldType: "date",
-						Order:     pointy.Float64(0),
+						Order:     pointer(0),
 					},
 					{
 						FieldName: "month",
 						FieldType: "string",
-						Order:     pointy.Float64(1),
+						Order:     pointer(1),
 					},
 					{
 						FieldName: "invoiceNumber",
 						FieldType: "int",
-						Order:     pointy.Float64(2),
+						Order:     pointer(2),
 					},
 				},
-				Paused: pointy.Bool(false),
+				Paused: pointer(false),
 			},
 		},
 		TotalCount: 2,
@@ -232,7 +231,7 @@ func TestOnlineArchiveServiceOp_Get(t *testing.T) {
 		CollName:    "employees",
 		Criteria: &OnlineArchiveCriteria{
 			DateField:       "created",
-			ExpireAfterDays: pointy.Float64(5),
+			ExpireAfterDays: pointer(5),
 		},
 		DBName:  "people",
 		GroupID: groupID,
@@ -240,20 +239,20 @@ func TestOnlineArchiveServiceOp_Get(t *testing.T) {
 			{
 				FieldName: "firstName",
 				FieldType: "string",
-				Order:     pointy.Float64(0),
+				Order:     pointer(0),
 			},
 			{
 				FieldName: "lastName",
 				FieldType: "string",
-				Order:     pointy.Float64(1),
+				Order:     pointer(1),
 			},
 			{
 				FieldName: "created",
 				FieldType: "date",
-				Order:     pointy.Float64(2),
+				Order:     pointer(2),
 			},
 		},
-		Paused: pointy.Bool(false),
+		Paused: pointer(false),
 	}
 
 	if diff := deep.Equal(archive, expected); diff != nil {
@@ -272,14 +271,14 @@ func TestOnlineArchiveServiceOp_Create(t *testing.T) {
 		CollName: "employees",
 		Criteria: &OnlineArchiveCriteria{
 			DateField:       "created",
-			ExpireAfterDays: pointy.Float64(5),
+			ExpireAfterDays: pointer(5),
 		},
 		DBName: "people",
 		PartitionFields: []*PartitionFields{
 			{
 				FieldName: "created",
 				FieldType: "date",
-				Order:     pointy.Float64(0),
+				Order:     pointer(0),
 			},
 		},
 	}
@@ -359,7 +358,7 @@ func TestOnlineArchiveServiceOp_Update(t *testing.T) {
 
 	updateRequest := &OnlineArchive{
 		Criteria: &OnlineArchiveCriteria{
-			ExpireAfterDays: pointy.Float64(6),
+			ExpireAfterDays: pointer(6),
 		},
 	}
 
@@ -403,7 +402,7 @@ func TestOnlineArchiveServiceOp_Update(t *testing.T) {
 		t.Fatalf("OnlineArchives.Update returned error: %v", err)
 	}
 
-	expectedExpireAfterDays := pointy.Float64(6)
+	expectedExpireAfterDays := pointer(6)
 	if *(archive.Criteria.ExpireAfterDays) != *expectedExpireAfterDays {
 		t.Errorf("expected expireAfterDays '%f', received '%f'", *expectedExpireAfterDays, *archive.Criteria.ExpireAfterDays)
 	}

--- a/mongodbatlas/private_endpoints_deprecated_test.go
+++ b/mongodbatlas/private_endpoints_deprecated_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestPrivateEndpointDeprecated_Create(t *testing.T) {
@@ -225,7 +224,7 @@ func TestPrivateEndpointDeprecated_AddOneInterfaceEndpoint(t *testing.T) {
 	expected := &InterfaceEndpointConnectionDeprecated{
 		ID:               "vpce-08fb7e9319909ec7b",
 		ConnectionStatus: "PENDING",
-		DeleteRequested:  pointy.Bool(false),
+		DeleteRequested:  pointer(false),
 	}
 
 	if !reflect.DeepEqual(interfaceEndpoint, expected) {
@@ -258,7 +257,7 @@ func TestPrivateEndpointsDeprecated_GetOneInterfaceEndpoint(t *testing.T) {
 	expected := &InterfaceEndpointConnectionDeprecated{
 		ID:               "vpce-08fb7e9319909ec7b",
 		ConnectionStatus: "PENDING",
-		DeleteRequested:  pointy.Bool(false),
+		DeleteRequested:  pointer(false),
 	}
 
 	if !reflect.DeepEqual(interfaceEndpoint, expected) {

--- a/mongodbatlas/private_endpoints_test.go
+++ b/mongodbatlas/private_endpoints_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestPrivateEndpointAWS_Create(t *testing.T) {
@@ -569,7 +568,7 @@ func TestPrivateEndpoint_AddOneInterfaceEndpointAWS(t *testing.T) {
 	expected := &InterfaceEndpointConnection{
 		InterfaceEndpointID: "vpce-08fb7e9319909ec7b",
 		AWSConnectionStatus: "PENDING",
-		DeleteRequested:     pointy.Bool(false),
+		DeleteRequested:     pointer(false),
 	}
 
 	if !reflect.DeepEqual(interfaceEndpoint, expected) {
@@ -623,7 +622,7 @@ func TestPrivateEndpoint_AddOneInterfaceEndpointAzure(t *testing.T) {
 		PrivateEndpointIPAddress:  "10.0.0.4",
 		PrivateEndpointResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/privatelink/providers/Microsoft.Network/privateEndpoints/test",
 		AWSConnectionStatus:       "INITIATING",
-		DeleteRequested:           pointy.Bool(false),
+		DeleteRequested:           pointer(false),
 	}
 
 	if !reflect.DeepEqual(interfaceEndpoint, expected) {
@@ -723,7 +722,7 @@ func TestPrivateEndpoint_AddOneInterfaceEndpointGCP(t *testing.T) {
 	expected := &InterfaceEndpointConnection{
 		ID:              "2948cdcc04958372bc938493",
 		Status:          "INITIATING",
-		DeleteRequested: pointy.Bool(false),
+		DeleteRequested: pointer(false),
 		Endpoints: []*GCPEndpoint{
 			{
 				Status:                "AVAILABLE",
@@ -776,7 +775,7 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointAWS(t *testing.T) {
 	expected := &InterfaceEndpointConnection{
 		InterfaceEndpointID: "vpce-08fb7e9319909ec7b",
 		AWSConnectionStatus: "PENDING",
-		DeleteRequested:     pointy.Bool(false),
+		DeleteRequested:     pointer(false),
 	}
 
 	if !reflect.DeepEqual(interfaceEndpoint, expected) {
@@ -813,7 +812,7 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointAzure(t *testing.T) {
 		PrivateEndpointIPAddress:  "10.0.0.4",
 		PrivateEndpointResourceID: interfaceEndpointID,
 		Status:                    "INITIATING",
-		DeleteRequested:           pointy.Bool(false),
+		DeleteRequested:           pointer(false),
 	}
 
 	if !reflect.DeepEqual(interfaceEndpoint, expected) {
@@ -868,7 +867,7 @@ func TestPrivateEndpoints_GetOneInterfaceEndpointGCP(t *testing.T) {
 	expected := &InterfaceEndpointConnection{
 		ID:              "2948cdcc04958372bc938493",
 		Status:          "INITIATING",
-		DeleteRequested: pointy.Bool(false),
+		DeleteRequested: pointer(false),
 		Endpoints: []*GCPEndpoint{
 			{
 				Status:                "AVAILABLE",

--- a/mongodbatlas/private_ip_mode_test.go
+++ b/mongodbatlas/private_ip_mode_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestPrivateIPMode_Get(t *testing.T) {
@@ -43,7 +42,7 @@ func TestPrivateIPMode_Get(t *testing.T) {
 	}
 
 	expected := &PrivateIPMode{
-		Enabled: pointy.Bool(true),
+		Enabled: pointer(true),
 	}
 
 	if diff := deep.Equal(privateIPMode, expected); diff != nil {
@@ -58,7 +57,7 @@ func TestPrivateIPMode_Update(t *testing.T) {
 	groupID := "1"
 
 	updateRequest := &PrivateIPMode{
-		Enabled: pointy.Bool(true),
+		Enabled: pointer(true),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/"+privateIPModePath, groupID), func(w http.ResponseWriter, r *http.Request) {
@@ -90,7 +89,7 @@ func TestPrivateIPMode_Update(t *testing.T) {
 		t.Fatalf("PrivateIPMode.Update returned error: %v", err)
 	}
 
-	if enabled := pointy.BoolValue(privateIPMode.Enabled, false); !enabled {
+	if enabled := pointerValue(privateIPMode.Enabled, false); !enabled {
 		t.Errorf("expected privateIPMode '%t', received '%t'", true, enabled)
 	}
 }

--- a/mongodbatlas/private_ip_mode_test.go
+++ b/mongodbatlas/private_ip_mode_test.go
@@ -89,7 +89,7 @@ func TestPrivateIPMode_Update(t *testing.T) {
 		t.Fatalf("PrivateIPMode.Update returned error: %v", err)
 	}
 
-	if enabled := pointerValue(privateIPMode.Enabled, false); !enabled {
-		t.Errorf("expected privateIPMode '%t', received '%t'", true, enabled)
+	if enabled := privateIPMode.Enabled; !*enabled {
+		t.Errorf("expected privateIPMode '%t', received '%v'", true, enabled)
 	}
 }

--- a/mongodbatlas/project_settings_test.go
+++ b/mongodbatlas/project_settings_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestProjects_GetProjectSettings(t *testing.T) {
@@ -44,11 +43,11 @@ func TestProjects_GetProjectSettings(t *testing.T) {
 	}
 
 	expected := &ProjectSettings{
-		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
-		IsDataExplorerEnabled:                       pointy.Bool(true),
-		IsPerformanceAdvisorEnabled:                 pointy.Bool(true),
-		IsRealtimePerformancePanelEnabled:           pointy.Bool(true),
-		IsSchemaAdvisorEnabled:                      pointy.Bool(true),
+		IsCollectDatabaseSpecificsStatisticsEnabled: pointer(true),
+		IsDataExplorerEnabled:                       pointer(true),
+		IsPerformanceAdvisorEnabled:                 pointer(true),
+		IsRealtimePerformancePanelEnabled:           pointer(true),
+		IsSchemaAdvisorEnabled:                      pointer(true),
 	}
 
 	if diff := deep.Equal(projectSettings, expected); diff != nil {
@@ -72,11 +71,11 @@ func TestProjects_UpdateProjectSettings(t *testing.T) {
 	})
 
 	body := &ProjectSettings{
-		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
-		IsDataExplorerEnabled:                       pointy.Bool(true),
-		IsPerformanceAdvisorEnabled:                 pointy.Bool(true),
-		IsRealtimePerformancePanelEnabled:           pointy.Bool(true),
-		IsSchemaAdvisorEnabled:                      pointy.Bool(true),
+		IsCollectDatabaseSpecificsStatisticsEnabled: pointer(true),
+		IsDataExplorerEnabled:                       pointer(true),
+		IsPerformanceAdvisorEnabled:                 pointer(true),
+		IsRealtimePerformancePanelEnabled:           pointer(true),
+		IsSchemaAdvisorEnabled:                      pointer(true),
 	}
 
 	response, _, err := client.Projects.UpdateProjectSettings(ctx, groupID, body)
@@ -85,11 +84,11 @@ func TestProjects_UpdateProjectSettings(t *testing.T) {
 	}
 
 	expected := &ProjectSettings{
-		IsCollectDatabaseSpecificsStatisticsEnabled: pointy.Bool(true),
-		IsDataExplorerEnabled:                       pointy.Bool(true),
-		IsPerformanceAdvisorEnabled:                 pointy.Bool(true),
-		IsRealtimePerformancePanelEnabled:           pointy.Bool(true),
-		IsSchemaAdvisorEnabled:                      pointy.Bool(true),
+		IsCollectDatabaseSpecificsStatisticsEnabled: pointer(true),
+		IsDataExplorerEnabled:                       pointer(true),
+		IsPerformanceAdvisorEnabled:                 pointer(true),
+		IsRealtimePerformancePanelEnabled:           pointer(true),
+		IsSchemaAdvisorEnabled:                      pointer(true),
 	}
 
 	if diff := deep.Equal(response, expected); diff != nil {

--- a/mongodbatlas/projects_test.go
+++ b/mongodbatlas/projects_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestProject_GetAllProjects(t *testing.T) {
@@ -240,7 +239,7 @@ func TestProject_Create(t *testing.T) {
 		},
 		Name:                      "ProjectFoobar",
 		OrgID:                     "5a0a1e7e0f2912c554080adc",
-		WithDefaultAlertsSettings: pointy.Bool(true),
+		WithDefaultAlertsSettings: pointer(true),
 	}
 
 	if diff := deep.Equal(project, expected); diff != nil {

--- a/mongodbatlas/search_test.go
+++ b/mongodbatlas/search_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestSearch_ListIndexes(t *testing.T) {
@@ -443,7 +442,7 @@ func TestSearch_ListAnalyzers(t *testing.T) {
 	expected := []*SearchAnalyzer{
 		{
 			BaseAnalyzer:   "lucene.standard",
-			MaxTokenLength: pointy.Int(32),
+			MaxTokenLength: pointer(32),
 			Name:           "my_new_analyzer",
 		},
 		{
@@ -483,9 +482,9 @@ func TestSearch_UpdateAllAnalyzers(t *testing.T) {
 	request := []*SearchAnalyzer{
 		{
 			BaseAnalyzer:   "lucene.standard",
-			MaxTokenLength: pointy.Int(32),
+			MaxTokenLength: pointer(32),
 			Name:           "my_new_analyzer",
-			IgnoreCase:     pointy.Bool(true),
+			IgnoreCase:     pointer(true),
 		},
 		{
 			BaseAnalyzer: "lucene.english",
@@ -502,9 +501,9 @@ func TestSearch_UpdateAllAnalyzers(t *testing.T) {
 	expected := []*SearchAnalyzer{
 		{
 			BaseAnalyzer:   "lucene.standard",
-			MaxTokenLength: pointy.Int(32),
+			MaxTokenLength: pointer(32),
 			Name:           "my_new_analyzer",
-			IgnoreCase:     pointy.Bool(true),
+			IgnoreCase:     pointer(true),
 		},
 		{
 			BaseAnalyzer: "lucene.english",

--- a/mongodbatlas/serverless_instances_test.go
+++ b/mongodbatlas/serverless_instances_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 const (
@@ -178,7 +177,7 @@ func TestServerlessInstances_Get(t *testing.T) {
 		Name:                         "test1",
 		ProviderSettings:             &ProviderSettings{RegionName: "US_EAST_1", BackingProviderName: "AWS", ProviderName: "SERVERLESS"},
 		StateName:                    "IDLE",
-		TerminationProtectionEnabled: pointy.Bool(false),
+		TerminationProtectionEnabled: pointer(false),
 		ConnectionStrings:            &ConnectionStrings{StandardSrv: "mongodb+srv://instance1.example.com"},
 		CreateDate:                   "2021-06-25T21:32:06Z",
 		Links: []*Link{
@@ -293,8 +292,8 @@ func TestServerlessInstances_Update(t *testing.T) {
 	})
 
 	bodyParam := &ServerlessUpdateRequestParams{
-		ServerlessBackupOptions:      &ServerlessBackupOptions{ServerlessContinuousBackupEnabled: pointy.Bool(true)},
-		TerminationProtectionEnabled: pointy.Bool(true),
+		ServerlessBackupOptions:      &ServerlessBackupOptions{ServerlessContinuousBackupEnabled: pointer(true)},
+		TerminationProtectionEnabled: pointer(true),
 	}
 
 	serverlessInstance, _, err := client.ServerlessInstances.Update(ctx, groupID, "sample", bodyParam)
@@ -311,8 +310,8 @@ func TestServerlessInstances_Update(t *testing.T) {
 		StateName:                    "IDLE",
 		ConnectionStrings:            &ConnectionStrings{StandardSrv: "mongodb+srv://instanceName1.example.com"},
 		CreateDate:                   "2021-06-25T21:31:10Z",
-		ServerlessBackupOptions:      &ServerlessBackupOptions{ServerlessContinuousBackupEnabled: pointy.Bool(true)},
-		TerminationProtectionEnabled: pointy.Bool(true),
+		ServerlessBackupOptions:      &ServerlessBackupOptions{ServerlessContinuousBackupEnabled: pointer(true)},
+		TerminationProtectionEnabled: pointer(true),
 		Links: []*Link{
 			{
 				Rel:  "self",

--- a/mongodbatlas/x509_authentication_database_users_test.go
+++ b/mongodbatlas/x509_authentication_database_users_test.go
@@ -108,14 +108,14 @@ func TestX509AuthDBUsers_GetUserCertificates(t *testing.T) {
 
 	expected := []UserCertificate{
 		{
-			ID:        pointer64(5433027191242719574),
+			ID:        pointer(int64(5433027191242719574)),
 			CreatedAt: "2019-12-03T21:00:42Z",
 			GroupID:   "ec13d5f09d521a5206e5d726",
 			NotAfter:  "2020-06-03T22:00:42Z",
 			Subject:   "CN=myX509User",
 		},
 		{
-			ID:        pointer64(946028664465903704),
+			ID:        pointer(int64(946028664465903704)),
 			CreatedAt: "2019-12-05T13:50:49Z",
 			GroupID:   "ec13d5f09d521a5206e5d726",
 			NotAfter:  "2020-03-05T14:50:49Z",

--- a/mongodbatlas/x509_authentication_database_users_test.go
+++ b/mongodbatlas/x509_authentication_database_users_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openlyinc/pointy"
 )
 
 func TestX509AuthDBUsers_CreateUserCertificate(t *testing.T) {
@@ -109,14 +108,14 @@ func TestX509AuthDBUsers_GetUserCertificates(t *testing.T) {
 
 	expected := []UserCertificate{
 		{
-			ID:        pointy.Int64(5433027191242719574),
+			ID:        pointer64(5433027191242719574),
 			CreatedAt: "2019-12-03T21:00:42Z",
 			GroupID:   "ec13d5f09d521a5206e5d726",
 			NotAfter:  "2020-06-03T22:00:42Z",
 			Subject:   "CN=myX509User",
 		},
 		{
-			ID:        pointy.Int64(946028664465903704),
+			ID:        pointer64(946028664465903704),
 			CreatedAt: "2019-12-05T13:50:49Z",
 			GroupID:   "ec13d5f09d521a5206e5d726",
 			NotAfter:  "2020-03-05T14:50:49Z",


### PR DESCRIPTION
## Description

Pointy is no longer necessary with generics we can have our own implementation

Pointy has also been a source of issues with snyk which would flag its dependency on yaml.v2 every now and then 


