### PR TITLE
CLOUDP-166849

### DIFF
--- a/openapi/atlas-api-transformed.yaml
+++ b/openapi/atlas-api-transformed.yaml
@@ -40525,7 +40525,4 @@ components:
             description: Atlas Search Index
             url: https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/
       title: mappings
-  securitySchemes:
-    DigestAuth:
-      scheme: digest
-      type: http
+  securitySchemes: {}

--- a/openapi/atlas-api-transformed.yaml
+++ b/openapi/atlas-api-transformed.yaml
@@ -273,8 +273,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Get All Alert Configuration Matchers Field Names
       tags:
         - Alert Configurations
@@ -302,8 +300,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Authorized Clusters in All Projects
       tags:
         - Clusters
@@ -330,8 +326,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Example resource info for versioning of the Atlas API
       tags:
         - Test
@@ -361,8 +355,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Delete the federation settings instance.
       tags:
         - Federated Authentication
@@ -428,8 +420,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Org Config Connected to One Federation
       tags:
         - Federated Authentication
@@ -468,8 +458,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Org Config Connected to One Federation
       tags:
         - Federated Authentication
@@ -525,8 +513,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Org Config Connected to One Federation
       tags:
         - Federated Authentication
@@ -558,8 +544,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Role Mappings from One Organization
       tags:
         - Federated Authentication
@@ -595,8 +579,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Add One Role Mapping to One Organization
       tags:
         - Federated Authentication
@@ -635,8 +617,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Role Mapping from One Organization
       tags:
         - Federated Authentication
@@ -676,8 +656,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Role Mapping from One Organization
       tags:
         - Federated Authentication
@@ -724,8 +702,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Role Mapping in One Organization
       tags:
         - Federated Authentication
@@ -756,8 +732,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return all identity providers from the specified federation.
       tags:
         - Federated Authentication
@@ -787,8 +761,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return one identity provider from the specified federation.
       tags:
         - Federated Authentication
@@ -824,8 +796,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update the identity provider.
       tags:
         - Federated Authentication
@@ -855,8 +825,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return the metadata of one identity provider in the specified federation.
       tags:
         - Federated Authentication
@@ -937,8 +905,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Project
       tags:
         - Projects
@@ -1002,8 +968,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Project
       tags:
         - Projects
@@ -1031,8 +995,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Project
       tags:
         - Projects
@@ -1067,8 +1029,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Project Name
       tags:
         - Projects
@@ -1108,8 +1068,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Project IP Access List
       tags:
         - Project IP Access List
@@ -1162,8 +1120,6 @@ paths:
           $ref: "#/components/responses/forbidden"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Add Entries to Project IP Access List
       tags:
         - Project IP Access List
@@ -1223,8 +1179,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Entry from One Project IP Access List
       tags:
         - Project IP Access List
@@ -1279,8 +1233,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Project IP Access List Entry
       tags:
         - Project IP Access List
@@ -1321,8 +1273,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Status of One Project IP Access List Entry
       tags:
         - Project IP Access List
@@ -1355,8 +1305,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Alert Configurations for One Project
       tags:
         - Alert Configurations
@@ -1392,8 +1340,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Alert Configuration in One Project
       tags:
         - Alert Configurations
@@ -1434,8 +1380,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Alert Configuration from One Project
       tags:
         - Alert Configurations
@@ -1478,8 +1422,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Alert Configuration from One Project
       tags:
         - Alert Configurations
@@ -1536,8 +1478,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Toggle One State of One Alert Configuration in One Project
       tags:
         - Alert Configurations
@@ -1592,8 +1532,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Alert Configuration for One Project
       tags:
         - Alert Configurations
@@ -1642,8 +1580,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Open Alerts for Alert Configuration
       tags:
         - Alerts
@@ -1687,8 +1623,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Alerts from One Project
       tags:
         - Alerts
@@ -1730,8 +1664,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Alert from One Project
       tags:
         - Alerts
@@ -1783,8 +1715,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Acknowledge One Alert from One Project
       tags:
         - Alerts
@@ -1828,8 +1758,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Alert Configurations Set for One Alert
       tags:
         - Alert Configurations
@@ -1862,8 +1790,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Organization API Keys Assigned to One Project
       tags:
         - Programmatic API Keys
@@ -1898,8 +1824,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create and Assign One Organization API Key to One Project
       tags:
         - Programmatic API Keys
@@ -1933,8 +1857,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Unassign One Organization API Key from One Project
       tags:
         - Programmatic API Keys
@@ -1982,8 +1904,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Roles of One Organization API Key to One Project
       tags:
         - Programmatic API Keys
