### PR TITLE
CLOUDP-169104: Fix encoding for AWS IAM usernames

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -161,7 +161,7 @@ func (s *DatabaseUsersServiceOp) Get(ctx context.Context, databaseName, groupID,
 	}
 
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
-	escapedEntry := url.PathEscape(username)
+	escapedEntry := url.QueryEscape(username)
 	path := fmt.Sprintf("%s/%s/%s", basePath, databaseName, escapedEntry)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)


### PR DESCRIPTION
## Description

As per the old docs:
> AWS IAM usernames include characters which must be URL encoded.
> Replace all : characters with %3A.
> Replace all / characters with %2F.

https://www.mongodb.com/docs/atlas/reference/api/database-users-get-single-user/#example-request

Using `url.PathEscape` would only encode `/` characters, while `url.QueryEscape` encode both `:` and `/`

Link to any related issue(s): https://github.com/mongodb/mongodb-atlas-cli/issues/1817

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

