### PR TITLE
CLOUDP-155910: add ability to generate client from api preview

### DIFF
--- a/.github/workflows/autoupdate-dev.yaml
+++ b/.github/workflows/autoupdate-dev.yaml
@@ -1,0 +1,40 @@
+name: Generate Client
+on:
+  workflow_dispatch:
+  
+jobs:
+  generate-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: sdkv2
+      - name: Fetch changes
+        working-directory: ./tools
+        run: |
+          API_BASE_URL=${{ secrets.MDB_CURRENT_API_PREVIEW_URL }} make fetch_openapi
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@v13
+        id: verify-changed-files
+        with:
+          files: |
+             **/atlas-api.yaml
+      - name: Run generation
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        working-directory: ./tools
+        run: make clean_and_generate
+      - uses: peter-evans/create-pull-request@v4
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        with:
+          title: "OpenAPI client update based on OpenAPI file"
+          commit-message: "openapi client update"
+          delete-branch: true
+          draft: true
+          base: sdkv2
+          branch: sdkv2dev
+          body: "Alpha SDK for testing"
+


### PR DESCRIPTION
## Description

API preview url might change a lot so decided to use the secret to expose it. 
I have tried to reuse the existing workflow but with a number of changes, it seems like a copy of the production one is much easier.

To reduce noise workflow is run on demand but it can be changed to a cron job as well. 
Secret created:
![Screenshot 2023-03-13 at 16 10 55](https://user-images.githubusercontent.com/981838/224748640-1a822021-703c-4dd5-937e-8f0510d53eee.png)


