### PR TITLE
CLOUDP-168427: remove parameters from the Error object

### DIFF
--- a/mongodbatlasv2/model_error.go
+++ b/mongodbatlasv2/model_error.go
@@ -24,7 +24,7 @@ type Error struct {
 	Error *int32 `json:"error,omitempty"`
 	// Application error code returned with this error.
 	ErrorCode *string `json:"errorCode,omitempty"`
-	Parameters []map[string]interface{} `json:"parameters,omitempty"`
+	Parameters []interface{} `json:"parameters,omitempty"`
 	// Application error message returned with this error.
 	Reason *string `json:"reason,omitempty"`
 }
@@ -143,9 +143,9 @@ func (o *Error) SetErrorCode(v string) {
 }
 
 // GetParameters returns the Parameters field value if set, zero value otherwise.
-func (o *Error) GetParameters() []map[string]interface{} {
+func (o *Error) GetParameters() []interface{} {
 	if o == nil || IsNil(o.Parameters) {
-		var ret []map[string]interface{}
+		var ret []interface{}
 		return ret
 	}
 	return o.Parameters
@@ -153,7 +153,7 @@ func (o *Error) GetParameters() []map[string]interface{} {
 
 // GetParametersOk returns a tuple with the Parameters field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Error) GetParametersOk() ([]map[string]interface{}, bool) {
+func (o *Error) GetParametersOk() ([]interface{}, bool) {
 	if o == nil || IsNil(o.Parameters) {
 		return nil, false
 	}
@@ -169,8 +169,8 @@ func (o *Error) HasParameters() bool {
 	return false
 }
 
-// SetParameters gets a reference to the given []map[string]interface{} and assigns it to the Parameters field.
-func (o *Error) SetParameters(v []map[string]interface{}) {
+// SetParameters gets a reference to the given []interface{} and assigns it to the Parameters field.
+func (o *Error) SetParameters(v []interface{}) {
 	o.Parameters = v
 }
 

--- a/openapi/atlas-api-transformed.yaml
+++ b/openapi/atlas-api-transformed.yaml
@@ -21835,9 +21835,7 @@ components:
           example: TOO_MANY_GROUP_NOTIFICATIONS
         parameters:
           type: array
-          items:
-            type: object
-            description: Parameter uses to give more information about the error.
+          items: {}
         reason:
           type: string
           description: Application error message returned with this error.

--- a/tools/transformer/src/atlasTransformations.js
+++ b/tools/transformer/src/atlasTransformations.js
@@ -51,5 +51,10 @@ module.exports = function runTransformations(openapi) {
     description: "This endpoint does not return a response body",
   };
 
+  // Temp workaround for CLOUDP-168427
+  if (openapi.components.schemas.Error) {
+    openapi.components.schemas.Error.properties.parameters.items = {};
+  }
+
   return openapi;
 };


### PR DESCRIPTION
CLOUDP-168427

## Description

Temp workaround that will enable us to process errors in the GO SDK. 
Actuall fix made in the openapi.