@@ -2028,8 +1948,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Assign One Organization API Key to One Project
       tags:
         - Programmatic API Keys
@@ -2055,8 +1973,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return the Auditing Configuration for One Project
       tags:
         - Auditing
@@ -2090,8 +2006,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Auditing Configuration for One Project
       tags:
         - Auditing
@@ -2116,8 +2030,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Custom DNS Configuration for Atlas Clusters on AWS
       tags:
         - AWS Clusters DNS
@@ -2150,8 +2062,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Toggle State of One Custom DNS Configuration for Atlas Clusters on AWS
       tags:
         - AWS Clusters DNS
@@ -2176,8 +2086,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All AWS S3 Buckets Used for Cloud Backup Snapshot Exports
       tags:
         - Cloud Backups
@@ -2212,8 +2120,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Grant Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
       tags:
         - Cloud Backups
@@ -2247,8 +2153,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Revoke Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
       tags:
         - Cloud Backups
@@ -2284,8 +2188,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One AWS S3 Bucket Used for Cloud Backup Snapshot Exports
       tags:
         - Cloud Backups
@@ -2310,8 +2212,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Cloud Provider Access Roles
       tags:
         - Cloud Provider Access
@@ -2350,8 +2250,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Cloud Provider Access Role
       tags:
         - Cloud Provider Access
@@ -2394,8 +2292,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Deauthorize One Cloud Provider Access Role
       tags:
         - Cloud Provider Access
@@ -2430,8 +2326,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return specified Cloud Provider Access Role
       tags:
         - Cloud Provider Access
@@ -2480,8 +2374,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Authorize One Cloud Provider Access Role
       tags:
         - Cloud Provider Access
@@ -2511,8 +2403,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Multi-Cloud Clusters from One Project
       tags:
         - Multi-Cloud Clusters
@@ -2633,8 +2523,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Multi-Cloud Cluster from One Project
       tags:
         - Multi-Cloud Clusters
@@ -2676,8 +2564,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Cloud Provider Regions
       tags:
         - Clusters
@@ -2716,8 +2602,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Upgrade One Shared-tier Cluster
       tags:
         - Clusters
@@ -2757,8 +2641,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Upgrades One Shared-Tier Cluster to the Serverless Instance
       tags:
         - Clusters
@@ -2800,8 +2682,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Multi-Cloud Cluster from One Project
       tags:
         - Multi-Cloud Clusters
@@ -2836,8 +2716,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Multi-Cloud Cluster from One Project
       tags:
         - Multi-Cloud Clusters
@@ -2886,8 +2764,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Modify One Multi-Cloud Cluster from One Project
       tags:
         - Multi-Cloud Clusters
@@ -2924,8 +2800,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Cloud Backup Snapshot Export Jobs
       tags:
         - Cloud Backups
@@ -2971,8 +2845,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Cloud Backup Snapshot Export Job
       tags:
         - Cloud Backups
@@ -3013,8 +2885,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Cloud Backup Snapshot Export Job
       tags:
         - Cloud Backups
@@ -3051,8 +2921,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Restore Jobs for One Cluster
       tags:
         - Cloud Backups
@@ -3097,8 +2965,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Restore One Snapshot of One Cluster
       tags:
         - Cloud Backups
@@ -3138,8 +3004,6 @@ paths:
           $ref: "#/components/responses/methodNotAllowed"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Cancel One Restore Job of One Cluster
       tags:
         - Cloud Backups
@@ -3182,8 +3046,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Restore Job of One Cluster
       tags:
         - Cloud Backups
@@ -3220,8 +3082,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove All Cloud Backup Schedules
       tags:
         - Cloud Backups
@@ -3255,8 +3115,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Cloud Backup Schedule
       tags:
         - Cloud Backups
@@ -3304,8 +3162,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Cloud Backup Schedule for One Cluster
       tags:
         - Cloud Backups
@@ -3344,8 +3200,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Replica Set Cloud Backups
       tags:
         - Cloud Backups
@@ -3386,8 +3240,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Take One On-Demand Snapshot
       tags:
         - Cloud Backups
@@ -3425,8 +3277,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Sharded Cluster Cloud Backup
       tags:
         - Cloud Backups
@@ -3471,8 +3321,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Sharded Cluster Cloud Backup
       tags:
         - Cloud Backups
@@ -3508,8 +3356,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Sharded Cluster Cloud Backups
       tags:
         - Cloud Backups
@@ -3549,8 +3395,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Replica Set Cloud Backup
       tags:
         - Cloud Backups
@@ -3594,8 +3438,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Replica Set Cloud Backup
       tags:
         - Cloud Backups
