### PR TITLE
CLOUDP-168044: disable readonly models marshaling

### DIFF
--- a/mongodbatlasv2/model_access_list_item.go
+++ b/mongodbatlasv2/model_access_list_item.go
@@ -99,18 +99,15 @@ func (o *AccessListItem) SetIpAddress(v string) {
 	o.IpAddress = v
 }
 
-func (o AccessListItem) MarshalJSON() ([]byte, error) {
+func (o AccessListItem) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AccessListItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: cidrBlock is readOnly
-	// skip: ipAddress is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_add_user_to_team.go
+++ b/mongodbatlasv2/model_add_user_to_team.go
@@ -65,14 +65,13 @@ func (o *AddUserToTeam) SetId(v string) {
 	o.Id = v
 }
 
-func (o AddUserToTeam) MarshalJSON() ([]byte, error) {
+func (o AddUserToTeam) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AddUserToTeam) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id

--- a/mongodbatlasv2/model_alert.go
+++ b/mongodbatlasv2/model_alert.go
@@ -439,31 +439,19 @@ func (o *Alert) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o Alert) MarshalJSON() ([]byte, error) {
+func (o Alert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Alert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: created is readOnly
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_alert_audit.go
+++ b/mongodbatlasv2/model_alert_audit.go
@@ -492,32 +492,19 @@ func (o *AlertAudit) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o AlertAudit) MarshalJSON() ([]byte, error) {
+func (o AlertAudit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AlertAudit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: alertId is readOnly
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_alert_config.go
+++ b/mongodbatlasv2/model_alert_config.go
@@ -347,33 +347,27 @@ func (o *AlertConfig) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o AlertConfig) MarshalJSON() ([]byte, error) {
+func (o AlertConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AlertConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	if !IsNil(o.EventTypeName) {
 		toSerialize["eventTypeName"] = o.EventTypeName
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_alert_config_audit.go
+++ b/mongodbatlasv2/model_alert_config_audit.go
@@ -492,32 +492,19 @@ func (o *AlertConfigAudit) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o AlertConfigAudit) MarshalJSON() ([]byte, error) {
+func (o AlertConfigAudit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AlertConfigAudit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: alertConfigId is readOnly
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_alert_config_view_for_nds_group.go
@@ -413,33 +413,27 @@ func (o *AlertConfigViewForNdsGroup) SetThreshold(v ThresholdViewInteger) {
 	o.Threshold = &v
 }
 
-func (o AlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o AlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	if !IsNil(o.EventTypeName) {
 		toSerialize["eventTypeName"] = o.EventTypeName
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	if !IsNil(o.MetricThreshold) {
 		toSerialize["metricThreshold"] = o.MetricThreshold
 	}

--- a/mongodbatlasv2/model_alert_view_for_nds_group.go
+++ b/mongodbatlasv2/model_alert_view_for_nds_group.go
@@ -750,14 +750,13 @@ func (o *AlertViewForNdsGroup) SetParentClusterId(v string) {
 	o.ParentClusterId = &v
 }
 
-func (o AlertViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o AlertViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AlertViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AcknowledgedUntil) {
@@ -766,29 +765,12 @@ func (o AlertViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.EventTypeName) {
 		toSerialize["eventTypeName"] = o.EventTypeName
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
-	// skip: clusterName is readOnly
-	// skip: hostnameAndPort is readOnly
-	// skip: replicaSetName is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
-	// skip: metricName is readOnly
-	// skip: nonRunningHostIds is readOnly
-	// skip: parentClusterId is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_api_atlas_partition_field_view.go
+++ b/mongodbatlasv2/model_api_atlas_partition_field_view.go
@@ -94,14 +94,13 @@ func (o *ApiAtlasPartitionFieldView) SetOrder(v int32) {
 	o.Order = v
 }
 
-func (o ApiAtlasPartitionFieldView) MarshalJSON() ([]byte, error) {
+func (o ApiAtlasPartitionFieldView) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ApiAtlasPartitionFieldView) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["fieldName"] = o.FieldName

--- a/mongodbatlasv2/model_api_instance_size_view.go
+++ b/mongodbatlasv2/model_api_instance_size_view.go
@@ -106,18 +106,15 @@ func (o *ApiInstanceSizeView) SetName(v string) {
 	o.Name = &v
 }
 
-func (o ApiInstanceSizeView) MarshalJSON() ([]byte, error) {
+func (o ApiInstanceSizeView) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ApiInstanceSizeView) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: availableRegions is readOnly
-	// skip: name is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_api_user.go
+++ b/mongodbatlasv2/model_api_user.go
@@ -242,23 +242,18 @@ func (o *ApiUser) SetRoles(v []RoleAssignment) {
 	o.Roles = v
 }
 
-func (o ApiUser) MarshalJSON() ([]byte, error) {
+func (o ApiUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ApiUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Desc) {
 		toSerialize["desc"] = o.Desc
 	}
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: privateKey is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Roles) {
 		toSerialize["roles"] = o.Roles
 	}

--- a/mongodbatlasv2/model_api_user_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_api_user_event_view_for_nds_group.go
@@ -458,31 +458,19 @@ func (o *ApiUserEventViewForNdsGroup) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o ApiUserEventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o ApiUserEventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ApiUserEventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_api_user_event_view_for_org.go
+++ b/mongodbatlasv2/model_api_user_event_view_for_org.go
@@ -458,31 +458,19 @@ func (o *ApiUserEventViewForOrg) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o ApiUserEventViewForOrg) MarshalJSON() ([]byte, error) {
+func (o ApiUserEventViewForOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ApiUserEventViewForOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_app_service_alert.go
+++ b/mongodbatlasv2/model_app_service_alert.go
@@ -465,32 +465,20 @@ func (o *AppServiceAlert) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o AppServiceAlert) MarshalJSON() ([]byte, error) {
+func (o AppServiceAlert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AppServiceAlert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_app_service_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_app_service_alert_config_view_for_nds_group.go
@@ -341,31 +341,25 @@ func (o *AppServiceAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o AppServiceAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o AppServiceAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AppServiceAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_app_service_event.go
+++ b/mongodbatlasv2/model_app_service_event.go
@@ -254,22 +254,16 @@ func (o *AppServiceEvent) SetRaw(v Raw) {
 	o.Raw = &v
 }
 
-func (o AppServiceEvent) MarshalJSON() ([]byte, error) {
+func (o AppServiceEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AppServiceEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}

--- a/mongodbatlasv2/model_app_service_metric_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_app_service_metric_alert_config_view_for_nds_group.go
@@ -374,24 +374,19 @@ func (o *AppServiceMetricAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o AppServiceMetricAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o AppServiceMetricAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AppServiceMetricAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -401,7 +396,6 @@ func (o AppServiceMetricAlertConfigViewForNdsGroup) ToMap() (map[string]interfac
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_app_service_metric_matcher.go
+++ b/mongodbatlasv2/model_app_service_metric_matcher.go
@@ -139,14 +139,13 @@ func (o *AppServiceMetricMatcher) SetValue(v string) {
 	o.Value = &v
 }
 
-func (o AppServiceMetricMatcher) MarshalJSON() ([]byte, error) {
+func (o AppServiceMetricMatcher) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AppServiceMetricMatcher) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FieldName) {

--- a/mongodbatlasv2/model_app_user.go
+++ b/mongodbatlasv2/model_app_user.go
@@ -432,30 +432,24 @@ func (o *AppUser) SetUsername(v string) {
 	o.Username = v
 }
 
-func (o AppUser) MarshalJSON() ([]byte, error) {
+func (o AppUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AppUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["country"] = o.Country
-	// skip: createdAt is readOnly
 	toSerialize["emailAddress"] = o.EmailAddress
 	toSerialize["firstName"] = o.FirstName
-	// skip: id is readOnly
-	// skip: lastAuth is readOnly
 	toSerialize["lastName"] = o.LastName
-	// skip: links is readOnly
 	toSerialize["mobileNumber"] = o.MobileNumber
 	toSerialize["password"] = o.Password
 	if !IsNil(o.Roles) {
 		toSerialize["roles"] = o.Roles
 	}
-	// skip: teamIds is readOnly
 	toSerialize["username"] = o.Username
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_audit_log.go
+++ b/mongodbatlasv2/model_audit_log.go
@@ -157,19 +157,17 @@ func (o *AuditLog) SetEnabled(v bool) {
 	o.Enabled = v
 }
 
-func (o AuditLog) MarshalJSON() ([]byte, error) {
+func (o AuditLog) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AuditLog) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["auditAuthorizationSuccess"] = o.AuditAuthorizationSuccess
 	toSerialize["auditFilter"] = o.AuditFilter
-	// skip: configurationType is readOnly
 	toSerialize["enabled"] = o.Enabled
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_auto_export_policy.go
+++ b/mongodbatlasv2/model_auto_export_policy.go
@@ -106,14 +106,13 @@ func (o *AutoExportPolicy) SetFrequencyType(v string) {
 	o.FrequencyType = &v
 }
 
-func (o AutoExportPolicy) MarshalJSON() ([]byte, error) {
+func (o AutoExportPolicy) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AutoExportPolicy) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ExportBucketId) {

--- a/mongodbatlasv2/model_auto_scaling.go
+++ b/mongodbatlasv2/model_auto_scaling.go
@@ -105,14 +105,13 @@ func (o *AutoScaling) SetDiskGBEnabled(v bool) {
 	o.DiskGBEnabled = &v
 }
 
-func (o AutoScaling) MarshalJSON() ([]byte, error) {
+func (o AutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Compute) {

--- a/mongodbatlasv2/model_auto_scaling_v15.go
+++ b/mongodbatlasv2/model_auto_scaling_v15.go
@@ -104,14 +104,13 @@ func (o *AutoScalingV15) SetDiskGB(v DiskGBAutoScaling) {
 	o.DiskGB = &v
 }
 
-func (o AutoScalingV15) MarshalJSON() ([]byte, error) {
+func (o AutoScalingV15) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AutoScalingV15) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Compute) {

--- a/mongodbatlasv2/model_automation_config_event.go
+++ b/mongodbatlasv2/model_automation_config_event.go
@@ -458,31 +458,19 @@ func (o *AutomationConfigEvent) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o AutomationConfigEvent) MarshalJSON() ([]byte, error) {
+func (o AutomationConfigEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AutomationConfigEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_available_deployment.go
+++ b/mongodbatlasv2/model_available_deployment.go
@@ -370,27 +370,15 @@ func (o *AvailableDeployment) SetTlsEnabled(v bool) {
 	o.TlsEnabled = v
 }
 
-func (o AvailableDeployment) MarshalJSON() ([]byte, error) {
+func (o AvailableDeployment) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AvailableDeployment) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: agentVersion is readOnly
-	// skip: clusterId is readOnly
-	// skip: dbSizeBytes is readOnly
-	// skip: featureCompatibilityVersion is readOnly
-	// skip: managed is readOnly
-	// skip: mongoDBVersion is readOnly
-	// skip: name is readOnly
-	// skip: oplogSizeMB is readOnly
-	// skip: sharded is readOnly
-	// skip: shardsSize is readOnly
-	// skip: tlsEnabled is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_available_project.go
+++ b/mongodbatlasv2/model_available_project.go
@@ -160,14 +160,13 @@ func (o *AvailableProject) SetProjectId(v string) {
 	o.ProjectId = v
 }
 
-func (o AvailableProject) MarshalJSON() ([]byte, error) {
+func (o AvailableProject) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AvailableProject) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Deployments) {
@@ -176,8 +175,6 @@ func (o AvailableProject) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.MigrationHosts) {
 		toSerialize["migrationHosts"] = o.MigrationHosts
 	}
-	// skip: name is readOnly
-	// skip: projectId is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_available_region.go
+++ b/mongodbatlasv2/model_available_region.go
@@ -106,18 +106,15 @@ func (o *AvailableRegion) SetName(v string) {
 	o.Name = &v
 }
 
-func (o AvailableRegion) MarshalJSON() ([]byte, error) {
+func (o AvailableRegion) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AvailableRegion) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: default is readOnly
-	// skip: name is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_aws_auto_scaling.go
+++ b/mongodbatlasv2/model_aws_auto_scaling.go
@@ -71,14 +71,13 @@ func (o *AWSAutoScaling) SetCompute(v AWSComputeAutoScaling) {
 	o.Compute = &v
 }
 
-func (o AWSAutoScaling) MarshalJSON() ([]byte, error) {
+func (o AWSAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Compute) {

--- a/mongodbatlasv2/model_aws_cloud_provider_container.go
+++ b/mongodbatlasv2/model_aws_cloud_provider_container.go
@@ -235,26 +235,22 @@ func (o *AWSCloudProviderContainer) SetProvisioned(v bool) {
 	o.Provisioned = &v
 }
 
-func (o AWSCloudProviderContainer) MarshalJSON() ([]byte, error) {
+func (o AWSCloudProviderContainer) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSCloudProviderContainer) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AtlasCidrBlock) {
 		toSerialize["atlasCidrBlock"] = o.AtlasCidrBlock
 	}
 	toSerialize["regionName"] = o.RegionName
-	// skip: vpcId is readOnly
-	// skip: id is readOnly
 	if !IsNil(o.ProviderName) {
 		toSerialize["providerName"] = o.ProviderName
 	}
-	// skip: provisioned is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_aws_compute_auto_scaling.go
+++ b/mongodbatlasv2/model_aws_compute_auto_scaling.go
@@ -106,14 +106,13 @@ func (o *AWSComputeAutoScaling) SetMinInstanceSize(v string) {
 	o.MinInstanceSize = &v
 }
 
-func (o AWSComputeAutoScaling) MarshalJSON() ([]byte, error) {
+func (o AWSComputeAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSComputeAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MaxInstanceSize) {

--- a/mongodbatlasv2/model_aws_custom_dns_enabled.go
+++ b/mongodbatlasv2/model_aws_custom_dns_enabled.go
@@ -65,14 +65,13 @@ func (o *AWSCustomDNSEnabled) SetEnabled(v bool) {
 	o.Enabled = v
 }
 
-func (o AWSCustomDNSEnabled) MarshalJSON() ([]byte, error) {
+func (o AWSCustomDNSEnabled) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSCustomDNSEnabled) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["enabled"] = o.Enabled

--- a/mongodbatlasv2/model_aws_hardware_spec.go
+++ b/mongodbatlasv2/model_aws_hardware_spec.go
@@ -178,14 +178,13 @@ func (o *AWSHardwareSpec) SetNodeCount(v int32) {
 	o.NodeCount = &v
 }
 
-func (o AWSHardwareSpec) MarshalJSON() ([]byte, error) {
+func (o AWSHardwareSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSHardwareSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DiskIOPS) {

--- a/mongodbatlasv2/model_aws_interface_endpoint.go
+++ b/mongodbatlasv2/model_aws_interface_endpoint.go
@@ -174,20 +174,15 @@ func (o *AWSInterfaceEndpoint) SetInterfaceEndpointId(v string) {
 	o.InterfaceEndpointId = &v
 }
 
-func (o AWSInterfaceEndpoint) MarshalJSON() ([]byte, error) {
+func (o AWSInterfaceEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSInterfaceEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: connectionStatus is readOnly
-	// skip: deleteRequested is readOnly
-	// skip: errorMessage is readOnly
-	// skip: interfaceEndpointId is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_aws_peer_vpc.go
+++ b/mongodbatlasv2/model_aws_peer_vpc.go
@@ -309,24 +309,19 @@ func (o *AWSPeerVpc) SetVpcId(v string) {
 	o.VpcId = v
 }
 
-func (o AWSPeerVpc) MarshalJSON() ([]byte, error) {
+func (o AWSPeerVpc) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSPeerVpc) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["accepterRegionName"] = o.AccepterRegionName
 	toSerialize["awsAccountId"] = o.AwsAccountId
-	// skip: connectionId is readOnly
 	toSerialize["containerId"] = o.ContainerId
-	// skip: errorStateName is readOnly
-	// skip: id is readOnly
 	toSerialize["routeTableCidrBlock"] = o.RouteTableCidrBlock
-	// skip: statusName is readOnly
 	toSerialize["vpcId"] = o.VpcId
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_aws_peer_vpc_request.go
+++ b/mongodbatlasv2/model_aws_peer_vpc_request.go
@@ -336,25 +336,20 @@ func (o *AWSPeerVpcRequest) SetVpcId(v string) {
 	o.VpcId = v
 }
 
-func (o AWSPeerVpcRequest) MarshalJSON() ([]byte, error) {
+func (o AWSPeerVpcRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSPeerVpcRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["containerId"] = o.ContainerId
 	toSerialize["providerName"] = o.ProviderName
 	toSerialize["accepterRegionName"] = o.AccepterRegionName
 	toSerialize["awsAccountId"] = o.AwsAccountId
-	// skip: connectionId is readOnly
-	// skip: errorStateName is readOnly
-	// skip: id is readOnly
 	toSerialize["routeTableCidrBlock"] = o.RouteTableCidrBlock
-	// skip: statusName is readOnly
 	toSerialize["vpcId"] = o.VpcId
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_aws_private_link_connection.go
+++ b/mongodbatlasv2/model_aws_private_link_connection.go
@@ -242,22 +242,15 @@ func (o *AWSPrivateLinkConnection) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o AWSPrivateLinkConnection) MarshalJSON() ([]byte, error) {
+func (o AWSPrivateLinkConnection) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSPrivateLinkConnection) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: endpointServiceName is readOnly
-	// skip: errorMessage is readOnly
-	// skip: id is readOnly
-	// skip: interfaceEndpoints is readOnly
-	// skip: regionName is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_aws_provider_settings.go
+++ b/mongodbatlasv2/model_aws_provider_settings.go
@@ -275,14 +275,13 @@ func (o *AWSProviderSettings) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o AWSProviderSettings) MarshalJSON() ([]byte, error) {
+func (o AWSProviderSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSProviderSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AutoScaling) {

--- a/mongodbatlasv2/model_aws_region_config.go
+++ b/mongodbatlasv2/model_aws_region_config.go
@@ -305,14 +305,13 @@ func (o *AWSRegionConfig) SetRegionName(v string) {
 	o.RegionName = &v
 }
 
-func (o AWSRegionConfig) MarshalJSON() ([]byte, error) {
+func (o AWSRegionConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSRegionConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AnalyticsAutoScaling) {

--- a/mongodbatlasv2/model_awskms.go
+++ b/mongodbatlasv2/model_awskms.go
@@ -276,14 +276,13 @@ func (o *AWSKMS) SetValid(v bool) {
 	o.Valid = &v
 }
 
-func (o AWSKMS) MarshalJSON() ([]byte, error) {
+func (o AWSKMS) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AWSKMS) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AccessKeyID) {
@@ -304,7 +303,6 @@ func (o AWSKMS) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SecretAccessKey) {
 		toSerialize["secretAccessKey"] = o.SecretAccessKey
 	}
-	// skip: valid is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_azure_auto_scaling.go
+++ b/mongodbatlasv2/model_azure_auto_scaling.go
@@ -71,14 +71,13 @@ func (o *AzureAutoScaling) SetCompute(v AzureComputeAutoScaling) {
 	o.Compute = &v
 }
 
-func (o AzureAutoScaling) MarshalJSON() ([]byte, error) {
+func (o AzureAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzureAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Compute) {

--- a/mongodbatlasv2/model_azure_cloud_provider_container.go
+++ b/mongodbatlasv2/model_azure_cloud_provider_container.go
@@ -262,25 +262,20 @@ func (o *AzureCloudProviderContainer) SetProvisioned(v bool) {
 	o.Provisioned = &v
 }
 
-func (o AzureCloudProviderContainer) MarshalJSON() ([]byte, error) {
+func (o AzureCloudProviderContainer) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzureCloudProviderContainer) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["atlasCidrBlock"] = o.AtlasCidrBlock
-	// skip: azureSubscriptionId is readOnly
 	toSerialize["region"] = o.Region
-	// skip: vnetName is readOnly
-	// skip: id is readOnly
 	if !IsNil(o.ProviderName) {
 		toSerialize["providerName"] = o.ProviderName
 	}
-	// skip: provisioned is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_azure_compute_auto_scaling.go
+++ b/mongodbatlasv2/model_azure_compute_auto_scaling.go
@@ -106,14 +106,13 @@ func (o *AzureComputeAutoScaling) SetMinInstanceSize(v string) {
 	o.MinInstanceSize = &v
 }
 
-func (o AzureComputeAutoScaling) MarshalJSON() ([]byte, error) {
+func (o AzureComputeAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzureComputeAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MaxInstanceSize) {

--- a/mongodbatlasv2/model_azure_hardware_spec.go
+++ b/mongodbatlasv2/model_azure_hardware_spec.go
@@ -106,14 +106,13 @@ func (o *AzureHardwareSpec) SetNodeCount(v int32) {
 	o.NodeCount = &v
 }
 
-func (o AzureHardwareSpec) MarshalJSON() ([]byte, error) {
+func (o AzureHardwareSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzureHardwareSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.InstanceSize) {

--- a/mongodbatlasv2/model_azure_key_vault.go
+++ b/mongodbatlasv2/model_azure_key_vault.go
@@ -378,14 +378,13 @@ func (o *AzureKeyVault) SetValid(v bool) {
 	o.Valid = &v
 }
 
-func (o AzureKeyVault) MarshalJSON() ([]byte, error) {
+func (o AzureKeyVault) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzureKeyVault) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AzureEnvironment) {
@@ -415,7 +414,6 @@ func (o AzureKeyVault) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.TenantID) {
 		toSerialize["tenantID"] = o.TenantID
 	}
-	// skip: valid is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_azure_peer_network.go
+++ b/mongodbatlasv2/model_azure_peer_network.go
@@ -275,23 +275,19 @@ func (o *AzurePeerNetwork) SetVnetName(v string) {
 	o.VnetName = v
 }
 
-func (o AzurePeerNetwork) MarshalJSON() ([]byte, error) {
+func (o AzurePeerNetwork) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzurePeerNetwork) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["azureDirectoryId"] = o.AzureDirectoryId
 	toSerialize["azureSubscriptionId"] = o.AzureSubscriptionId
 	toSerialize["containerId"] = o.ContainerId
-	// skip: errorState is readOnly
-	// skip: id is readOnly
 	toSerialize["resourceGroupName"] = o.ResourceGroupName
-	// skip: status is readOnly
 	toSerialize["vnetName"] = o.VnetName
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_azure_peer_network_request.go
+++ b/mongodbatlasv2/model_azure_peer_network_request.go
@@ -302,24 +302,20 @@ func (o *AzurePeerNetworkRequest) SetVnetName(v string) {
 	o.VnetName = v
 }
 
-func (o AzurePeerNetworkRequest) MarshalJSON() ([]byte, error) {
+func (o AzurePeerNetworkRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzurePeerNetworkRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["containerId"] = o.ContainerId
 	toSerialize["providerName"] = o.ProviderName
 	toSerialize["azureDirectoryId"] = o.AzureDirectoryId
 	toSerialize["azureSubscriptionId"] = o.AzureSubscriptionId
-	// skip: errorState is readOnly
-	// skip: id is readOnly
 	toSerialize["resourceGroupName"] = o.ResourceGroupName
-	// skip: status is readOnly
 	toSerialize["vnetName"] = o.VnetName
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_azure_private_endpoint.go
+++ b/mongodbatlasv2/model_azure_private_endpoint.go
@@ -242,24 +242,18 @@ func (o *AzurePrivateEndpoint) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o AzurePrivateEndpoint) MarshalJSON() ([]byte, error) {
+func (o AzurePrivateEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzurePrivateEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: deleteRequested is readOnly
-	// skip: errorMessage is readOnly
-	// skip: privateEndpointConnectionName is readOnly
 	if !IsNil(o.PrivateEndpointIPAddress) {
 		toSerialize["privateEndpointIPAddress"] = o.PrivateEndpointIPAddress
 	}
-	// skip: privateEndpointResourceId is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_azure_private_link_connection.go
+++ b/mongodbatlasv2/model_azure_private_link_connection.go
@@ -276,23 +276,15 @@ func (o *AzurePrivateLinkConnection) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o AzurePrivateLinkConnection) MarshalJSON() ([]byte, error) {
+func (o AzurePrivateLinkConnection) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzurePrivateLinkConnection) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: errorMessage is readOnly
-	// skip: id is readOnly
-	// skip: privateEndpoints is readOnly
-	// skip: privateLinkServiceName is readOnly
-	// skip: privateLinkServiceResourceId is readOnly
-	// skip: regionName is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_azure_provider_settings.go
+++ b/mongodbatlasv2/model_azure_provider_settings.go
@@ -199,14 +199,13 @@ func (o *AzureProviderSettings) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o AzureProviderSettings) MarshalJSON() ([]byte, error) {
+func (o AzureProviderSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzureProviderSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AutoScaling) {

--- a/mongodbatlasv2/model_azure_region_config.go
+++ b/mongodbatlasv2/model_azure_region_config.go
@@ -305,14 +305,13 @@ func (o *AzureRegionConfig) SetRegionName(v string) {
 	o.RegionName = &v
 }
 
-func (o AzureRegionConfig) MarshalJSON() ([]byte, error) {
+func (o AzureRegionConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o AzureRegionConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AnalyticsAutoScaling) {

--- a/mongodbatlasv2/model_bi_connector.go
+++ b/mongodbatlasv2/model_bi_connector.go
@@ -106,14 +106,13 @@ func (o *BiConnector) SetReadPreference(v string) {
 	o.ReadPreference = &v
 }
 
-func (o BiConnector) MarshalJSON() ([]byte, error) {
+func (o BiConnector) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o BiConnector) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Enabled) {

--- a/mongodbatlasv2/model_billing_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_billing_event_view_for_nds_group.go
@@ -526,33 +526,19 @@ func (o *BillingEventViewForNdsGroup) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o BillingEventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o BillingEventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o BillingEventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: invoiceId is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: paymentId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_billing_event_view_for_org.go
+++ b/mongodbatlasv2/model_billing_event_view_for_org.go
@@ -526,33 +526,19 @@ func (o *BillingEventViewForOrg) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o BillingEventViewForOrg) MarshalJSON() ([]byte, error) {
+func (o BillingEventViewForOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o BillingEventViewForOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: invoiceId is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: paymentId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_billing_threshold_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_billing_threshold_alert_config_view_for_nds_group.go
@@ -373,24 +373,19 @@ func (o *BillingThresholdAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o BillingThresholdAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o BillingThresholdAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o BillingThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -400,7 +395,6 @@ func (o BillingThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]interfac
 	if !IsNil(o.Threshold) {
 		toSerialize["threshold"] = o.Threshold
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_bson_timestamp.go
+++ b/mongodbatlasv2/model_bson_timestamp.go
@@ -107,18 +107,15 @@ func (o *BSONTimestamp) SetIncrement(v int32) {
 	o.Increment = &v
 }
 
-func (o BSONTimestamp) MarshalJSON() ([]byte, error) {
+func (o BSONTimestamp) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o BSONTimestamp) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: date is readOnly
-	// skip: increment is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_char_filterhtml_strip.go
+++ b/mongodbatlasv2/model_char_filterhtml_strip.go
@@ -99,14 +99,13 @@ func (o *CharFilterhtmlStrip) SetType(v string) {
 	o.Type = v
 }
 
-func (o CharFilterhtmlStrip) MarshalJSON() ([]byte, error) {
+func (o CharFilterhtmlStrip) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CharFilterhtmlStrip) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.IgnoredTags) {

--- a/mongodbatlasv2/model_char_filtericu_normalize.go
+++ b/mongodbatlasv2/model_char_filtericu_normalize.go
@@ -65,14 +65,13 @@ func (o *CharFiltericuNormalize) SetType(v string) {
 	o.Type = v
 }
 
-func (o CharFiltericuNormalize) MarshalJSON() ([]byte, error) {
+func (o CharFiltericuNormalize) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CharFiltericuNormalize) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_char_filtermapping.go
+++ b/mongodbatlasv2/model_char_filtermapping.go
@@ -91,14 +91,13 @@ func (o *CharFiltermapping) SetType(v string) {
 	o.Type = v
 }
 
-func (o CharFiltermapping) MarshalJSON() ([]byte, error) {
+func (o CharFiltermapping) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CharFiltermapping) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["mappings"] = o.Mappings

--- a/mongodbatlasv2/model_char_filtermapping_mappings.go
+++ b/mongodbatlasv2/model_char_filtermapping_mappings.go
@@ -71,14 +71,13 @@ func (o *CharFiltermappingMappings) SetAdditionalPropertiesField(v string) {
 	o.AdditionalPropertiesField = &v
 }
 
-func (o CharFiltermappingMappings) MarshalJSON() ([]byte, error) {
+func (o CharFiltermappingMappings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CharFiltermappingMappings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AdditionalPropertiesField) {

--- a/mongodbatlasv2/model_char_filterpersian.go
+++ b/mongodbatlasv2/model_char_filterpersian.go
@@ -65,14 +65,13 @@ func (o *CharFilterpersian) SetType(v string) {
 	o.Type = v
 }
 
-func (o CharFilterpersian) MarshalJSON() ([]byte, error) {
+func (o CharFilterpersian) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CharFilterpersian) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_checkpoint.go
+++ b/mongodbatlasv2/model_checkpoint.go
@@ -345,25 +345,15 @@ func (o *Checkpoint) SetTimestamp(v time.Time) {
 	o.Timestamp = &v
 }
 
-func (o Checkpoint) MarshalJSON() ([]byte, error) {
+func (o Checkpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Checkpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusterId is readOnly
-	// skip: completed is readOnly
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: parts is readOnly
-	// skip: restorable is readOnly
-	// skip: started is readOnly
-	// skip: timestamp is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_checkpoint_part.go
+++ b/mongodbatlasv2/model_checkpoint_part.go
@@ -207,23 +207,18 @@ func (o *CheckpointPart) SetTypeName(v string) {
 	o.TypeName = &v
 }
 
-func (o CheckpointPart) MarshalJSON() ([]byte, error) {
+func (o CheckpointPart) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CheckpointPart) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: replicaSetName is readOnly
-	// skip: shardName is readOnly
-	// skip: tokenDiscovered is readOnly
 	if !IsNil(o.TokenTimestamp) {
 		toSerialize["tokenTimestamp"] = o.TokenTimestamp
 	}
-	// skip: typeName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cloud_provider_access.go
+++ b/mongodbatlasv2/model_cloud_provider_access.go
@@ -72,14 +72,13 @@ func (o *CloudProviderAccess) SetAwsIamRoles(v []CloudProviderAccessAWSIAMRole) 
 	o.AwsIamRoles = v
 }
 
-func (o CloudProviderAccess) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccess) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccess) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AwsIamRoles) {

--- a/mongodbatlasv2/model_cloud_provider_access_awsiam_role.go
+++ b/mongodbatlasv2/model_cloud_provider_access_awsiam_role.go
@@ -304,25 +304,18 @@ func (o *CloudProviderAccessAWSIAMRole) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o CloudProviderAccessAWSIAMRole) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccessAWSIAMRole) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccessAWSIAMRole) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: atlasAWSAccountArn is readOnly
-	// skip: atlasAssumedRoleExternalId is readOnly
-	// skip: authorizedDate is readOnly
-	// skip: createdDate is readOnly
-	// skip: featureUsages is readOnly
 	if !IsNil(o.IamAssumedRoleArn) {
 		toSerialize["iamAssumedRoleArn"] = o.IamAssumedRoleArn
 	}
-	// skip: roleId is readOnly
 	toSerialize["providerName"] = o.ProviderName
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_cloud_provider_access_azure_service_principal.go
+++ b/mongodbatlasv2/model_cloud_provider_access_azure_service_principal.go
@@ -304,23 +304,18 @@ func (o *CloudProviderAccessAzureServicePrincipal) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o CloudProviderAccessAzureServicePrincipal) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccessAzureServicePrincipal) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccessAzureServicePrincipal) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
 	if !IsNil(o.AtlasAzureAppId) {
 		toSerialize["atlasAzureAppId"] = o.AtlasAzureAppId
 	}
-	// skip: createdDate is readOnly
-	// skip: featureUsages is readOnly
-	// skip: lastUpdatedDate is readOnly
 	if !IsNil(o.ServicePrincipalId) {
 		toSerialize["servicePrincipalId"] = o.ServicePrincipalId
 	}

--- a/mongodbatlasv2/model_cloud_provider_access_data_lake_feature_usage.go
+++ b/mongodbatlasv2/model_cloud_provider_access_data_lake_feature_usage.go
@@ -105,20 +105,18 @@ func (o *CloudProviderAccessDataLakeFeatureUsage) SetFeatureType(v string) {
 	o.FeatureType = &v
 }
 
-func (o CloudProviderAccessDataLakeFeatureUsage) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccessDataLakeFeatureUsage) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccessDataLakeFeatureUsage) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FeatureId) {
 		toSerialize["featureId"] = o.FeatureId
 	}
-	// skip: featureType is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cloud_provider_access_encryption_at_rest_feature_usage.go
+++ b/mongodbatlasv2/model_cloud_provider_access_encryption_at_rest_feature_usage.go
@@ -107,20 +107,18 @@ func (o *CloudProviderAccessEncryptionAtRestFeatureUsage) SetFeatureType(v strin
 	o.FeatureType = &v
 }
 
-func (o CloudProviderAccessEncryptionAtRestFeatureUsage) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccessEncryptionAtRestFeatureUsage) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccessEncryptionAtRestFeatureUsage) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if o.FeatureId != nil {
 		toSerialize["featureId"] = o.FeatureId
 	}
-	// skip: featureType is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cloud_provider_access_export_snapshot_feature_usage.go
+++ b/mongodbatlasv2/model_cloud_provider_access_export_snapshot_feature_usage.go
@@ -105,20 +105,18 @@ func (o *CloudProviderAccessExportSnapshotFeatureUsage) SetFeatureType(v string)
 	o.FeatureType = &v
 }
 
-func (o CloudProviderAccessExportSnapshotFeatureUsage) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccessExportSnapshotFeatureUsage) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccessExportSnapshotFeatureUsage) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FeatureId) {
 		toSerialize["featureId"] = o.FeatureId
 	}
-	// skip: featureType is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cloud_provider_access_feature_usage_data_lake_feature_id.go
+++ b/mongodbatlasv2/model_cloud_provider_access_feature_usage_data_lake_feature_id.go
@@ -106,17 +106,15 @@ func (o *CloudProviderAccessFeatureUsageDataLakeFeatureId) SetName(v string) {
 	o.Name = &v
 }
 
-func (o CloudProviderAccessFeatureUsageDataLakeFeatureId) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccessFeatureUsageDataLakeFeatureId) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccessFeatureUsageDataLakeFeatureId) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: groupId is readOnly
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}

--- a/mongodbatlasv2/model_cloud_provider_access_feature_usage_export_snapshot_feature_id.go
+++ b/mongodbatlasv2/model_cloud_provider_access_feature_usage_export_snapshot_feature_id.go
@@ -106,18 +106,15 @@ func (o *CloudProviderAccessFeatureUsageExportSnapshotFeatureId) SetGroupId(v st
 	o.GroupId = &v
 }
 
-func (o CloudProviderAccessFeatureUsageExportSnapshotFeatureId) MarshalJSON() ([]byte, error) {
+func (o CloudProviderAccessFeatureUsageExportSnapshotFeatureId) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CloudProviderAccessFeatureUsageExportSnapshotFeatureId) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: exportBucketId is readOnly
-	// skip: groupId is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster.go
+++ b/mongodbatlasv2/model_cluster.go
@@ -412,27 +412,15 @@ func (o *Cluster) SetVersions(v []string) {
 	o.Versions = v
 }
 
-func (o Cluster) MarshalJSON() ([]byte, error) {
+func (o Cluster) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Cluster) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: alertCount is readOnly
-	// skip: authEnabled is readOnly
-	// skip: availability is readOnly
-	// skip: backupEnabled is readOnly
-	// skip: clusterId is readOnly
-	// skip: dataSizeBytes is readOnly
-	// skip: name is readOnly
-	// skip: nodeCount is readOnly
-	// skip: sslEnabled is readOnly
-	// skip: type is readOnly
-	// skip: versions is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_alert.go
+++ b/mongodbatlasv2/model_cluster_alert.go
@@ -499,33 +499,20 @@ func (o *ClusterAlert) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o ClusterAlert) MarshalJSON() ([]byte, error) {
+func (o ClusterAlert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterAlert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_cluster_alert_config_view_for_nds_group.go
@@ -341,31 +341,25 @@ func (o *ClusterAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o ClusterAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o ClusterAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_description_connection_strings.go
+++ b/mongodbatlasv2/model_cluster_description_connection_strings.go
@@ -276,23 +276,15 @@ func (o *ClusterDescriptionConnectionStrings) SetStandardSrv(v string) {
 	o.StandardSrv = &v
 }
 
-func (o ClusterDescriptionConnectionStrings) MarshalJSON() ([]byte, error) {
+func (o ClusterDescriptionConnectionStrings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterDescriptionConnectionStrings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: awsPrivateLink is readOnly
-	// skip: awsPrivateLinkSrv is readOnly
-	// skip: private is readOnly
-	// skip: privateEndpoint is readOnly
-	// skip: privateSrv is readOnly
-	// skip: standard is readOnly
-	// skip: standardSrv is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_description_connection_strings_private_endpoint.go
+++ b/mongodbatlasv2/model_cluster_description_connection_strings_private_endpoint.go
@@ -208,21 +208,15 @@ func (o *ClusterDescriptionConnectionStringsPrivateEndpoint) SetType(v string) {
 	o.Type = &v
 }
 
-func (o ClusterDescriptionConnectionStringsPrivateEndpoint) MarshalJSON() ([]byte, error) {
+func (o ClusterDescriptionConnectionStringsPrivateEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterDescriptionConnectionStringsPrivateEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: connectionString is readOnly
-	// skip: endpoints is readOnly
-	// skip: srvConnectionString is readOnly
-	// skip: srvShardOptimizedConnectionString is readOnly
-	// skip: type is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_description_connection_strings_private_endpoint_endpoint.go
+++ b/mongodbatlasv2/model_cluster_description_connection_strings_private_endpoint_endpoint.go
@@ -140,19 +140,15 @@ func (o *ClusterDescriptionConnectionStringsPrivateEndpointEndpoint) SetRegion(v
 	o.Region = &v
 }
 
-func (o ClusterDescriptionConnectionStringsPrivateEndpointEndpoint) MarshalJSON() ([]byte, error) {
+func (o ClusterDescriptionConnectionStringsPrivateEndpointEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterDescriptionConnectionStringsPrivateEndpointEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: endpointId is readOnly
-	// skip: providerName is readOnly
-	// skip: region is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_description_process_args.go
+++ b/mongodbatlasv2/model_cluster_description_process_args.go
@@ -426,14 +426,13 @@ func (o *ClusterDescriptionProcessArgs) SetSampleSizeBIConnector(v int32) {
 	o.SampleSizeBIConnector = &v
 }
 
-func (o ClusterDescriptionProcessArgs) MarshalJSON() ([]byte, error) {
+func (o ClusterDescriptionProcessArgs) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterDescriptionProcessArgs) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DefaultReadConcern) {

--- a/mongodbatlasv2/model_cluster_description_v15.go
+++ b/mongodbatlasv2/model_cluster_description_v15.go
@@ -771,14 +771,13 @@ func (o *ClusterDescriptionV15) SetVersionReleaseSystem(v string) {
 	o.VersionReleaseSystem = &v
 }
 
-func (o ClusterDescriptionV15) MarshalJSON() ([]byte, error) {
+func (o ClusterDescriptionV15) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterDescriptionV15) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.BackupEnabled) {
@@ -793,23 +792,18 @@ func (o ClusterDescriptionV15) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ConnectionStrings) {
 		toSerialize["connectionStrings"] = o.ConnectionStrings
 	}
-	// skip: createDate is readOnly
 	if !IsNil(o.DiskSizeGB) {
 		toSerialize["diskSizeGB"] = o.DiskSizeGB
 	}
 	if !IsNil(o.EncryptionAtRestProvider) {
 		toSerialize["encryptionAtRestProvider"] = o.EncryptionAtRestProvider
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
 	if !IsNil(o.Labels) {
 		toSerialize["labels"] = o.Labels
 	}
-	// skip: links is readOnly
 	if !IsNil(o.MongoDBMajorVersion) {
 		toSerialize["mongoDBMajorVersion"] = o.MongoDBMajorVersion
 	}
-	// skip: mongoDBVersion is readOnly
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
@@ -825,7 +819,6 @@ func (o ClusterDescriptionV15) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.RootCertType) {
 		toSerialize["rootCertType"] = o.RootCertType
 	}
-	// skip: stateName is readOnly
 	if !IsNil(o.TerminationProtectionEnabled) {
 		toSerialize["terminationProtectionEnabled"] = o.TerminationProtectionEnabled
 	}

--- a/mongodbatlasv2/model_cluster_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_cluster_event_view_for_nds_group.go
@@ -288,26 +288,19 @@ func (o *ClusterEventViewForNdsGroup) SetShardName(v string) {
 	o.ShardName = &v
 }
 
-func (o ClusterEventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o ClusterEventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterEventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: shardName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_matcher.go
+++ b/mongodbatlasv2/model_cluster_matcher.go
@@ -139,14 +139,13 @@ func (o *ClusterMatcher) SetValue(v string) {
 	o.Value = &v
 }
 
-func (o ClusterMatcher) MarshalJSON() ([]byte, error) {
+func (o ClusterMatcher) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterMatcher) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FieldName) {

--- a/mongodbatlasv2/model_cluster_outage_simulation.go
+++ b/mongodbatlasv2/model_cluster_outage_simulation.go
@@ -243,24 +243,18 @@ func (o *ClusterOutageSimulation) SetState(v string) {
 	o.State = &v
 }
 
-func (o ClusterOutageSimulation) MarshalJSON() ([]byte, error) {
+func (o ClusterOutageSimulation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterOutageSimulation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusterName is readOnly
-	// skip: groupId is readOnly
-	// skip: id is readOnly
 	if !IsNil(o.OutageFilters) {
 		toSerialize["outageFilters"] = o.OutageFilters
 	}
-	// skip: startRequestDate is readOnly
-	// skip: state is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cluster_outage_simulation_outage_filter.go
+++ b/mongodbatlasv2/model_cluster_outage_simulation_outage_filter.go
@@ -140,14 +140,13 @@ func (o *ClusterOutageSimulationOutageFilter) SetType(v string) {
 	o.Type = &v
 }
 
-func (o ClusterOutageSimulationOutageFilter) MarshalJSON() ([]byte, error) {
+func (o ClusterOutageSimulationOutageFilter) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterOutageSimulationOutageFilter) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CloudProvider) {

--- a/mongodbatlasv2/model_cluster_status.go
+++ b/mongodbatlasv2/model_cluster_status.go
@@ -106,20 +106,18 @@ func (o *ClusterStatus) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o ClusterStatus) MarshalJSON() ([]byte, error) {
+func (o ClusterStatus) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ClusterStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ChangeStatus) {
 		toSerialize["changeStatus"] = o.ChangeStatus
 	}
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_collation.go
+++ b/mongodbatlasv2/model_collation.go
@@ -365,14 +365,13 @@ func (o *Collation) SetStrength(v int32) {
 	o.Strength = &v
 }
 
-func (o Collation) MarshalJSON() ([]byte, error) {
+func (o Collation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Collation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Alternate) {

--- a/mongodbatlasv2/model_compute_auto_scaling.go
+++ b/mongodbatlasv2/model_compute_auto_scaling.go
@@ -106,14 +106,13 @@ func (o *ComputeAutoScaling) SetScaleDownEnabled(v bool) {
 	o.ScaleDownEnabled = &v
 }
 
-func (o ComputeAutoScaling) MarshalJSON() ([]byte, error) {
+func (o ComputeAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ComputeAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Enabled) {

--- a/mongodbatlasv2/model_compute_auto_scaling_v15.go
+++ b/mongodbatlasv2/model_compute_auto_scaling_v15.go
@@ -172,14 +172,13 @@ func (o *ComputeAutoScalingV15) SetScaleDownEnabled(v bool) {
 	o.ScaleDownEnabled = &v
 }
 
-func (o ComputeAutoScalingV15) MarshalJSON() ([]byte, error) {
+func (o ComputeAutoScalingV15) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ComputeAutoScalingV15) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Enabled) {

--- a/mongodbatlasv2/model_connected_org_config.go
+++ b/mongodbatlasv2/model_connected_org_config.go
@@ -255,14 +255,13 @@ func (o *ConnectedOrgConfig) SetUserConflicts(v []FederatedUser) {
 	o.UserConflicts = v
 }
 
-func (o ConnectedOrgConfig) MarshalJSON() ([]byte, error) {
+func (o ConnectedOrgConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ConnectedOrgConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DomainAllowList) {
@@ -270,7 +269,6 @@ func (o ConnectedOrgConfig) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["domainRestrictionEnabled"] = o.DomainRestrictionEnabled
 	toSerialize["identityProviderId"] = o.IdentityProviderId
-	// skip: orgId is readOnly
 	if !IsNil(o.PostAuthRoleGrants) {
 		toSerialize["postAuthRoleGrants"] = o.PostAuthRoleGrants
 	}

--- a/mongodbatlasv2/model_container_peer.go
+++ b/mongodbatlasv2/model_container_peer.go
@@ -99,18 +99,16 @@ func (o *ContainerPeer) SetId(v string) {
 	o.Id = &v
 }
 
-func (o ContainerPeer) MarshalJSON() ([]byte, error) {
+func (o ContainerPeer) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ContainerPeer) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["containerId"] = o.ContainerId
-	// skip: id is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_cps_backup_threshold_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_cps_backup_threshold_alert_config_view_for_nds_group.go
@@ -373,24 +373,19 @@ func (o *CpsBackupThresholdAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o CpsBackupThresholdAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o CpsBackupThresholdAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CpsBackupThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -400,7 +395,6 @@ func (o CpsBackupThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]interf
 	if !IsNil(o.Threshold) {
 		toSerialize["threshold"] = o.Threshold
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_create_api_key.go
+++ b/mongodbatlasv2/model_create_api_key.go
@@ -106,14 +106,13 @@ func (o *CreateApiKey) SetRoles(v []string) {
 	o.Roles = v
 }
 
-func (o CreateApiKey) MarshalJSON() ([]byte, error) {
+func (o CreateApiKey) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateApiKey) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Desc) {

--- a/mongodbatlasv2/model_create_aws_endpoint_request.go
+++ b/mongodbatlasv2/model_create_aws_endpoint_request.go
@@ -72,14 +72,13 @@ func (o *CreateAWSEndpointRequest) SetId(v string) {
 	o.Id = &v
 }
 
-func (o CreateAWSEndpointRequest) MarshalJSON() ([]byte, error) {
+func (o CreateAWSEndpointRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateAWSEndpointRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {

--- a/mongodbatlasv2/model_create_aws_endpoint_request_all_of.go
+++ b/mongodbatlasv2/model_create_aws_endpoint_request_all_of.go
@@ -72,14 +72,13 @@ func (o *CreateAWSEndpointRequestAllOf) SetId(v string) {
 	o.Id = &v
 }
 
-func (o CreateAWSEndpointRequestAllOf) MarshalJSON() ([]byte, error) {
+func (o CreateAWSEndpointRequestAllOf) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateAWSEndpointRequestAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {

--- a/mongodbatlasv2/model_create_azure_endpoint_request.go
+++ b/mongodbatlasv2/model_create_azure_endpoint_request.go
@@ -106,14 +106,13 @@ func (o *CreateAzureEndpointRequest) SetPrivateEndpointIPAddress(v string) {
 	o.PrivateEndpointIPAddress = &v
 }
 
-func (o CreateAzureEndpointRequest) MarshalJSON() ([]byte, error) {
+func (o CreateAzureEndpointRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateAzureEndpointRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {

--- a/mongodbatlasv2/model_create_azure_endpoint_request_all_of.go
+++ b/mongodbatlasv2/model_create_azure_endpoint_request_all_of.go
@@ -106,14 +106,13 @@ func (o *CreateAzureEndpointRequestAllOf) SetPrivateEndpointIPAddress(v string) 
 	o.PrivateEndpointIPAddress = &v
 }
 
-func (o CreateAzureEndpointRequestAllOf) MarshalJSON() ([]byte, error) {
+func (o CreateAzureEndpointRequestAllOf) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateAzureEndpointRequestAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {

--- a/mongodbatlasv2/model_create_endpoint_service_request.go
+++ b/mongodbatlasv2/model_create_endpoint_service_request.go
@@ -92,14 +92,13 @@ func (o *CreateEndpointServiceRequest) SetRegion(v string) {
 	o.Region = v
 }
 
-func (o CreateEndpointServiceRequest) MarshalJSON() ([]byte, error) {
+func (o CreateEndpointServiceRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateEndpointServiceRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["providerName"] = o.ProviderName

--- a/mongodbatlasv2/model_create_gcp_endpoint_group_request.go
+++ b/mongodbatlasv2/model_create_gcp_endpoint_group_request.go
@@ -140,14 +140,13 @@ func (o *CreateGCPEndpointGroupRequest) SetGcpProjectId(v string) {
 	o.GcpProjectId = &v
 }
 
-func (o CreateGCPEndpointGroupRequest) MarshalJSON() ([]byte, error) {
+func (o CreateGCPEndpointGroupRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateGCPEndpointGroupRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.EndpointGroupName) {

--- a/mongodbatlasv2/model_create_gcp_endpoint_group_request_all_of.go
+++ b/mongodbatlasv2/model_create_gcp_endpoint_group_request_all_of.go
@@ -140,14 +140,13 @@ func (o *CreateGCPEndpointGroupRequestAllOf) SetGcpProjectId(v string) {
 	o.GcpProjectId = &v
 }
 
-func (o CreateGCPEndpointGroupRequestAllOf) MarshalJSON() ([]byte, error) {
+func (o CreateGCPEndpointGroupRequestAllOf) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateGCPEndpointGroupRequestAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.EndpointGroupName) {

--- a/mongodbatlasv2/model_create_gcp_forwarding_rule_request.go
+++ b/mongodbatlasv2/model_create_gcp_forwarding_rule_request.go
@@ -106,14 +106,13 @@ func (o *CreateGCPForwardingRuleRequest) SetIpAddress(v string) {
 	o.IpAddress = &v
 }
 
-func (o CreateGCPForwardingRuleRequest) MarshalJSON() ([]byte, error) {
+func (o CreateGCPForwardingRuleRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateGCPForwardingRuleRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.EndpointName) {

--- a/mongodbatlasv2/model_create_organization_request.go
+++ b/mongodbatlasv2/model_create_organization_request.go
@@ -132,14 +132,13 @@ func (o *CreateOrganizationRequest) SetOrgOwnerId(v string) {
 	o.OrgOwnerId = &v
 }
 
-func (o CreateOrganizationRequest) MarshalJSON() ([]byte, error) {
+func (o CreateOrganizationRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateOrganizationRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ApiKey) {

--- a/mongodbatlasv2/model_create_organization_response.go
+++ b/mongodbatlasv2/model_create_organization_response.go
@@ -138,20 +138,18 @@ func (o *CreateOrganizationResponse) SetOrganization(v Organization) {
 	o.Organization = &v
 }
 
-func (o CreateOrganizationResponse) MarshalJSON() ([]byte, error) {
+func (o CreateOrganizationResponse) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CreateOrganizationResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ApiKey) {
 		toSerialize["apiKey"] = o.ApiKey
 	}
-	// skip: orgOwnerId is readOnly
 	if !IsNil(o.Organization) {
 		toSerialize["organization"] = o.Organization
 	}

--- a/mongodbatlasv2/model_custom_criteria.go
+++ b/mongodbatlasv2/model_custom_criteria.go
@@ -99,14 +99,13 @@ func (o *CustomCriteria) SetType(v string) {
 	o.Type = &v
 }
 
-func (o CustomCriteria) MarshalJSON() ([]byte, error) {
+func (o CustomCriteria) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CustomCriteria) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["query"] = o.Query

--- a/mongodbatlasv2/model_custom_db_role.go
+++ b/mongodbatlasv2/model_custom_db_role.go
@@ -133,14 +133,13 @@ func (o *CustomDBRole) SetRoleName(v string) {
 	o.RoleName = v
 }
 
-func (o CustomDBRole) MarshalJSON() ([]byte, error) {
+func (o CustomDBRole) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CustomDBRole) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Actions) {

--- a/mongodbatlasv2/model_custom_zone_mappings.go
+++ b/mongodbatlasv2/model_custom_zone_mappings.go
@@ -72,14 +72,13 @@ func (o *CustomZoneMappings) SetCustomZoneMappings(v []ZoneMapping) {
 	o.CustomZoneMappings = v
 }
 
-func (o CustomZoneMappings) MarshalJSON() ([]byte, error) {
+func (o CustomZoneMappings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CustomZoneMappings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CustomZoneMappings) {

--- a/mongodbatlasv2/model_customer_x509.go
+++ b/mongodbatlasv2/model_customer_x509.go
@@ -106,20 +106,18 @@ func (o *CustomerX509) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o CustomerX509) MarshalJSON() ([]byte, error) {
+func (o CustomerX509) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o CustomerX509) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Cas) {
 		toSerialize["cas"] = o.Cas
 	}
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_daily_schedule.go
+++ b/mongodbatlasv2/model_daily_schedule.go
@@ -200,14 +200,13 @@ func (o *DailySchedule) SetType(v string) {
 	o.Type = v
 }
 
-func (o DailySchedule) MarshalJSON() ([]byte, error) {
+func (o DailySchedule) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DailySchedule) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.EndHour) {

--- a/mongodbatlasv2/model_data_explorer_accessed_event.go
+++ b/mongodbatlasv2/model_data_explorer_accessed_event.go
@@ -560,34 +560,19 @@ func (o *DataExplorerAccessedEvent) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o DataExplorerAccessedEvent) MarshalJSON() ([]byte, error) {
+func (o DataExplorerAccessedEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataExplorerAccessedEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: collection is readOnly
-	// skip: created is readOnly
-	// skip: database is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: opType is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_data_federation_query_limit.go
+++ b/mongodbatlasv2/model_data_federation_query_limit.go
@@ -263,21 +263,15 @@ func (o *DataFederationQueryLimit) SetValue(v int64) {
 	o.Value = v
 }
 
-func (o DataFederationQueryLimit) MarshalJSON() ([]byte, error) {
+func (o DataFederationQueryLimit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataFederationQueryLimit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: currentUsage is readOnly
-	// skip: defaultLimit is readOnly
-	// skip: lastModifiedDate is readOnly
-	// skip: maximumLimit is readOnly
-	// skip: name is readOnly
 	if !IsNil(o.OverrunPolicy) {
 		toSerialize["overrunPolicy"] = o.OverrunPolicy
 	}

--- a/mongodbatlasv2/model_data_federation_tenant_query_limit.go
+++ b/mongodbatlasv2/model_data_federation_tenant_query_limit.go
@@ -297,25 +297,18 @@ func (o *DataFederationTenantQueryLimit) SetValue(v int64) {
 	o.Value = v
 }
 
-func (o DataFederationTenantQueryLimit) MarshalJSON() ([]byte, error) {
+func (o DataFederationTenantQueryLimit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataFederationTenantQueryLimit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: currentUsage is readOnly
-	// skip: defaultLimit is readOnly
-	// skip: lastModifiedDate is readOnly
-	// skip: maximumLimit is readOnly
-	// skip: name is readOnly
 	if !IsNil(o.OverrunPolicy) {
 		toSerialize["overrunPolicy"] = o.OverrunPolicy
 	}
-	// skip: tenantName is readOnly
 	toSerialize["value"] = o.Value
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_data_lake_atlas_store.go
+++ b/mongodbatlasv2/model_data_lake_atlas_store.go
@@ -199,20 +199,18 @@ func (o *DataLakeAtlasStore) SetProvider(v string) {
 	o.Provider = v
 }
 
-func (o DataLakeAtlasStore) MarshalJSON() ([]byte, error) {
+func (o DataLakeAtlasStore) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeAtlasStore) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ClusterName) {
 		toSerialize["clusterName"] = o.ClusterName
 	}
-	// skip: projectId is readOnly
 	if !IsNil(o.ReadPreference) {
 		toSerialize["readPreference"] = o.ReadPreference
 	}

--- a/mongodbatlasv2/model_data_lake_atlas_store_read_preference.go
+++ b/mongodbatlasv2/model_data_lake_atlas_store_read_preference.go
@@ -140,14 +140,13 @@ func (o *DataLakeAtlasStoreReadPreference) SetTagSets(v [][]DataLakeAtlasStoreRe
 	o.TagSets = v
 }
 
-func (o DataLakeAtlasStoreReadPreference) MarshalJSON() ([]byte, error) {
+func (o DataLakeAtlasStoreReadPreference) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeAtlasStoreReadPreference) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MaxStalenessSeconds) {

--- a/mongodbatlasv2/model_data_lake_atlas_store_read_preference_tag.go
+++ b/mongodbatlasv2/model_data_lake_atlas_store_read_preference_tag.go
@@ -106,14 +106,13 @@ func (o *DataLakeAtlasStoreReadPreferenceTag) SetValue(v string) {
 	o.Value = &v
 }
 
-func (o DataLakeAtlasStoreReadPreferenceTag) MarshalJSON() ([]byte, error) {
+func (o DataLakeAtlasStoreReadPreferenceTag) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeAtlasStoreReadPreferenceTag) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Name) {

--- a/mongodbatlasv2/model_data_lake_aws_cloud_provider_config.go
+++ b/mongodbatlasv2/model_data_lake_aws_cloud_provider_config.go
@@ -194,19 +194,15 @@ func (o *DataLakeAWSCloudProviderConfig) SetTestS3Bucket(v string) {
 	o.TestS3Bucket = v
 }
 
-func (o DataLakeAWSCloudProviderConfig) MarshalJSON() ([]byte, error) {
+func (o DataLakeAWSCloudProviderConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeAWSCloudProviderConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: externalId is readOnly
-	// skip: iamAssumedRoleARN is readOnly
-	// skip: iamUserARN is readOnly
 	toSerialize["roleId"] = o.RoleId
 	toSerialize["testS3Bucket"] = o.TestS3Bucket
 	return toSerialize, nil

--- a/mongodbatlasv2/model_data_lake_cloud_provider_config.go
+++ b/mongodbatlasv2/model_data_lake_cloud_provider_config.go
@@ -64,14 +64,13 @@ func (o *DataLakeCloudProviderConfig) SetAws(v DataLakeAWSCloudProviderConfig) {
 	o.Aws = v
 }
 
-func (o DataLakeCloudProviderConfig) MarshalJSON() ([]byte, error) {
+func (o DataLakeCloudProviderConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeCloudProviderConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["aws"] = o.Aws

--- a/mongodbatlasv2/model_data_lake_data_process_region.go
+++ b/mongodbatlasv2/model_data_lake_data_process_region.go
@@ -91,14 +91,13 @@ func (o *DataLakeDataProcessRegion) SetRegion(v DataLakeRegion) {
 	o.Region = v
 }
 
-func (o DataLakeDataProcessRegion) MarshalJSON() ([]byte, error) {
+func (o DataLakeDataProcessRegion) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeDataProcessRegion) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["cloudProvider"] = o.CloudProvider

--- a/mongodbatlasv2/model_data_lake_database.go
+++ b/mongodbatlasv2/model_data_lake_database.go
@@ -178,14 +178,13 @@ func (o *DataLakeDatabase) SetViews(v []DataLakeView) {
 	o.Views = v
 }
 
-func (o DataLakeDatabase) MarshalJSON() ([]byte, error) {
+func (o DataLakeDatabase) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeDatabase) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Collections) {

--- a/mongodbatlasv2/model_data_lake_database_collection.go
+++ b/mongodbatlasv2/model_data_lake_database_collection.go
@@ -106,14 +106,13 @@ func (o *DataLakeDatabaseCollection) SetName(v string) {
 	o.Name = &v
 }
 
-func (o DataLakeDatabaseCollection) MarshalJSON() ([]byte, error) {
+func (o DataLakeDatabaseCollection) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeDatabaseCollection) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DataSources) {

--- a/mongodbatlasv2/model_data_lake_database_data_source.go
+++ b/mongodbatlasv2/model_data_lake_database_data_source.go
@@ -382,14 +382,13 @@ func (o *DataLakeDatabaseDataSource) SetUrls(v []string) {
 	o.Urls = v
 }
 
-func (o DataLakeDatabaseDataSource) MarshalJSON() ([]byte, error) {
+func (o DataLakeDatabaseDataSource) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeDatabaseDataSource) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AllowInsecure) {

--- a/mongodbatlasv2/model_data_lake_http_store.go
+++ b/mongodbatlasv2/model_data_lake_http_store.go
@@ -204,14 +204,13 @@ func (o *DataLakeHTTPStore) SetProvider(v string) {
 	o.Provider = v
 }
 
-func (o DataLakeHTTPStore) MarshalJSON() ([]byte, error) {
+func (o DataLakeHTTPStore) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeHTTPStore) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AllowInsecure) {

--- a/mongodbatlasv2/model_data_lake_online_archive_store.go
+++ b/mongodbatlasv2/model_data_lake_online_archive_store.go
@@ -179,14 +179,13 @@ func (o *DataLakeOnlineArchiveStore) SetProvider(v string) {
 	o.Provider = v
 }
 
-func (o DataLakeOnlineArchiveStore) MarshalJSON() ([]byte, error) {
+func (o DataLakeOnlineArchiveStore) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeOnlineArchiveStore) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["clusterId"] = o.ClusterId

--- a/mongodbatlasv2/model_data_lake_s3_store.go
+++ b/mongodbatlasv2/model_data_lake_s3_store.go
@@ -344,14 +344,13 @@ func (o *DataLakeS3Store) SetProvider(v string) {
 	o.Provider = v
 }
 
-func (o DataLakeS3Store) MarshalJSON() ([]byte, error) {
+func (o DataLakeS3Store) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeS3Store) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AdditionalStorageClasses) {

--- a/mongodbatlasv2/model_data_lake_storage.go
+++ b/mongodbatlasv2/model_data_lake_storage.go
@@ -106,14 +106,13 @@ func (o *DataLakeStorage) SetStores(v []DataLakeStore) {
 	o.Stores = v
 }
 
-func (o DataLakeStorage) MarshalJSON() ([]byte, error) {
+func (o DataLakeStorage) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeStorage) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Databases) {

--- a/mongodbatlasv2/model_data_lake_tenant.go
+++ b/mongodbatlasv2/model_data_lake_tenant.go
@@ -171,14 +171,13 @@ func (o *DataLakeTenant) SetStorage(v DataLakeStorage) {
 	o.Storage = &v
 }
 
-func (o DataLakeTenant) MarshalJSON() ([]byte, error) {
+func (o DataLakeTenant) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeTenant) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CloudProviderConfig) {

--- a/mongodbatlasv2/model_data_lake_view.go
+++ b/mongodbatlasv2/model_data_lake_view.go
@@ -140,14 +140,13 @@ func (o *DataLakeView) SetSource(v string) {
 	o.Source = &v
 }
 
-func (o DataLakeView) MarshalJSON() ([]byte, error) {
+func (o DataLakeView) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataLakeView) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Name) {

--- a/mongodbatlasv2/model_data_metric_alert.go
+++ b/mongodbatlasv2/model_data_metric_alert.go
@@ -634,39 +634,23 @@ func (o *DataMetricAlert) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o DataMetricAlert) MarshalJSON() ([]byte, error) {
+func (o DataMetricAlert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataMetricAlert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: hostnameAndPort is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_data_metric_event.go
+++ b/mongodbatlasv2/model_data_metric_event.go
@@ -627,38 +627,22 @@ func (o *DataMetricEvent) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o DataMetricEvent) MarshalJSON() ([]byte, error) {
+func (o DataMetricEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataMetricEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: port is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: shardName is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_data_metric_threshold.go
+++ b/mongodbatlasv2/model_data_metric_threshold.go
@@ -206,14 +206,13 @@ func (o *DataMetricThreshold) SetUnits(v DataMetricUnits) {
 	o.Units = &v
 }
 
-func (o DataMetricThreshold) MarshalJSON() ([]byte, error) {
+func (o DataMetricThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataMetricThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MetricName) {

--- a/mongodbatlasv2/model_data_metric_value.go
+++ b/mongodbatlasv2/model_data_metric_value.go
@@ -105,17 +105,15 @@ func (o *DataMetricValue) SetUnits(v DataMetricUnits) {
 	o.Units = &v
 }
 
-func (o DataMetricValue) MarshalJSON() ([]byte, error) {
+func (o DataMetricValue) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataMetricValue) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: number is readOnly
 	if !IsNil(o.Units) {
 		toSerialize["units"] = o.Units
 	}

--- a/mongodbatlasv2/model_data_protection_settings.go
+++ b/mongodbatlasv2/model_data_protection_settings.go
@@ -412,17 +412,15 @@ func (o *DataProtectionSettings) SetUpdatedUser(v string) {
 	o.UpdatedUser = &v
 }
 
-func (o DataProtectionSettings) MarshalJSON() ([]byte, error) {
+func (o DataProtectionSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DataProtectionSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: authorizedEmail is readOnly
 	if !IsNil(o.CopyProtectionEnabled) {
 		toSerialize["copyProtectionEnabled"] = o.CopyProtectionEnabled
 	}
@@ -444,9 +442,6 @@ func (o DataProtectionSettings) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ScheduledPolicyItems) {
 		toSerialize["scheduledPolicyItems"] = o.ScheduledPolicyItems
 	}
-	// skip: state is readOnly
-	// skip: updatedDate is readOnly
-	// skip: updatedUser is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_database.go
+++ b/mongodbatlasv2/model_database.go
@@ -106,20 +106,18 @@ func (o *Database) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o Database) MarshalJSON() ([]byte, error) {
+func (o Database) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Database) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DatabaseName) {
 		toSerialize["databaseName"] = o.DatabaseName
 	}
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_database_user.go
+++ b/mongodbatlasv2/model_database_user.go
@@ -440,14 +440,13 @@ func (o *DatabaseUser) SetX509Type(v string) {
 	o.X509Type = &v
 }
 
-func (o DatabaseUser) MarshalJSON() ([]byte, error) {
+func (o DatabaseUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DatabaseUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AwsIAMType) {
@@ -464,7 +463,6 @@ func (o DatabaseUser) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LdapAuthType) {
 		toSerialize["ldapAuthType"] = o.LdapAuthType
 	}
-	// skip: links is readOnly
 	if !IsNil(o.Password) {
 		toSerialize["password"] = o.Password
 	}

--- a/mongodbatlasv2/model_datadog.go
+++ b/mongodbatlasv2/model_datadog.go
@@ -133,14 +133,13 @@ func (o *Datadog) SetType(v string) {
 	o.Type = &v
 }
 
-func (o Datadog) MarshalJSON() ([]byte, error) {
+func (o Datadog) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Datadog) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["apiKey"] = o.ApiKey

--- a/mongodbatlasv2/model_datadog_notification.go
+++ b/mongodbatlasv2/model_datadog_notification.go
@@ -205,14 +205,13 @@ func (o *DatadogNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o DatadogNotification) MarshalJSON() ([]byte, error) {
+func (o DatadogNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DatadogNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DatadogApiKey) {

--- a/mongodbatlasv2/model_date_criteria.go
+++ b/mongodbatlasv2/model_date_criteria.go
@@ -178,14 +178,13 @@ func (o *DateCriteria) SetType(v string) {
 	o.Type = &v
 }
 
-func (o DateCriteria) MarshalJSON() ([]byte, error) {
+func (o DateCriteria) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DateCriteria) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DateField) {

--- a/mongodbatlasv2/model_db_action.go
+++ b/mongodbatlasv2/model_db_action.go
@@ -99,14 +99,13 @@ func (o *DBAction) SetResources(v []DBResource) {
 	o.Resources = v
 }
 
-func (o DBAction) MarshalJSON() ([]byte, error) {
+func (o DBAction) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DBAction) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["action"] = o.Action

--- a/mongodbatlasv2/model_db_resource.go
+++ b/mongodbatlasv2/model_db_resource.go
@@ -119,14 +119,13 @@ func (o *DBResource) SetDb(v string) {
 	o.Db = v
 }
 
-func (o DBResource) MarshalJSON() ([]byte, error) {
+func (o DBResource) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DBResource) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["cluster"] = o.Cluster

--- a/mongodbatlasv2/model_dedicated_hardware_spec.go
+++ b/mongodbatlasv2/model_dedicated_hardware_spec.go
@@ -178,14 +178,13 @@ func (o *DedicatedHardwareSpec) SetInstanceSize(v string) {
 	o.InstanceSize = &v
 }
 
-func (o DedicatedHardwareSpec) MarshalJSON() ([]byte, error) {
+func (o DedicatedHardwareSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DedicatedHardwareSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.NodeCount) {

--- a/mongodbatlasv2/model_default_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_default_alert_config_view_for_nds_group.go
@@ -341,31 +341,25 @@ func (o *DefaultAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o DefaultAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o DefaultAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DefaultAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_default_alert_view_for_nds_group.go
+++ b/mongodbatlasv2/model_default_alert_view_for_nds_group.go
@@ -466,32 +466,19 @@ func (o *DefaultAlertViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o DefaultAlertViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o DefaultAlertViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DefaultAlertViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: created is readOnly
-	// skip: eventTypeName is readOnly
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_default_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_default_event_view_for_nds_group.go
@@ -459,31 +459,19 @@ func (o *DefaultEventViewForNdsGroup) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o DefaultEventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o DefaultEventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DefaultEventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_default_event_view_for_org.go
+++ b/mongodbatlasv2/model_default_event_view_for_org.go
@@ -459,31 +459,19 @@ func (o *DefaultEventViewForOrg) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o DefaultEventViewForOrg) MarshalJSON() ([]byte, error) {
+func (o DefaultEventViewForOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DefaultEventViewForOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_default_limit.go
+++ b/mongodbatlasv2/model_default_limit.go
@@ -194,20 +194,15 @@ func (o *DefaultLimit) SetValue(v int64) {
 	o.Value = v
 }
 
-func (o DefaultLimit) MarshalJSON() ([]byte, error) {
+func (o DefaultLimit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DefaultLimit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: currentUsage is readOnly
-	// skip: defaultLimit is readOnly
-	// skip: maximumLimit is readOnly
-	// skip: name is readOnly
 	toSerialize["value"] = o.Value
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_default_schedule.go
+++ b/mongodbatlasv2/model_default_schedule.go
@@ -64,14 +64,13 @@ func (o *DefaultSchedule) SetType(v string) {
 	o.Type = v
 }
 
-func (o DefaultSchedule) MarshalJSON() ([]byte, error) {
+func (o DefaultSchedule) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DefaultSchedule) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_delete_copied_backups.go
+++ b/mongodbatlasv2/model_delete_copied_backups.go
@@ -140,14 +140,13 @@ func (o *DeleteCopiedBackups) SetReplicationSpecId(v string) {
 	o.ReplicationSpecId = &v
 }
 
-func (o DeleteCopiedBackups) MarshalJSON() ([]byte, error) {
+func (o DeleteCopiedBackups) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DeleteCopiedBackups) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CloudProvider) {

--- a/mongodbatlasv2/model_destination.go
+++ b/mongodbatlasv2/model_destination.go
@@ -155,14 +155,13 @@ func (o *Destination) SetPrivateLinkId(v string) {
 	o.PrivateLinkId = &v
 }
 
-func (o Destination) MarshalJSON() ([]byte, error) {
+func (o Destination) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Destination) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["clusterName"] = o.ClusterName

--- a/mongodbatlasv2/model_disk_backup_base_restore_member.go
+++ b/mongodbatlasv2/model_disk_backup_base_restore_member.go
@@ -72,17 +72,15 @@ func (o *DiskBackupBaseRestoreMember) SetReplicaSetName(v string) {
 	o.ReplicaSetName = &v
 }
 
-func (o DiskBackupBaseRestoreMember) MarshalJSON() ([]byte, error) {
+func (o DiskBackupBaseRestoreMember) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupBaseRestoreMember) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: replicaSetName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_disk_backup_copy_setting.go
+++ b/mongodbatlasv2/model_disk_backup_copy_setting.go
@@ -208,14 +208,13 @@ func (o *DiskBackupCopySetting) SetShouldCopyOplogs(v bool) {
 	o.ShouldCopyOplogs = &v
 }
 
-func (o DiskBackupCopySetting) MarshalJSON() ([]byte, error) {
+func (o DiskBackupCopySetting) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupCopySetting) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CloudProvider) {

--- a/mongodbatlasv2/model_disk_backup_export_job.go
+++ b/mongodbatlasv2/model_disk_backup_export_job.go
@@ -439,34 +439,24 @@ func (o *DiskBackupExportJob) SetState(v string) {
 	o.State = &v
 }
 
-func (o DiskBackupExportJob) MarshalJSON() ([]byte, error) {
+func (o DiskBackupExportJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupExportJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: components is readOnly
-	// skip: createdAt is readOnly
 	if !IsNil(o.CustomData) {
 		toSerialize["customData"] = o.CustomData
 	}
-	// skip: deliveryUrl is readOnly
-	// skip: exportBucketId is readOnly
 	if !IsNil(o.ExportStatus) {
 		toSerialize["exportStatus"] = o.ExportStatus
 	}
-	// skip: finishedAt is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: prefix is readOnly
 	if !IsNil(o.SnapshotId) {
 		toSerialize["snapshotId"] = o.SnapshotId
 	}
-	// skip: state is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_disk_backup_export_job_request.go
+++ b/mongodbatlasv2/model_disk_backup_export_job_request.go
@@ -160,21 +160,19 @@ func (o *DiskBackupExportJobRequest) SetSnapshotId(v string) {
 	o.SnapshotId = v
 }
 
-func (o DiskBackupExportJobRequest) MarshalJSON() ([]byte, error) {
+func (o DiskBackupExportJobRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupExportJobRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CustomData) {
 		toSerialize["customData"] = o.CustomData
 	}
 	toSerialize["exportBucketId"] = o.ExportBucketId
-	// skip: links is readOnly
 	toSerialize["snapshotId"] = o.SnapshotId
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_disk_backup_on_demand_snapshot_request.go
+++ b/mongodbatlasv2/model_disk_backup_on_demand_snapshot_request.go
@@ -140,20 +140,18 @@ func (o *DiskBackupOnDemandSnapshotRequest) SetRetentionInDays(v int32) {
 	o.RetentionInDays = &v
 }
 
-func (o DiskBackupOnDemandSnapshotRequest) MarshalJSON() ([]byte, error) {
+func (o DiskBackupOnDemandSnapshotRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupOnDemandSnapshotRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Description) {
 		toSerialize["description"] = o.Description
 	}
-	// skip: links is readOnly
 	if !IsNil(o.RetentionInDays) {
 		toSerialize["retentionInDays"] = o.RetentionInDays
 	}

--- a/mongodbatlasv2/model_disk_backup_replica_set.go
+++ b/mongodbatlasv2/model_disk_backup_replica_set.go
@@ -583,32 +583,15 @@ func (o *DiskBackupReplicaSet) SetType(v string) {
 	o.Type = &v
 }
 
-func (o DiskBackupReplicaSet) MarshalJSON() ([]byte, error) {
+func (o DiskBackupReplicaSet) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupReplicaSet) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: cloudProvider is readOnly
-	// skip: copyRegions is readOnly
-	// skip: createdAt is readOnly
-	// skip: description is readOnly
-	// skip: expiresAt is readOnly
-	// skip: frequencyType is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: masterKeyUUID is readOnly
-	// skip: mongodVersion is readOnly
-	// skip: policyItems is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: snapshotType is readOnly
-	// skip: status is readOnly
-	// skip: storageSizeBytes is readOnly
-	// skip: type is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_disk_backup_restore_job.go
+++ b/mongodbatlasv2/model_disk_backup_restore_job.go
@@ -629,29 +629,19 @@ func (o *DiskBackupRestoreJob) SetTimestamp(v time.Time) {
 	o.Timestamp = &v
 }
 
-func (o DiskBackupRestoreJob) MarshalJSON() ([]byte, error) {
+func (o DiskBackupRestoreJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupRestoreJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: cancelled is readOnly
-	// skip: components is readOnly
 	toSerialize["deliveryType"] = o.DeliveryType
-	// skip: deliveryUrl is readOnly
 	if !IsNil(o.DesiredTimestamp) {
 		toSerialize["desiredTimestamp"] = o.DesiredTimestamp
 	}
-	// skip: expired is readOnly
-	// skip: expiresAt is readOnly
-	// skip: failed is readOnly
-	// skip: finishedAt is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.OplogInc) {
 		toSerialize["oplogInc"] = o.OplogInc
 	}
@@ -666,7 +656,6 @@ func (o DiskBackupRestoreJob) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["targetClusterName"] = o.TargetClusterName
 	toSerialize["targetGroupId"] = o.TargetGroupId
-	// skip: timestamp is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_disk_backup_sharded_cluster_snapshot.go
+++ b/mongodbatlasv2/model_disk_backup_sharded_cluster_snapshot.go
@@ -549,31 +549,15 @@ func (o *DiskBackupShardedClusterSnapshot) SetType(v string) {
 	o.Type = &v
 }
 
-func (o DiskBackupShardedClusterSnapshot) MarshalJSON() ([]byte, error) {
+func (o DiskBackupShardedClusterSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupShardedClusterSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: createdAt is readOnly
-	// skip: description is readOnly
-	// skip: expiresAt is readOnly
-	// skip: frequencyType is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: masterKeyUUID is readOnly
-	// skip: members is readOnly
-	// skip: mongodVersion is readOnly
-	// skip: policyItems is readOnly
-	// skip: snapshotIds is readOnly
-	// skip: snapshotType is readOnly
-	// skip: status is readOnly
-	// skip: storageSizeBytes is readOnly
-	// skip: type is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_disk_backup_sharded_cluster_snapshot_member.go
+++ b/mongodbatlasv2/model_disk_backup_sharded_cluster_snapshot_member.go
@@ -119,19 +119,15 @@ func (o *DiskBackupShardedClusterSnapshotMember) SetReplicaSetName(v string) {
 	o.ReplicaSetName = v
 }
 
-func (o DiskBackupShardedClusterSnapshotMember) MarshalJSON() ([]byte, error) {
+func (o DiskBackupShardedClusterSnapshotMember) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupShardedClusterSnapshotMember) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: cloudProvider is readOnly
-	// skip: id is readOnly
-	// skip: replicaSetName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_disk_backup_snapshot_aws_export_bucket.go
+++ b/mongodbatlasv2/model_disk_backup_snapshot_aws_export_bucket.go
@@ -208,17 +208,15 @@ func (o *DiskBackupSnapshotAWSExportBucket) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o DiskBackupSnapshotAWSExportBucket) MarshalJSON() ([]byte, error) {
+func (o DiskBackupSnapshotAWSExportBucket) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupSnapshotAWSExportBucket) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
 	if !IsNil(o.BucketName) {
 		toSerialize["bucketName"] = o.BucketName
 	}
@@ -228,7 +226,6 @@ func (o DiskBackupSnapshotAWSExportBucket) ToMap() (map[string]interface{}, erro
 	if !IsNil(o.IamRoleId) {
 		toSerialize["iamRoleId"] = o.IamRoleId
 	}
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_disk_backup_snapshot_schedule.go
+++ b/mongodbatlasv2/model_disk_backup_snapshot_schedule.go
@@ -514,21 +514,18 @@ func (o *DiskBackupSnapshotSchedule) SetUseOrgAndGroupNamesInExportPrefix(v bool
 	o.UseOrgAndGroupNamesInExportPrefix = &v
 }
 
-func (o DiskBackupSnapshotSchedule) MarshalJSON() ([]byte, error) {
+func (o DiskBackupSnapshotSchedule) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskBackupSnapshotSchedule) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AutoExportEnabled) {
 		toSerialize["autoExportEnabled"] = o.AutoExportEnabled
 	}
-	// skip: clusterId is readOnly
-	// skip: clusterName is readOnly
 	if !IsNil(o.CopySettings) {
 		toSerialize["copySettings"] = o.CopySettings
 	}
@@ -538,8 +535,6 @@ func (o DiskBackupSnapshotSchedule) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Export) {
 		toSerialize["export"] = o.Export
 	}
-	// skip: links is readOnly
-	// skip: nextSnapshot is readOnly
 	if !IsNil(o.Policies) {
 		toSerialize["policies"] = o.Policies
 	}

--- a/mongodbatlasv2/model_disk_gb_auto_scaling.go
+++ b/mongodbatlasv2/model_disk_gb_auto_scaling.go
@@ -72,14 +72,13 @@ func (o *DiskGBAutoScaling) SetEnabled(v bool) {
 	o.Enabled = &v
 }
 
-func (o DiskGBAutoScaling) MarshalJSON() ([]byte, error) {
+func (o DiskGBAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskGBAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Enabled) {

--- a/mongodbatlasv2/model_disk_partition.go
+++ b/mongodbatlasv2/model_disk_partition.go
@@ -106,18 +106,15 @@ func (o *DiskPartition) SetPartitionName(v string) {
 	o.PartitionName = &v
 }
 
-func (o DiskPartition) MarshalJSON() ([]byte, error) {
+func (o DiskPartition) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DiskPartition) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: partitionName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_dls_ingestion_sink.go
+++ b/mongodbatlasv2/model_dls_ingestion_sink.go
@@ -174,14 +174,13 @@ func (o *DLSIngestionSink) SetType(v string) {
 	o.Type = &v
 }
 
-func (o DLSIngestionSink) MarshalJSON() ([]byte, error) {
+func (o DLSIngestionSink) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o DLSIngestionSink) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MetadataProvider) {

--- a/mongodbatlasv2/model_email_notification.go
+++ b/mongodbatlasv2/model_email_notification.go
@@ -167,14 +167,13 @@ func (o *EmailNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o EmailNotification) MarshalJSON() ([]byte, error) {
+func (o EmailNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o EmailNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_encryption_at_rest.go
+++ b/mongodbatlasv2/model_encryption_at_rest.go
@@ -137,14 +137,13 @@ func (o *EncryptionAtRest) SetGoogleCloudKms(v GoogleCloudKMS) {
 	o.GoogleCloudKms = &v
 }
 
-func (o EncryptionAtRest) MarshalJSON() ([]byte, error) {
+func (o EncryptionAtRest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o EncryptionAtRest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AwsKms) {

--- a/mongodbatlasv2/model_encryption_key_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_encryption_key_alert_config_view_for_nds_group.go
@@ -373,24 +373,19 @@ func (o *EncryptionKeyAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o EncryptionKeyAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o EncryptionKeyAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o EncryptionKeyAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -400,7 +395,6 @@ func (o EncryptionKeyAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}
 	if !IsNil(o.Threshold) {
 		toSerialize["threshold"] = o.Threshold
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_error.go
+++ b/mongodbatlasv2/model_error.go
@@ -206,14 +206,13 @@ func (o *Error) SetReason(v string) {
 	o.Reason = &v
 }
 
-func (o Error) MarshalJSON() ([]byte, error) {
+func (o Error) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Error) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Detail) {

--- a/mongodbatlasv2/model_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_event_view_for_nds_group.go
@@ -1056,52 +1056,24 @@ func (o *EventViewForNdsGroup) SetTargetUsername(v string) {
 	o.TargetUsername = &v
 }
 
-func (o EventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o EventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o EventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.EventTypeName) {
 		toSerialize["eventTypeName"] = o.EventTypeName
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
-	// skip: alertId is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: invoiceId is readOnly
-	// skip: paymentId is readOnly
-	// skip: shardName is readOnly
-	// skip: collection is readOnly
-	// skip: database is readOnly
-	// skip: opType is readOnly
-	// skip: port is readOnly
-	// skip: replicaSetName is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
-	// skip: metricName is readOnly
-	// skip: whitelistEntry is readOnly
-	// skip: endpointId is readOnly
-	// skip: providerEndpointId is readOnly
-	// skip: teamId is readOnly
-	// skip: targetUsername is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_event_view_for_org.go
+++ b/mongodbatlasv2/model_event_view_for_org.go
@@ -717,40 +717,21 @@ func (o *EventViewForOrg) SetTargetUsername(v string) {
 	o.TargetUsername = &v
 }
 
-func (o EventViewForOrg) MarshalJSON() ([]byte, error) {
+func (o EventViewForOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o EventViewForOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.EventTypeName) {
 		toSerialize["eventTypeName"] = o.EventTypeName
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
-	// skip: alertId is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: invoiceId is readOnly
-	// skip: paymentId is readOnly
-	// skip: whitelistEntry is readOnly
-	// skip: teamId is readOnly
-	// skip: targetUsername is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_example_resource_response_view20230101.go
+++ b/mongodbatlasv2/model_example_resource_response_view20230101.go
@@ -99,18 +99,16 @@ func (o *ExampleResourceResponseView20230101) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o ExampleResourceResponseView20230101) MarshalJSON() ([]byte, error) {
+func (o ExampleResourceResponseView20230101) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ExampleResourceResponseView20230101) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["data"] = o.Data
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_example_resource_response_view20230201.go
+++ b/mongodbatlasv2/model_example_resource_response_view20230201.go
@@ -167,14 +167,13 @@ func (o *ExampleResourceResponseView20230201) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o ExampleResourceResponseView20230201) MarshalJSON() ([]byte, error) {
+func (o ExampleResourceResponseView20230201) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ExampleResourceResponseView20230201) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AdditionalInfo) {
@@ -184,7 +183,6 @@ func (o ExampleResourceResponseView20230201) ToMap() (map[string]interface{}, er
 		toSerialize["data"] = o.Data
 	}
 	toSerialize["description"] = o.Description
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_export_status.go
+++ b/mongodbatlasv2/model_export_status.go
@@ -106,18 +106,15 @@ func (o *ExportStatus) SetTotalCollections(v int32) {
 	o.TotalCollections = &v
 }
 
-func (o ExportStatus) MarshalJSON() ([]byte, error) {
+func (o ExportStatus) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ExportStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: exportedCollections is readOnly
-	// skip: totalCollections is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_federated_user.go
+++ b/mongodbatlasv2/model_federated_user.go
@@ -180,21 +180,19 @@ func (o *FederatedUser) SetUserId(v string) {
 	o.UserId = &v
 }
 
-func (o FederatedUser) MarshalJSON() ([]byte, error) {
+func (o FederatedUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FederatedUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["emailAddress"] = o.EmailAddress
 	toSerialize["federationSettingsId"] = o.FederationSettingsId
 	toSerialize["firstName"] = o.FirstName
 	toSerialize["lastName"] = o.LastName
-	// skip: userId is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_field_transformation.go
+++ b/mongodbatlasv2/model_field_transformation.go
@@ -106,14 +106,13 @@ func (o *FieldTransformation) SetType(v string) {
 	o.Type = &v
 }
 
-func (o FieldTransformation) MarshalJSON() ([]byte, error) {
+func (o FieldTransformation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FieldTransformation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Field) {

--- a/mongodbatlasv2/model_for_nds_group.go
+++ b/mongodbatlasv2/model_for_nds_group.go
@@ -356,28 +356,19 @@ func (o *ForNdsGroup) SetShardName(v string) {
 	o.ShardName = &v
 }
 
-func (o ForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o ForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: port is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: replicaSetName is readOnly
-	// skip: shardName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_free_auto_scaling.go
+++ b/mongodbatlasv2/model_free_auto_scaling.go
@@ -72,14 +72,13 @@ func (o *FreeAutoScaling) SetCompute(v string) {
 	o.Compute = &v
 }
 
-func (o FreeAutoScaling) MarshalJSON() ([]byte, error) {
+func (o FreeAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FreeAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Compute) {

--- a/mongodbatlasv2/model_free_provider_settings.go
+++ b/mongodbatlasv2/model_free_provider_settings.go
@@ -199,14 +199,13 @@ func (o *FreeProviderSettings) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o FreeProviderSettings) MarshalJSON() ([]byte, error) {
+func (o FreeProviderSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FreeProviderSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AutoScaling) {

--- a/mongodbatlasv2/model_fts_analyzers.go
+++ b/mongodbatlasv2/model_fts_analyzers.go
@@ -159,14 +159,13 @@ func (o *FTSAnalyzers) SetTokenizer(v FTSAnalyzersTokenizer) {
 	o.Tokenizer = v
 }
 
-func (o FTSAnalyzers) MarshalJSON() ([]byte, error) {
+func (o FTSAnalyzers) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FTSAnalyzers) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CharFilters) {

--- a/mongodbatlasv2/model_fts_index.go
+++ b/mongodbatlasv2/model_fts_index.go
@@ -364,14 +364,13 @@ func (o *FTSIndex) SetSynonyms(v []FTSSynonymMappingDefinition) {
 	o.Synonyms = v
 }
 
-func (o FTSIndex) MarshalJSON() ([]byte, error) {
+func (o FTSIndex) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FTSIndex) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Analyzer) {
@@ -382,7 +381,6 @@ func (o FTSIndex) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["collectionName"] = o.CollectionName
 	toSerialize["database"] = o.Database
-	// skip: indexID is readOnly
 	if !IsNil(o.Mappings) {
 		toSerialize["mappings"] = o.Mappings
 	}
@@ -390,7 +388,6 @@ func (o FTSIndex) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SearchAnalyzer) {
 		toSerialize["searchAnalyzer"] = o.SearchAnalyzer
 	}
-	// skip: status is readOnly
 	if !IsNil(o.Synonyms) {
 		toSerialize["synonyms"] = o.Synonyms
 	}

--- a/mongodbatlasv2/model_fts_index_audit.go
+++ b/mongodbatlasv2/model_fts_index_audit.go
@@ -458,31 +458,19 @@ func (o *FTSIndexAudit) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o FTSIndexAudit) MarshalJSON() ([]byte, error) {
+func (o FTSIndexAudit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FTSIndexAudit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_fts_mappings.go
+++ b/mongodbatlasv2/model_fts_mappings.go
@@ -110,14 +110,13 @@ func (o *FTSMappings) SetFields(v map[string]map[string]interface{}) {
 	o.Fields = v
 }
 
-func (o FTSMappings) MarshalJSON() ([]byte, error) {
+func (o FTSMappings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FTSMappings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Dynamic) {

--- a/mongodbatlasv2/model_fts_metric.go
+++ b/mongodbatlasv2/model_fts_metric.go
@@ -92,18 +92,15 @@ func (o *FTSMetric) SetUnits(v string) {
 	o.Units = v
 }
 
-func (o FTSMetric) MarshalJSON() ([]byte, error) {
+func (o FTSMetric) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FTSMetric) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: metricName is readOnly
-	// skip: units is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_fts_metrics.go
+++ b/mongodbatlasv2/model_fts_metrics.go
@@ -228,22 +228,15 @@ func (o *FTSMetrics) SetStatusMetrics(v []FTSMetric) {
 	o.StatusMetrics = v
 }
 
-func (o FTSMetrics) MarshalJSON() ([]byte, error) {
+func (o FTSMetrics) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FTSMetrics) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: groupId is readOnly
-	// skip: hardwareMetrics is readOnly
-	// skip: indexMetrics is readOnly
-	// skip: links is readOnly
-	// skip: processId is readOnly
-	// skip: statusMetrics is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_fts_synonym_mapping_definition.go
+++ b/mongodbatlasv2/model_fts_synonym_mapping_definition.go
@@ -120,14 +120,13 @@ func (o *FTSSynonymMappingDefinition) SetSource(v SynonymSource) {
 	o.Source = v
 }
 
-func (o FTSSynonymMappingDefinition) MarshalJSON() ([]byte, error) {
+func (o FTSSynonymMappingDefinition) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o FTSSynonymMappingDefinition) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["analyzer"] = o.Analyzer

--- a/mongodbatlasv2/model_gcp_auto_scaling.go
+++ b/mongodbatlasv2/model_gcp_auto_scaling.go
@@ -71,14 +71,13 @@ func (o *GCPAutoScaling) SetCompute(v GCPComputeAutoScaling) {
 	o.Compute = &v
 }
 
-func (o GCPAutoScaling) MarshalJSON() ([]byte, error) {
+func (o GCPAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Compute) {

--- a/mongodbatlasv2/model_gcp_cloud_provider_container.go
+++ b/mongodbatlasv2/model_gcp_cloud_provider_container.go
@@ -269,27 +269,22 @@ func (o *GCPCloudProviderContainer) SetProvisioned(v bool) {
 	o.Provisioned = &v
 }
 
-func (o GCPCloudProviderContainer) MarshalJSON() ([]byte, error) {
+func (o GCPCloudProviderContainer) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPCloudProviderContainer) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["atlasCidrBlock"] = o.AtlasCidrBlock
-	// skip: gcpProjectId is readOnly
-	// skip: networkName is readOnly
 	if !IsNil(o.Regions) {
 		toSerialize["regions"] = o.Regions
 	}
-	// skip: id is readOnly
 	if !IsNil(o.ProviderName) {
 		toSerialize["providerName"] = o.ProviderName
 	}
-	// skip: provisioned is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_gcp_compute_auto_scaling.go
+++ b/mongodbatlasv2/model_gcp_compute_auto_scaling.go
@@ -106,14 +106,13 @@ func (o *GCPComputeAutoScaling) SetMinInstanceSize(v string) {
 	o.MinInstanceSize = &v
 }
 
-func (o GCPComputeAutoScaling) MarshalJSON() ([]byte, error) {
+func (o GCPComputeAutoScaling) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPComputeAutoScaling) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MaxInstanceSize) {

--- a/mongodbatlasv2/model_gcp_consumer_forwarding_rule.go
+++ b/mongodbatlasv2/model_gcp_consumer_forwarding_rule.go
@@ -140,19 +140,15 @@ func (o *GCPConsumerForwardingRule) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o GCPConsumerForwardingRule) MarshalJSON() ([]byte, error) {
+func (o GCPConsumerForwardingRule) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPConsumerForwardingRule) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: endpointName is readOnly
-	// skip: ipAddress is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_gcp_endpoint_group.go
+++ b/mongodbatlasv2/model_gcp_endpoint_group.go
@@ -208,21 +208,15 @@ func (o *GCPEndpointGroup) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o GCPEndpointGroup) MarshalJSON() ([]byte, error) {
+func (o GCPEndpointGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPEndpointGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: deleteRequested is readOnly
-	// skip: endpointGroupName is readOnly
-	// skip: endpoints is readOnly
-	// skip: errorMessage is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_gcp_endpoint_service.go
+++ b/mongodbatlasv2/model_gcp_endpoint_service.go
@@ -242,26 +242,21 @@ func (o *GCPEndpointService) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o GCPEndpointService) MarshalJSON() ([]byte, error) {
+func (o GCPEndpointService) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPEndpointService) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.EndpointGroupNames) {
 		toSerialize["endpointGroupNames"] = o.EndpointGroupNames
 	}
-	// skip: errorMessage is readOnly
-	// skip: id is readOnly
-	// skip: regionName is readOnly
 	if !IsNil(o.ServiceAttachmentNames) {
 		toSerialize["serviceAttachmentNames"] = o.ServiceAttachmentNames
 	}
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_gcp_hardware_spec.go
+++ b/mongodbatlasv2/model_gcp_hardware_spec.go
@@ -106,14 +106,13 @@ func (o *GCPHardwareSpec) SetNodeCount(v int32) {
 	o.NodeCount = &v
 }
 
-func (o GCPHardwareSpec) MarshalJSON() ([]byte, error) {
+func (o GCPHardwareSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPHardwareSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.InstanceSize) {

--- a/mongodbatlasv2/model_gcp_peer_vpc.go
+++ b/mongodbatlasv2/model_gcp_peer_vpc.go
@@ -221,22 +221,18 @@ func (o *GCPPeerVpc) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o GCPPeerVpc) MarshalJSON() ([]byte, error) {
+func (o GCPPeerVpc) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPPeerVpc) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["containerId"] = o.ContainerId
-	// skip: errorMessage is readOnly
 	toSerialize["gcpProjectId"] = o.GcpProjectId
-	// skip: id is readOnly
 	toSerialize["networkName"] = o.NetworkName
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_gcp_peer_vpc_request.go
+++ b/mongodbatlasv2/model_gcp_peer_vpc_request.go
@@ -248,23 +248,19 @@ func (o *GCPPeerVpcRequest) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o GCPPeerVpcRequest) MarshalJSON() ([]byte, error) {
+func (o GCPPeerVpcRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPPeerVpcRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["containerId"] = o.ContainerId
 	toSerialize["providerName"] = o.ProviderName
-	// skip: errorMessage is readOnly
 	toSerialize["gcpProjectId"] = o.GcpProjectId
-	// skip: id is readOnly
 	toSerialize["networkName"] = o.NetworkName
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_gcp_provider_settings.go
+++ b/mongodbatlasv2/model_gcp_provider_settings.go
@@ -165,14 +165,13 @@ func (o *GCPProviderSettings) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o GCPProviderSettings) MarshalJSON() ([]byte, error) {
+func (o GCPProviderSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPProviderSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AutoScaling) {

--- a/mongodbatlasv2/model_gcp_region_config.go
+++ b/mongodbatlasv2/model_gcp_region_config.go
@@ -305,14 +305,13 @@ func (o *GCPRegionConfig) SetRegionName(v string) {
 	o.RegionName = &v
 }
 
-func (o GCPRegionConfig) MarshalJSON() ([]byte, error) {
+func (o GCPRegionConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GCPRegionConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AnalyticsAutoScaling) {

--- a/mongodbatlasv2/model_geo_sharding.go
+++ b/mongodbatlasv2/model_geo_sharding.go
@@ -106,18 +106,15 @@ func (o *GeoSharding) SetManagedNamespaces(v []ManagedNamespaces) {
 	o.ManagedNamespaces = v
 }
 
-func (o GeoSharding) MarshalJSON() ([]byte, error) {
+func (o GeoSharding) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GeoSharding) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: customZoneMapping is readOnly
-	// skip: managedNamespaces is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_google_cloud_kms.go
+++ b/mongodbatlasv2/model_google_cloud_kms.go
@@ -174,14 +174,13 @@ func (o *GoogleCloudKMS) SetValid(v bool) {
 	o.Valid = &v
 }
 
-func (o GoogleCloudKMS) MarshalJSON() ([]byte, error) {
+func (o GoogleCloudKMS) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GoogleCloudKMS) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Enabled) {
@@ -193,7 +192,6 @@ func (o GoogleCloudKMS) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ServiceAccountKey) {
 		toSerialize["serviceAccountKey"] = o.ServiceAccountKey
 	}
-	// skip: valid is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_greater_than_days_threshold.go
+++ b/mongodbatlasv2/model_greater_than_days_threshold.go
@@ -140,14 +140,13 @@ func (o *GreaterThanDaysThreshold) SetUnits(v string) {
 	o.Units = &v
 }
 
-func (o GreaterThanDaysThreshold) MarshalJSON() ([]byte, error) {
+func (o GreaterThanDaysThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GreaterThanDaysThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Operator) {

--- a/mongodbatlasv2/model_greater_than_raw_threshold.go
+++ b/mongodbatlasv2/model_greater_than_raw_threshold.go
@@ -143,14 +143,13 @@ func (o *GreaterThanRawThreshold) SetUnits(v RawMetricUnits) {
 	o.Units = &v
 }
 
-func (o GreaterThanRawThreshold) MarshalJSON() ([]byte, error) {
+func (o GreaterThanRawThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GreaterThanRawThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Operator) {

--- a/mongodbatlasv2/model_greater_than_raw_threshold_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_greater_than_raw_threshold_alert_config_view_for_nds_group.go
@@ -374,24 +374,19 @@ func (o *GreaterThanRawThresholdAlertConfigViewForNdsGroup) SetUpdated(v time.Ti
 	o.Updated = &v
 }
 
-func (o GreaterThanRawThresholdAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o GreaterThanRawThresholdAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GreaterThanRawThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -401,7 +396,6 @@ func (o GreaterThanRawThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]i
 	if !IsNil(o.Threshold) {
 		toSerialize["threshold"] = o.Threshold
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_greater_than_time_threshold.go
+++ b/mongodbatlasv2/model_greater_than_time_threshold.go
@@ -143,14 +143,13 @@ func (o *GreaterThanTimeThreshold) SetUnits(v TimeMetricUnits) {
 	o.Units = &v
 }
 
-func (o GreaterThanTimeThreshold) MarshalJSON() ([]byte, error) {
+func (o GreaterThanTimeThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GreaterThanTimeThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Operator) {

--- a/mongodbatlasv2/model_group.go
+++ b/mongodbatlasv2/model_group.go
@@ -249,20 +249,15 @@ func (o *Group) SetWithDefaultAlertsSettings(v bool) {
 	o.WithDefaultAlertsSettings = &v
 }
 
-func (o Group) MarshalJSON() ([]byte, error) {
+func (o Group) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Group) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusterCount is readOnly
-	// skip: created is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	toSerialize["name"] = o.Name
 	toSerialize["orgId"] = o.OrgId
 	if !IsNil(o.WithDefaultAlertsSettings) {

--- a/mongodbatlasv2/model_group_invitation.go
+++ b/mongodbatlasv2/model_group_invitation.go
@@ -345,27 +345,18 @@ func (o *GroupInvitation) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o GroupInvitation) MarshalJSON() ([]byte, error) {
+func (o GroupInvitation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupInvitation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: createdAt is readOnly
-	// skip: expiresAt is readOnly
-	// skip: groupId is readOnly
-	// skip: groupName is readOnly
-	// skip: id is readOnly
-	// skip: inviterUsername is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Roles) {
 		toSerialize["roles"] = o.Roles
 	}
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_group_invitation_request.go
+++ b/mongodbatlasv2/model_group_invitation_request.go
@@ -106,14 +106,13 @@ func (o *GroupInvitationRequest) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o GroupInvitationRequest) MarshalJSON() ([]byte, error) {
+func (o GroupInvitationRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupInvitationRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Roles) {

--- a/mongodbatlasv2/model_group_invitation_update_request.go
+++ b/mongodbatlasv2/model_group_invitation_update_request.go
@@ -72,14 +72,13 @@ func (o *GroupInvitationUpdateRequest) SetRoles(v []string) {
 	o.Roles = v
 }
 
-func (o GroupInvitationUpdateRequest) MarshalJSON() ([]byte, error) {
+func (o GroupInvitationUpdateRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupInvitationUpdateRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Roles) {

--- a/mongodbatlasv2/model_group_maintenance_window.go
+++ b/mongodbatlasv2/model_group_maintenance_window.go
@@ -160,14 +160,13 @@ func (o *GroupMaintenanceWindow) SetStartASAP(v bool) {
 	o.StartASAP = &v
 }
 
-func (o GroupMaintenanceWindow) MarshalJSON() ([]byte, error) {
+func (o GroupMaintenanceWindow) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupMaintenanceWindow) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AutoDeferOnceEnabled) {

--- a/mongodbatlasv2/model_group_name.go
+++ b/mongodbatlasv2/model_group_name.go
@@ -72,14 +72,13 @@ func (o *GroupName) SetName(v string) {
 	o.Name = &v
 }
 
-func (o GroupName) MarshalJSON() ([]byte, error) {
+func (o GroupName) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupName) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Name) {

--- a/mongodbatlasv2/model_group_notification.go
+++ b/mongodbatlasv2/model_group_notification.go
@@ -235,14 +235,13 @@ func (o *GroupNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o GroupNotification) MarshalJSON() ([]byte, error) {
+func (o GroupNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_group_paginated_event.go
+++ b/mongodbatlasv2/model_group_paginated_event.go
@@ -140,19 +140,15 @@ func (o *GroupPaginatedEvent) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o GroupPaginatedEvent) MarshalJSON() ([]byte, error) {
+func (o GroupPaginatedEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupPaginatedEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_group_paginated_integration.go
+++ b/mongodbatlasv2/model_group_paginated_integration.go
@@ -140,19 +140,15 @@ func (o *GroupPaginatedIntegration) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o GroupPaginatedIntegration) MarshalJSON() ([]byte, error) {
+func (o GroupPaginatedIntegration) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupPaginatedIntegration) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_group_settings.go
+++ b/mongodbatlasv2/model_group_settings.go
@@ -242,14 +242,13 @@ func (o *GroupSettings) SetIsSchemaAdvisorEnabled(v bool) {
 	o.IsSchemaAdvisorEnabled = &v
 }
 
-func (o GroupSettings) MarshalJSON() ([]byte, error) {
+func (o GroupSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o GroupSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.IsCollectDatabaseSpecificsStatisticsEnabled) {

--- a/mongodbatlasv2/model_hardware_spec.go
+++ b/mongodbatlasv2/model_hardware_spec.go
@@ -178,14 +178,13 @@ func (o *HardwareSpec) SetNodeCount(v int32) {
 	o.NodeCount = &v
 }
 
-func (o HardwareSpec) MarshalJSON() ([]byte, error) {
+func (o HardwareSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HardwareSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DiskIOPS) {

--- a/mongodbatlasv2/model_hip_chat_notification.go
+++ b/mongodbatlasv2/model_hip_chat_notification.go
@@ -201,14 +201,13 @@ func (o *HipChatNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o HipChatNotification) MarshalJSON() ([]byte, error) {
+func (o HipChatNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HipChatNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_host_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_host_alert_config_view_for_nds_group.go
@@ -341,31 +341,25 @@ func (o *HostAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o HostAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o HostAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HostAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_host_alert_view_for_nds_group.go
+++ b/mongodbatlasv2/model_host_alert_view_for_nds_group.go
@@ -567,35 +567,20 @@ func (o *HostAlertViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o HostAlertViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o HostAlertViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HostAlertViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: hostnameAndPort is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_host_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_host_event_view_for_nds_group.go
@@ -560,34 +560,19 @@ func (o *HostEventViewForNdsGroup) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o HostEventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o HostEventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HostEventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: port is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: shardName is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_host_matcher.go
+++ b/mongodbatlasv2/model_host_matcher.go
@@ -138,14 +138,13 @@ func (o *HostMatcher) SetValue(v MatcherHostType) {
 	o.Value = &v
 }
 
-func (o HostMatcher) MarshalJSON() ([]byte, error) {
+func (o HostMatcher) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HostMatcher) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FieldName) {

--- a/mongodbatlasv2/model_host_metric_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_host_metric_alert_config_view_for_nds_group.go
@@ -374,24 +374,19 @@ func (o *HostMetricAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o HostMetricAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o HostMetricAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HostMetricAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -401,7 +396,6 @@ func (o HostMetricAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, e
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_host_metric_value.go
+++ b/mongodbatlasv2/model_host_metric_value.go
@@ -105,17 +105,15 @@ func (o *HostMetricValue) SetUnits(v string) {
 	o.Units = &v
 }
 
-func (o HostMetricValue) MarshalJSON() ([]byte, error) {
+func (o HostMetricValue) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HostMetricValue) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: number is readOnly
 	if !IsNil(o.Units) {
 		toSerialize["units"] = o.Units
 	}

--- a/mongodbatlasv2/model_host_view_atlas.go
+++ b/mongodbatlasv2/model_host_view_atlas.go
@@ -413,27 +413,15 @@ func (o *HostViewAtlas) SetVersion(v string) {
 	o.Version = &v
 }
 
-func (o HostViewAtlas) MarshalJSON() ([]byte, error) {
+func (o HostViewAtlas) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o HostViewAtlas) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
-	// skip: groupId is readOnly
-	// skip: hostname is readOnly
-	// skip: id is readOnly
-	// skip: lastPing is readOnly
-	// skip: links is readOnly
-	// skip: port is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: typeName is readOnly
-	// skip: userAlias is readOnly
-	// skip: version is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_identity_provider.go
+++ b/mongodbatlasv2/model_identity_provider.go
@@ -472,14 +472,13 @@ func (o *IdentityProvider) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o IdentityProvider) MarshalJSON() ([]byte, error) {
+func (o IdentityProvider) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o IdentityProvider) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AcsUrl) {

--- a/mongodbatlasv2/model_identity_provider_update.go
+++ b/mongodbatlasv2/model_identity_provider_update.go
@@ -336,14 +336,13 @@ func (o *IdentityProviderUpdate) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o IdentityProviderUpdate) MarshalJSON() ([]byte, error) {
+func (o IdentityProviderUpdate) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o IdentityProviderUpdate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AssociatedDomains) {

--- a/mongodbatlasv2/model_index_options.go
+++ b/mongodbatlasv2/model_index_options.go
@@ -685,14 +685,13 @@ func (o *IndexOptions) SetWeights(v map[string]map[string]interface{}) {
 	o.Weights = v
 }
 
-func (o IndexOptions) MarshalJSON() ([]byte, error) {
+func (o IndexOptions) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o IndexOptions) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["2dsphereIndexVersion"] = o.Var2dsphereIndexVersion

--- a/mongodbatlasv2/model_index_request.go
+++ b/mongodbatlasv2/model_index_request.go
@@ -192,14 +192,13 @@ func (o *IndexRequest) SetOptions(v IndexOptions) {
 	o.Options = &v
 }
 
-func (o IndexRequest) MarshalJSON() ([]byte, error) {
+func (o IndexRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o IndexRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Collation) {

--- a/mongodbatlasv2/model_ingestion_pipeline.go
+++ b/mongodbatlasv2/model_ingestion_pipeline.go
@@ -343,20 +343,15 @@ func (o *IngestionPipeline) SetTransformations(v []FieldTransformation) {
 	o.Transformations = v
 }
 
-func (o IngestionPipeline) MarshalJSON() ([]byte, error) {
+func (o IngestionPipeline) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o IngestionPipeline) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
-	// skip: createdDate is readOnly
-	// skip: groupId is readOnly
-	// skip: lastUpdatedDate is readOnly
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
@@ -366,7 +361,6 @@ func (o IngestionPipeline) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Source) {
 		toSerialize["source"] = o.Source
 	}
-	// skip: state is readOnly
 	if !IsNil(o.Transformations) {
 		toSerialize["transformations"] = o.Transformations
 	}

--- a/mongodbatlasv2/model_ingestion_pipeline_run.go
+++ b/mongodbatlasv2/model_ingestion_pipeline_run.go
@@ -412,26 +412,15 @@ func (o *IngestionPipelineRun) SetStats(v PipelineRunStats) {
 	o.Stats = &v
 }
 
-func (o IngestionPipelineRun) MarshalJSON() ([]byte, error) {
+func (o IngestionPipelineRun) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o IngestionPipelineRun) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
-	// skip: backupFrequencyType is readOnly
-	// skip: createdDate is readOnly
-	// skip: datasetName is readOnly
-	// skip: groupId is readOnly
-	// skip: lastUpdatedDate is readOnly
-	// skip: phase is readOnly
-	// skip: pipelineId is readOnly
-	// skip: snapshotId is readOnly
-	// skip: state is readOnly
 	if !IsNil(o.Stats) {
 		toSerialize["stats"] = o.Stats
 	}

--- a/mongodbatlasv2/model_inherited_role.go
+++ b/mongodbatlasv2/model_inherited_role.go
@@ -92,14 +92,13 @@ func (o *InheritedRole) SetRole(v string) {
 	o.Role = v
 }
 
-func (o InheritedRole) MarshalJSON() ([]byte, error) {
+func (o InheritedRole) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o InheritedRole) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["db"] = o.Db

--- a/mongodbatlasv2/model_integration.go
+++ b/mongodbatlasv2/model_integration.go
@@ -71,14 +71,13 @@ func (o *Integration) SetType(v string) {
 	o.Type = &v
 }
 
-func (o Integration) MarshalJSON() ([]byte, error) {
+func (o Integration) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Integration) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Type) {

--- a/mongodbatlasv2/model_invoice.go
+++ b/mongodbatlasv2/model_invoice.go
@@ -685,37 +685,18 @@ func (o *Invoice) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o Invoice) MarshalJSON() ([]byte, error) {
+func (o Invoice) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Invoice) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: amountBilledCents is readOnly
-	// skip: amountPaidCents is readOnly
-	// skip: created is readOnly
-	// skip: creditsCents is readOnly
-	// skip: endDate is readOnly
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: lineItems is readOnly
-	// skip: linkedInvoices is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: payments is readOnly
-	// skip: refunds is readOnly
-	// skip: salesTaxCents is readOnly
-	// skip: startDate is readOnly
-	// skip: startingBalanceCents is readOnly
 	if !IsNil(o.StatusName) {
 		toSerialize["statusName"] = o.StatusName
 	}
-	// skip: subtotalCents is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_key.go
+++ b/mongodbatlasv2/model_key.go
@@ -160,20 +160,15 @@ func (o *Key) SetRoles(v []RoleAssignment) {
 	o.Roles = v
 }
 
-func (o Key) MarshalJSON() ([]byte, error) {
+func (o Key) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Key) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: accessList is readOnly
-	// skip: id is readOnly
-	// skip: publicKey is readOnly
-	// skip: roles is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_label.go
+++ b/mongodbatlasv2/model_label.go
@@ -106,14 +106,13 @@ func (o *Label) SetValue(v string) {
 	o.Value = &v
 }
 
-func (o Label) MarshalJSON() ([]byte, error) {
+func (o Label) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Label) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Key) {

--- a/mongodbatlasv2/model_legacy_cluster_description.go
+++ b/mongodbatlasv2/model_legacy_cluster_description.go
@@ -1121,14 +1121,13 @@ func (o *LegacyClusterDescription) SetVersionReleaseSystem(v string) {
 	o.VersionReleaseSystem = &v
 }
 
-func (o LegacyClusterDescription) MarshalJSON() ([]byte, error) {
+func (o LegacyClusterDescription) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LegacyClusterDescription) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AutoScaling) {
@@ -1146,28 +1145,21 @@ func (o LegacyClusterDescription) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ConnectionStrings) {
 		toSerialize["connectionStrings"] = o.ConnectionStrings
 	}
-	// skip: createDate is readOnly
 	if !IsNil(o.DiskSizeGB) {
 		toSerialize["diskSizeGB"] = o.DiskSizeGB
 	}
 	if !IsNil(o.EncryptionAtRestProvider) {
 		toSerialize["encryptionAtRestProvider"] = o.EncryptionAtRestProvider
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
 	if !IsNil(o.Labels) {
 		toSerialize["labels"] = o.Labels
 	}
-	// skip: links is readOnly
 	if !IsNil(o.MongoDBMajorVersion) {
 		toSerialize["mongoDBMajorVersion"] = o.MongoDBMajorVersion
 	}
 	if !IsNil(o.MongoDBVersion) {
 		toSerialize["mongoDBVersion"] = o.MongoDBVersion
 	}
-	// skip: mongoURI is readOnly
-	// skip: mongoURIUpdated is readOnly
-	// skip: mongoURIWithOptions is readOnly
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
@@ -1198,8 +1190,6 @@ func (o LegacyClusterDescription) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.RootCertType) {
 		toSerialize["rootCertType"] = o.RootCertType
 	}
-	// skip: srvAddress is readOnly
-	// skip: stateName is readOnly
 	if !IsNil(o.TerminationProtectionEnabled) {
 		toSerialize["terminationProtectionEnabled"] = o.TerminationProtectionEnabled
 	}

--- a/mongodbatlasv2/model_legacy_replication_spec.go
+++ b/mongodbatlasv2/model_legacy_replication_spec.go
@@ -178,14 +178,13 @@ func (o *LegacyReplicationSpec) SetZoneName(v string) {
 	o.ZoneName = &v
 }
 
-func (o LegacyReplicationSpec) MarshalJSON() ([]byte, error) {
+func (o LegacyReplicationSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LegacyReplicationSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {

--- a/mongodbatlasv2/model_less_than_days_threshold.go
+++ b/mongodbatlasv2/model_less_than_days_threshold.go
@@ -140,14 +140,13 @@ func (o *LessThanDaysThreshold) SetUnits(v string) {
 	o.Units = &v
 }
 
-func (o LessThanDaysThreshold) MarshalJSON() ([]byte, error) {
+func (o LessThanDaysThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LessThanDaysThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Operator) {

--- a/mongodbatlasv2/model_less_than_time_threshold.go
+++ b/mongodbatlasv2/model_less_than_time_threshold.go
@@ -143,14 +143,13 @@ func (o *LessThanTimeThreshold) SetUnits(v TimeMetricUnits) {
 	o.Units = &v
 }
 
-func (o LessThanTimeThreshold) MarshalJSON() ([]byte, error) {
+func (o LessThanTimeThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LessThanTimeThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Operator) {

--- a/mongodbatlasv2/model_less_than_time_threshold_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_less_than_time_threshold_alert_config_view_for_nds_group.go
@@ -374,24 +374,19 @@ func (o *LessThanTimeThresholdAlertConfigViewForNdsGroup) SetUpdated(v time.Time
 	o.Updated = &v
 }
 
-func (o LessThanTimeThresholdAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o LessThanTimeThresholdAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LessThanTimeThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -401,7 +396,6 @@ func (o LessThanTimeThresholdAlertConfigViewForNdsGroup) ToMap() (map[string]int
 	if !IsNil(o.Threshold) {
 		toSerialize["threshold"] = o.Threshold
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_line_item.go
+++ b/mongodbatlasv2/model_line_item.go
@@ -617,35 +617,18 @@ func (o *LineItem) SetUnitPriceDollars(v float64) {
 	o.UnitPriceDollars = &v
 }
 
-func (o LineItem) MarshalJSON() ([]byte, error) {
+func (o LineItem) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LineItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
-	// skip: discountCents is readOnly
-	// skip: endDate is readOnly
-	// skip: groupId is readOnly
 	if !IsNil(o.GroupName) {
 		toSerialize["groupName"] = o.GroupName
 	}
-	// skip: note is readOnly
-	// skip: percentDiscount is readOnly
-	// skip: quantity is readOnly
-	// skip: sku is readOnly
-	// skip: startDate is readOnly
-	// skip: stitchAppName is readOnly
-	// skip: tierLowerBound is readOnly
-	// skip: tierUpperBound is readOnly
-	// skip: totalPriceCents is readOnly
-	// skip: unit is readOnly
-	// skip: unitPriceDollars is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_link.go
+++ b/mongodbatlasv2/model_link.go
@@ -106,14 +106,13 @@ func (o *Link) SetRel(v string) {
 	o.Rel = &v
 }
 
-func (o Link) MarshalJSON() ([]byte, error) {
+func (o Link) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Link) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Href) {

--- a/mongodbatlasv2/model_link_atlas.go
+++ b/mongodbatlasv2/model_link_atlas.go
@@ -106,14 +106,13 @@ func (o *LinkAtlas) SetRel(v string) {
 	o.Rel = &v
 }
 
-func (o LinkAtlas) MarshalJSON() ([]byte, error) {
+func (o LinkAtlas) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LinkAtlas) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Href) {

--- a/mongodbatlasv2/model_live_migration_request.go
+++ b/mongodbatlasv2/model_live_migration_request.go
@@ -185,17 +185,15 @@ func (o *LiveMigrationRequest) SetSource(v Source) {
 	o.Source = v
 }
 
-func (o LiveMigrationRequest) MarshalJSON() ([]byte, error) {
+func (o LiveMigrationRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LiveMigrationRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
 	toSerialize["destination"] = o.Destination
 	toSerialize["dropEnabled"] = o.DropEnabled
 	if !IsNil(o.MigrationHosts) {

--- a/mongodbatlasv2/model_live_migration_response.go
+++ b/mongodbatlasv2/model_live_migration_response.go
@@ -218,23 +218,18 @@ func (o *LiveMigrationResponse) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o LiveMigrationResponse) MarshalJSON() ([]byte, error) {
+func (o LiveMigrationResponse) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o LiveMigrationResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
 	if o.LagTimeSeconds.IsSet() {
 		toSerialize["lagTimeSeconds"] = o.LagTimeSeconds.Get()
 	}
-	// skip: migrationHosts is readOnly
-	// skip: readyForCutover is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_managed_namespace.go
+++ b/mongodbatlasv2/model_managed_namespace.go
@@ -288,14 +288,13 @@ func (o *ManagedNamespace) SetPresplitHashedZones(v bool) {
 	o.PresplitHashedZones = &v
 }
 
-func (o ManagedNamespace) MarshalJSON() ([]byte, error) {
+func (o ManagedNamespace) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ManagedNamespace) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Collection) {

--- a/mongodbatlasv2/model_managed_namespaces.go
+++ b/mongodbatlasv2/model_managed_namespaces.go
@@ -267,18 +267,16 @@ func (o *ManagedNamespaces) SetPresplitHashedZones(v bool) {
 	o.PresplitHashedZones = &v
 }
 
-func (o ManagedNamespaces) MarshalJSON() ([]byte, error) {
+func (o ManagedNamespaces) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ManagedNamespaces) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["collection"] = o.Collection
-	// skip: customShardKey is readOnly
 	toSerialize["db"] = o.Db
 	if !IsNil(o.IsCustomShardKeyHashed) {
 		toSerialize["isCustomShardKeyHashed"] = o.IsCustomShardKeyHashed

--- a/mongodbatlasv2/model_matcher.go
+++ b/mongodbatlasv2/model_matcher.go
@@ -140,14 +140,13 @@ func (o *Matcher) SetValue(v string) {
 	o.Value = &v
 }
 
-func (o Matcher) MarshalJSON() ([]byte, error) {
+func (o Matcher) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Matcher) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FieldName) {

--- a/mongodbatlasv2/model_measurement.go
+++ b/mongodbatlasv2/model_measurement.go
@@ -140,19 +140,15 @@ func (o *Measurement) SetUnits(v string) {
 	o.Units = &v
 }
 
-func (o Measurement) MarshalJSON() ([]byte, error) {
+func (o Measurement) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Measurement) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: dataPoints is readOnly
-	// skip: name is readOnly
-	// skip: units is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_measurement_view_atlas.go
+++ b/mongodbatlasv2/model_measurement_view_atlas.go
@@ -140,19 +140,15 @@ func (o *MeasurementViewAtlas) SetUnits(v string) {
 	o.Units = &v
 }
 
-func (o MeasurementViewAtlas) MarshalJSON() ([]byte, error) {
+func (o MeasurementViewAtlas) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MeasurementViewAtlas) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: dataPoints is readOnly
-	// skip: name is readOnly
-	// skip: units is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_measurements_general_view_atlas.go
+++ b/mongodbatlasv2/model_measurements_general_view_atlas.go
@@ -379,26 +379,15 @@ func (o *MeasurementsGeneralViewAtlas) SetStart(v time.Time) {
 	o.Start = &v
 }
 
-func (o MeasurementsGeneralViewAtlas) MarshalJSON() ([]byte, error) {
+func (o MeasurementsGeneralViewAtlas) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MeasurementsGeneralViewAtlas) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: databaseName is readOnly
-	// skip: end is readOnly
-	// skip: granularity is readOnly
-	// skip: groupId is readOnly
-	// skip: hostId is readOnly
-	// skip: links is readOnly
-	// skip: measurements is readOnly
-	// skip: partitionName is readOnly
-	// skip: processId is readOnly
-	// skip: start is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_measurements_indexes.go
+++ b/mongodbatlasv2/model_measurements_indexes.go
@@ -379,26 +379,15 @@ func (o *MeasurementsIndexes) SetStart(v time.Time) {
 	o.Start = &v
 }
 
-func (o MeasurementsIndexes) MarshalJSON() ([]byte, error) {
+func (o MeasurementsIndexes) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MeasurementsIndexes) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: collectionName is readOnly
-	// skip: databaseName is readOnly
-	// skip: end is readOnly
-	// skip: granularity is readOnly
-	// skip: groupId is readOnly
-	// skip: indexIds is readOnly
-	// skip: indexStatsMeasurements is readOnly
-	// skip: links is readOnly
-	// skip: processId is readOnly
-	// skip: start is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_measurements_non_index.go
+++ b/mongodbatlasv2/model_measurements_non_index.go
@@ -311,24 +311,15 @@ func (o *MeasurementsNonIndex) SetStatusMeasurements(v []Measurement) {
 	o.StatusMeasurements = v
 }
 
-func (o MeasurementsNonIndex) MarshalJSON() ([]byte, error) {
+func (o MeasurementsNonIndex) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MeasurementsNonIndex) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: end is readOnly
-	// skip: granularity is readOnly
-	// skip: groupId is readOnly
-	// skip: hardwareMeasurements is readOnly
-	// skip: links is readOnly
-	// skip: processId is readOnly
-	// skip: start is readOnly
-	// skip: statusMeasurements is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_metric_data_point.go
+++ b/mongodbatlasv2/model_metric_data_point.go
@@ -107,18 +107,15 @@ func (o *MetricDataPoint) SetValue(v float32) {
 	o.Value = &v
 }
 
-func (o MetricDataPoint) MarshalJSON() ([]byte, error) {
+func (o MetricDataPoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MetricDataPoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: timestamp is readOnly
-	// skip: value is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_metric_data_point_view_atlas.go
+++ b/mongodbatlasv2/model_metric_data_point_view_atlas.go
@@ -107,18 +107,15 @@ func (o *MetricDataPointViewAtlas) SetValue(v float32) {
 	o.Value = &v
 }
 
-func (o MetricDataPointViewAtlas) MarshalJSON() ([]byte, error) {
+func (o MetricDataPointViewAtlas) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MetricDataPointViewAtlas) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: timestamp is readOnly
-	// skip: value is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_microsoft_teams.go
+++ b/mongodbatlasv2/model_microsoft_teams.go
@@ -99,14 +99,13 @@ func (o *MicrosoftTeams) SetType(v string) {
 	o.Type = &v
 }
 
-func (o MicrosoftTeams) MarshalJSON() ([]byte, error) {
+func (o MicrosoftTeams) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MicrosoftTeams) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["microsoftTeamsWebhookUrl"] = o.MicrosoftTeamsWebhookUrl

--- a/mongodbatlasv2/model_microsoft_teams_notification.go
+++ b/mongodbatlasv2/model_microsoft_teams_notification.go
@@ -167,14 +167,13 @@ func (o *MicrosoftTeamsNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o MicrosoftTeamsNotification) MarshalJSON() ([]byte, error) {
+func (o MicrosoftTeamsNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MicrosoftTeamsNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_mongo_db_access_logs.go
+++ b/mongodbatlasv2/model_mongo_db_access_logs.go
@@ -344,27 +344,18 @@ func (o *MongoDBAccessLogs) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o MongoDBAccessLogs) MarshalJSON() ([]byte, error) {
+func (o MongoDBAccessLogs) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MongoDBAccessLogs) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AuthResult) {
 		toSerialize["authResult"] = o.AuthResult
 	}
-	// skip: authSource is readOnly
-	// skip: failureReason is readOnly
-	// skip: groupId is readOnly
-	// skip: hostname is readOnly
-	// skip: ipAddress is readOnly
-	// skip: logLine is readOnly
-	// skip: timestamp is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_mongo_db_access_logs_list.go
+++ b/mongodbatlasv2/model_mongo_db_access_logs_list.go
@@ -72,17 +72,15 @@ func (o *MongoDBAccessLogsList) SetAccessLogs(v []MongoDBAccessLogs) {
 	o.AccessLogs = v
 }
 
-func (o MongoDBAccessLogsList) MarshalJSON() ([]byte, error) {
+func (o MongoDBAccessLogsList) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MongoDBAccessLogsList) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: accessLogs is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_monthly_schedule.go
+++ b/mongodbatlasv2/model_monthly_schedule.go
@@ -234,14 +234,13 @@ func (o *MonthlySchedule) SetType(v string) {
 	o.Type = v
 }
 
-func (o MonthlySchedule) MarshalJSON() ([]byte, error) {
+func (o MonthlySchedule) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o MonthlySchedule) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DayOfMonth) {

--- a/mongodbatlasv2/model_namespace_obj.go
+++ b/mongodbatlasv2/model_namespace_obj.go
@@ -106,18 +106,15 @@ func (o *NamespaceObj) SetType(v string) {
 	o.Type = &v
 }
 
-func (o NamespaceObj) MarshalJSON() ([]byte, error) {
+func (o NamespaceObj) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NamespaceObj) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: namespace is readOnly
-	// skip: type is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_namespaces.go
+++ b/mongodbatlasv2/model_namespaces.go
@@ -72,17 +72,15 @@ func (o *Namespaces) SetNamespaces(v []NamespaceObj) {
 	o.Namespaces = v
 }
 
-func (o Namespaces) MarshalJSON() ([]byte, error) {
+func (o Namespaces) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Namespaces) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: namespaces is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_nds_audit_view_for_nds_group.go
+++ b/mongodbatlasv2/model_nds_audit_view_for_nds_group.go
@@ -492,32 +492,19 @@ func (o *NDSAuditViewForNdsGroup) SetWhitelistEntry(v string) {
 	o.WhitelistEntry = &v
 }
 
-func (o NDSAuditViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o NDSAuditViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSAuditViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
-	// skip: whitelistEntry is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_nds_audit_view_for_org.go
+++ b/mongodbatlasv2/model_nds_audit_view_for_org.go
@@ -492,32 +492,19 @@ func (o *NDSAuditViewForOrg) SetWhitelistEntry(v string) {
 	o.WhitelistEntry = &v
 }
 
-func (o NDSAuditViewForOrg) MarshalJSON() ([]byte, error) {
+func (o NDSAuditViewForOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSAuditViewForOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
-	// skip: whitelistEntry is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_nds_auto_scaling_audit_view_for_nds_group.go
+++ b/mongodbatlasv2/model_nds_auto_scaling_audit_view_for_nds_group.go
@@ -458,31 +458,19 @@ func (o *NDSAutoScalingAuditViewForNdsGroup) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o NDSAutoScalingAuditViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o NDSAutoScalingAuditViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSAutoScalingAuditViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_nds_label.go
+++ b/mongodbatlasv2/model_nds_label.go
@@ -106,14 +106,13 @@ func (o *NDSLabel) SetValue(v string) {
 	o.Value = &v
 }
 
-func (o NDSLabel) MarshalJSON() ([]byte, error) {
+func (o NDSLabel) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSLabel) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Key) {

--- a/mongodbatlasv2/model_nds_notification.go
+++ b/mongodbatlasv2/model_nds_notification.go
@@ -167,14 +167,13 @@ func (o *NDSNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o NDSNotification) MarshalJSON() ([]byte, error) {
+func (o NDSNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_nds_serverless_instance_audit.go
+++ b/mongodbatlasv2/model_nds_serverless_instance_audit.go
@@ -458,31 +458,19 @@ func (o *NDSServerlessInstanceAudit) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o NDSServerlessInstanceAudit) MarshalJSON() ([]byte, error) {
+func (o NDSServerlessInstanceAudit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSServerlessInstanceAudit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_nds_tenant_endpoint_audit.go
+++ b/mongodbatlasv2/model_nds_tenant_endpoint_audit.go
@@ -526,33 +526,19 @@ func (o *NDSTenantEndpointAudit) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o NDSTenantEndpointAudit) MarshalJSON() ([]byte, error) {
+func (o NDSTenantEndpointAudit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSTenantEndpointAudit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
-	// skip: endpointId is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: providerEndpointId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_nds_user_to_dn_mapping.go
+++ b/mongodbatlasv2/model_nds_user_to_dn_mapping.go
@@ -119,14 +119,13 @@ func (o *NDSUserToDNMapping) SetSubstitution(v string) {
 	o.Substitution = v
 }
 
-func (o NDSUserToDNMapping) MarshalJSON() ([]byte, error) {
+func (o NDSUserToDNMapping) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSUserToDNMapping) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["ldapQuery"] = o.LdapQuery

--- a/mongodbatlasv2/model_ndsldap.go
+++ b/mongodbatlasv2/model_ndsldap.go
@@ -386,14 +386,13 @@ func (o *NDSLDAP) SetUserToDNMapping(v []NDSUserToDNMapping) {
 	o.UserToDNMapping = v
 }
 
-func (o NDSLDAP) MarshalJSON() ([]byte, error) {
+func (o NDSLDAP) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSLDAP) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AuthenticationEnabled) {
@@ -417,7 +416,6 @@ func (o NDSLDAP) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Hostname) {
 		toSerialize["hostname"] = o.Hostname
 	}
-	// skip: links is readOnly
 	if !IsNil(o.Port) {
 		toSerialize["port"] = o.Port
 	}

--- a/mongodbatlasv2/model_ndsldap_verify_connectivity_job_request.go
+++ b/mongodbatlasv2/model_ndsldap_verify_connectivity_job_request.go
@@ -241,24 +241,18 @@ func (o *NDSLDAPVerifyConnectivityJobRequest) SetValidations(v []NDSLDAPVerifyCo
 	o.Validations = v
 }
 
-func (o NDSLDAPVerifyConnectivityJobRequest) MarshalJSON() ([]byte, error) {
+func (o NDSLDAPVerifyConnectivityJobRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSLDAPVerifyConnectivityJobRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: groupId is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Request) {
 		toSerialize["request"] = o.Request
 	}
-	// skip: requestId is readOnly
-	// skip: status is readOnly
-	// skip: validations is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_ndsldap_verify_connectivity_job_request_params.go
+++ b/mongodbatlasv2/model_ndsldap_verify_connectivity_job_request_params.go
@@ -254,14 +254,13 @@ func (o *NDSLDAPVerifyConnectivityJobRequestParams) SetPort(v int32) {
 	o.Port = v
 }
 
-func (o NDSLDAPVerifyConnectivityJobRequestParams) MarshalJSON() ([]byte, error) {
+func (o NDSLDAPVerifyConnectivityJobRequestParams) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSLDAPVerifyConnectivityJobRequestParams) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AuthzQueryTemplate) {
@@ -273,7 +272,6 @@ func (o NDSLDAPVerifyConnectivityJobRequestParams) ToMap() (map[string]interface
 		toSerialize["caCertificate"] = o.CaCertificate
 	}
 	toSerialize["hostname"] = o.Hostname
-	// skip: links is readOnly
 	toSerialize["port"] = o.Port
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_ndsldap_verify_connectivity_job_request_validation.go
+++ b/mongodbatlasv2/model_ndsldap_verify_connectivity_job_request_validation.go
@@ -106,18 +106,15 @@ func (o *NDSLDAPVerifyConnectivityJobRequestValidation) SetValidationType(v stri
 	o.ValidationType = &v
 }
 
-func (o NDSLDAPVerifyConnectivityJobRequestValidation) MarshalJSON() ([]byte, error) {
+func (o NDSLDAPVerifyConnectivityJobRequestValidation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSLDAPVerifyConnectivityJobRequestValidation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: status is readOnly
-	// skip: validationType is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_ndsx509_user_authentication_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_ndsx509_user_authentication_alert_config_view_for_nds_group.go
@@ -373,24 +373,19 @@ func (o *NDSX509UserAuthenticationAlertConfigViewForNdsGroup) SetUpdated(v time.
 	o.Updated = &v
 }
 
-func (o NDSX509UserAuthenticationAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o NDSX509UserAuthenticationAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NDSX509UserAuthenticationAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -400,7 +395,6 @@ func (o NDSX509UserAuthenticationAlertConfigViewForNdsGroup) ToMap() (map[string
 	if !IsNil(o.Threshold) {
 		toSerialize["threshold"] = o.Threshold
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_net_peer_request_base.go
+++ b/mongodbatlasv2/model_net_peer_request_base.go
@@ -92,14 +92,13 @@ func (o *NetPeerRequestBase) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o NetPeerRequestBase) MarshalJSON() ([]byte, error) {
+func (o NetPeerRequestBase) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NetPeerRequestBase) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["containerId"] = o.ContainerId

--- a/mongodbatlasv2/model_network_permission_entry.go
+++ b/mongodbatlasv2/model_network_permission_entry.go
@@ -277,14 +277,13 @@ func (o *NetworkPermissionEntry) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o NetworkPermissionEntry) MarshalJSON() ([]byte, error) {
+func (o NetworkPermissionEntry) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NetworkPermissionEntry) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AwsSecurityGroup) {
@@ -299,11 +298,9 @@ func (o NetworkPermissionEntry) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.DeleteAfterDate) {
 		toSerialize["deleteAfterDate"] = o.DeleteAfterDate
 	}
-	// skip: groupId is readOnly
 	if !IsNil(o.IpAddress) {
 		toSerialize["ipAddress"] = o.IpAddress
 	}
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_network_permission_entry_status.go
+++ b/mongodbatlasv2/model_network_permission_entry_status.go
@@ -65,17 +65,15 @@ func (o *NetworkPermissionEntryStatus) SetSTATUS(v string) {
 	o.STATUS = v
 }
 
-func (o NetworkPermissionEntryStatus) MarshalJSON() ([]byte, error) {
+func (o NetworkPermissionEntryStatus) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NetworkPermissionEntryStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: STATUS is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_new_relic.go
+++ b/mongodbatlasv2/model_new_relic.go
@@ -180,14 +180,13 @@ func (o *NewRelic) SetWriteToken(v string) {
 	o.WriteToken = v
 }
 
-func (o NewRelic) MarshalJSON() ([]byte, error) {
+func (o NewRelic) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NewRelic) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["accountId"] = o.AccountId

--- a/mongodbatlasv2/model_number_metric_alert.go
+++ b/mongodbatlasv2/model_number_metric_alert.go
@@ -634,39 +634,23 @@ func (o *NumberMetricAlert) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o NumberMetricAlert) MarshalJSON() ([]byte, error) {
+func (o NumberMetricAlert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NumberMetricAlert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: hostnameAndPort is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_number_metric_event.go
+++ b/mongodbatlasv2/model_number_metric_event.go
@@ -627,38 +627,22 @@ func (o *NumberMetricEvent) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o NumberMetricEvent) MarshalJSON() ([]byte, error) {
+func (o NumberMetricEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NumberMetricEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: port is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: shardName is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_number_metric_threshold.go
+++ b/mongodbatlasv2/model_number_metric_threshold.go
@@ -206,14 +206,13 @@ func (o *NumberMetricThreshold) SetUnits(v NumberMetricUnits) {
 	o.Units = &v
 }
 
-func (o NumberMetricThreshold) MarshalJSON() ([]byte, error) {
+func (o NumberMetricThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NumberMetricThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MetricName) {

--- a/mongodbatlasv2/model_number_metric_value.go
+++ b/mongodbatlasv2/model_number_metric_value.go
@@ -105,17 +105,15 @@ func (o *NumberMetricValue) SetUnits(v NumberMetricUnits) {
 	o.Units = &v
 }
 
-func (o NumberMetricValue) MarshalJSON() ([]byte, error) {
+func (o NumberMetricValue) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o NumberMetricValue) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: number is readOnly
 	if !IsNil(o.Units) {
 		toSerialize["units"] = o.Units
 	}

--- a/mongodbatlasv2/model_on_demand_cps_snapshot_source.go
+++ b/mongodbatlasv2/model_on_demand_cps_snapshot_source.go
@@ -208,14 +208,13 @@ func (o *OnDemandCpsSnapshotSource) SetType(v string) {
 	o.Type = &v
 }
 
-func (o OnDemandCpsSnapshotSource) MarshalJSON() ([]byte, error) {
+func (o OnDemandCpsSnapshotSource) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OnDemandCpsSnapshotSource) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ClusterName) {
@@ -227,7 +226,6 @@ func (o OnDemandCpsSnapshotSource) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.DatabaseName) {
 		toSerialize["databaseName"] = o.DatabaseName
 	}
-	// skip: groupId is readOnly
 	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}

--- a/mongodbatlasv2/model_online_archive.go
+++ b/mongodbatlasv2/model_online_archive.go
@@ -373,18 +373,15 @@ func (o *OnlineArchive) SetState(v string) {
 	o.State = &v
 }
 
-func (o OnlineArchive) MarshalJSON() ([]byte, error) {
+func (o OnlineArchive) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OnlineArchive) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
-	// skip: clusterName is readOnly
 	if !IsNil(o.CollName) {
 		toSerialize["collName"] = o.CollName
 	}
@@ -395,14 +392,12 @@ func (o OnlineArchive) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.DbName) {
 		toSerialize["dbName"] = o.DbName
 	}
-	// skip: groupId is readOnly
 	if !IsNil(o.PartitionFields) {
 		toSerialize["partitionFields"] = o.PartitionFields
 	}
 	if !IsNil(o.Schedule) {
 		toSerialize["schedule"] = o.Schedule
 	}
-	// skip: state is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_ops_genie.go
+++ b/mongodbatlasv2/model_ops_genie.go
@@ -137,14 +137,13 @@ func (o *OpsGenie) SetType(v string) {
 	o.Type = &v
 }
 
-func (o OpsGenie) MarshalJSON() ([]byte, error) {
+func (o OpsGenie) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OpsGenie) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["apiKey"] = o.ApiKey

--- a/mongodbatlasv2/model_ops_genie_notification.go
+++ b/mongodbatlasv2/model_ops_genie_notification.go
@@ -205,14 +205,13 @@ func (o *OpsGenieNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o OpsGenieNotification) MarshalJSON() ([]byte, error) {
+func (o OpsGenieNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OpsGenieNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_org_event_view_for_org.go
+++ b/mongodbatlasv2/model_org_event_view_for_org.go
@@ -492,32 +492,19 @@ func (o *OrgEventViewForOrg) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o OrgEventViewForOrg) MarshalJSON() ([]byte, error) {
+func (o OrgEventViewForOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrgEventViewForOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: invoiceId is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_org_federation_settings.go
+++ b/mongodbatlasv2/model_org_federation_settings.go
@@ -208,14 +208,13 @@ func (o *OrgFederationSettings) SetIdentityProviderStatus(v string) {
 	o.IdentityProviderStatus = &v
 }
 
-func (o OrgFederationSettings) MarshalJSON() ([]byte, error) {
+func (o OrgFederationSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrgFederationSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FederatedDomains) {
@@ -224,7 +223,6 @@ func (o OrgFederationSettings) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.HasRoleMappings) {
 		toSerialize["hasRoleMappings"] = o.HasRoleMappings
 	}
-	// skip: id is readOnly
 	if !IsNil(o.IdentityProviderId) {
 		toSerialize["identityProviderId"] = o.IdentityProviderId
 	}

--- a/mongodbatlasv2/model_org_group.go
+++ b/mongodbatlasv2/model_org_group.go
@@ -276,27 +276,21 @@ func (o *OrgGroup) SetTags(v []string) {
 	o.Tags = v
 }
 
-func (o OrgGroup) MarshalJSON() ([]byte, error) {
+func (o OrgGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrgGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusters is readOnly
-	// skip: groupId is readOnly
 	if !IsNil(o.GroupName) {
 		toSerialize["groupName"] = o.GroupName
 	}
-	// skip: orgId is readOnly
 	if !IsNil(o.OrgName) {
 		toSerialize["orgName"] = o.OrgName
 	}
-	// skip: planType is readOnly
-	// skip: tags is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_org_notification.go
+++ b/mongodbatlasv2/model_org_notification.go
@@ -235,14 +235,13 @@ func (o *OrgNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o OrgNotification) MarshalJSON() ([]byte, error) {
+func (o OrgNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrgNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_org_paginated_event.go
+++ b/mongodbatlasv2/model_org_paginated_event.go
@@ -140,19 +140,15 @@ func (o *OrgPaginatedEvent) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o OrgPaginatedEvent) MarshalJSON() ([]byte, error) {
+func (o OrgPaginatedEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrgPaginatedEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_organization.go
+++ b/mongodbatlasv2/model_organization.go
@@ -167,19 +167,15 @@ func (o *Organization) SetName(v string) {
 	o.Name = v
 }
 
-func (o Organization) MarshalJSON() ([]byte, error) {
+func (o Organization) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Organization) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: id is readOnly
-	// skip: isDeleted is readOnly
-	// skip: links is readOnly
 	toSerialize["name"] = o.Name
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_organization_invitation.go
+++ b/mongodbatlasv2/model_organization_invitation.go
@@ -372,27 +372,19 @@ func (o *OrganizationInvitation) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o OrganizationInvitation) MarshalJSON() ([]byte, error) {
+func (o OrganizationInvitation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrganizationInvitation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: createdAt is readOnly
-	// skip: expiresAt is readOnly
-	// skip: id is readOnly
-	// skip: inviterUsername is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
 	toSerialize["orgName"] = o.OrgName
 	if !IsNil(o.Roles) {
 		toSerialize["roles"] = o.Roles
 	}
-	// skip: teamIds is readOnly
 	if !IsNil(o.Username) {
 		toSerialize["username"] = o.Username
 	}

--- a/mongodbatlasv2/model_organization_invitation_request.go
+++ b/mongodbatlasv2/model_organization_invitation_request.go
@@ -140,14 +140,13 @@ func (o *OrganizationInvitationRequest) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o OrganizationInvitationRequest) MarshalJSON() ([]byte, error) {
+func (o OrganizationInvitationRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrganizationInvitationRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Roles) {

--- a/mongodbatlasv2/model_organization_invitation_update_request.go
+++ b/mongodbatlasv2/model_organization_invitation_update_request.go
@@ -106,14 +106,13 @@ func (o *OrganizationInvitationUpdateRequest) SetTeamIds(v []string) {
 	o.TeamIds = v
 }
 
-func (o OrganizationInvitationUpdateRequest) MarshalJSON() ([]byte, error) {
+func (o OrganizationInvitationUpdateRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrganizationInvitationUpdateRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Roles) {

--- a/mongodbatlasv2/model_organization_settings.go
+++ b/mongodbatlasv2/model_organization_settings.go
@@ -140,14 +140,13 @@ func (o *OrganizationSettings) SetRestrictEmployeeAccess(v bool) {
 	o.RestrictEmployeeAccess = &v
 }
 
-func (o OrganizationSettings) MarshalJSON() ([]byte, error) {
+func (o OrganizationSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o OrganizationSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ApiAccessListRequired) {

--- a/mongodbatlasv2/model_pager_duty.go
+++ b/mongodbatlasv2/model_pager_duty.go
@@ -133,14 +133,13 @@ func (o *PagerDuty) SetType(v string) {
 	o.Type = &v
 }
 
-func (o PagerDuty) MarshalJSON() ([]byte, error) {
+func (o PagerDuty) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PagerDuty) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Region) {

--- a/mongodbatlasv2/model_pager_duty_notification.go
+++ b/mongodbatlasv2/model_pager_duty_notification.go
@@ -205,14 +205,13 @@ func (o *PagerDutyNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o PagerDutyNotification) MarshalJSON() ([]byte, error) {
+func (o PagerDutyNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PagerDutyNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_paginated_alert.go
+++ b/mongodbatlasv2/model_paginated_alert.go
@@ -140,19 +140,15 @@ func (o *PaginatedAlert) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedAlert) MarshalJSON() ([]byte, error) {
+func (o PaginatedAlert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedAlert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_alert_config.go
+++ b/mongodbatlasv2/model_paginated_alert_config.go
@@ -140,19 +140,15 @@ func (o *PaginatedAlertConfig) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedAlertConfig) MarshalJSON() ([]byte, error) {
+func (o PaginatedAlertConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedAlertConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_api_user.go
+++ b/mongodbatlasv2/model_paginated_api_api_user.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiApiUser) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiApiUser) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiApiUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiApiUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_app_user.go
+++ b/mongodbatlasv2/model_paginated_api_app_user.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiAppUser) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiAppUser) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiAppUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiAppUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_atlas_checkpoint.go
+++ b/mongodbatlasv2/model_paginated_api_atlas_checkpoint.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiAtlasCheckpoint) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiAtlasCheckpoint) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiAtlasCheckpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiAtlasCheckpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_atlas_database_user.go
+++ b/mongodbatlasv2/model_paginated_api_atlas_database_user.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiAtlasDatabaseUser) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiAtlasDatabaseUser) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiAtlasDatabaseUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiAtlasDatabaseUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_atlas_disk_backup_export_job.go
+++ b/mongodbatlasv2/model_paginated_api_atlas_disk_backup_export_job.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiAtlasDiskBackupExportJob) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiAtlasDiskBackupExportJob) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiAtlasDiskBackupExportJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiAtlasDiskBackupExportJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_atlas_provider_regions.go
+++ b/mongodbatlasv2/model_paginated_api_atlas_provider_regions.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiAtlasProviderRegions) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiAtlasProviderRegions) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiAtlasProviderRegions) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiAtlasProviderRegions) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_atlas_serverless_backup_restore_job.go
+++ b/mongodbatlasv2/model_paginated_api_atlas_serverless_backup_restore_job.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiAtlasServerlessBackupRestoreJob) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiAtlasServerlessBackupRestoreJob) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiAtlasServerlessBackupRestoreJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiAtlasServerlessBackupRestoreJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_atlas_serverless_backup_snapshot.go
+++ b/mongodbatlasv2/model_paginated_api_atlas_serverless_backup_snapshot.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiAtlasServerlessBackupSnapshot) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiAtlasServerlessBackupSnapshot) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiAtlasServerlessBackupSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiAtlasServerlessBackupSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_invoice.go
+++ b/mongodbatlasv2/model_paginated_api_invoice.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiInvoice) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiInvoice) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiInvoice) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiInvoice) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_api_user_access_list.go
+++ b/mongodbatlasv2/model_paginated_api_user_access_list.go
@@ -140,19 +140,15 @@ func (o *PaginatedApiUserAccessList) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedApiUserAccessList) MarshalJSON() ([]byte, error) {
+func (o PaginatedApiUserAccessList) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedApiUserAccessList) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_app_user.go
+++ b/mongodbatlasv2/model_paginated_app_user.go
@@ -140,19 +140,15 @@ func (o *PaginatedAppUser) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedAppUser) MarshalJSON() ([]byte, error) {
+func (o PaginatedAppUser) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedAppUser) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_atlas_group.go
+++ b/mongodbatlasv2/model_paginated_atlas_group.go
@@ -140,19 +140,15 @@ func (o *PaginatedAtlasGroup) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedAtlasGroup) MarshalJSON() ([]byte, error) {
+func (o PaginatedAtlasGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedAtlasGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_aws_peer_vpc.go
+++ b/mongodbatlasv2/model_paginated_aws_peer_vpc.go
@@ -140,19 +140,15 @@ func (o *PaginatedAWSPeerVpc) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedAWSPeerVpc) MarshalJSON() ([]byte, error) {
+func (o PaginatedAWSPeerVpc) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedAWSPeerVpc) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_azure_peer_network.go
+++ b/mongodbatlasv2/model_paginated_azure_peer_network.go
@@ -140,19 +140,15 @@ func (o *PaginatedAzurePeerNetwork) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedAzurePeerNetwork) MarshalJSON() ([]byte, error) {
+func (o PaginatedAzurePeerNetwork) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedAzurePeerNetwork) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_backup_snapshot.go
+++ b/mongodbatlasv2/model_paginated_backup_snapshot.go
@@ -140,19 +140,15 @@ func (o *PaginatedBackupSnapshot) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedBackupSnapshot) MarshalJSON() ([]byte, error) {
+func (o PaginatedBackupSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedBackupSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_backup_snapshot_export_bucket.go
+++ b/mongodbatlasv2/model_paginated_backup_snapshot_export_bucket.go
@@ -140,19 +140,15 @@ func (o *PaginatedBackupSnapshotExportBucket) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedBackupSnapshotExportBucket) MarshalJSON() ([]byte, error) {
+func (o PaginatedBackupSnapshotExportBucket) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedBackupSnapshotExportBucket) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_cloud_backup_replica_set.go
+++ b/mongodbatlasv2/model_paginated_cloud_backup_replica_set.go
@@ -140,19 +140,15 @@ func (o *PaginatedCloudBackupReplicaSet) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedCloudBackupReplicaSet) MarshalJSON() ([]byte, error) {
+func (o PaginatedCloudBackupReplicaSet) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedCloudBackupReplicaSet) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_cloud_backup_restore_job.go
+++ b/mongodbatlasv2/model_paginated_cloud_backup_restore_job.go
@@ -140,19 +140,15 @@ func (o *PaginatedCloudBackupRestoreJob) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedCloudBackupRestoreJob) MarshalJSON() ([]byte, error) {
+func (o PaginatedCloudBackupRestoreJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedCloudBackupRestoreJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_cloud_backup_sharded_cluster_snapshot.go
+++ b/mongodbatlasv2/model_paginated_cloud_backup_sharded_cluster_snapshot.go
@@ -140,19 +140,15 @@ func (o *PaginatedCloudBackupShardedClusterSnapshot) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedCloudBackupShardedClusterSnapshot) MarshalJSON() ([]byte, error) {
+func (o PaginatedCloudBackupShardedClusterSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedCloudBackupShardedClusterSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_cloud_provider_container.go
+++ b/mongodbatlasv2/model_paginated_cloud_provider_container.go
@@ -140,19 +140,15 @@ func (o *PaginatedCloudProviderContainer) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedCloudProviderContainer) MarshalJSON() ([]byte, error) {
+func (o PaginatedCloudProviderContainer) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedCloudProviderContainer) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_cluster_description_v15.go
+++ b/mongodbatlasv2/model_paginated_cluster_description_v15.go
@@ -140,19 +140,15 @@ func (o *PaginatedClusterDescriptionV15) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedClusterDescriptionV15) MarshalJSON() ([]byte, error) {
+func (o PaginatedClusterDescriptionV15) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedClusterDescriptionV15) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_database.go
+++ b/mongodbatlasv2/model_paginated_database.go
@@ -140,19 +140,15 @@ func (o *PaginatedDatabase) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedDatabase) MarshalJSON() ([]byte, error) {
+func (o PaginatedDatabase) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedDatabase) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_disk_partition.go
+++ b/mongodbatlasv2/model_paginated_disk_partition.go
@@ -140,19 +140,15 @@ func (o *PaginatedDiskPartition) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedDiskPartition) MarshalJSON() ([]byte, error) {
+func (o PaginatedDiskPartition) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedDiskPartition) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_gcp_peer_vpc.go
+++ b/mongodbatlasv2/model_paginated_gcp_peer_vpc.go
@@ -140,19 +140,15 @@ func (o *PaginatedGCPPeerVpc) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedGCPPeerVpc) MarshalJSON() ([]byte, error) {
+func (o PaginatedGCPPeerVpc) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedGCPPeerVpc) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_host_view_atlas.go
+++ b/mongodbatlasv2/model_paginated_host_view_atlas.go
@@ -140,19 +140,15 @@ func (o *PaginatedHostViewAtlas) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedHostViewAtlas) MarshalJSON() ([]byte, error) {
+func (o PaginatedHostViewAtlas) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedHostViewAtlas) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_legacy_cluster.go
+++ b/mongodbatlasv2/model_paginated_legacy_cluster.go
@@ -140,19 +140,15 @@ func (o *PaginatedLegacyCluster) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedLegacyCluster) MarshalJSON() ([]byte, error) {
+func (o PaginatedLegacyCluster) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedLegacyCluster) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_network_access.go
+++ b/mongodbatlasv2/model_paginated_network_access.go
@@ -140,19 +140,15 @@ func (o *PaginatedNetworkAccess) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedNetworkAccess) MarshalJSON() ([]byte, error) {
+func (o PaginatedNetworkAccess) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedNetworkAccess) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_online_archive.go
+++ b/mongodbatlasv2/model_paginated_online_archive.go
@@ -140,19 +140,15 @@ func (o *PaginatedOnlineArchive) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedOnlineArchive) MarshalJSON() ([]byte, error) {
+func (o PaginatedOnlineArchive) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedOnlineArchive) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_org_group.go
+++ b/mongodbatlasv2/model_paginated_org_group.go
@@ -140,19 +140,15 @@ func (o *PaginatedOrgGroup) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedOrgGroup) MarshalJSON() ([]byte, error) {
+func (o PaginatedOrgGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedOrgGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_organization.go
+++ b/mongodbatlasv2/model_paginated_organization.go
@@ -140,19 +140,15 @@ func (o *PaginatedOrganization) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedOrganization) MarshalJSON() ([]byte, error) {
+func (o PaginatedOrganization) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedOrganization) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_pipeline_run.go
+++ b/mongodbatlasv2/model_paginated_pipeline_run.go
@@ -140,19 +140,15 @@ func (o *PaginatedPipelineRun) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedPipelineRun) MarshalJSON() ([]byte, error) {
+func (o PaginatedPipelineRun) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedPipelineRun) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_private_link_connection.go
+++ b/mongodbatlasv2/model_paginated_private_link_connection.go
@@ -140,19 +140,15 @@ func (o *PaginatedPrivateLinkConnection) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedPrivateLinkConnection) MarshalJSON() ([]byte, error) {
+func (o PaginatedPrivateLinkConnection) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedPrivateLinkConnection) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_restore_job.go
+++ b/mongodbatlasv2/model_paginated_restore_job.go
@@ -140,19 +140,15 @@ func (o *PaginatedRestoreJob) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedRestoreJob) MarshalJSON() ([]byte, error) {
+func (o PaginatedRestoreJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedRestoreJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_serverless_instance_description.go
+++ b/mongodbatlasv2/model_paginated_serverless_instance_description.go
@@ -140,19 +140,15 @@ func (o *PaginatedServerlessInstanceDescription) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedServerlessInstanceDescription) MarshalJSON() ([]byte, error) {
+func (o PaginatedServerlessInstanceDescription) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedServerlessInstanceDescription) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_snapshot.go
+++ b/mongodbatlasv2/model_paginated_snapshot.go
@@ -140,19 +140,15 @@ func (o *PaginatedSnapshot) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedSnapshot) MarshalJSON() ([]byte, error) {
+func (o PaginatedSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_team.go
+++ b/mongodbatlasv2/model_paginated_team.go
@@ -140,19 +140,15 @@ func (o *PaginatedTeam) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedTeam) MarshalJSON() ([]byte, error) {
+func (o PaginatedTeam) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedTeam) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_team_role.go
+++ b/mongodbatlasv2/model_paginated_team_role.go
@@ -140,19 +140,15 @@ func (o *PaginatedTeamRole) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedTeamRole) MarshalJSON() ([]byte, error) {
+func (o PaginatedTeamRole) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedTeamRole) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_tenant_restore.go
+++ b/mongodbatlasv2/model_paginated_tenant_restore.go
@@ -140,19 +140,15 @@ func (o *PaginatedTenantRestore) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedTenantRestore) MarshalJSON() ([]byte, error) {
+func (o PaginatedTenantRestore) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedTenantRestore) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_tenant_snapshot.go
+++ b/mongodbatlasv2/model_paginated_tenant_snapshot.go
@@ -140,19 +140,15 @@ func (o *PaginatedTenantSnapshot) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedTenantSnapshot) MarshalJSON() ([]byte, error) {
+func (o PaginatedTenantSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedTenantSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_paginated_user_cert.go
+++ b/mongodbatlasv2/model_paginated_user_cert.go
@@ -140,19 +140,15 @@ func (o *PaginatedUserCert) SetTotalCount(v int32) {
 	o.TotalCount = &v
 }
 
-func (o PaginatedUserCert) MarshalJSON() ([]byte, error) {
+func (o PaginatedUserCert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PaginatedUserCert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
-	// skip: results is readOnly
-	// skip: totalCount is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_partition_field.go
+++ b/mongodbatlasv2/model_partition_field.go
@@ -128,18 +128,16 @@ func (o *PartitionField) SetOrder(v int32) {
 	o.Order = v
 }
 
-func (o PartitionField) MarshalJSON() ([]byte, error) {
+func (o PartitionField) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PartitionField) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["fieldName"] = o.FieldName
-	// skip: fieldType is readOnly
 	toSerialize["order"] = o.Order
 	return toSerialize, nil
 }

--- a/mongodbatlasv2/model_payment.go
+++ b/mongodbatlasv2/model_payment.go
@@ -311,26 +311,18 @@ func (o *Payment) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o Payment) MarshalJSON() ([]byte, error) {
+func (o Payment) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Payment) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: amountBilledCents is readOnly
-	// skip: amountPaidCents is readOnly
-	// skip: created is readOnly
-	// skip: id is readOnly
-	// skip: salesTaxCents is readOnly
 	if !IsNil(o.StatusName) {
 		toSerialize["statusName"] = o.StatusName
 	}
-	// skip: subtotalCents is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_pem_file_info.go
+++ b/mongodbatlasv2/model_pem_file_info.go
@@ -104,14 +104,13 @@ func (o *PemFileInfo) SetFileName(v string) {
 	o.FileName = &v
 }
 
-func (o PemFileInfo) MarshalJSON() ([]byte, error) {
+func (o PemFileInfo) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PemFileInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Certificates) {

--- a/mongodbatlasv2/model_pem_file_info_view.go
+++ b/mongodbatlasv2/model_pem_file_info_view.go
@@ -106,14 +106,13 @@ func (o *PemFileInfoView) SetFileName(v string) {
 	o.FileName = &v
 }
 
-func (o PemFileInfoView) MarshalJSON() ([]byte, error) {
+func (o PemFileInfoView) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PemFileInfoView) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Certificates) {

--- a/mongodbatlasv2/model_performance_advisor_index.go
+++ b/mongodbatlasv2/model_performance_advisor_index.go
@@ -242,22 +242,15 @@ func (o *PerformanceAdvisorIndex) SetWeight(v float64) {
 	o.Weight = &v
 }
 
-func (o PerformanceAdvisorIndex) MarshalJSON() ([]byte, error) {
+func (o PerformanceAdvisorIndex) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PerformanceAdvisorIndex) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: avgObjSize is readOnly
-	// skip: id is readOnly
-	// skip: impact is readOnly
-	// skip: index is readOnly
-	// skip: namespace is readOnly
-	// skip: weight is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_performance_advisor_op_stats.go
+++ b/mongodbatlasv2/model_performance_advisor_op_stats.go
@@ -174,20 +174,15 @@ func (o *PerformanceAdvisorOpStats) SetTs(v int64) {
 	o.Ts = &v
 }
 
-func (o PerformanceAdvisorOpStats) MarshalJSON() ([]byte, error) {
+func (o PerformanceAdvisorOpStats) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PerformanceAdvisorOpStats) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: ms is readOnly
-	// skip: nReturned is readOnly
-	// skip: nScanned is readOnly
-	// skip: ts is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_performance_advisor_operation.go
+++ b/mongodbatlasv2/model_performance_advisor_operation.go
@@ -105,17 +105,15 @@ func (o *PerformanceAdvisorOperation) SetStats(v PerformanceAdvisorOpStats) {
 	o.Stats = &v
 }
 
-func (o PerformanceAdvisorOperation) MarshalJSON() ([]byte, error) {
+func (o PerformanceAdvisorOperation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PerformanceAdvisorOperation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: predicates is readOnly
 	if !IsNil(o.Stats) {
 		toSerialize["stats"] = o.Stats
 	}

--- a/mongodbatlasv2/model_performance_advisor_response.go
+++ b/mongodbatlasv2/model_performance_advisor_response.go
@@ -106,18 +106,15 @@ func (o *PerformanceAdvisorResponse) SetSuggestedIndexes(v []PerformanceAdvisorI
 	o.SuggestedIndexes = v
 }
 
-func (o PerformanceAdvisorResponse) MarshalJSON() ([]byte, error) {
+func (o PerformanceAdvisorResponse) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PerformanceAdvisorResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: shapes is readOnly
-	// skip: suggestedIndexes is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_performance_advisor_shape.go
+++ b/mongodbatlasv2/model_performance_advisor_shape.go
@@ -242,22 +242,15 @@ func (o *PerformanceAdvisorShape) SetOperations(v []PerformanceAdvisorOperation)
 	o.Operations = v
 }
 
-func (o PerformanceAdvisorShape) MarshalJSON() ([]byte, error) {
+func (o PerformanceAdvisorShape) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PerformanceAdvisorShape) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: avgMs is readOnly
-	// skip: count is readOnly
-	// skip: id is readOnly
-	// skip: inefficiencyScore is readOnly
-	// skip: namespace is readOnly
-	// skip: operations is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_performance_advisor_slow_query.go
+++ b/mongodbatlasv2/model_performance_advisor_slow_query.go
@@ -106,18 +106,15 @@ func (o *PerformanceAdvisorSlowQuery) SetNamespace(v string) {
 	o.Namespace = &v
 }
 
-func (o PerformanceAdvisorSlowQuery) MarshalJSON() ([]byte, error) {
+func (o PerformanceAdvisorSlowQuery) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PerformanceAdvisorSlowQuery) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: line is readOnly
-	// skip: namespace is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_performance_advisor_slow_query_list.go
+++ b/mongodbatlasv2/model_performance_advisor_slow_query_list.go
@@ -72,17 +72,15 @@ func (o *PerformanceAdvisorSlowQueryList) SetSlowQueries(v []PerformanceAdvisorS
 	o.SlowQueries = v
 }
 
-func (o PerformanceAdvisorSlowQueryList) MarshalJSON() ([]byte, error) {
+func (o PerformanceAdvisorSlowQueryList) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PerformanceAdvisorSlowQueryList) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: slowQueries is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_periodic_cps_snapshot_source.go
+++ b/mongodbatlasv2/model_periodic_cps_snapshot_source.go
@@ -242,14 +242,13 @@ func (o *PeriodicCpsSnapshotSource) SetType(v string) {
 	o.Type = &v
 }
 
-func (o PeriodicCpsSnapshotSource) MarshalJSON() ([]byte, error) {
+func (o PeriodicCpsSnapshotSource) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PeriodicCpsSnapshotSource) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ClusterName) {
@@ -261,7 +260,6 @@ func (o PeriodicCpsSnapshotSource) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.DatabaseName) {
 		toSerialize["databaseName"] = o.DatabaseName
 	}
-	// skip: groupId is readOnly
 	if !IsNil(o.PolicyItemId) {
 		toSerialize["policyItemId"] = o.PolicyItemId
 	}

--- a/mongodbatlasv2/model_pipeline_run_stats.go
+++ b/mongodbatlasv2/model_pipeline_run_stats.go
@@ -106,18 +106,15 @@ func (o *PipelineRunStats) SetNumDocs(v int64) {
 	o.NumDocs = &v
 }
 
-func (o PipelineRunStats) MarshalJSON() ([]byte, error) {
+func (o PipelineRunStats) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PipelineRunStats) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: bytesExported is readOnly
-	// skip: numDocs is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_policy.go
+++ b/mongodbatlasv2/model_policy.go
@@ -106,14 +106,13 @@ func (o *Policy) SetPolicyItems(v []PolicyItem) {
 	o.PolicyItems = v
 }
 
-func (o Policy) MarshalJSON() ([]byte, error) {
+func (o Policy) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Policy) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Id) {

--- a/mongodbatlasv2/model_policy_item.go
+++ b/mongodbatlasv2/model_policy_item.go
@@ -180,19 +180,17 @@ func (o *PolicyItem) SetRetentionValue(v int32) {
 	o.RetentionValue = v
 }
 
-func (o PolicyItem) MarshalJSON() ([]byte, error) {
+func (o PolicyItem) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PolicyItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["frequencyInterval"] = o.FrequencyInterval
 	toSerialize["frequencyType"] = o.FrequencyType
-	// skip: id is readOnly
 	toSerialize["retentionUnit"] = o.RetentionUnit
 	toSerialize["retentionValue"] = o.RetentionValue
 	return toSerialize, nil

--- a/mongodbatlasv2/model_private_ip_mode.go
+++ b/mongodbatlasv2/model_private_ip_mode.go
@@ -65,14 +65,13 @@ func (o *PrivateIPMode) SetEnabled(v bool) {
 	o.Enabled = v
 }
 
-func (o PrivateIPMode) MarshalJSON() ([]byte, error) {
+func (o PrivateIPMode) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PrivateIPMode) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["enabled"] = o.Enabled

--- a/mongodbatlasv2/model_private_network_endpoint_id_entry.go
+++ b/mongodbatlasv2/model_private_network_endpoint_id_entry.go
@@ -175,14 +175,13 @@ func (o *PrivateNetworkEndpointIdEntry) SetType(v string) {
 	o.Type = &v
 }
 
-func (o PrivateNetworkEndpointIdEntry) MarshalJSON() ([]byte, error) {
+func (o PrivateNetworkEndpointIdEntry) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o PrivateNetworkEndpointIdEntry) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Comment) {

--- a/mongodbatlasv2/model_project_setting_item.go
+++ b/mongodbatlasv2/model_project_setting_item.go
@@ -65,14 +65,13 @@ func (o *ProjectSettingItem) SetEnabled(v bool) {
 	o.Enabled = v
 }
 
-func (o ProjectSettingItem) MarshalJSON() ([]byte, error) {
+func (o ProjectSettingItem) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ProjectSettingItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["enabled"] = o.Enabled

--- a/mongodbatlasv2/model_prometheus.go
+++ b/mongodbatlasv2/model_prometheus.go
@@ -318,14 +318,13 @@ func (o *Prometheus) SetUsername(v string) {
 	o.Username = v
 }
 
-func (o Prometheus) MarshalJSON() ([]byte, error) {
+func (o Prometheus) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Prometheus) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["enabled"] = o.Enabled

--- a/mongodbatlasv2/model_provider_regions.go
+++ b/mongodbatlasv2/model_provider_regions.go
@@ -106,17 +106,15 @@ func (o *ProviderRegions) SetProvider(v string) {
 	o.Provider = &v
 }
 
-func (o ProviderRegions) MarshalJSON() ([]byte, error) {
+func (o ProviderRegions) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ProviderRegions) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: instanceSizes is readOnly
 	if !IsNil(o.Provider) {
 		toSerialize["provider"] = o.Provider
 	}

--- a/mongodbatlasv2/model_raw.go
+++ b/mongodbatlasv2/model_raw.go
@@ -378,30 +378,24 @@ func (o *Raw) SetSeverity(v string) {
 	o.Severity = &v
 }
 
-func (o Raw) MarshalJSON() ([]byte, error) {
+func (o Raw) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Raw) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.T) {
 		toSerialize["_t"] = o.T
 	}
-	// skip: alertConfigId is readOnly
-	// skip: cid is readOnly
-	// skip: cre is readOnly
 	if !IsNil(o.Description) {
 		toSerialize["description"] = o.Description
 	}
 	if !IsNil(o.Gn) {
 		toSerialize["gn"] = o.Gn
 	}
-	// skip: id is readOnly
-	// skip: orgId is readOnly
 	if !IsNil(o.OrgName) {
 		toSerialize["orgName"] = o.OrgName
 	}

--- a/mongodbatlasv2/model_raw_metric_alert.go
+++ b/mongodbatlasv2/model_raw_metric_alert.go
@@ -634,39 +634,23 @@ func (o *RawMetricAlert) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o RawMetricAlert) MarshalJSON() ([]byte, error) {
+func (o RawMetricAlert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RawMetricAlert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: hostnameAndPort is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_raw_metric_event.go
+++ b/mongodbatlasv2/model_raw_metric_event.go
@@ -627,38 +627,22 @@ func (o *RawMetricEvent) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o RawMetricEvent) MarshalJSON() ([]byte, error) {
+func (o RawMetricEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RawMetricEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: port is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: shardName is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_raw_metric_threshold.go
+++ b/mongodbatlasv2/model_raw_metric_threshold.go
@@ -210,14 +210,13 @@ func (o *RawMetricThreshold) SetUnits(v RawMetricUnits) {
 	o.Units = &v
 }
 
-func (o RawMetricThreshold) MarshalJSON() ([]byte, error) {
+func (o RawMetricThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RawMetricThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MetricName) {

--- a/mongodbatlasv2/model_raw_metric_value.go
+++ b/mongodbatlasv2/model_raw_metric_value.go
@@ -109,17 +109,15 @@ func (o *RawMetricValue) SetUnits(v RawMetricUnits) {
 	o.Units = &v
 }
 
-func (o RawMetricValue) MarshalJSON() ([]byte, error) {
+func (o RawMetricValue) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RawMetricValue) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: number is readOnly
 	if !IsNil(o.Units) {
 		toSerialize["units"] = o.Units
 	}

--- a/mongodbatlasv2/model_refund.go
+++ b/mongodbatlasv2/model_refund.go
@@ -175,20 +175,15 @@ func (o *Refund) SetReason(v string) {
 	o.Reason = &v
 }
 
-func (o Refund) MarshalJSON() ([]byte, error) {
+func (o Refund) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Refund) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: amountCents is readOnly
-	// skip: created is readOnly
-	// skip: paymentId is readOnly
-	// skip: reason is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_region_spec.go
+++ b/mongodbatlasv2/model_region_spec.go
@@ -174,14 +174,13 @@ func (o *RegionSpec) SetReadOnlyNodes(v int32) {
 	o.ReadOnlyNodes = &v
 }
 
-func (o RegionSpec) MarshalJSON() ([]byte, error) {
+func (o RegionSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RegionSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AnalyticsNodes) {

--- a/mongodbatlasv2/model_replica_set_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_replica_set_alert_config_view_for_nds_group.go
@@ -374,24 +374,19 @@ func (o *ReplicaSetAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o ReplicaSetAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o ReplicaSetAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ReplicaSetAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -401,7 +396,6 @@ func (o ReplicaSetAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, e
 	if !IsNil(o.Threshold) {
 		toSerialize["threshold"] = o.Threshold
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_replica_set_alert_view_for_nds_group.go
+++ b/mongodbatlasv2/model_replica_set_alert_view_for_nds_group.go
@@ -634,37 +634,20 @@ func (o *ReplicaSetAlertViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o ReplicaSetAlertViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o ReplicaSetAlertViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ReplicaSetAlertViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: hostnameAndPort is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: nonRunningHostIds is readOnly
-	// skip: orgId is readOnly
-	// skip: parentClusterId is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_replica_set_matcher.go
+++ b/mongodbatlasv2/model_replica_set_matcher.go
@@ -139,14 +139,13 @@ func (o *ReplicaSetMatcher) SetValue(v string) {
 	o.Value = &v
 }
 
-func (o ReplicaSetMatcher) MarshalJSON() ([]byte, error) {
+func (o ReplicaSetMatcher) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ReplicaSetMatcher) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.FieldName) {

--- a/mongodbatlasv2/model_replication_spec.go
+++ b/mongodbatlasv2/model_replication_spec.go
@@ -174,17 +174,15 @@ func (o *ReplicationSpec) SetZoneName(v string) {
 	o.ZoneName = &v
 }
 
-func (o ReplicationSpec) MarshalJSON() ([]byte, error) {
+func (o ReplicationSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ReplicationSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: id is readOnly
 	if !IsNil(o.NumShards) {
 		toSerialize["numShards"] = o.NumShards
 	}

--- a/mongodbatlasv2/model_restore_job.go
+++ b/mongodbatlasv2/model_restore_job.go
@@ -642,30 +642,19 @@ func (o *RestoreJob) SetTimestamp(v BSONTimestamp) {
 	o.Timestamp = &v
 }
 
-func (o RestoreJob) MarshalJSON() ([]byte, error) {
+func (o RestoreJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RestoreJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: batchId is readOnly
 	if !IsNil(o.CheckpointId) {
 		toSerialize["checkpointId"] = o.CheckpointId
 	}
-	// skip: clusterId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	toSerialize["delivery"] = o.Delivery
-	// skip: encryptionEnabled is readOnly
-	// skip: groupId is readOnly
-	// skip: hashes is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: masterKeyUUID is readOnly
 	if !IsNil(o.OplogInc) {
 		toSerialize["oplogInc"] = o.OplogInc
 	}
@@ -678,7 +667,6 @@ func (o RestoreJob) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SnapshotId) {
 		toSerialize["snapshotId"] = o.SnapshotId
 	}
-	// skip: statusName is readOnly
 	if !IsNil(o.Timestamp) {
 		toSerialize["timestamp"] = o.Timestamp
 	}

--- a/mongodbatlasv2/model_restore_job_delivery.go
+++ b/mongodbatlasv2/model_restore_job_delivery.go
@@ -444,27 +444,22 @@ func (o *RestoreJobDelivery) SetUrlV2(v string) {
 	o.UrlV2 = &v
 }
 
-func (o RestoreJobDelivery) MarshalJSON() ([]byte, error) {
+func (o RestoreJobDelivery) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RestoreJobDelivery) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: authHeader is readOnly
-	// skip: authValue is readOnly
 	if !IsNil(o.ExpirationHours) {
 		toSerialize["expirationHours"] = o.ExpirationHours
 	}
-	// skip: expires is readOnly
 	if !IsNil(o.MaxDownloads) {
 		toSerialize["maxDownloads"] = o.MaxDownloads
 	}
 	toSerialize["methodName"] = o.MethodName
-	// skip: statusName is readOnly
 	if !IsNil(o.TargetClusterId) {
 		toSerialize["targetClusterId"] = o.TargetClusterId
 	}
@@ -474,8 +469,6 @@ func (o RestoreJobDelivery) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.TargetGroupId) {
 		toSerialize["targetGroupId"] = o.TargetGroupId
 	}
-	// skip: url is readOnly
-	// skip: urlV2 is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_restore_job_file_hash.go
+++ b/mongodbatlasv2/model_restore_job_file_hash.go
@@ -174,20 +174,15 @@ func (o *RestoreJobFileHash) SetTypeName(v string) {
 	o.TypeName = &v
 }
 
-func (o RestoreJobFileHash) MarshalJSON() ([]byte, error) {
+func (o RestoreJobFileHash) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RestoreJobFileHash) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: fileName is readOnly
-	// skip: hash is readOnly
-	// skip: links is readOnly
-	// skip: typeName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_role.go
+++ b/mongodbatlasv2/model_role.go
@@ -119,14 +119,13 @@ func (o *Role) SetRoleName(v string) {
 	o.RoleName = v
 }
 
-func (o Role) MarshalJSON() ([]byte, error) {
+func (o Role) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Role) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["collectionName"] = o.CollectionName

--- a/mongodbatlasv2/model_role_assignment.go
+++ b/mongodbatlasv2/model_role_assignment.go
@@ -140,14 +140,13 @@ func (o *RoleAssignment) SetRoleName(v string) {
 	o.RoleName = &v
 }
 
-func (o RoleAssignment) MarshalJSON() ([]byte, error) {
+func (o RoleAssignment) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RoleAssignment) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.GroupId) {

--- a/mongodbatlasv2/model_role_mapping.go
+++ b/mongodbatlasv2/model_role_mapping.go
@@ -133,18 +133,16 @@ func (o *RoleMapping) SetRoleAssignments(v []RoleAssignment) {
 	o.RoleAssignments = v
 }
 
-func (o RoleMapping) MarshalJSON() ([]byte, error) {
+func (o RoleMapping) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RoleMapping) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["externalGroupName"] = o.ExternalGroupName
-	// skip: id is readOnly
 	if !IsNil(o.RoleAssignments) {
 		toSerialize["roleAssignments"] = o.RoleAssignments
 	}

--- a/mongodbatlasv2/model_rpu_metric_threshold.go
+++ b/mongodbatlasv2/model_rpu_metric_threshold.go
@@ -206,14 +206,13 @@ func (o *RPUMetricThreshold) SetUnits(v ServerlessMetricUnits) {
 	o.Units = &v
 }
 
-func (o RPUMetricThreshold) MarshalJSON() ([]byte, error) {
+func (o RPUMetricThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o RPUMetricThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MetricName) {

--- a/mongodbatlasv2/model_sample_dataset_status.go
+++ b/mongodbatlasv2/model_sample_dataset_status.go
@@ -243,22 +243,15 @@ func (o *SampleDatasetStatus) SetState(v string) {
 	o.State = &v
 }
 
-func (o SampleDatasetStatus) MarshalJSON() ([]byte, error) {
+func (o SampleDatasetStatus) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SampleDatasetStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
-	// skip: clusterName is readOnly
-	// skip: completeDate is readOnly
-	// skip: createDate is readOnly
-	// skip: errorMessage is readOnly
-	// skip: state is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_aws_tenant_endpoint.go
+++ b/mongodbatlasv2/model_serverless_aws_tenant_endpoint.go
@@ -276,23 +276,15 @@ func (o *ServerlessAWSTenantEndpoint) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o ServerlessAWSTenantEndpoint) MarshalJSON() ([]byte, error) {
+func (o ServerlessAWSTenantEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessAWSTenantEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
-	// skip: cloudProviderEndpointId is readOnly
-	// skip: comment is readOnly
-	// skip: endpointServiceName is readOnly
-	// skip: errorMessage is readOnly
-	// skip: providerName is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_aws_tenant_endpoint_update.go
+++ b/mongodbatlasv2/model_serverless_aws_tenant_endpoint_update.go
@@ -132,14 +132,13 @@ func (o *ServerlessAWSTenantEndpointUpdate) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o ServerlessAWSTenantEndpointUpdate) MarshalJSON() ([]byte, error) {
+func (o ServerlessAWSTenantEndpointUpdate) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessAWSTenantEndpointUpdate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CloudProviderEndpointId) {

--- a/mongodbatlasv2/model_serverless_azure_tenant_endpoint.go
+++ b/mongodbatlasv2/model_serverless_azure_tenant_endpoint.go
@@ -344,25 +344,15 @@ func (o *ServerlessAzureTenantEndpoint) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o ServerlessAzureTenantEndpoint) MarshalJSON() ([]byte, error) {
+func (o ServerlessAzureTenantEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessAzureTenantEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
-	// skip: cloudProviderEndpointId is readOnly
-	// skip: comment is readOnly
-	// skip: endpointServiceName is readOnly
-	// skip: errorMessage is readOnly
-	// skip: privateEndpointIpAddress is readOnly
-	// skip: privateLinkServiceResourceId is readOnly
-	// skip: providerName is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_azure_tenant_endpoint_update.go
+++ b/mongodbatlasv2/model_serverless_azure_tenant_endpoint_update.go
@@ -166,14 +166,13 @@ func (o *ServerlessAzureTenantEndpointUpdate) SetProviderName(v string) {
 	o.ProviderName = v
 }
 
-func (o ServerlessAzureTenantEndpointUpdate) MarshalJSON() ([]byte, error) {
+func (o ServerlessAzureTenantEndpointUpdate) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessAzureTenantEndpointUpdate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CloudProviderEndpointId) {

--- a/mongodbatlasv2/model_serverless_backup_options.go
+++ b/mongodbatlasv2/model_serverless_backup_options.go
@@ -76,14 +76,13 @@ func (o *ServerlessBackupOptions) SetServerlessContinuousBackupEnabled(v bool) {
 	o.ServerlessContinuousBackupEnabled = &v
 }
 
-func (o ServerlessBackupOptions) MarshalJSON() ([]byte, error) {
+func (o ServerlessBackupOptions) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessBackupOptions) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ServerlessContinuousBackupEnabled) {

--- a/mongodbatlasv2/model_serverless_backup_restore_job.go
+++ b/mongodbatlasv2/model_serverless_backup_restore_job.go
@@ -595,28 +595,19 @@ func (o *ServerlessBackupRestoreJob) SetTimestamp(v time.Time) {
 	o.Timestamp = &v
 }
 
-func (o ServerlessBackupRestoreJob) MarshalJSON() ([]byte, error) {
+func (o ServerlessBackupRestoreJob) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessBackupRestoreJob) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: cancelled is readOnly
 	toSerialize["deliveryType"] = o.DeliveryType
-	// skip: deliveryUrl is readOnly
 	if !IsNil(o.DesiredTimestamp) {
 		toSerialize["desiredTimestamp"] = o.DesiredTimestamp
 	}
-	// skip: expired is readOnly
-	// skip: expiresAt is readOnly
-	// skip: failed is readOnly
-	// skip: finishedAt is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.OplogInc) {
 		toSerialize["oplogInc"] = o.OplogInc
 	}
@@ -631,7 +622,6 @@ func (o ServerlessBackupRestoreJob) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["targetClusterName"] = o.TargetClusterName
 	toSerialize["targetGroupId"] = o.TargetGroupId
-	// skip: timestamp is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_backup_snapshot.go
+++ b/mongodbatlasv2/model_serverless_backup_snapshot.go
@@ -379,26 +379,15 @@ func (o *ServerlessBackupSnapshot) SetStorageSizeBytes(v int64) {
 	o.StorageSizeBytes = &v
 }
 
-func (o ServerlessBackupSnapshot) MarshalJSON() ([]byte, error) {
+func (o ServerlessBackupSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessBackupSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: createdAt is readOnly
-	// skip: expiresAt is readOnly
-	// skip: frequencyType is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: mongodVersion is readOnly
-	// skip: serverlessInstanceName is readOnly
-	// skip: snapshotType is readOnly
-	// skip: status is readOnly
-	// skip: storageSizeBytes is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_instance_description.go
+++ b/mongodbatlasv2/model_serverless_instance_description.go
@@ -407,30 +407,22 @@ func (o *ServerlessInstanceDescription) SetTerminationProtectionEnabled(v bool) 
 	o.TerminationProtectionEnabled = &v
 }
 
-func (o ServerlessInstanceDescription) MarshalJSON() ([]byte, error) {
+func (o ServerlessInstanceDescription) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessInstanceDescription) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ConnectionStrings) {
 		toSerialize["connectionStrings"] = o.ConnectionStrings
 	}
-	// skip: createDate is readOnly
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: mongoDBVersion is readOnly
-	// skip: name is readOnly
 	toSerialize["providerSettings"] = o.ProviderSettings
 	if !IsNil(o.ServerlessBackupOptions) {
 		toSerialize["serverlessBackupOptions"] = o.ServerlessBackupOptions
 	}
-	// skip: stateName is readOnly
 	if !IsNil(o.TerminationProtectionEnabled) {
 		toSerialize["terminationProtectionEnabled"] = o.TerminationProtectionEnabled
 	}

--- a/mongodbatlasv2/model_serverless_instance_description_connection_strings.go
+++ b/mongodbatlasv2/model_serverless_instance_description_connection_strings.go
@@ -106,18 +106,15 @@ func (o *ServerlessInstanceDescriptionConnectionStrings) SetStandardSrv(v string
 	o.StandardSrv = &v
 }
 
-func (o ServerlessInstanceDescriptionConnectionStrings) MarshalJSON() ([]byte, error) {
+func (o ServerlessInstanceDescriptionConnectionStrings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessInstanceDescriptionConnectionStrings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: privateEndpoint is readOnly
-	// skip: standardSrv is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_instance_description_connection_strings_private_endpoint.go
+++ b/mongodbatlasv2/model_serverless_instance_description_connection_strings_private_endpoint.go
@@ -140,19 +140,15 @@ func (o *ServerlessInstanceDescriptionConnectionStringsPrivateEndpoint) SetType(
 	o.Type = &v
 }
 
-func (o ServerlessInstanceDescriptionConnectionStringsPrivateEndpoint) MarshalJSON() ([]byte, error) {
+func (o ServerlessInstanceDescriptionConnectionStringsPrivateEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessInstanceDescriptionConnectionStringsPrivateEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: endpoints is readOnly
-	// skip: srvConnectionString is readOnly
-	// skip: type is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_instance_description_connection_strings_private_endpoint_endpoint.go
+++ b/mongodbatlasv2/model_serverless_instance_description_connection_strings_private_endpoint_endpoint.go
@@ -140,19 +140,15 @@ func (o *ServerlessInstanceDescriptionConnectionStringsPrivateEndpointEndpoint) 
 	o.Region = &v
 }
 
-func (o ServerlessInstanceDescriptionConnectionStringsPrivateEndpointEndpoint) MarshalJSON() ([]byte, error) {
+func (o ServerlessInstanceDescriptionConnectionStringsPrivateEndpointEndpoint) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessInstanceDescriptionConnectionStringsPrivateEndpointEndpoint) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: endpointId is readOnly
-	// skip: providerName is readOnly
-	// skip: region is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_instance_description_create.go
+++ b/mongodbatlasv2/model_serverless_instance_description_create.go
@@ -196,14 +196,13 @@ func (o *ServerlessInstanceDescriptionCreate) SetTerminationProtectionEnabled(v 
 	o.TerminationProtectionEnabled = &v
 }
 
-func (o ServerlessInstanceDescriptionCreate) MarshalJSON() ([]byte, error) {
+func (o ServerlessInstanceDescriptionCreate) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessInstanceDescriptionCreate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
@@ -211,7 +210,6 @@ func (o ServerlessInstanceDescriptionCreate) ToMap() (map[string]interface{}, er
 	if !IsNil(o.ServerlessBackupOptions) {
 		toSerialize["serverlessBackupOptions"] = o.ServerlessBackupOptions
 	}
-	// skip: stateName is readOnly
 	if !IsNil(o.TerminationProtectionEnabled) {
 		toSerialize["terminationProtectionEnabled"] = o.TerminationProtectionEnabled
 	}

--- a/mongodbatlasv2/model_serverless_instance_description_update.go
+++ b/mongodbatlasv2/model_serverless_instance_description_update.go
@@ -109,14 +109,13 @@ func (o *ServerlessInstanceDescriptionUpdate) SetTerminationProtectionEnabled(v 
 	o.TerminationProtectionEnabled = &v
 }
 
-func (o ServerlessInstanceDescriptionUpdate) MarshalJSON() ([]byte, error) {
+func (o ServerlessInstanceDescriptionUpdate) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessInstanceDescriptionUpdate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ServerlessBackupOptions) {

--- a/mongodbatlasv2/model_serverless_metric_alert_config_view_for_nds_group.go
+++ b/mongodbatlasv2/model_serverless_metric_alert_config_view_for_nds_group.go
@@ -373,24 +373,19 @@ func (o *ServerlessMetricAlertConfigViewForNdsGroup) SetUpdated(v time.Time) {
 	o.Updated = &v
 }
 
-func (o ServerlessMetricAlertConfigViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o ServerlessMetricAlertConfigViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessMetricAlertConfigViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: created is readOnly
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Matchers) {
 		toSerialize["matchers"] = o.Matchers
 	}
@@ -400,7 +395,6 @@ func (o ServerlessMetricAlertConfigViewForNdsGroup) ToMap() (map[string]interfac
 	if !IsNil(o.Notifications) {
 		toSerialize["notifications"] = o.Notifications
 	}
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_serverless_provider_settings.go
+++ b/mongodbatlasv2/model_serverless_provider_settings.go
@@ -130,14 +130,13 @@ func (o *ServerlessProviderSettings) SetRegionName(v string) {
 	o.RegionName = v
 }
 
-func (o ServerlessProviderSettings) MarshalJSON() ([]byte, error) {
+func (o ServerlessProviderSettings) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessProviderSettings) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["backingProviderName"] = o.BackingProviderName

--- a/mongodbatlasv2/model_serverless_tenant_endpoint_create.go
+++ b/mongodbatlasv2/model_serverless_tenant_endpoint_create.go
@@ -72,14 +72,13 @@ func (o *ServerlessTenantEndpointCreate) SetComment(v string) {
 	o.Comment = &v
 }
 
-func (o ServerlessTenantEndpointCreate) MarshalJSON() ([]byte, error) {
+func (o ServerlessTenantEndpointCreate) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ServerlessTenantEndpointCreate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Comment) {

--- a/mongodbatlasv2/model_slack.go
+++ b/mongodbatlasv2/model_slack.go
@@ -162,14 +162,13 @@ func (o *Slack) SetType(v string) {
 	o.Type = &v
 }
 
-func (o Slack) MarshalJSON() ([]byte, error) {
+func (o Slack) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Slack) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["apiToken"] = o.ApiToken

--- a/mongodbatlasv2/model_slack_notification.go
+++ b/mongodbatlasv2/model_slack_notification.go
@@ -201,14 +201,13 @@ func (o *SlackNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o SlackNotification) MarshalJSON() ([]byte, error) {
+func (o SlackNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SlackNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ApiToken) {

--- a/mongodbatlasv2/model_sms_notification.go
+++ b/mongodbatlasv2/model_sms_notification.go
@@ -167,14 +167,13 @@ func (o *SMSNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o SMSNotification) MarshalJSON() ([]byte, error) {
+func (o SMSNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SMSNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_snapshot.go
+++ b/mongodbatlasv2/model_snapshot.go
@@ -377,18 +377,15 @@ func (o *Snapshot) SetParts(v []SnapshotPart) {
 	o.Parts = v
 }
 
-func (o Snapshot) MarshalJSON() ([]byte, error) {
+func (o Snapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Snapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusterId is readOnly
-	// skip: complete is readOnly
 	if !IsNil(o.Created) {
 		toSerialize["created"] = o.Created
 	}
@@ -398,13 +395,9 @@ func (o Snapshot) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Expires) {
 		toSerialize["expires"] = o.Expires
 	}
-	// skip: groupId is readOnly
-	// skip: id is readOnly
 	if !IsNil(o.LastOplogAppliedTimestamp) {
 		toSerialize["lastOplogAppliedTimestamp"] = o.LastOplogAppliedTimestamp
 	}
-	// skip: links is readOnly
-	// skip: parts is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_snapshot_part.go
+++ b/mongodbatlasv2/model_snapshot_part.go
@@ -378,26 +378,15 @@ func (o *SnapshotPart) SetTypeName(v string) {
 	o.TypeName = &v
 }
 
-func (o SnapshotPart) MarshalJSON() ([]byte, error) {
+func (o SnapshotPart) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SnapshotPart) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusterId is readOnly
-	// skip: compressionSetting is readOnly
-	// skip: dataSizeBytes is readOnly
-	// skip: encryptionEnabled is readOnly
-	// skip: fileSizeBytes is readOnly
-	// skip: masterKeyUUID is readOnly
-	// skip: mongodVersion is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: storageSizeBytes is readOnly
-	// skip: typeName is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_snapshot_retention.go
+++ b/mongodbatlasv2/model_snapshot_retention.go
@@ -126,17 +126,15 @@ func (o *SnapshotRetention) SetRetentionValue(v int32) {
 	o.RetentionValue = v
 }
 
-func (o SnapshotRetention) MarshalJSON() ([]byte, error) {
+func (o SnapshotRetention) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SnapshotRetention) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
 	toSerialize["retentionUnit"] = o.RetentionUnit
 	toSerialize["retentionValue"] = o.RetentionValue
 	return toSerialize, nil

--- a/mongodbatlasv2/model_snapshot_schedule.go
+++ b/mongodbatlasv2/model_snapshot_schedule.go
@@ -315,21 +315,18 @@ func (o *SnapshotSchedule) SetWeeklySnapshotRetentionWeeks(v int32) {
 	o.WeeklySnapshotRetentionWeeks = v
 }
 
-func (o SnapshotSchedule) MarshalJSON() ([]byte, error) {
+func (o SnapshotSchedule) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SnapshotSchedule) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["clusterCheckpointIntervalMin"] = o.ClusterCheckpointIntervalMin
 	toSerialize["clusterId"] = o.ClusterId
 	toSerialize["dailySnapshotRetentionDays"] = o.DailySnapshotRetentionDays
-	// skip: groupId is readOnly
-	// skip: links is readOnly
 	toSerialize["monthlySnapshotRetentionMonths"] = o.MonthlySnapshotRetentionMonths
 	toSerialize["pointInTimeWindowHours"] = o.PointInTimeWindowHours
 	toSerialize["snapshotIntervalHours"] = o.SnapshotIntervalHours

--- a/mongodbatlasv2/model_source.go
+++ b/mongodbatlasv2/model_source.go
@@ -248,14 +248,13 @@ func (o *Source) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o Source) MarshalJSON() ([]byte, error) {
+func (o Source) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Source) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CaCertificatePath) {

--- a/mongodbatlasv2/model_summary_notification.go
+++ b/mongodbatlasv2/model_summary_notification.go
@@ -167,14 +167,13 @@ func (o *SummaryNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o SummaryNotification) MarshalJSON() ([]byte, error) {
+func (o SummaryNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SummaryNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_synonym_source.go
+++ b/mongodbatlasv2/model_synonym_source.go
@@ -65,14 +65,13 @@ func (o *SynonymSource) SetCollection(v string) {
 	o.Collection = v
 }
 
-func (o SynonymSource) MarshalJSON() ([]byte, error) {
+func (o SynonymSource) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SynonymSource) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["collection"] = o.Collection

--- a/mongodbatlasv2/model_system_status.go
+++ b/mongodbatlasv2/model_system_status.go
@@ -181,21 +181,16 @@ func (o *SystemStatus) SetThrottling(v bool) {
 	o.Throttling = v
 }
 
-func (o SystemStatus) MarshalJSON() ([]byte, error) {
+func (o SystemStatus) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o SystemStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["apiKey"] = o.ApiKey.Get()
-	// skip: appName is readOnly
-	// skip: build is readOnly
-	// skip: links is readOnly
-	// skip: throttling is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_target_org.go
+++ b/mongodbatlasv2/model_target_org.go
@@ -65,14 +65,13 @@ func (o *TargetOrg) SetLinkToken(v string) {
 	o.LinkToken = v
 }
 
-func (o TargetOrg) MarshalJSON() ([]byte, error) {
+func (o TargetOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TargetOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["linkToken"] = o.LinkToken

--- a/mongodbatlasv2/model_target_org_request.go
+++ b/mongodbatlasv2/model_target_org_request.go
@@ -72,14 +72,13 @@ func (o *TargetOrgRequest) SetAccessListIps(v []string) {
 	o.AccessListIps = v
 }
 
-func (o TargetOrgRequest) MarshalJSON() ([]byte, error) {
+func (o TargetOrgRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TargetOrgRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.AccessListIps) {

--- a/mongodbatlasv2/model_team.go
+++ b/mongodbatlasv2/model_team.go
@@ -160,18 +160,15 @@ func (o *Team) SetUsernames(v []string) {
 	o.Usernames = v
 }
 
-func (o Team) MarshalJSON() ([]byte, error) {
+func (o Team) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Team) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: id is readOnly
-	// skip: links is readOnly
 	toSerialize["name"] = o.Name
 	if !IsNil(o.Usernames) {
 		toSerialize["usernames"] = o.Usernames

--- a/mongodbatlasv2/model_team_event.go
+++ b/mongodbatlasv2/model_team_event.go
@@ -492,32 +492,19 @@ func (o *TeamEvent) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o TeamEvent) MarshalJSON() ([]byte, error) {
+func (o TeamEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TeamEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: teamId is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_team_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_team_event_view_for_nds_group.go
@@ -492,32 +492,19 @@ func (o *TeamEventViewForNdsGroup) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o TeamEventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o TeamEventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TeamEventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: teamId is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_team_notification.go
+++ b/mongodbatlasv2/model_team_notification.go
@@ -269,14 +269,13 @@ func (o *TeamNotification) SetTypeName(v string) {
 	o.TypeName = v
 }
 
-func (o TeamNotification) MarshalJSON() ([]byte, error) {
+func (o TeamNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TeamNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_team_response.go
+++ b/mongodbatlasv2/model_team_response.go
@@ -140,18 +140,15 @@ func (o *TeamResponse) SetName(v string) {
 	o.Name = &v
 }
 
-func (o TeamResponse) MarshalJSON() ([]byte, error) {
+func (o TeamResponse) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TeamResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: id is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}

--- a/mongodbatlasv2/model_team_role.go
+++ b/mongodbatlasv2/model_team_role.go
@@ -140,17 +140,15 @@ func (o *TeamRole) SetTeamId(v string) {
 	o.TeamId = &v
 }
 
-func (o TeamRole) MarshalJSON() ([]byte, error) {
+func (o TeamRole) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TeamRole) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: links is readOnly
 	if !IsNil(o.RoleNames) {
 		toSerialize["roleNames"] = o.RoleNames
 	}

--- a/mongodbatlasv2/model_tenant_hardware_spec.go
+++ b/mongodbatlasv2/model_tenant_hardware_spec.go
@@ -72,14 +72,13 @@ func (o *TenantHardwareSpec) SetInstanceSize(v string) {
 	o.InstanceSize = &v
 }
 
-func (o TenantHardwareSpec) MarshalJSON() ([]byte, error) {
+func (o TenantHardwareSpec) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TenantHardwareSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.InstanceSize) {

--- a/mongodbatlasv2/model_tenant_region_config.go
+++ b/mongodbatlasv2/model_tenant_region_config.go
@@ -207,14 +207,13 @@ func (o *TenantRegionConfig) SetRegionName(v string) {
 	o.RegionName = &v
 }
 
-func (o TenantRegionConfig) MarshalJSON() ([]byte, error) {
+func (o TenantRegionConfig) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TenantRegionConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.BackingProviderName) {

--- a/mongodbatlasv2/model_tenant_restore.go
+++ b/mongodbatlasv2/model_tenant_restore.go
@@ -501,28 +501,16 @@ func (o *TenantRestore) SetTargetProjectId(v string) {
 	o.TargetProjectId = &v
 }
 
-func (o TenantRestore) MarshalJSON() ([]byte, error) {
+func (o TenantRestore) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TenantRestore) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: clusterName is readOnly
-	// skip: deliveryType is readOnly
-	// skip: expirationDate is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: projectId is readOnly
-	// skip: restoreFinishedDate is readOnly
-	// skip: restoreScheduledDate is readOnly
-	// skip: snapshotFinishedDate is readOnly
 	toSerialize["snapshotId"] = o.SnapshotId
-	// skip: snapshotUrl is readOnly
-	// skip: status is readOnly
 	toSerialize["targetDeploymentItemName"] = o.TargetDeploymentItemName
 	if !IsNil(o.TargetProjectId) {
 		toSerialize["targetProjectId"] = o.TargetProjectId

--- a/mongodbatlasv2/model_tenant_snapshot.go
+++ b/mongodbatlasv2/model_tenant_snapshot.go
@@ -311,24 +311,15 @@ func (o *TenantSnapshot) SetStatus(v string) {
 	o.Status = &v
 }
 
-func (o TenantSnapshot) MarshalJSON() ([]byte, error) {
+func (o TenantSnapshot) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TenantSnapshot) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: expiration is readOnly
-	// skip: finishTime is readOnly
-	// skip: id is readOnly
-	// skip: links is readOnly
-	// skip: mongoDBVersion is readOnly
-	// skip: scheduledTime is readOnly
-	// skip: startTime is readOnly
-	// skip: status is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_threshold_view_integer.go
+++ b/mongodbatlasv2/model_threshold_view_integer.go
@@ -139,14 +139,13 @@ func (o *ThresholdViewInteger) SetUnits(v string) {
 	o.Units = &v
 }
 
-func (o ThresholdViewInteger) MarshalJSON() ([]byte, error) {
+func (o ThresholdViewInteger) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ThresholdViewInteger) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Operator) {

--- a/mongodbatlasv2/model_time_metric_alert.go
+++ b/mongodbatlasv2/model_time_metric_alert.go
@@ -634,39 +634,23 @@ func (o *TimeMetricAlert) SetUpdated(v time.Time) {
 	o.Updated = v
 }
 
-func (o TimeMetricAlert) MarshalJSON() ([]byte, error) {
+func (o TimeMetricAlert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TimeMetricAlert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["acknowledgedUntil"] = o.AcknowledgedUntil
 	if !IsNil(o.AcknowledgementComment) {
 		toSerialize["acknowledgementComment"] = o.AcknowledgementComment
 	}
-	// skip: acknowledgingUsername is readOnly
-	// skip: alertConfigId is readOnly
-	// skip: clusterName is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: hostnameAndPort is readOnly
-	// skip: id is readOnly
-	// skip: lastNotified is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: resolved is readOnly
-	// skip: status is readOnly
-	// skip: updated is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_time_metric_event.go
+++ b/mongodbatlasv2/model_time_metric_event.go
@@ -627,38 +627,22 @@ func (o *TimeMetricEvent) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o TimeMetricEvent) MarshalJSON() ([]byte, error) {
+func (o TimeMetricEvent) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TimeMetricEvent) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.CurrentValue) {
 		toSerialize["currentValue"] = o.CurrentValue
 	}
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: metricName is readOnly
-	// skip: orgId is readOnly
-	// skip: port is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: replicaSetName is readOnly
-	// skip: shardName is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_time_metric_threshold.go
+++ b/mongodbatlasv2/model_time_metric_threshold.go
@@ -210,14 +210,13 @@ func (o *TimeMetricThreshold) SetUnits(v TimeMetricUnits) {
 	o.Units = &v
 }
 
-func (o TimeMetricThreshold) MarshalJSON() ([]byte, error) {
+func (o TimeMetricThreshold) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TimeMetricThreshold) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MetricName) {

--- a/mongodbatlasv2/model_time_metric_value.go
+++ b/mongodbatlasv2/model_time_metric_value.go
@@ -109,17 +109,15 @@ func (o *TimeMetricValue) SetUnits(v TimeMetricUnits) {
 	o.Units = &v
 }
 
-func (o TimeMetricValue) MarshalJSON() ([]byte, error) {
+func (o TimeMetricValue) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TimeMetricValue) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: number is readOnly
 	if !IsNil(o.Units) {
 		toSerialize["units"] = o.Units
 	}

--- a/mongodbatlasv2/model_toggle.go
+++ b/mongodbatlasv2/model_toggle.go
@@ -72,14 +72,13 @@ func (o *Toggle) SetEnabled(v bool) {
 	o.Enabled = &v
 }
 
-func (o Toggle) MarshalJSON() ([]byte, error) {
+func (o Toggle) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Toggle) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Enabled) {

--- a/mongodbatlasv2/model_token_filterascii_folding.go
+++ b/mongodbatlasv2/model_token_filterascii_folding.go
@@ -103,14 +103,13 @@ func (o *TokenFilterasciiFolding) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilterasciiFolding) MarshalJSON() ([]byte, error) {
+func (o TokenFilterasciiFolding) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilterasciiFolding) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.OriginalTokens) {

--- a/mongodbatlasv2/model_token_filterdaitch_mokotoff_soundex.go
+++ b/mongodbatlasv2/model_token_filterdaitch_mokotoff_soundex.go
@@ -103,14 +103,13 @@ func (o *TokenFilterdaitchMokotoffSoundex) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilterdaitchMokotoffSoundex) MarshalJSON() ([]byte, error) {
+func (o TokenFilterdaitchMokotoffSoundex) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilterdaitchMokotoffSoundex) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.OriginalTokens) {

--- a/mongodbatlasv2/model_token_filteredge_gram.go
+++ b/mongodbatlasv2/model_token_filteredge_gram.go
@@ -157,14 +157,13 @@ func (o *TokenFilteredgeGram) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilteredgeGram) MarshalJSON() ([]byte, error) {
+func (o TokenFilteredgeGram) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilteredgeGram) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["maxGram"] = o.MaxGram

--- a/mongodbatlasv2/model_token_filtericu_folding.go
+++ b/mongodbatlasv2/model_token_filtericu_folding.go
@@ -65,14 +65,13 @@ func (o *TokenFiltericuFolding) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFiltericuFolding) MarshalJSON() ([]byte, error) {
+func (o TokenFiltericuFolding) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFiltericuFolding) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_token_filtericu_normalizer.go
+++ b/mongodbatlasv2/model_token_filtericu_normalizer.go
@@ -103,14 +103,13 @@ func (o *TokenFiltericuNormalizer) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFiltericuNormalizer) MarshalJSON() ([]byte, error) {
+func (o TokenFiltericuNormalizer) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFiltericuNormalizer) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.NormalizationForm) {

--- a/mongodbatlasv2/model_token_filterlength.go
+++ b/mongodbatlasv2/model_token_filterlength.go
@@ -141,14 +141,13 @@ func (o *TokenFilterlength) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilterlength) MarshalJSON() ([]byte, error) {
+func (o TokenFilterlength) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilterlength) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Max) {

--- a/mongodbatlasv2/model_token_filterlowercase.go
+++ b/mongodbatlasv2/model_token_filterlowercase.go
@@ -65,14 +65,13 @@ func (o *TokenFilterlowercase) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilterlowercase) MarshalJSON() ([]byte, error) {
+func (o TokenFilterlowercase) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilterlowercase) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_token_filtern_gram.go
+++ b/mongodbatlasv2/model_token_filtern_gram.go
@@ -157,14 +157,13 @@ func (o *TokenFilternGram) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilternGram) MarshalJSON() ([]byte, error) {
+func (o TokenFilternGram) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilternGram) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["maxGram"] = o.MaxGram

--- a/mongodbatlasv2/model_token_filterregex.go
+++ b/mongodbatlasv2/model_token_filterregex.go
@@ -146,14 +146,13 @@ func (o *TokenFilterregex) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilterregex) MarshalJSON() ([]byte, error) {
+func (o TokenFilterregex) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilterregex) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["matches"] = o.Matches

--- a/mongodbatlasv2/model_token_filterreverse.go
+++ b/mongodbatlasv2/model_token_filterreverse.go
@@ -65,14 +65,13 @@ func (o *TokenFilterreverse) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilterreverse) MarshalJSON() ([]byte, error) {
+func (o TokenFilterreverse) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilterreverse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_token_filtershingle.go
+++ b/mongodbatlasv2/model_token_filtershingle.go
@@ -119,14 +119,13 @@ func (o *TokenFiltershingle) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFiltershingle) MarshalJSON() ([]byte, error) {
+func (o TokenFiltershingle) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFiltershingle) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["maxShingleSize"] = o.MaxShingleSize

--- a/mongodbatlasv2/model_token_filtersnowball_stemming.go
+++ b/mongodbatlasv2/model_token_filtersnowball_stemming.go
@@ -92,14 +92,13 @@ func (o *TokenFiltersnowballStemming) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFiltersnowballStemming) MarshalJSON() ([]byte, error) {
+func (o TokenFiltersnowballStemming) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFiltersnowballStemming) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["stemmerName"] = o.StemmerName

--- a/mongodbatlasv2/model_token_filterstopword.go
+++ b/mongodbatlasv2/model_token_filterstopword.go
@@ -130,14 +130,13 @@ func (o *TokenFilterstopword) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFilterstopword) MarshalJSON() ([]byte, error) {
+func (o TokenFilterstopword) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFilterstopword) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.IgnoreCase) {

--- a/mongodbatlasv2/model_token_filtertrim.go
+++ b/mongodbatlasv2/model_token_filtertrim.go
@@ -65,14 +65,13 @@ func (o *TokenFiltertrim) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenFiltertrim) MarshalJSON() ([]byte, error) {
+func (o TokenFiltertrim) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenFiltertrim) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_tokenizeredge_gram.go
+++ b/mongodbatlasv2/model_tokenizeredge_gram.go
@@ -119,14 +119,13 @@ func (o *TokenizeredgeGram) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenizeredgeGram) MarshalJSON() ([]byte, error) {
+func (o TokenizeredgeGram) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenizeredgeGram) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["maxGram"] = o.MaxGram

--- a/mongodbatlasv2/model_tokenizerkeyword.go
+++ b/mongodbatlasv2/model_tokenizerkeyword.go
@@ -65,14 +65,13 @@ func (o *Tokenizerkeyword) SetType(v string) {
 	o.Type = v
 }
 
-func (o Tokenizerkeyword) MarshalJSON() ([]byte, error) {
+func (o Tokenizerkeyword) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Tokenizerkeyword) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type

--- a/mongodbatlasv2/model_tokenizern_gram.go
+++ b/mongodbatlasv2/model_tokenizern_gram.go
@@ -119,14 +119,13 @@ func (o *TokenizernGram) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenizernGram) MarshalJSON() ([]byte, error) {
+func (o TokenizernGram) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenizernGram) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["maxGram"] = o.MaxGram

--- a/mongodbatlasv2/model_tokenizerregex_capture_group.go
+++ b/mongodbatlasv2/model_tokenizerregex_capture_group.go
@@ -119,14 +119,13 @@ func (o *TokenizerregexCaptureGroup) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenizerregexCaptureGroup) MarshalJSON() ([]byte, error) {
+func (o TokenizerregexCaptureGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenizerregexCaptureGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["group"] = o.Group

--- a/mongodbatlasv2/model_tokenizerregex_split.go
+++ b/mongodbatlasv2/model_tokenizerregex_split.go
@@ -92,14 +92,13 @@ func (o *TokenizerregexSplit) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenizerregexSplit) MarshalJSON() ([]byte, error) {
+func (o TokenizerregexSplit) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenizerregexSplit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["pattern"] = o.Pattern

--- a/mongodbatlasv2/model_tokenizerstandard.go
+++ b/mongodbatlasv2/model_tokenizerstandard.go
@@ -103,14 +103,13 @@ func (o *Tokenizerstandard) SetType(v string) {
 	o.Type = v
 }
 
-func (o Tokenizerstandard) MarshalJSON() ([]byte, error) {
+func (o Tokenizerstandard) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Tokenizerstandard) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MaxTokenLength) {

--- a/mongodbatlasv2/model_tokenizeruax_url_email.go
+++ b/mongodbatlasv2/model_tokenizeruax_url_email.go
@@ -103,14 +103,13 @@ func (o *TokenizeruaxUrlEmail) SetType(v string) {
 	o.Type = v
 }
 
-func (o TokenizeruaxUrlEmail) MarshalJSON() ([]byte, error) {
+func (o TokenizeruaxUrlEmail) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TokenizeruaxUrlEmail) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MaxTokenLength) {

--- a/mongodbatlasv2/model_tokenizerwhitespace.go
+++ b/mongodbatlasv2/model_tokenizerwhitespace.go
@@ -103,14 +103,13 @@ func (o *Tokenizerwhitespace) SetType(v string) {
 	o.Type = v
 }
 
-func (o Tokenizerwhitespace) MarshalJSON() ([]byte, error) {
+func (o Tokenizerwhitespace) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Tokenizerwhitespace) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.MaxTokenLength) {

--- a/mongodbatlasv2/model_trigger_ingestion_request.go
+++ b/mongodbatlasv2/model_trigger_ingestion_request.go
@@ -65,14 +65,13 @@ func (o *TriggerIngestionRequest) SetSnapshotId(v string) {
 	o.SnapshotId = v
 }
 
-func (o TriggerIngestionRequest) MarshalJSON() ([]byte, error) {
+func (o TriggerIngestionRequest) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o TriggerIngestionRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["snapshotId"] = o.SnapshotId

--- a/mongodbatlasv2/model_update_custom_db_role.go
+++ b/mongodbatlasv2/model_update_custom_db_role.go
@@ -106,14 +106,13 @@ func (o *UpdateCustomDBRole) SetInheritedRoles(v []InheritedRole) {
 	o.InheritedRoles = v
 }
 
-func (o UpdateCustomDBRole) MarshalJSON() ([]byte, error) {
+func (o UpdateCustomDBRole) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UpdateCustomDBRole) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Actions) {

--- a/mongodbatlasv2/model_user_access_list.go
+++ b/mongodbatlasv2/model_user_access_list.go
@@ -277,27 +277,21 @@ func (o *UserAccessList) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o UserAccessList) MarshalJSON() ([]byte, error) {
+func (o UserAccessList) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserAccessList) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CidrBlock) {
 		toSerialize["cidrBlock"] = o.CidrBlock
 	}
-	// skip: count is readOnly
-	// skip: created is readOnly
 	if !IsNil(o.IpAddress) {
 		toSerialize["ipAddress"] = o.IpAddress
 	}
-	// skip: lastUsed is readOnly
-	// skip: lastUsedAddress is readOnly
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_user_cert.go
+++ b/mongodbatlasv2/model_user_cert.go
@@ -281,25 +281,18 @@ func (o *UserCert) SetSubject(v string) {
 	o.Subject = &v
 }
 
-func (o UserCert) MarshalJSON() ([]byte, error) {
+func (o UserCert) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserCert) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
-	// skip: createdAt is readOnly
-	// skip: groupId is readOnly
-	// skip: links is readOnly
 	if !IsNil(o.MonthsUntilExpiration) {
 		toSerialize["monthsUntilExpiration"] = o.MonthsUntilExpiration
 	}
-	// skip: notAfter is readOnly
-	// skip: subject is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_user_event_view_for_nds_group.go
+++ b/mongodbatlasv2/model_user_event_view_for_nds_group.go
@@ -492,32 +492,19 @@ func (o *UserEventViewForNdsGroup) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o UserEventViewForNdsGroup) MarshalJSON() ([]byte, error) {
+func (o UserEventViewForNdsGroup) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserEventViewForNdsGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: targetUsername is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_user_event_view_for_org.go
+++ b/mongodbatlasv2/model_user_event_view_for_org.go
@@ -492,32 +492,19 @@ func (o *UserEventViewForOrg) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o UserEventViewForOrg) MarshalJSON() ([]byte, error) {
+func (o UserEventViewForOrg) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserEventViewForOrg) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiKeyId is readOnly
-	// skip: created is readOnly
 	toSerialize["eventTypeName"] = o.EventTypeName
-	// skip: groupId is readOnly
-	// skip: id is readOnly
-	// skip: isGlobalAdmin is readOnly
-	// skip: links is readOnly
-	// skip: orgId is readOnly
-	// skip: publicKey is readOnly
 	if !IsNil(o.Raw) {
 		toSerialize["raw"] = o.Raw
 	}
-	// skip: remoteAddress is readOnly
-	// skip: targetUsername is readOnly
-	// skip: userId is readOnly
-	// skip: username is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_user_notification.go
+++ b/mongodbatlasv2/model_user_notification.go
@@ -235,14 +235,13 @@ func (o *UserNotification) SetUsername(v string) {
 	o.Username = &v
 }
 
-func (o UserNotification) MarshalJSON() ([]byte, error) {
+func (o UserNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_user_role_assignment.go
+++ b/mongodbatlasv2/model_user_role_assignment.go
@@ -106,17 +106,15 @@ func (o *UserRoleAssignment) SetRoles(v []string) {
 	o.Roles = v
 }
 
-func (o UserRoleAssignment) MarshalJSON() ([]byte, error) {
+func (o UserRoleAssignment) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserRoleAssignment) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: apiUserId is readOnly
 	if !IsNil(o.Roles) {
 		toSerialize["roles"] = o.Roles
 	}

--- a/mongodbatlasv2/model_user_scope.go
+++ b/mongodbatlasv2/model_user_scope.go
@@ -92,14 +92,13 @@ func (o *UserScope) SetType(v string) {
 	o.Type = v
 }
 
-func (o UserScope) MarshalJSON() ([]byte, error) {
+func (o UserScope) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserScope) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name

--- a/mongodbatlasv2/model_user_security.go
+++ b/mongodbatlasv2/model_user_security.go
@@ -138,14 +138,13 @@ func (o *UserSecurity) SetLinks(v []Link) {
 	o.Links = v
 }
 
-func (o UserSecurity) MarshalJSON() ([]byte, error) {
+func (o UserSecurity) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o UserSecurity) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.CustomerX509) {
@@ -154,7 +153,6 @@ func (o UserSecurity) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Ldap) {
 		toSerialize["ldap"] = o.Ldap
 	}
-	// skip: links is readOnly
 	return toSerialize, nil
 }
 

--- a/mongodbatlasv2/model_validation.go
+++ b/mongodbatlasv2/model_validation.go
@@ -228,21 +228,18 @@ func (o *Validation) UnsetStatus() {
 	o.Status.Unset()
 }
 
-func (o Validation) MarshalJSON() ([]byte, error) {
+func (o Validation) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Validation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: _id is readOnly
 	if o.ErrorMessage.IsSet() {
 		toSerialize["errorMessage"] = o.ErrorMessage.Get()
 	}
-	// skip: groupId is readOnly
 	if !IsNil(o.SourceGroupId) {
 		toSerialize["sourceGroupId"] = o.SourceGroupId
 	}

--- a/mongodbatlasv2/model_victor_ops.go
+++ b/mongodbatlasv2/model_victor_ops.go
@@ -133,14 +133,13 @@ func (o *VictorOps) SetType(v string) {
 	o.Type = &v
 }
 
-func (o VictorOps) MarshalJSON() ([]byte, error) {
+func (o VictorOps) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o VictorOps) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["apiKey"] = o.ApiKey

--- a/mongodbatlasv2/model_victor_ops_notification.go
+++ b/mongodbatlasv2/model_victor_ops_notification.go
@@ -201,14 +201,13 @@ func (o *VictorOpsNotification) SetVictorOpsRoutingKey(v string) {
 	o.VictorOpsRoutingKey = &v
 }
 
-func (o VictorOpsNotification) MarshalJSON() ([]byte, error) {
+func (o VictorOpsNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o VictorOpsNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_webhook.go
+++ b/mongodbatlasv2/model_webhook.go
@@ -133,14 +133,13 @@ func (o *Webhook) SetUrl(v string) {
 	o.Url = v
 }
 
-func (o Webhook) MarshalJSON() ([]byte, error) {
+func (o Webhook) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o Webhook) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Secret) {

--- a/mongodbatlasv2/model_webhook_notification.go
+++ b/mongodbatlasv2/model_webhook_notification.go
@@ -201,14 +201,13 @@ func (o *WebhookNotification) SetWebhookUrl(v string) {
 	o.WebhookUrl = &v
 }
 
-func (o WebhookNotification) MarshalJSON() ([]byte, error) {
+func (o WebhookNotification) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o WebhookNotification) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DelayMin) {

--- a/mongodbatlasv2/model_weekly_schedule.go
+++ b/mongodbatlasv2/model_weekly_schedule.go
@@ -234,14 +234,13 @@ func (o *WeeklySchedule) SetType(v string) {
 	o.Type = v
 }
 
-func (o WeeklySchedule) MarshalJSON() ([]byte, error) {
+func (o WeeklySchedule) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o WeeklySchedule) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.DayOfWeek) {

--- a/mongodbatlasv2/model_x509_certificate.go
+++ b/mongodbatlasv2/model_x509_certificate.go
@@ -138,14 +138,13 @@ func (o *X509Certificate) SetNotBefore(v time.Time) {
 	o.NotBefore = &v
 }
 
-func (o X509Certificate) MarshalJSON() ([]byte, error) {
+func (o X509Certificate) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o X509Certificate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Content) {

--- a/mongodbatlasv2/model_x509_certificate_view.go
+++ b/mongodbatlasv2/model_x509_certificate_view.go
@@ -107,14 +107,13 @@ func (o *X509CertificateView) SetNotBefore(v time.Time) {
 	o.NotBefore = &v
 }
 
-func (o X509CertificateView) MarshalJSON() ([]byte, error) {
+func (o X509CertificateView) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o X509CertificateView) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.NotAfter) {

--- a/mongodbatlasv2/model_zone_mapping.go
+++ b/mongodbatlasv2/model_zone_mapping.go
@@ -92,14 +92,13 @@ func (o *ZoneMapping) SetZone(v string) {
 	o.Zone = v
 }
 
-func (o ZoneMapping) MarshalJSON() ([]byte, error) {
+func (o ZoneMapping) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o ZoneMapping) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["location"] = o.Location

--- a/tools/config/go-templates/model_simple.mustache
+++ b/tools/config/go-templates/model_simple.mustache
@@ -260,14 +260,13 @@ func (o *{{classname}}) Unset{{name}}() {
 
 {{/required}}
 {{/vars}}
-func (o {{classname}}) MarshalJSON() ([]byte, error) {
+func (o {{classname}}) MarshalJSONWithoutReadOnly() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
 	return json.Marshal(toSerialize)
 }
-
 func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
 	{{#parent}}
@@ -320,9 +319,6 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 		toSerialize["{{baseName}}"] = o.{{name}}
 	}
 	{{/required}}
-	{{/isReadOnly}}
-	{{#isReadOnly}}
-	// skip: {{baseName}} is readOnly
 	{{/isReadOnly}}
 	{{/isNullable}}
 	{{/vars}}


### PR DESCRIPTION
## Description

CLOUDP-168044

Disable read-only models marshaling functionality. 
Readonly models are by default removed from JSON string to prevent them from being sent to the server.

Only first commit matters. Rest of the changes are regenerated models (almost every response type.

## Implications
 
This change has some implications that we need to test
If the model is used in the request and response feature was removing read-only fields in a request.
For example ID of the object was removed automatically. When this is missing we need to test if extra objects not causing any side effects.
