### PR TITLE
CLOUDP-167925: add support for PrivateEndpoint.srvShardOptimizedConnectionString

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -113,10 +113,11 @@ type ReplicationSpec struct {
 // Atlas returns this parameter only if you deployed a private endpoint to all regions
 // to which you deployed this cluster's nodes.
 type PrivateEndpoint struct {
-	ConnectionString    string     `json:"connectionString,omitempty"`
-	Endpoints           []Endpoint `json:"endpoints,omitempty"`
-	SRVConnectionString string     `json:"srvConnectionString,omitempty"`
-	Type                string     `json:"type,omitempty"`
+	ConnectionString                  string     `json:"connectionString,omitempty"`
+	Endpoints                         []Endpoint `json:"endpoints,omitempty"`
+	SRVConnectionString               string     `json:"srvConnectionString,omitempty"`
+	SRVShardOptimizedConnectionString string     `json:"srvShardOptimizedConnectionString,omitempty"`
+	Type                              string     `json:"type,omitempty"`
 }
 
 // Endpoint through which you connect to Atlas.

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -67,6 +67,7 @@ func TestClusters_ListClusters(t *testing.T) {
 						   }
 						  ],
 						  "srvConnectionString": "mongodb+srv://cluster0-pl-0-auylw.mongodb.net",
+						  "srvShardOptimizedConnectionString": "mongodb+srv://cluster0-pl-0-auylw-lb.mongodb.net",
 						  "type": "MONGOD"
 						 }
 						]
@@ -142,6 +143,7 @@ func TestClusters_ListClusters(t *testing.T) {
 						   }
 						  ],
 						  "srvConnectionString": "mongodb+srv://cluster0-pl-0-auylw.mongodb.net",
+						  "srvShardOptimizedConnectionString": "mongodb+srv://cluster0-pl-0-auylw-lb.mongodb.net",
 						  "type": "MONGOD"
 						 }
 						]
@@ -211,9 +213,10 @@ func TestClusters_ListClusters(t *testing.T) {
 			PrivateSrv:        "mongodb+srv://cluster0-pri.auylw.mongodb.net",
 			PrivateEndpoint: []PrivateEndpoint{
 				{
-					ConnectionString:    "mongodb://pl-0-us-east-1-auylw.mongodb.net:1024,pl-0-us-east-1-auylw.mongodb.net:1025,pl-0-us-east-1-auylw.mongodb.net:1026/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0-shard-0",
-					SRVConnectionString: "mongodb+srv://cluster0-pl-0-auylw.mongodb.net",
-					Type:                "MONGOD",
+					ConnectionString:                  "mongodb://pl-0-us-east-1-auylw.mongodb.net:1024,pl-0-us-east-1-auylw.mongodb.net:1025,pl-0-us-east-1-auylw.mongodb.net:1026/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0-shard-0",
+					SRVConnectionString:               "mongodb+srv://cluster0-pl-0-auylw.mongodb.net",
+					SRVShardOptimizedConnectionString: "mongodb+srv://cluster0-pl-0-auylw-lb.mongodb.net",
+					Type:                              "MONGOD",
 					Endpoints: []Endpoint{
 						{
 							EndpointID:   "vpce-0d00c26273372c6ef",
@@ -886,6 +889,7 @@ func TestClusters_Get(t *testing.T) {
 				   }
 				  ],
 				  "srvConnectionString": "mongodb+srv://cluster0-pl-0-auylw.mongodb.net",
+				  "srvShardOptimizedConnectionString": "mongodb+srv://cluster0-pl-0-auylw-lb.mongodb.net",
 				  "type": "MONGOD"
 				 }
 				]
@@ -943,9 +947,10 @@ func TestClusters_Get(t *testing.T) {
 			PrivateSrv:        "mongodb+srv://cluster0-pri.auylw.mongodb.net",
 			PrivateEndpoint: []PrivateEndpoint{
 				{
-					ConnectionString:    "mongodb://pl-0-us-east-1-auylw.mongodb.net:1024,pl-0-us-east-1-auylw.mongodb.net:1025,pl-0-us-east-1-auylw.mongodb.net:1026/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0-shard-0",
-					SRVConnectionString: "mongodb+srv://cluster0-pl-0-auylw.mongodb.net",
-					Type:                "MONGOD",
+					ConnectionString:                  "mongodb://pl-0-us-east-1-auylw.mongodb.net:1024,pl-0-us-east-1-auylw.mongodb.net:1025,pl-0-us-east-1-auylw.mongodb.net:1026/?ssl=true&authSource=admin&replicaSet=Cluster0-shard-0-shard-0",
+					SRVConnectionString:               "mongodb+srv://cluster0-pl-0-auylw.mongodb.net",
+					SRVShardOptimizedConnectionString: "mongodb+srv://cluster0-pl-0-auylw-lb.mongodb.net",
+					Type:                              "MONGOD",
 					Endpoints: []Endpoint{
 						{
 							EndpointID:   "vpce-0d00c26273372c6ef",


### PR DESCRIPTION
## Description

CLOUDP-167925: add support for PrivateEndpoint.srvShardOptimizedConnectionString
https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Multi-Cloud-Clusters/operation/getCluster (see response samples connectionStrings.privateEndpoint)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