@@ -3647,8 +3489,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Change Expiration Date for One Cloud Backup
       tags:
         - Cloud Backups
@@ -3699,8 +3539,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Download One M2 or M5 Cluster Snapshot
       tags:
         - Shared-Tier Snapshots
@@ -3751,8 +3589,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Restore Job from One M2 or M5 Cluster
       tags:
         - Shared-Tier Restore Jobs
@@ -3788,8 +3624,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Restore Jobs for One M2 or M5 Cluster
       tags:
         - Shared-Tier Restore Jobs
@@ -3834,8 +3668,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Restore Job for One M2 or M5 Cluster
       tags:
         - Shared-Tier Restore Jobs
@@ -3871,8 +3703,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Snapshots for One M2 or M5 Cluster
       tags:
         - Shared-Tier Snapshots
@@ -3918,8 +3748,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Snapshot for One M2 or M5 Cluster
       tags:
         - Shared-Tier Snapshots
@@ -3958,8 +3786,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Legacy Backup Checkpoints
       tags:
         - Legacy Backup
@@ -4008,8 +3834,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Legacy Backup Checkpoint
       tags:
         - Legacy Backup
@@ -4058,8 +3882,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Atlas Search Index
       tags:
         - Atlas Search
@@ -4114,8 +3936,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Atlas Search Indexes for One Collection
       tags:
         - Atlas Search
@@ -4162,8 +3982,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Atlas Search Index
       tags:
         - Atlas Search
@@ -4216,8 +4034,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Atlas Search Index
       tags:
         - Atlas Search
@@ -4277,8 +4093,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Atlas Search Index
       tags:
         - Atlas Search
@@ -4312,8 +4126,6 @@ paths:
           description: OK
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Managed Namespace in One Global Multi-Cloud Cluster
       tags:
         - Global Clusters
@@ -4350,8 +4162,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove All Custom Zone Mappings from One Global Multi-Cloud Cluster
       tags:
         - Global Clusters
@@ -4394,8 +4204,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Add One Entry to One Custom Zone Mapping
       tags:
         - Global Clusters
@@ -4444,8 +4252,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Managed Namespace from One Global Multi-Cloud Cluster
       tags:
         - Global Clusters
@@ -4489,8 +4295,6 @@ paths:
           $ref: "#/components/responses/methodNotAllowed"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Managed Namespace in One Global Multi-Cloud Cluster
       tags:
         - Global Clusters
@@ -4538,8 +4342,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Rolling Index
       tags:
         - Rolling Index
@@ -4580,8 +4382,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Online Archives for One Cluster
       tags:
         - Online Archive
@@ -4631,8 +4431,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Online Archive
       tags:
         - Online Archive
@@ -4711,8 +4509,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Download Online Archive Query Logs
       tags:
         - Online Archive
@@ -4757,8 +4553,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Online Archive
       tags:
         - Online Archive
@@ -4810,8 +4604,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Online Archive
       tags:
         - Online Archive
@@ -4872,8 +4664,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Online Archive
       tags:
         - Online Archive
@@ -4912,8 +4702,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: End an Outage Simulation
       tags:
         - Cluster Outage Simulation
@@ -4951,8 +4739,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Outage Simulation
       tags:
         - Cluster Outage Simulation
@@ -4995,8 +4781,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Start an Outage Simulation
       tags:
         - Cluster Outage Simulation
@@ -5042,8 +4826,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Advanced Configuration Options for One Cluster
       tags:
         - Clusters
@@ -5094,8 +4876,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Advanced Configuration Options for One Cluster
       tags:
         - Clusters
@@ -5131,8 +4911,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Test Failover for One Multi-Cloud Cluster
       tags:
         - Multi-Cloud Clusters
@@ -5186,8 +4964,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Legacy Backup Restore Jobs
       tags:
         - Legacy Backup
@@ -5230,8 +5006,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Legacy Backup Restore Job
       tags:
         - Legacy Backup Restore Jobs
@@ -5278,8 +5052,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Legacy Backup Restore Job
       tags:
         - Legacy Backup
@@ -5314,8 +5086,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Snapshot Schedule
       tags:
         - Legacy Backup
@@ -5356,8 +5126,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Snapshot Schedule for One Cluster
       tags:
         - Legacy Backup
@@ -5407,8 +5175,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Legacy Backup Snapshots
       tags:
         - Legacy Backup
@@ -5449,8 +5215,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Legacy Backup Snapshot
       tags:
         - Legacy Backup
@@ -5494,8 +5258,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Legacy Backup Snapshot
       tags:
         - Legacy Backup
