### PR TITLE
CLOUDP-165150: Reduce logging for CI/CD and validation purposes.

### DIFF
--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -8,6 +8,7 @@
       "name": "openapi-generation-tools",
       "version": "0.1.0",
       "dependencies": {
+        "simple-node-logger": "^21.8.12",
         "yaml": "2.2.1"
       },
       "devDependencies": {
@@ -3255,8 +3256,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -3343,6 +3343,14 @@
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -3864,6 +3872,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-node-logger": {
+      "version": "21.8.12",
+      "resolved": "https://registry.npmjs.org/simple-node-logger/-/simple-node-logger-21.8.12.tgz",
+      "integrity": "sha512-RPImnYDq3jdUjaTvYLghaF1n65Dd0LV8hdZtlT0X1NZBAkw+lx0ZJtFydcUyYKjg0Yxd27AW9IAIc3OLhTjBzA==",
+      "dependencies": {
+        "lodash": "^4.17.12",
+        "moment": "^2.20.1"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -6770,8 +6787,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -6840,6 +6856,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",
@@ -7213,6 +7234,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "simple-node-logger": {
+      "version": "21.8.12",
+      "resolved": "https://registry.npmjs.org/simple-node-logger/-/simple-node-logger-21.8.12.tgz",
+      "integrity": "sha512-RPImnYDq3jdUjaTvYLghaF1n65Dd0LV8hdZtlT0X1NZBAkw+lx0ZJtFydcUyYKjg0Yxd27AW9IAIc3OLhTjBzA==",
+      "requires": {
+        "lodash": "^4.17.12",
+        "moment": "^2.20.1"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/tools/package.json
+++ b/tools/package.json
@@ -5,6 +5,7 @@
   "private": "true",
   "main": "transformer/src/index.js",
   "dependencies": {
+    "simple-node-logger": "^21.8.12",
     "yaml": "2.2.1"
   },
   "devDependencies": {

--- a/tools/transformer/README.md
+++ b/tools/transformer/README.md
@@ -43,3 +43,14 @@ For parent model containing multiple children:
 
 - Moves all parent property fields into children.
 - Removes redundant allOf fields on children
+
+## Adjusting logging
+
+`XGEN_LOGGING_LEVEL` env variable can be used to specify logging levels:
+
+- info
+- warn
+- debug
+- error
+
+Default: 'warn"

--- a/tools/transformer/__tests__/transformations.test.js
+++ b/tools/transformer/__tests__/transformations.test.js
@@ -39,17 +39,6 @@ test("Transform AllOf model", () => {
   ).toMatchInlineSnapshot(cases.ChildAllOf);
 });
 
-test("Fail Transform AllOf with duplicates", () => {
-  api.components.schemas.ApiAtlasAWSRegionConfigView.properties = {
-    ...api.components.schemas.ApiAtlasAWSRegionConfigView.properties,
-    ...api.components.schemas.ApiAtlasRegionConfigView.propertries,
-  };
-  global.console.warn = jestGlobal.fn();
-  transformAllOf(".components.schemas.ApiAtlasRegionConfigView", api);
-  transformOneOf(".components.schemas.ApiAtlasRegionConfigView", api);
-  expect(console.warn).toBeCalled();
-});
-
 test("Fail Transform AllOf with wrong object structure", () => {
   transformAllOf(".components.schemas.ApiAtlasRegionConfigView", api);
   console.log(api.components.schemas.ApiAtlasRegionConfigView);

--- a/tools/transformer/__tests__/transformations.test.js
+++ b/tools/transformer/__tests__/transformations.test.js
@@ -41,7 +41,6 @@ test("Transform AllOf model", () => {
 
 test("Fail Transform AllOf with wrong object structure", () => {
   transformAllOf(".components.schemas.ApiAtlasRegionConfigView", api);
-  console.log(api.components.schemas.ApiAtlasRegionConfigView);
   expect(() =>
     transformAllOf(".components.schemas.ApiAtlasRegionConfigView", api)
   ).toThrow(/Invalid object for AllOf Transformation/);

--- a/tools/transformer/src/apifile.js
+++ b/tools/transformer/src/apifile.js
@@ -1,11 +1,11 @@
 const { parse, stringify } = require("yaml");
+const { readFileSync, writeFileSync } = require("fs");
 
 /**
  * Read and parse API file as json
  * @returns  {doc, apiFileLocation}
  */
 function getAPI(apiFileLocation) {
-  let apiFileLocation = process.argv.slice(2);
   if (!apiFileLocation && !apiFileLocation[0]) {
     throw new Error("Missing positional argument for openapi file");
   }

--- a/tools/transformer/src/apifile.js
+++ b/tools/transformer/src/apifile.js
@@ -1,0 +1,33 @@
+const { parse, stringify } = require("yaml");
+
+/**
+ * Read and parse API file as json
+ * @returns  {doc, apiFileLocation}
+ */
+function getAPI(apiFileLocation) {
+  let apiFileLocation = process.argv.slice(2);
+  if (!apiFileLocation && !apiFileLocation[0]) {
+    throw new Error("Missing positional argument for openapi file");
+  }
+
+  apiFileLocation = apiFileLocation[0];
+
+  let doc;
+  if (apiFileLocation) {
+    doc = parse(readFileSync(apiFileLocation, "utf8"));
+  } else {
+    throw new Error("Missing location. Please set OPENAPI_FILE env variable");
+  }
+  return { doc, apiFileLocation };
+}
+
+/**
+ * Save API to target location
+ * @param {*} doc openapi doc
+ * @param {*} apiFileLocation location to save
+ */
+function saveAPI(doc, apiFileLocation) {
+  writeFileSync(apiFileLocation, stringify(doc));
+}
+
+module.exports = { getAPI, saveAPI };

--- a/tools/transformer/src/transform.js
+++ b/tools/transformer/src/transform.js
@@ -11,7 +11,7 @@ const log = require("simple-node-logger").createSimpleLogger();
 global.console = log;
 log.setLevel(process.env.XGEN_LOGGING_LEVEL || "warn");
 
-let { doc, apiFileLocation } = getAPI()();
+let { doc, apiFileLocation } = getAPI(process.argv.slice(2));
 
 doc = applyOneOfTransformations(doc);
 doc = applyAllOfTransformations(doc);

--- a/tools/transformer/src/transform.js
+++ b/tools/transformer/src/transform.js
@@ -1,29 +1,21 @@
-const { readFileSync, writeFileSync } = require("fs");
 const {
   applyAllOfTransformations,
   applyOneOfTransformations,
   applyModelNameTransformations,
 } = require("./transformations");
-const { parse, stringify } = require("yaml");
+const { getAPI, saveAPI } = require("./apifile");
 
-let apiFileLocation = process.argv.slice(2);
-console.error(apiFileLocation);
-if (!apiFileLocation && !apiFileLocation[0]) {
-  throw new Error("Missing positional argument for openapi file");
-}
+const log = require("simple-node-logger").createSimpleLogger();
 
-apiFileLocation = apiFileLocation[0];
+// Override default logger
+global.console = log;
+log.setLevel("warn");
 
-let doc;
-if (apiFileLocation) {
-  doc = parse(readFileSync(apiFileLocation, "utf8"));
-} else {
-  throw new Error("Missing location. Please set OPENAPI_FILE env variable");
-}
+let { doc, apiFileLocation } = getAPI()();
 
 doc = applyOneOfTransformations(doc);
 doc = applyAllOfTransformations(doc);
 
 doc = applyModelNameTransformations(doc, "ApiAtlas", "View");
 
-writeFileSync(apiFileLocation, stringify(doc));
+saveAPI(doc, apiFileLocation);

--- a/tools/transformer/src/transform.js
+++ b/tools/transformer/src/transform.js
@@ -9,7 +9,7 @@ const log = require("simple-node-logger").createSimpleLogger();
 
 // Override default logger
 global.console = log;
-log.setLevel("warn");
+log.setLevel(process.env.XGEN_LOGGING_LEVEL || "warn");
 
 let { doc, apiFileLocation } = getAPI()();
 

--- a/tools/transformer/src/transformations.js
+++ b/tools/transformer/src/transformations.js
@@ -203,7 +203,7 @@ function transformOneOfProperties(parentObject, api) {
     ]);
     if (duplicates.length > 0) {
       const duplicatesSource = childObject.title || "";
-      console.warn(
+      console.info(
         `## ${duplicatesSource} - Detected properties that would be overriden: ${duplicates}\n`
       );
     }


### PR DESCRIPTION
## Description

Required fixes in the transformer before we start adding linting and flagging invalid cases:

- Minimize logging for end users (do not run debug or trace commands) so output of the transformer can be used to figure out what is wrong with the openapi. Warn will be default. 
- Add abstraction for file storage (so we can introduce more ways we read and store openapi file - it will enable us to use transformer as validator case.)

## Verification

Done `make transform_openapi`
We now only see ERRORS and WARNINGS. Some of the warnings will be downgraded to info/