### PR TITLE
chore: rename master workflow

### DIFF
--- a/.github/workflows/autoupdate-dev.yaml
+++ b/.github/workflows/autoupdate-dev.yaml
@@ -1,4 +1,4 @@
-name: Generate Client
+name: Generate Client Dev
 on:
   workflow_dispatch:
   

--- a/.github/workflows/autoupdate-master.yaml
+++ b/.github/workflows/autoupdate-master.yaml
@@ -1,4 +1,4 @@
-name: Generate Client
+name: Generate Client Master
 on:
  schedule:
    - cron: '30 8 * * *'


### PR DESCRIPTION
I have found that we have 3 duplicated workflows names between sdkv2 and master. This PR renames workflows to make it clear which one is which. Once we select workflow we see workflow file but it is better to make it clear in the workflow list as well. 