@@ -5546,8 +5308,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Change One Legacy Backup Snapshot Expiration
       tags:
         - Legacy Backup
@@ -5583,8 +5343,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Status of All Cluster Operations
       tags:
         - Clusters
@@ -5661,8 +5419,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Download Logs for One Multi-Cloud Cluster Host in One Project
       tags:
         - Monitoring and Logs
@@ -5707,8 +5463,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Network Peering Containers in One Project for One Cloud
         Provider
       tags:
@@ -5749,8 +5503,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One New Network Peering Container
       tags:
         - Network Peering
@@ -5779,8 +5531,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Network Peering Containers in One Project
       tags:
         - Network Peering
@@ -5816,8 +5566,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Network Peering Container
       tags:
         - Network Peering
@@ -5853,8 +5601,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Network Peering Container
       tags:
         - Network Peering
@@ -5905,8 +5651,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Network Peering Container
       tags:
         - Network Peering
@@ -5932,8 +5676,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Custom Roles in One Project
       tags:
         - Custom Database Roles
@@ -5971,8 +5713,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Custom Role
       tags:
         - Custom Database Roles
@@ -6011,8 +5751,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Custom Role from One Project
       tags:
         - Custom Database Roles
@@ -6045,8 +5783,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Custom Role in One Project
       tags:
         - Custom Database Roles
@@ -6092,8 +5828,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Custom Role in One Project
       tags:
         - Custom Database Roles
@@ -6129,8 +5863,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Federated Database Instances in One Project
       tags:
         - Data Federation
@@ -6172,8 +5904,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Federated Database Instance in One Project
       tags:
         - Data Federation
@@ -6200,8 +5930,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Federated Database Instance from One Project
       tags:
         - Data Federation
@@ -6236,8 +5964,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Federated Database Instance in One Project
       tags:
         - Data Federation
@@ -6287,8 +6013,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Federated Database Instance in One Project
       tags:
         - Data Federation
@@ -6324,8 +6048,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Query Limits for One Federated Database Instance
       tags:
         - Data Federation
@@ -6377,8 +6099,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Delete One Query Limit For One Federated Database Instance
       tags:
         - Data Federation
@@ -6437,8 +6157,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Federated Database Instance Query Limit for One Project
       tags:
         - Data Federation
@@ -6508,8 +6226,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Configure One Query Limit for One Federated Database Instance
       tags:
         - Data Federation
@@ -6571,8 +6287,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Download Query Logs for One Federated Database Instance
       tags:
         - Data Federation
@@ -6599,8 +6313,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return the Data Protection Policy settings
       tags:
         - Cloud Backups
@@ -6634,8 +6346,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update or enable the Data Protection Policy settings
       tags:
         - Cloud Backups
@@ -6663,8 +6373,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Database Users from One Project
       tags:
         - Database Users
@@ -6758,8 +6466,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Database User in One Project
       tags:
         - Database Users
@@ -6825,8 +6531,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Database User from One Project
       tags:
         - Database Users
@@ -6895,8 +6599,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Database User from One Project
       tags:
         - Database Users
@@ -6978,8 +6680,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Database User in One Project
       tags:
         - Database Users
@@ -7017,8 +6717,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All X.509 Certificates Assigned to One MongoDB User
       tags:
         - X.509 Authentication
@@ -7075,8 +6773,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One X.509 Certificate for One MongoDB User
       tags:
         - X.509 Authentication
@@ -7153,8 +6849,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Database Access History for One Cluster using Its Cluster Name
       tags:
         - Access Tracking
@@ -7230,8 +6924,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Database Access History for One Cluster using Its Hostname
       tags:
         - Access Tracking
@@ -7260,8 +6952,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Configuration for Encryption at Rest using Customer-Managed
         Keys for One Project
       tags:
@@ -7318,8 +7008,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Configuration for Encryption at Rest using Customer-Managed Keys
         for One Project
       tags:
@@ -7400,8 +7088,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Events from One Project
       tags:
         - Events
@@ -7452,8 +7138,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Event from One Project
       tags:
         - Events
@@ -7479,8 +7163,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Atlas Search Metric Types for One Process
       tags:
         - Monitoring and Logs
@@ -7537,8 +7219,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Atlas Search Index Metrics for One Namespace
       tags:
         - Monitoring and Logs
@@ -7596,8 +7276,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Atlas Search Metrics for One Index in One Specified Namespace
       tags:
         - Monitoring and Logs
@@ -7656,8 +7334,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Atlas Search Hardware and Status Metrics
       tags:
         - Monitoring and Logs
@@ -7690,8 +7366,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Active Third-Party Service Integrations
       tags:
         - Third-Party Integrations
