### PR TITLE
fix: add way to manually dispatch master branch

### DIFF
--- a/.github/workflows/autoupdate-master.yaml
+++ b/.github/workflows/autoupdate-master.yaml
@@ -2,6 +2,8 @@ name: Generate Client Master
 on:
  schedule:
    - cron: '30 8 * * *'
+ workflow_dispatch:
+  
  
 jobs:
   generate-client:


### PR DESCRIPTION
This change will allow us to not rely on the schedule and dispatch autoupdates multiple times a day manually or by bot trigger.