@@ -7734,8 +7408,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Third-Party Service Integration
       tags:
         - Third-Party Integrations
@@ -7782,8 +7454,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Third-Party Service Integration
       tags:
         - Third-Party Integrations
@@ -7842,8 +7512,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Configure One Third-Party Service Integration
       tags:
         - Third-Party Integrations
@@ -7900,8 +7568,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Third-Party Service Integration
       tags:
         - Third-Party Integrations
@@ -7933,8 +7599,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Project Invitations
       tags:
         - Projects
@@ -7970,8 +7634,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Project Invitation
       tags:
         - Projects
@@ -8003,8 +7665,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Invite One MongoDB Cloud User to Join One Project
       tags:
         - Projects
@@ -8034,8 +7694,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Cancel One Project Invitation
       tags:
         - Projects
@@ -8070,8 +7728,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Project Invitation
       tags:
         - Projects
@@ -8118,8 +7774,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Project Invitation by Invitation ID
       tags:
         - Projects
@@ -8149,8 +7803,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Limits for One Project
       tags:
         - Projects
@@ -8218,8 +7870,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Project Limit
       tags:
         - Projects
@@ -8291,8 +7941,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Limit for One Project
       tags:
         - Projects
@@ -8369,8 +8017,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Set One Project Limit
       tags:
         - Projects
@@ -8409,8 +8055,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Migrate One Local Managed Cluster to MongoDB Atlas
       tags:
         - Cloud Migration Service
@@ -8447,8 +8091,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Validate One Migration Request
       tags:
         - Cloud Migration Service
@@ -8487,8 +8129,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Migration Validation Job
       tags:
         - Cloud Migration Service
@@ -8515,8 +8155,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Migration Job
       tags:
         - Cloud Migration Service
@@ -8546,8 +8184,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Cut Over the Migrated Cluster
       tags:
         - Cloud Migration Service
@@ -8568,8 +8204,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Reset One Maintenance Window for One Project
       tags:
         - Maintenance Windows
@@ -8592,8 +8226,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Maintenance Window for One Project
       tags:
         - Maintenance Windows
@@ -8620,8 +8252,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Maintenance Window for One Project
       tags:
         - Maintenance Windows
@@ -8646,8 +8276,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Toggle Automatic Deferral of Maintenance for One Project
       tags:
         - Maintenance Windows
@@ -8671,8 +8299,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Defer One Maintenance Window for One Project
       tags:
         - Maintenance Windows
@@ -8700,8 +8326,6 @@ paths:
           $ref: "#/components/responses/forbidden"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Disable Managed Slow Operation Threshold
       tags:
         - Performance Advisor
@@ -8729,8 +8353,6 @@ paths:
           $ref: "#/components/responses/forbidden"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Enable Managed Slow Operation Threshold
       tags:
         - Performance Advisor
@@ -8774,8 +8396,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Network Peering Connections in One Project
       tags:
         - Network Peering
@@ -8821,8 +8441,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One New Network Peering Connection
       tags:
         - Network Peering
@@ -8856,8 +8474,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Existing Network Peering Connection
       tags:
         - Network Peering
@@ -8896,8 +8512,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Network Peering Connection in One Project
       tags:
         - Network Peering
@@ -8947,8 +8561,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One New Network Peering Connection
       tags:
         - Network Peering
@@ -8975,8 +8587,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Data Lake Pipelines from One Project
       tags:
         - Data Lake Pipelines
@@ -9008,8 +8618,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9037,8 +8645,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9072,8 +8678,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9116,8 +8720,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9154,8 +8756,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Available Ingestion Schedules for One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9203,8 +8803,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Available Backup Snapshots for One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9239,8 +8837,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Pause One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9275,8 +8871,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Resume One Data Lake Pipeline
       tags:
         - Data Lake Pipelines
@@ -9321,8 +8915,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Data Lake Pipeline Runs from One Project
       tags:
         - Data Lake Pipelines
@@ -9361,8 +8953,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Delete Pipeline Run Dataset
       tags:
         - Data Lake Pipelines
@@ -9407,8 +8997,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Data Lake Pipeline Run
       tags:
         - Data Lake Pipelines
@@ -9448,8 +9036,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Trigger on demand snapshot ingestion
       tags:
         - Data Lake Pipelines
@@ -9483,8 +9069,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Private Endpoint Service for One Provider
       tags:
         - Private Endpoint Services
@@ -9512,8 +9096,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Regionalized Private Endpoint Status
       tags:
         - Private Endpoint Services
@@ -9549,8 +9131,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Toggle Regionalized Private Endpoint Status
       tags:
         - Private Endpoint Services
@@ -9588,8 +9168,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Private Endpoints for One Serverless Instance
       tags:
         - Serverless Private Endpoints
@@ -9637,8 +9215,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
@@ -9678,8 +9254,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
@@ -9724,8 +9298,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
@@ -9774,8 +9346,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Private Endpoint for One Serverless Instance
       tags:
         - Serverless Private Endpoints
@@ -9812,8 +9382,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Private Endpoint Services for One Provider
       tags:
         - Private Endpoint Services
@@ -9855,8 +9423,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Private Endpoint Service for One Provider
       tags:
         - Private Endpoint Services
@@ -9904,8 +9470,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Private Endpoint Service for One Provider
       tags:
         - Private Endpoint Services
@@ -9970,8 +9534,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Private Endpoint for One Provider
       tags:
         - Private Endpoint Services
@@ -10023,8 +9585,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Private Endpoint for One Provider
       tags:
         - Private Endpoint Services
@@ -10082,8 +9642,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Private Endpoint for One Provider
       tags:
         - Private Endpoint Services
@@ -10112,8 +9670,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Verify Connect via Peering Only Mode for One Project
       tags:
         - Network Peering
@@ -10149,8 +9705,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Disable Connect via Peering Only Mode for One Project
       tags:
         - Network Peering
@@ -10182,8 +9736,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Federated Database Instance and Online Archive Private
         Endpoints in One Project
       tags:
@@ -10221,8 +9773,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Federated Database Instance and Online Archive Private
         Endpoint for One Project
       tags:
@@ -10256,8 +9806,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Federated Database Instance and Online Archive Private
         Endpoint from One Project
       tags:
@@ -10298,8 +9846,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Federated Database Instance and Online Archive Private
         Endpoint in One Project
       tags:
@@ -10328,8 +9874,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All MongoDB Processes in One Project
       tags:
         - Monitoring and Logs
@@ -10367,8 +9911,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One MongoDB Process by ID
       tags:
         - Monitoring and Logs
@@ -10409,8 +9951,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Available Databases for One MongoDB Process
       tags:
         - Monitoring and Logs
@@ -10455,8 +9995,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Database for a MongoDB Process
       tags:
         - Monitoring and Logs
@@ -10569,8 +10107,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Available Disks for One MongoDB Process
       tags:
         - Monitoring and Logs
@@ -10626,8 +10162,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Measurements of One Disk
       tags:
         - Monitoring and Logs
@@ -10721,8 +10255,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Measurements of One Disk for One MongoDB Process
       tags:
         - Monitoring and Logs
@@ -10931,8 +10463,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Measurements for One MongoDB Process
       tags:
         - Monitoring and Logs
@@ -10998,8 +10528,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Namespaces for One Host
       tags:
         - Performance Advisor
@@ -11091,8 +10619,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Slow Queries
       tags:
         - Performance Advisor
@@ -11186,8 +10712,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Suggested Indexes
       tags:
         - Performance Advisor
@@ -11235,8 +10759,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Load Sample Dataset Request into Cluster
       tags:
         - Clusters
@@ -11270,8 +10792,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Check Status of Cluster Sample Dataset Request
       tags:
         - Clusters
@@ -11299,8 +10819,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Serverless Instances from One Project
       tags:
         - Serverless Instances
@@ -11334,8 +10852,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Serverless Instance in One Project
       tags:
         - Serverless Instances
@@ -11370,8 +10886,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Restore Jobs for One Serverless Instance
       tags:
         - Cloud Backups
@@ -11418,8 +10932,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Restore One Snapshot of One Serverless Instance
       tags:
         - Cloud Backups
@@ -11464,8 +10976,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Restore Job for One Serverless Instance
       tags:
         - Cloud Backups
@@ -11504,8 +11014,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Snapshots of One Serverless Instance
       tags:
         - Cloud Backups
@@ -11552,8 +11060,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Snapshot of One Serverless Instance
       tags:
         - Cloud Backups
@@ -11587,8 +11093,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Serverless Instance from One Project
       tags:
         - Serverless Instances
@@ -11625,8 +11129,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Serverless Instance from One Project
       tags:
         - Serverless Instances
@@ -11667,8 +11169,6 @@ paths:
           $ref: "#/components/responses/paymentRequired"
         "409":
           $ref: "#/components/responses/conflict"
-      security:
-        - DigestAuth: []
       summary: Update One Serverless Instance in One Project
       tags:
         - Serverless Instances
@@ -11696,8 +11196,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Project Settings
       tags:
         - Projects
@@ -11731,8 +11229,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Project Settings
       tags:
         - Projects
@@ -11767,8 +11263,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Teams in One Project
       tags:
         - Teams
@@ -11812,8 +11306,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Add One or More Teams to One Project
       tags:
         - Teams
@@ -11852,8 +11344,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Team from One Project
       tags:
         - Teams
@@ -11904,8 +11394,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Team Roles in One Project
       tags:
         - Teams
@@ -11929,8 +11417,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return the Current LDAP or X.509 Configuration
       tags:
         - LDAP Configuration
@@ -11966,8 +11452,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Edit the LDAP or X.509 Configuration
       tags:
         - LDAP Configuration
@@ -11994,8 +11478,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Disable Customer-Managed X.509
       tags:
         - X.509 Authentication
@@ -12019,8 +11501,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove the Current LDAP User to DN Mapping
       tags:
         - LDAP Configuration
@@ -12054,8 +11534,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Verify the LDAP Configuration in One Project
       tags:
         - LDAP Configuration
@@ -12091,8 +11569,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return the Status of One Verify LDAP Configuration Request
       tags:
         - LDAP Configuration
@@ -12145,8 +11621,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Users in One Project
       tags:
         - Projects
@@ -12184,8 +11658,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One User from One Project
       tags:
         - Projects
@@ -12224,8 +11696,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Organizations
       tags:
         - Organizations
@@ -12267,8 +11737,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Organization
       tags:
         - Organizations
@@ -12299,8 +11767,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Organization
       tags:
         - Organizations
@@ -12330,8 +11796,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Organization
       tags:
         - Organizations
@@ -12367,8 +11831,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Rename One Organization
       tags:
         - Organizations
@@ -12401,8 +11863,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Organization API Keys
       tags:
         - Programmatic API Keys
@@ -12438,8 +11898,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12473,8 +11931,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12512,8 +11968,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12561,8 +12015,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12604,8 +12056,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Access List Entries for One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12657,8 +12107,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create Access List Entries for One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12708,8 +12156,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Access List Entry for One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12762,8 +12208,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Access List Entry for One Organization API Key
       tags:
         - Programmatic API Keys
@@ -12831,8 +12275,6 @@ paths:
           $ref: "#/components/responses/badRequest"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Events from One Organization
       tags:
         - Events
@@ -12883,8 +12325,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Event from One Organization
       tags:
         - Events
@@ -12913,8 +12353,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Federation Settings for One Organization
       tags:
         - Federated Authentication
@@ -12964,8 +12402,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One or More Projects in One Organization
       tags:
         - Organizations
@@ -13004,8 +12440,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Organization Invitations
       tags:
         - Organizations
@@ -13042,8 +12476,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Organization Invitation
       tags:
         - Organizations
@@ -13079,8 +12511,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Invite One MongoDB Cloud User to Join One Atlas Organization
       tags:
         - Organizations
@@ -13111,8 +12541,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Cancel One Organization Invitation
       tags:
         - Organizations
@@ -13149,8 +12577,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Organization Invitation
       tags:
         - Organizations
@@ -13198,8 +12624,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update One Organization Invitation by Invitation ID
       tags:
         - Organizations
@@ -13232,8 +12656,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Invoices for One Organization
       tags:
         - Invoices
@@ -13262,8 +12684,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Pending Invoices for One Organization
       tags:
         - Invoices
@@ -13305,8 +12725,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Organization Invoice
       tags:
         - Invoices
@@ -13341,8 +12759,6 @@ paths:
           $ref: "#/components/responses/unauthorized"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Organization Invoice as CSV
       tags:
         - Invoices
@@ -13368,8 +12784,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Projects Available for Migration
       tags:
         - Cloud Migration Service
@@ -13388,8 +12802,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Link-Token
       tags:
         - Cloud Migration Service
@@ -13420,8 +12832,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Link-Token
       tags:
         - Cloud Migration Service
@@ -13450,8 +12860,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return Settings for One Organization
       tags:
         - Organizations
@@ -13485,8 +12893,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Update Settings for One Organization
       tags:
         - Organizations
@@ -13522,8 +12928,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All Teams in One Organization
       tags:
         - Teams
@@ -13564,8 +12968,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One Team in One Organization
       tags:
         - Teams
@@ -13604,8 +13006,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Team using its Name
       tags:
         - Teams
@@ -13643,8 +13043,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One Team from One Organization
       tags:
         - Teams
@@ -13686,8 +13084,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One Team using its ID
       tags:
         - Teams
@@ -13737,8 +13133,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Rename One Team
       tags:
         - Teams
@@ -13786,8 +13180,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All MongoDB Cloud Users Assigned to One Team
       tags:
         - Teams
@@ -13842,8 +13234,6 @@ paths:
           $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Assign MongoDB Cloud Users from One Organization to One Team
       tags:
         - Teams
@@ -13894,8 +13284,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Remove One MongoDB Cloud User from One Team
       tags:
         - Teams
@@ -13926,8 +13314,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return All MongoDB Cloud Users in One Organization
       tags:
         - Organizations
@@ -13961,8 +13347,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Create One MongoDB Cloud User
       tags:
         - MongoDB Cloud Users
@@ -13996,8 +13380,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One MongoDB Cloud User using Their Username
       tags:
         - MongoDB Cloud Users
@@ -14032,8 +13414,6 @@ paths:
           $ref: "#/components/responses/notFound"
         "500":
           $ref: "#/components/responses/internalServerError"
-      security:
-        - DigestAuth: []
       summary: Return One MongoDB Cloud User using Its ID
       tags:
         - MongoDB Cloud Users

--- a/tools/transformer/README.md
+++ b/tools/transformer/README.md
@@ -82,6 +82,10 @@ For each model:
 - Remove prefix or suffix from model name
 - Ignore if model name is not matching prefix or suffix
 
+5. Digest transformation
+
+Removes digest authentication which is not recognized by many generators
+
 ## Transformation Validation
 
 Transformation engine does perform validation for invalid cases.

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -3,6 +3,7 @@ const {
   applyOneOfTransformations,
   applyModelNameTransformations,
   applyDiscriminatorTransformations,
+  applyDigestTransformations,
 } = require("./transformations");
 
 const ignoredModelNames = require("./name.ignore.json").ignoreModels;
@@ -39,6 +40,7 @@ module.exports = function runTransformations(openapi) {
     "View",
     ignoredModelNames
   );
+  openapi = applyDigestTransformations(openapi);
 
   return openapi;
 };

--- a/tools/transformer/src/transformations/digest.js
+++ b/tools/transformer/src/transformations/digest.js
@@ -3,6 +3,13 @@ function applyDigestTransformations(api) {
   if (hasSchemas) {
     delete api.components.securitySchemes.DigestAuth;
   }
+
+  Object.keys(api.paths).forEach((path) => {
+     Object.keys(api.paths[path]).forEach((method)=>{
+      delete api.paths[path][method].security
+     });
+  });
+
   return api;
 }
 

--- a/tools/transformer/src/transformations/digest.js
+++ b/tools/transformer/src/transformations/digest.js
@@ -1,0 +1,11 @@
+function applyDigestTransformations(api) {
+  const hasSchemas = api && api.components && api.components.securitySchemes;
+  if (hasSchemas) {
+    delete api.components.securitySchemes.DigestAuth;
+  }
+  return api;
+}
+
+module.exports = {
+  applyDigestTransformations,
+};

--- a/tools/transformer/src/transformations/digest.js
+++ b/tools/transformer/src/transformations/digest.js
@@ -1,14 +1,16 @@
+/**
+ * Remove digest auth from paths and security schemes
+ */
 function applyDigestTransformations(api) {
   const hasSchemas = api && api.components && api.components.securitySchemes;
   if (hasSchemas) {
     delete api.components.securitySchemes.DigestAuth;
+    Object.keys(api.paths).forEach((path) => {
+      Object.keys(api.paths[path]).forEach((method) => {
+        delete api.paths[path][method].security;
+      });
+    });
   }
-
-  Object.keys(api.paths).forEach((path) => {
-     Object.keys(api.paths[path]).forEach((method)=>{
-      delete api.paths[path][method].security
-     });
-  });
 
   return api;
 }

--- a/tools/transformer/src/transformations/index.js
+++ b/tools/transformer/src/transformations/index.js
@@ -2,6 +2,7 @@ const { applyAllOfTransformations, transformAllOf } = require("./allOf");
 const { applyModelNameTransformations } = require("./name");
 const { applyOneOfTransformations, transformOneOf } = require("./oneOf");
 const { applyDiscriminatorTransformations } = require("./discriminator");
+const { applyDigestTransformations } = require("./digest");
 
 module.exports = {
   applyModelNameTransformations,
@@ -10,4 +11,5 @@ module.exports = {
   applyAllOfTransformations,
   applyOneOfTransformations,
   applyDiscriminatorTransformations,
+  applyDigestTransformations,
 };


### PR DESCRIPTION
## Description

 Remove digest from openapi as it does generate +400 lines of warnings and a lot of dead code in the SDK. 
 Digest is not supported authentication scheme by many generators. 
 
 After removing security we can still pass custom http/token refresh option.
 Security in generated clients is only used to automatically configure authentication.