### PR TITLE
fix: externalise structure for query and path params

### DIFF
--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -71,7 +71,7 @@ type AccessTrackingApiListAccessLogsByClusterNameRequest struct {
 	start *time.Time
 }
 
-type AccessTrackingApiListAccessLogsByClusterNameQueryParams struct {
+type AccessTrackingApiListAccessLogsByClusterNameParams struct {
 		GroupId string
 		ClusterName string
 		AuthResult *bool
@@ -262,7 +262,7 @@ type AccessTrackingApiListAccessLogsByHostnameRequest struct {
 	start *time.Time
 }
 
-type AccessTrackingApiListAccessLogsByHostnameQueryParams struct {
+type AccessTrackingApiListAccessLogsByHostnameParams struct {
 		GroupId string
 		Hostname string
 		AuthResult *bool

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -31,13 +31,13 @@ type AccessTrackingApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return AccessTrackingApiListAccessLogsByClusterNameRequest
+	@return ListAccessLogsByClusterNameApiRequest
 	*/
-	ListAccessLogsByClusterName(ctx context.Context, groupId string, clusterName string) AccessTrackingApiListAccessLogsByClusterNameRequest
+	ListAccessLogsByClusterName(ctx context.Context, groupId string, clusterName string) ListAccessLogsByClusterNameApiRequest
 
 	// ListAccessLogsByClusterNameExecute executes the request
 	//  @return MongoDBAccessLogsList
-	ListAccessLogsByClusterNameExecute(r AccessTrackingApiListAccessLogsByClusterNameRequest) (*MongoDBAccessLogsList, *http.Response, error)
+	ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 
 	/*
 	ListAccessLogsByHostname Return Database Access History for One Cluster using Its Hostname
@@ -47,19 +47,19 @@ type AccessTrackingApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param hostname Fully qualified domain name or IP address of the MongoDB host that stores the log files that you want to download.
-	@return AccessTrackingApiListAccessLogsByHostnameRequest
+	@return ListAccessLogsByHostnameApiRequest
 	*/
-	ListAccessLogsByHostname(ctx context.Context, groupId string, hostname string) AccessTrackingApiListAccessLogsByHostnameRequest
+	ListAccessLogsByHostname(ctx context.Context, groupId string, hostname string) ListAccessLogsByHostnameApiRequest
 
 	// ListAccessLogsByHostnameExecute executes the request
 	//  @return MongoDBAccessLogsList
-	ListAccessLogsByHostnameExecute(r AccessTrackingApiListAccessLogsByHostnameRequest) (*MongoDBAccessLogsList, *http.Response, error)
+	ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 }
 
 // AccessTrackingApiService AccessTrackingApi service
 type AccessTrackingApiService service
 
-type AccessTrackingApiListAccessLogsByClusterNameRequest struct {
+type ListAccessLogsByClusterNameApiRequest struct {
 	ctx context.Context
 	ApiService AccessTrackingApi
 	groupId string
@@ -82,36 +82,36 @@ type ListAccessLogsByClusterNameParams struct {
 }
 
 // Flag that indicates whether the response returns the successful authentication attempts only.
-func (r AccessTrackingApiListAccessLogsByClusterNameRequest) AuthResult(authResult bool) AccessTrackingApiListAccessLogsByClusterNameRequest {
+func (r ListAccessLogsByClusterNameApiRequest) AuthResult(authResult bool) ListAccessLogsByClusterNameApiRequest {
 	r.authResult = &authResult
 	return r
 }
 
 // Date and time when to stop retrieving database history. If you specify **end**, you must also specify **start**. This parameter uses the ISO 8601 timestamp format in UTC.
-func (r AccessTrackingApiListAccessLogsByClusterNameRequest) End(end string) AccessTrackingApiListAccessLogsByClusterNameRequest {
+func (r ListAccessLogsByClusterNameApiRequest) End(end string) ListAccessLogsByClusterNameApiRequest {
 	r.end = &end
 	return r
 }
 
 // One Internet Protocol address that attempted to authenticate with the database.
-func (r AccessTrackingApiListAccessLogsByClusterNameRequest) IpAddress(ipAddress string) AccessTrackingApiListAccessLogsByClusterNameRequest {
+func (r ListAccessLogsByClusterNameApiRequest) IpAddress(ipAddress string) ListAccessLogsByClusterNameApiRequest {
 	r.ipAddress = &ipAddress
 	return r
 }
 
 // Maximum number of lines from the log to return.
-func (r AccessTrackingApiListAccessLogsByClusterNameRequest) NLogs(nLogs int64) AccessTrackingApiListAccessLogsByClusterNameRequest {
+func (r ListAccessLogsByClusterNameApiRequest) NLogs(nLogs int64) ListAccessLogsByClusterNameApiRequest {
 	r.nLogs = &nLogs
 	return r
 }
 
 // Date and time when MongoDB Cloud begins retrieving database history. If you specify **start**, you must also specify **end**. This parameter uses the ISO 8601 timestamp format in UTC.
-func (r AccessTrackingApiListAccessLogsByClusterNameRequest) Start(start time.Time) AccessTrackingApiListAccessLogsByClusterNameRequest {
+func (r ListAccessLogsByClusterNameApiRequest) Start(start time.Time) ListAccessLogsByClusterNameApiRequest {
 	r.start = &start
 	return r
 }
 
-func (r AccessTrackingApiListAccessLogsByClusterNameRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
+func (r ListAccessLogsByClusterNameApiRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
 	return r.ApiService.ListAccessLogsByClusterNameExecute(r)
 }
 
@@ -123,10 +123,10 @@ Returns the access logs of one cluster identified by the cluster's name. Access 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return AccessTrackingApiListAccessLogsByClusterNameRequest
+ @return ListAccessLogsByClusterNameApiRequest
 */
-func (a *AccessTrackingApiService) ListAccessLogsByClusterName(ctx context.Context, groupId string, clusterName string) AccessTrackingApiListAccessLogsByClusterNameRequest {
-	return AccessTrackingApiListAccessLogsByClusterNameRequest{
+func (a *AccessTrackingApiService) ListAccessLogsByClusterName(ctx context.Context, groupId string, clusterName string) ListAccessLogsByClusterNameApiRequest {
+	return ListAccessLogsByClusterNameApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -136,7 +136,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByClusterName(ctx context.Conte
 
 // Execute executes the request
 //  @return MongoDBAccessLogsList
-func (a *AccessTrackingApiService) ListAccessLogsByClusterNameExecute(r AccessTrackingApiListAccessLogsByClusterNameRequest) (*MongoDBAccessLogsList, *http.Response, error) {
+func (a *AccessTrackingApiService) ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -250,7 +250,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByClusterNameExecute(r AccessTr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AccessTrackingApiListAccessLogsByHostnameRequest struct {
+type ListAccessLogsByHostnameApiRequest struct {
 	ctx context.Context
 	ApiService AccessTrackingApi
 	groupId string
@@ -273,36 +273,36 @@ type ListAccessLogsByHostnameParams struct {
 }
 
 // Flag that indicates whether the response returns the successful authentication attempts only.
-func (r AccessTrackingApiListAccessLogsByHostnameRequest) AuthResult(authResult bool) AccessTrackingApiListAccessLogsByHostnameRequest {
+func (r ListAccessLogsByHostnameApiRequest) AuthResult(authResult bool) ListAccessLogsByHostnameApiRequest {
 	r.authResult = &authResult
 	return r
 }
 
 // Date and time when to stop retrieving database history. If you specify **end**, you must also specify **start**. This parameter uses the ISO 8601 timestamp format in UTC.
-func (r AccessTrackingApiListAccessLogsByHostnameRequest) End(end time.Time) AccessTrackingApiListAccessLogsByHostnameRequest {
+func (r ListAccessLogsByHostnameApiRequest) End(end time.Time) ListAccessLogsByHostnameApiRequest {
 	r.end = &end
 	return r
 }
 
 // One Internet Protocol address that attempted to authenticate with the database.
-func (r AccessTrackingApiListAccessLogsByHostnameRequest) IpAddress(ipAddress string) AccessTrackingApiListAccessLogsByHostnameRequest {
+func (r ListAccessLogsByHostnameApiRequest) IpAddress(ipAddress string) ListAccessLogsByHostnameApiRequest {
 	r.ipAddress = &ipAddress
 	return r
 }
 
 // Maximum number of lines from the log to return.
-func (r AccessTrackingApiListAccessLogsByHostnameRequest) NLogs(nLogs int32) AccessTrackingApiListAccessLogsByHostnameRequest {
+func (r ListAccessLogsByHostnameApiRequest) NLogs(nLogs int32) ListAccessLogsByHostnameApiRequest {
 	r.nLogs = &nLogs
 	return r
 }
 
 // Date and time when MongoDB Cloud begins retrieving database history. If you specify **start**, you must also specify **end**. This parameter uses the ISO 8601 timestamp format in UTC.
-func (r AccessTrackingApiListAccessLogsByHostnameRequest) Start(start time.Time) AccessTrackingApiListAccessLogsByHostnameRequest {
+func (r ListAccessLogsByHostnameApiRequest) Start(start time.Time) ListAccessLogsByHostnameApiRequest {
 	r.start = &start
 	return r
 }
 
-func (r AccessTrackingApiListAccessLogsByHostnameRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
+func (r ListAccessLogsByHostnameApiRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
 	return r.ApiService.ListAccessLogsByHostnameExecute(r)
 }
 
@@ -314,10 +314,10 @@ Returns the access logs of one cluster identified by the cluster's hostname. Acc
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param hostname Fully qualified domain name or IP address of the MongoDB host that stores the log files that you want to download.
- @return AccessTrackingApiListAccessLogsByHostnameRequest
+ @return ListAccessLogsByHostnameApiRequest
 */
-func (a *AccessTrackingApiService) ListAccessLogsByHostname(ctx context.Context, groupId string, hostname string) AccessTrackingApiListAccessLogsByHostnameRequest {
-	return AccessTrackingApiListAccessLogsByHostnameRequest{
+func (a *AccessTrackingApiService) ListAccessLogsByHostname(ctx context.Context, groupId string, hostname string) ListAccessLogsByHostnameApiRequest {
+	return ListAccessLogsByHostnameApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -327,7 +327,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByHostname(ctx context.Context,
 
 // Execute executes the request
 //  @return MongoDBAccessLogsList
-func (a *AccessTrackingApiService) ListAccessLogsByHostnameExecute(r AccessTrackingApiListAccessLogsByHostnameRequest) (*MongoDBAccessLogsList, *http.Response, error) {
+func (a *AccessTrackingApiService) ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -70,14 +70,15 @@ type AccessTrackingApiListAccessLogsByClusterNameRequest struct {
 	nLogs *int64
 	start *time.Time
 }
+
 type AccessTrackingApiListAccessLogsByClusterNameQueryParams struct {
-		groupId string
-		clusterName string
-		authResult *bool
-		end *string
-		ipAddress *string
-		nLogs *int64
-		start *time.Time
+		GroupId string
+		ClusterName string
+		AuthResult *bool
+		End *string
+		IpAddress *string
+		NLogs *int64
+		Start *time.Time
 }
 
 // Flag that indicates whether the response returns the successful authentication attempts only.
@@ -260,14 +261,15 @@ type AccessTrackingApiListAccessLogsByHostnameRequest struct {
 	nLogs *int32
 	start *time.Time
 }
+
 type AccessTrackingApiListAccessLogsByHostnameQueryParams struct {
-		groupId string
-		hostname string
-		authResult *bool
-		end *time.Time
-		ipAddress *string
-		nLogs *int32
-		start *time.Time
+		GroupId string
+		Hostname string
+		AuthResult *bool
+		End *time.Time
+		IpAddress *string
+		NLogs *int32
+		Start *time.Time
 }
 
 // Flag that indicates whether the response returns the successful authentication attempts only.

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -70,6 +70,15 @@ type AccessTrackingApiListAccessLogsByClusterNameRequest struct {
 	nLogs *int64
 	start *time.Time
 }
+type AccessTrackingApiListAccessLogsByClusterNameQueryParams struct {
+		groupId string
+		clusterName string
+		authResult *bool
+		end *string
+		ipAddress *string
+		nLogs *int64
+		start *time.Time
+}
 
 // Flag that indicates whether the response returns the successful authentication attempts only.
 func (r AccessTrackingApiListAccessLogsByClusterNameRequest) AuthResult(authResult bool) AccessTrackingApiListAccessLogsByClusterNameRequest {
@@ -250,6 +259,15 @@ type AccessTrackingApiListAccessLogsByHostnameRequest struct {
 	ipAddress *string
 	nLogs *int32
 	start *time.Time
+}
+type AccessTrackingApiListAccessLogsByHostnameQueryParams struct {
+		groupId string
+		hostname string
+		authResult *bool
+		end *time.Time
+		ipAddress *string
+		nLogs *int32
+		start *time.Time
 }
 
 // Flag that indicates whether the response returns the successful authentication attempts only.

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -71,7 +71,7 @@ type ListAccessLogsByClusterNameApiRequest struct {
 	start *time.Time
 }
 
-type ListAccessLogsByClusterNameParams struct {
+type ListAccessLogsByClusterNameApiParams struct {
 		GroupId string
 		ClusterName string
 		AuthResult *bool
@@ -262,7 +262,7 @@ type ListAccessLogsByHostnameApiRequest struct {
 	start *time.Time
 }
 
-type ListAccessLogsByHostnameParams struct {
+type ListAccessLogsByHostnameApiParams struct {
 		GroupId string
 		Hostname string
 		AuthResult *bool

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -71,7 +71,7 @@ type AccessTrackingApiListAccessLogsByClusterNameRequest struct {
 	start *time.Time
 }
 
-type AccessTrackingApiListAccessLogsByClusterNameParams struct {
+type ListAccessLogsByClusterNameParams struct {
 		GroupId string
 		ClusterName string
 		AuthResult *bool
@@ -262,7 +262,7 @@ type AccessTrackingApiListAccessLogsByHostnameRequest struct {
 	start *time.Time
 }
 
-type AccessTrackingApiListAccessLogsByHostnameParams struct {
+type ListAccessLogsByHostnameParams struct {
 		GroupId string
 		Hostname string
 		AuthResult *bool

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -174,7 +174,7 @@ type AlertConfigurationsApiCreateAlertConfigurationRequest struct {
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
-type AlertConfigurationsApiCreateAlertConfigurationQueryParams struct {
+type AlertConfigurationsApiCreateAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
@@ -310,7 +310,7 @@ type AlertConfigurationsApiDeleteAlertConfigurationRequest struct {
 	alertConfigId string
 }
 
-type AlertConfigurationsApiDeleteAlertConfigurationQueryParams struct {
+type AlertConfigurationsApiDeleteAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 }
@@ -433,7 +433,7 @@ type AlertConfigurationsApiGetAlertConfigurationRequest struct {
 	alertConfigId string
 }
 
-type AlertConfigurationsApiGetAlertConfigurationQueryParams struct {
+type AlertConfigurationsApiGetAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 }
@@ -565,7 +565,7 @@ type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest struc
 	ApiService AlertConfigurationsApi
 }
 
-type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesQueryParams struct {
+type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesParams struct {
 }
 
 func (r AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest) Execute() ([]MatcherField, *http.Response, error) {
@@ -679,7 +679,7 @@ type AlertConfigurationsApiListAlertConfigurationsRequest struct {
 	pageNum *int32
 }
 
-type AlertConfigurationsApiListAlertConfigurationsQueryParams struct {
+type AlertConfigurationsApiListAlertConfigurationsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -848,7 +848,7 @@ type AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest struct {
 	pageNum *int32
 }
 
-type AlertConfigurationsApiListAlertConfigurationsByAlertIdQueryParams struct {
+type AlertConfigurationsApiListAlertConfigurationsByAlertIdParams struct {
 		GroupId string
 		AlertId string
 		IncludeCount *bool
@@ -1025,7 +1025,7 @@ type AlertConfigurationsApiToggleAlertConfigurationRequest struct {
 	toggle *Toggle
 }
 
-type AlertConfigurationsApiToggleAlertConfigurationQueryParams struct {
+type AlertConfigurationsApiToggleAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 		Toggle *Toggle
@@ -1174,7 +1174,7 @@ type AlertConfigurationsApiUpdateAlertConfigurationRequest struct {
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
-type AlertConfigurationsApiUpdateAlertConfigurationQueryParams struct {
+type AlertConfigurationsApiUpdateAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -174,7 +174,7 @@ type CreateAlertConfigurationApiRequest struct {
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
-type CreateAlertConfigurationParams struct {
+type CreateAlertConfigurationApiParams struct {
 		GroupId string
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
@@ -310,7 +310,7 @@ type DeleteAlertConfigurationApiRequest struct {
 	alertConfigId string
 }
 
-type DeleteAlertConfigurationParams struct {
+type DeleteAlertConfigurationApiParams struct {
 		GroupId string
 		AlertConfigId string
 }
@@ -433,7 +433,7 @@ type GetAlertConfigurationApiRequest struct {
 	alertConfigId string
 }
 
-type GetAlertConfigurationParams struct {
+type GetAlertConfigurationApiParams struct {
 		GroupId string
 		AlertConfigId string
 }
@@ -565,7 +565,7 @@ type ListAlertConfigurationMatchersFieldNamesApiRequest struct {
 	ApiService AlertConfigurationsApi
 }
 
-type ListAlertConfigurationMatchersFieldNamesParams struct {
+type ListAlertConfigurationMatchersFieldNamesApiParams struct {
 }
 
 func (r ListAlertConfigurationMatchersFieldNamesApiRequest) Execute() ([]MatcherField, *http.Response, error) {
@@ -679,7 +679,7 @@ type ListAlertConfigurationsApiRequest struct {
 	pageNum *int32
 }
 
-type ListAlertConfigurationsParams struct {
+type ListAlertConfigurationsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -848,7 +848,7 @@ type ListAlertConfigurationsByAlertIdApiRequest struct {
 	pageNum *int32
 }
 
-type ListAlertConfigurationsByAlertIdParams struct {
+type ListAlertConfigurationsByAlertIdApiParams struct {
 		GroupId string
 		AlertId string
 		IncludeCount *bool
@@ -1025,7 +1025,7 @@ type ToggleAlertConfigurationApiRequest struct {
 	toggle *Toggle
 }
 
-type ToggleAlertConfigurationParams struct {
+type ToggleAlertConfigurationApiParams struct {
 		GroupId string
 		AlertConfigId string
 		Toggle *Toggle
@@ -1174,7 +1174,7 @@ type UpdateAlertConfigurationApiRequest struct {
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
-type UpdateAlertConfigurationParams struct {
+type UpdateAlertConfigurationApiParams struct {
 		GroupId string
 		AlertConfigId string
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -173,6 +173,10 @@ type AlertConfigurationsApiCreateAlertConfigurationRequest struct {
 	groupId string
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
+type AlertConfigurationsApiCreateAlertConfigurationQueryParams struct {
+		groupId string
+		alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
+}
 
 // Creates one alert configuration for the specified project.
 func (r AlertConfigurationsApiCreateAlertConfigurationRequest) AlertConfigViewForNdsGroup(alertConfigViewForNdsGroup AlertConfigViewForNdsGroup) AlertConfigurationsApiCreateAlertConfigurationRequest {
@@ -304,6 +308,10 @@ type AlertConfigurationsApiDeleteAlertConfigurationRequest struct {
 	groupId string
 	alertConfigId string
 }
+type AlertConfigurationsApiDeleteAlertConfigurationQueryParams struct {
+		groupId string
+		alertConfigId string
+}
 
 func (r AlertConfigurationsApiDeleteAlertConfigurationRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteAlertConfigurationExecute(r)
@@ -421,6 +429,10 @@ type AlertConfigurationsApiGetAlertConfigurationRequest struct {
 	ApiService AlertConfigurationsApi
 	groupId string
 	alertConfigId string
+}
+type AlertConfigurationsApiGetAlertConfigurationQueryParams struct {
+		groupId string
+		alertConfigId string
 }
 
 func (r AlertConfigurationsApiGetAlertConfigurationRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
@@ -549,6 +561,8 @@ type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest struc
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 }
+type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesQueryParams struct {
+}
 
 func (r AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest) Execute() ([]MatcherField, *http.Response, error) {
 	return r.ApiService.ListAlertConfigurationMatchersFieldNamesExecute(r)
@@ -659,6 +673,12 @@ type AlertConfigurationsApiListAlertConfigurationsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type AlertConfigurationsApiListAlertConfigurationsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -821,6 +841,13 @@ type AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type AlertConfigurationsApiListAlertConfigurationsByAlertIdQueryParams struct {
+		groupId string
+		alertId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -991,6 +1018,11 @@ type AlertConfigurationsApiToggleAlertConfigurationRequest struct {
 	alertConfigId string
 	toggle *Toggle
 }
+type AlertConfigurationsApiToggleAlertConfigurationQueryParams struct {
+		groupId string
+		alertConfigId string
+		toggle *Toggle
+}
 
 // Enables or disables the specified alert configuration in the specified project.
 func (r AlertConfigurationsApiToggleAlertConfigurationRequest) Toggle(toggle Toggle) AlertConfigurationsApiToggleAlertConfigurationRequest {
@@ -1133,6 +1165,11 @@ type AlertConfigurationsApiUpdateAlertConfigurationRequest struct {
 	groupId string
 	alertConfigId string
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
+}
+type AlertConfigurationsApiUpdateAlertConfigurationQueryParams struct {
+		groupId string
+		alertConfigId string
+		alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
 // Updates one alert configuration in the specified project.

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -174,7 +174,7 @@ type AlertConfigurationsApiCreateAlertConfigurationRequest struct {
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
-type AlertConfigurationsApiCreateAlertConfigurationParams struct {
+type CreateAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
@@ -310,7 +310,7 @@ type AlertConfigurationsApiDeleteAlertConfigurationRequest struct {
 	alertConfigId string
 }
 
-type AlertConfigurationsApiDeleteAlertConfigurationParams struct {
+type DeleteAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 }
@@ -433,7 +433,7 @@ type AlertConfigurationsApiGetAlertConfigurationRequest struct {
 	alertConfigId string
 }
 
-type AlertConfigurationsApiGetAlertConfigurationParams struct {
+type GetAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 }
@@ -565,7 +565,7 @@ type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest struc
 	ApiService AlertConfigurationsApi
 }
 
-type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesParams struct {
+type ListAlertConfigurationMatchersFieldNamesParams struct {
 }
 
 func (r AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest) Execute() ([]MatcherField, *http.Response, error) {
@@ -679,7 +679,7 @@ type AlertConfigurationsApiListAlertConfigurationsRequest struct {
 	pageNum *int32
 }
 
-type AlertConfigurationsApiListAlertConfigurationsParams struct {
+type ListAlertConfigurationsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -848,7 +848,7 @@ type AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest struct {
 	pageNum *int32
 }
 
-type AlertConfigurationsApiListAlertConfigurationsByAlertIdParams struct {
+type ListAlertConfigurationsByAlertIdParams struct {
 		GroupId string
 		AlertId string
 		IncludeCount *bool
@@ -1025,7 +1025,7 @@ type AlertConfigurationsApiToggleAlertConfigurationRequest struct {
 	toggle *Toggle
 }
 
-type AlertConfigurationsApiToggleAlertConfigurationParams struct {
+type ToggleAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 		Toggle *Toggle
@@ -1174,7 +1174,7 @@ type AlertConfigurationsApiUpdateAlertConfigurationRequest struct {
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
-type AlertConfigurationsApiUpdateAlertConfigurationParams struct {
+type UpdateAlertConfigurationParams struct {
 		GroupId string
 		AlertConfigId string
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -173,9 +173,10 @@ type AlertConfigurationsApiCreateAlertConfigurationRequest struct {
 	groupId string
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
+
 type AlertConfigurationsApiCreateAlertConfigurationQueryParams struct {
-		groupId string
-		alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
+		GroupId string
+		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
 // Creates one alert configuration for the specified project.
@@ -308,9 +309,10 @@ type AlertConfigurationsApiDeleteAlertConfigurationRequest struct {
 	groupId string
 	alertConfigId string
 }
+
 type AlertConfigurationsApiDeleteAlertConfigurationQueryParams struct {
-		groupId string
-		alertConfigId string
+		GroupId string
+		AlertConfigId string
 }
 
 func (r AlertConfigurationsApiDeleteAlertConfigurationRequest) Execute() (*http.Response, error) {
@@ -430,9 +432,10 @@ type AlertConfigurationsApiGetAlertConfigurationRequest struct {
 	groupId string
 	alertConfigId string
 }
+
 type AlertConfigurationsApiGetAlertConfigurationQueryParams struct {
-		groupId string
-		alertConfigId string
+		GroupId string
+		AlertConfigId string
 }
 
 func (r AlertConfigurationsApiGetAlertConfigurationRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
@@ -561,6 +564,7 @@ type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest struc
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 }
+
 type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesQueryParams struct {
 }
 
@@ -674,11 +678,12 @@ type AlertConfigurationsApiListAlertConfigurationsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type AlertConfigurationsApiListAlertConfigurationsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -842,12 +847,13 @@ type AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type AlertConfigurationsApiListAlertConfigurationsByAlertIdQueryParams struct {
-		groupId string
-		alertId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		AlertId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1018,10 +1024,11 @@ type AlertConfigurationsApiToggleAlertConfigurationRequest struct {
 	alertConfigId string
 	toggle *Toggle
 }
+
 type AlertConfigurationsApiToggleAlertConfigurationQueryParams struct {
-		groupId string
-		alertConfigId string
-		toggle *Toggle
+		GroupId string
+		AlertConfigId string
+		Toggle *Toggle
 }
 
 // Enables or disables the specified alert configuration in the specified project.
@@ -1166,10 +1173,11 @@ type AlertConfigurationsApiUpdateAlertConfigurationRequest struct {
 	alertConfigId string
 	alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
+
 type AlertConfigurationsApiUpdateAlertConfigurationQueryParams struct {
-		groupId string
-		alertConfigId string
-		alertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
+		GroupId string
+		AlertConfigId string
+		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
 // Updates one alert configuration in the specified project.

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -31,13 +31,13 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return AlertConfigurationsApiCreateAlertConfigurationRequest
+	@return CreateAlertConfigurationApiRequest
 	*/
-	CreateAlertConfiguration(ctx context.Context, groupId string) AlertConfigurationsApiCreateAlertConfigurationRequest
+	CreateAlertConfiguration(ctx context.Context, groupId string) CreateAlertConfigurationApiRequest
 
 	// CreateAlertConfigurationExecute executes the request
 	//  @return AlertConfigViewForNdsGroup
-	CreateAlertConfigurationExecute(r AlertConfigurationsApiCreateAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+	CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 
 	/*
 	DeleteAlertConfiguration Remove One Alert Configuration from One Project
@@ -49,12 +49,12 @@ type AlertConfigurationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
-	@return AlertConfigurationsApiDeleteAlertConfigurationRequest
+	@return DeleteAlertConfigurationApiRequest
 	*/
-	DeleteAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiDeleteAlertConfigurationRequest
+	DeleteAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) DeleteAlertConfigurationApiRequest
 
 	// DeleteAlertConfigurationExecute executes the request
-	DeleteAlertConfigurationExecute(r AlertConfigurationsApiDeleteAlertConfigurationRequest) (*http.Response, error)
+	DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error)
 
 	/*
 	GetAlertConfiguration Return One Alert Configuration from One Project
@@ -66,13 +66,13 @@ type AlertConfigurationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
-	@return AlertConfigurationsApiGetAlertConfigurationRequest
+	@return GetAlertConfigurationApiRequest
 	*/
-	GetAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiGetAlertConfigurationRequest
+	GetAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) GetAlertConfigurationApiRequest
 
 	// GetAlertConfigurationExecute executes the request
 	//  @return AlertConfigViewForNdsGroup
-	GetAlertConfigurationExecute(r AlertConfigurationsApiGetAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+	GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 
 	/*
 	ListAlertConfigurationMatchersFieldNames Get All Alert Configuration Matchers Field Names
@@ -80,13 +80,13 @@ type AlertConfigurationsApi interface {
 	Get all field names that the `matchers.fieldName` parameter accepts when you create or update an Alert Configuration. You can successfully call this endpoint with any assigned role.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest
+	@return ListAlertConfigurationMatchersFieldNamesApiRequest
 	*/
-	ListAlertConfigurationMatchersFieldNames(ctx context.Context) AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest
+	ListAlertConfigurationMatchersFieldNames(ctx context.Context) ListAlertConfigurationMatchersFieldNamesApiRequest
 
 	// ListAlertConfigurationMatchersFieldNamesExecute executes the request
 	//  @return []MatcherField
-	ListAlertConfigurationMatchersFieldNamesExecute(r AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest) ([]MatcherField, *http.Response, error)
+	ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]MatcherField, *http.Response, error)
 
 	/*
 	ListAlertConfigurations Return All Alert Configurations for One Project
@@ -97,13 +97,13 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return AlertConfigurationsApiListAlertConfigurationsRequest
+	@return ListAlertConfigurationsApiRequest
 	*/
-	ListAlertConfigurations(ctx context.Context, groupId string) AlertConfigurationsApiListAlertConfigurationsRequest
+	ListAlertConfigurations(ctx context.Context, groupId string) ListAlertConfigurationsApiRequest
 
 	// ListAlertConfigurationsExecute executes the request
 	//  @return PaginatedAlertConfig
-	ListAlertConfigurationsExecute(r AlertConfigurationsApiListAlertConfigurationsRequest) (*PaginatedAlertConfig, *http.Response, error)
+	ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
 	ListAlertConfigurationsByAlertId Return All Alert Configurations Set for One Alert
@@ -115,13 +115,13 @@ type AlertConfigurationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertId Unique 24-hexadecimal digit string that identifies the alert. Use the [/alerts](#tag/Alerts/operation/listAlerts) endpoint to retrieve all alerts to which the authenticated user has access.
-	@return AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest
+	@return ListAlertConfigurationsByAlertIdApiRequest
 	*/
-	ListAlertConfigurationsByAlertId(ctx context.Context, groupId string, alertId string) AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest
+	ListAlertConfigurationsByAlertId(ctx context.Context, groupId string, alertId string) ListAlertConfigurationsByAlertIdApiRequest
 
 	// ListAlertConfigurationsByAlertIdExecute executes the request
 	//  @return PaginatedAlertConfig
-	ListAlertConfigurationsByAlertIdExecute(r AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest) (*PaginatedAlertConfig, *http.Response, error)
+	ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
 	ToggleAlertConfiguration Toggle One State of One Alert Configuration in One Project
@@ -135,13 +135,13 @@ This resource remains under revision and may change. Refer to the [legacy docume
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration that triggered this alert. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
-	@return AlertConfigurationsApiToggleAlertConfigurationRequest
+	@return ToggleAlertConfigurationApiRequest
 	*/
-	ToggleAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiToggleAlertConfigurationRequest
+	ToggleAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) ToggleAlertConfigurationApiRequest
 
 	// ToggleAlertConfigurationExecute executes the request
 	//  @return AlertConfigViewForNdsGroup
-	ToggleAlertConfigurationExecute(r AlertConfigurationsApiToggleAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+	ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 
 	/*
 	UpdateAlertConfiguration Update One Alert Configuration for One Project
@@ -155,19 +155,19 @@ This resource remains under revision and may change. Refer to the [legacy docume
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
-	@return AlertConfigurationsApiUpdateAlertConfigurationRequest
+	@return UpdateAlertConfigurationApiRequest
 	*/
-	UpdateAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiUpdateAlertConfigurationRequest
+	UpdateAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) UpdateAlertConfigurationApiRequest
 
 	// UpdateAlertConfigurationExecute executes the request
 	//  @return AlertConfigViewForNdsGroup
-	UpdateAlertConfigurationExecute(r AlertConfigurationsApiUpdateAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+	UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 }
 
 // AlertConfigurationsApiService AlertConfigurationsApi service
 type AlertConfigurationsApiService service
 
-type AlertConfigurationsApiCreateAlertConfigurationRequest struct {
+type CreateAlertConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 	groupId string
@@ -180,12 +180,12 @@ type CreateAlertConfigurationParams struct {
 }
 
 // Creates one alert configuration for the specified project.
-func (r AlertConfigurationsApiCreateAlertConfigurationRequest) AlertConfigViewForNdsGroup(alertConfigViewForNdsGroup AlertConfigViewForNdsGroup) AlertConfigurationsApiCreateAlertConfigurationRequest {
+func (r CreateAlertConfigurationApiRequest) AlertConfigViewForNdsGroup(alertConfigViewForNdsGroup AlertConfigViewForNdsGroup) CreateAlertConfigurationApiRequest {
 	r.alertConfigViewForNdsGroup = &alertConfigViewForNdsGroup
 	return r
 }
 
-func (r AlertConfigurationsApiCreateAlertConfigurationRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (r CreateAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.CreateAlertConfigurationExecute(r)
 }
 
@@ -198,10 +198,10 @@ Creates one alert configuration for the specified project. Alert configurations 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return AlertConfigurationsApiCreateAlertConfigurationRequest
+ @return CreateAlertConfigurationApiRequest
 */
-func (a *AlertConfigurationsApiService) CreateAlertConfiguration(ctx context.Context, groupId string) AlertConfigurationsApiCreateAlertConfigurationRequest {
-	return AlertConfigurationsApiCreateAlertConfigurationRequest{
+func (a *AlertConfigurationsApiService) CreateAlertConfiguration(ctx context.Context, groupId string) CreateAlertConfigurationApiRequest {
+	return CreateAlertConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -210,7 +210,7 @@ func (a *AlertConfigurationsApiService) CreateAlertConfiguration(ctx context.Con
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) CreateAlertConfigurationExecute(r AlertConfigurationsApiCreateAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -303,7 +303,7 @@ func (a *AlertConfigurationsApiService) CreateAlertConfigurationExecute(r AlertC
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertConfigurationsApiDeleteAlertConfigurationRequest struct {
+type DeleteAlertConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 	groupId string
@@ -315,7 +315,7 @@ type DeleteAlertConfigurationParams struct {
 		AlertConfigId string
 }
 
-func (r AlertConfigurationsApiDeleteAlertConfigurationRequest) Execute() (*http.Response, error) {
+func (r DeleteAlertConfigurationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteAlertConfigurationExecute(r)
 }
 
@@ -329,10 +329,10 @@ Removes one alert configuration from the specified project. To use this resource
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
- @return AlertConfigurationsApiDeleteAlertConfigurationRequest
+ @return DeleteAlertConfigurationApiRequest
 */
-func (a *AlertConfigurationsApiService) DeleteAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiDeleteAlertConfigurationRequest {
-	return AlertConfigurationsApiDeleteAlertConfigurationRequest{
+func (a *AlertConfigurationsApiService) DeleteAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) DeleteAlertConfigurationApiRequest {
+	return DeleteAlertConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -341,7 +341,7 @@ func (a *AlertConfigurationsApiService) DeleteAlertConfiguration(ctx context.Con
 }
 
 // Execute executes the request
-func (a *AlertConfigurationsApiService) DeleteAlertConfigurationExecute(r AlertConfigurationsApiDeleteAlertConfigurationRequest) (*http.Response, error) {
+func (a *AlertConfigurationsApiService) DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -426,7 +426,7 @@ func (a *AlertConfigurationsApiService) DeleteAlertConfigurationExecute(r AlertC
 	return localVarHTTPResponse, nil
 }
 
-type AlertConfigurationsApiGetAlertConfigurationRequest struct {
+type GetAlertConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 	groupId string
@@ -438,7 +438,7 @@ type GetAlertConfigurationParams struct {
 		AlertConfigId string
 }
 
-func (r AlertConfigurationsApiGetAlertConfigurationRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (r GetAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.GetAlertConfigurationExecute(r)
 }
 
@@ -452,10 +452,10 @@ Returns the specified alert configuration from the specified project. To use thi
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
- @return AlertConfigurationsApiGetAlertConfigurationRequest
+ @return GetAlertConfigurationApiRequest
 */
-func (a *AlertConfigurationsApiService) GetAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiGetAlertConfigurationRequest {
-	return AlertConfigurationsApiGetAlertConfigurationRequest{
+func (a *AlertConfigurationsApiService) GetAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) GetAlertConfigurationApiRequest {
+	return GetAlertConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -465,7 +465,7 @@ func (a *AlertConfigurationsApiService) GetAlertConfiguration(ctx context.Contex
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) GetAlertConfigurationExecute(r AlertConfigurationsApiGetAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -560,7 +560,7 @@ func (a *AlertConfigurationsApiService) GetAlertConfigurationExecute(r AlertConf
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest struct {
+type ListAlertConfigurationMatchersFieldNamesApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 }
@@ -568,7 +568,7 @@ type AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest struc
 type ListAlertConfigurationMatchersFieldNamesParams struct {
 }
 
-func (r AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest) Execute() ([]MatcherField, *http.Response, error) {
+func (r ListAlertConfigurationMatchersFieldNamesApiRequest) Execute() ([]MatcherField, *http.Response, error) {
 	return r.ApiService.ListAlertConfigurationMatchersFieldNamesExecute(r)
 }
 
@@ -578,10 +578,10 @@ ListAlertConfigurationMatchersFieldNames Get All Alert Configuration Matchers Fi
 Get all field names that the `matchers.fieldName` parameter accepts when you create or update an Alert Configuration. You can successfully call this endpoint with any assigned role.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest
+ @return ListAlertConfigurationMatchersFieldNamesApiRequest
 */
-func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames(ctx context.Context) AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest {
-	return AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest{
+func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames(ctx context.Context) ListAlertConfigurationMatchersFieldNamesApiRequest {
+	return ListAlertConfigurationMatchersFieldNamesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -589,7 +589,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames
 
 // Execute executes the request
 //  @return []MatcherField
-func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNamesExecute(r AlertConfigurationsApiListAlertConfigurationMatchersFieldNamesRequest) ([]MatcherField, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]MatcherField, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -670,7 +670,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertConfigurationsApiListAlertConfigurationsRequest struct {
+type ListAlertConfigurationsApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 	groupId string
@@ -687,24 +687,24 @@ type ListAlertConfigurationsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r AlertConfigurationsApiListAlertConfigurationsRequest) IncludeCount(includeCount bool) AlertConfigurationsApiListAlertConfigurationsRequest {
+func (r ListAlertConfigurationsApiRequest) IncludeCount(includeCount bool) ListAlertConfigurationsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r AlertConfigurationsApiListAlertConfigurationsRequest) ItemsPerPage(itemsPerPage int32) AlertConfigurationsApiListAlertConfigurationsRequest {
+func (r ListAlertConfigurationsApiRequest) ItemsPerPage(itemsPerPage int32) ListAlertConfigurationsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r AlertConfigurationsApiListAlertConfigurationsRequest) PageNum(pageNum int32) AlertConfigurationsApiListAlertConfigurationsRequest {
+func (r ListAlertConfigurationsApiRequest) PageNum(pageNum int32) ListAlertConfigurationsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r AlertConfigurationsApiListAlertConfigurationsRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
+func (r ListAlertConfigurationsApiRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
 	return r.ApiService.ListAlertConfigurationsExecute(r)
 }
 
@@ -717,10 +717,10 @@ Returns all alert configurations for one project. These alert configurations app
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return AlertConfigurationsApiListAlertConfigurationsRequest
+ @return ListAlertConfigurationsApiRequest
 */
-func (a *AlertConfigurationsApiService) ListAlertConfigurations(ctx context.Context, groupId string) AlertConfigurationsApiListAlertConfigurationsRequest {
-	return AlertConfigurationsApiListAlertConfigurationsRequest{
+func (a *AlertConfigurationsApiService) ListAlertConfigurations(ctx context.Context, groupId string) ListAlertConfigurationsApiRequest {
+	return ListAlertConfigurationsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -729,7 +729,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurations(ctx context.Cont
 
 // Execute executes the request
 //  @return PaginatedAlertConfig
-func (a *AlertConfigurationsApiService) ListAlertConfigurationsExecute(r AlertConfigurationsApiListAlertConfigurationsRequest) (*PaginatedAlertConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -838,7 +838,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationsExecute(r AlertCo
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest struct {
+type ListAlertConfigurationsByAlertIdApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 	groupId string
@@ -857,24 +857,24 @@ type ListAlertConfigurationsByAlertIdParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest) IncludeCount(includeCount bool) AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest {
+func (r ListAlertConfigurationsByAlertIdApiRequest) IncludeCount(includeCount bool) ListAlertConfigurationsByAlertIdApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest) ItemsPerPage(itemsPerPage int32) AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest {
+func (r ListAlertConfigurationsByAlertIdApiRequest) ItemsPerPage(itemsPerPage int32) ListAlertConfigurationsByAlertIdApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest) PageNum(pageNum int32) AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest {
+func (r ListAlertConfigurationsByAlertIdApiRequest) PageNum(pageNum int32) ListAlertConfigurationsByAlertIdApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
+func (r ListAlertConfigurationsByAlertIdApiRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
 	return r.ApiService.ListAlertConfigurationsByAlertIdExecute(r)
 }
 
@@ -888,10 +888,10 @@ Returns all alert configurations set for the specified alert. To use this resour
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertId Unique 24-hexadecimal digit string that identifies the alert. Use the [/alerts](#tag/Alerts/operation/listAlerts) endpoint to retrieve all alerts to which the authenticated user has access.
- @return AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest
+ @return ListAlertConfigurationsByAlertIdApiRequest
 */
-func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertId(ctx context.Context, groupId string, alertId string) AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest {
-	return AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest{
+func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertId(ctx context.Context, groupId string, alertId string) ListAlertConfigurationsByAlertIdApiRequest {
+	return ListAlertConfigurationsByAlertIdApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -901,7 +901,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertId(ctx con
 
 // Execute executes the request
 //  @return PaginatedAlertConfig
-func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertIdExecute(r AlertConfigurationsApiListAlertConfigurationsByAlertIdRequest) (*PaginatedAlertConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1017,7 +1017,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertIdExecute(
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertConfigurationsApiToggleAlertConfigurationRequest struct {
+type ToggleAlertConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 	groupId string
@@ -1032,12 +1032,12 @@ type ToggleAlertConfigurationParams struct {
 }
 
 // Enables or disables the specified alert configuration in the specified project.
-func (r AlertConfigurationsApiToggleAlertConfigurationRequest) Toggle(toggle Toggle) AlertConfigurationsApiToggleAlertConfigurationRequest {
+func (r ToggleAlertConfigurationApiRequest) Toggle(toggle Toggle) ToggleAlertConfigurationApiRequest {
 	r.toggle = &toggle
 	return r
 }
 
-func (r AlertConfigurationsApiToggleAlertConfigurationRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (r ToggleAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.ToggleAlertConfigurationExecute(r)
 }
 
@@ -1053,10 +1053,10 @@ This resource remains under revision and may change. Refer to the [legacy docume
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration that triggered this alert. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
- @return AlertConfigurationsApiToggleAlertConfigurationRequest
+ @return ToggleAlertConfigurationApiRequest
 */
-func (a *AlertConfigurationsApiService) ToggleAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiToggleAlertConfigurationRequest {
-	return AlertConfigurationsApiToggleAlertConfigurationRequest{
+func (a *AlertConfigurationsApiService) ToggleAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) ToggleAlertConfigurationApiRequest {
+	return ToggleAlertConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1066,7 +1066,7 @@ func (a *AlertConfigurationsApiService) ToggleAlertConfiguration(ctx context.Con
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) ToggleAlertConfigurationExecute(r AlertConfigurationsApiToggleAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1166,7 +1166,7 @@ func (a *AlertConfigurationsApiService) ToggleAlertConfigurationExecute(r AlertC
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertConfigurationsApiUpdateAlertConfigurationRequest struct {
+type UpdateAlertConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService AlertConfigurationsApi
 	groupId string
@@ -1181,12 +1181,12 @@ type UpdateAlertConfigurationParams struct {
 }
 
 // Updates one alert configuration in the specified project.
-func (r AlertConfigurationsApiUpdateAlertConfigurationRequest) AlertConfigViewForNdsGroup(alertConfigViewForNdsGroup AlertConfigViewForNdsGroup) AlertConfigurationsApiUpdateAlertConfigurationRequest {
+func (r UpdateAlertConfigurationApiRequest) AlertConfigViewForNdsGroup(alertConfigViewForNdsGroup AlertConfigViewForNdsGroup) UpdateAlertConfigurationApiRequest {
 	r.alertConfigViewForNdsGroup = &alertConfigViewForNdsGroup
 	return r
 }
 
-func (r AlertConfigurationsApiUpdateAlertConfigurationRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (r UpdateAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.UpdateAlertConfigurationExecute(r)
 }
 
@@ -1202,10 +1202,10 @@ Updates one alert configuration in the specified project. Alert configurations d
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
- @return AlertConfigurationsApiUpdateAlertConfigurationRequest
+ @return UpdateAlertConfigurationApiRequest
 */
-func (a *AlertConfigurationsApiService) UpdateAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) AlertConfigurationsApiUpdateAlertConfigurationRequest {
-	return AlertConfigurationsApiUpdateAlertConfigurationRequest{
+func (a *AlertConfigurationsApiService) UpdateAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) UpdateAlertConfigurationApiRequest {
+	return UpdateAlertConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1215,7 +1215,7 @@ func (a *AlertConfigurationsApiService) UpdateAlertConfiguration(ctx context.Con
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) UpdateAlertConfigurationExecute(r AlertConfigurationsApiUpdateAlertConfigurationRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -32,13 +32,13 @@ type AlertsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertId Unique 24-hexadecimal digit string that identifies the alert. Use the [/alerts](#tag/Alerts/operation/listAlerts) endpoint to retrieve all alerts to which the authenticated user has access.
-	@return AlertsApiAcknowledgeAlertRequest
+	@return AcknowledgeAlertApiRequest
 	*/
-	AcknowledgeAlert(ctx context.Context, groupId string, alertId string) AlertsApiAcknowledgeAlertRequest
+	AcknowledgeAlert(ctx context.Context, groupId string, alertId string) AcknowledgeAlertApiRequest
 
 	// AcknowledgeAlertExecute executes the request
 	//  @return AlertViewForNdsGroup
-	AcknowledgeAlertExecute(r AlertsApiAcknowledgeAlertRequest) (*AlertViewForNdsGroup, *http.Response, error)
+	AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
 	GetAlert Return One Alert from One Project
@@ -50,13 +50,13 @@ type AlertsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertId Unique 24-hexadecimal digit string that identifies the alert. Use the [/alerts](#tag/Alerts/operation/listAlerts) endpoint to retrieve all alerts to which the authenticated user has access.
-	@return AlertsApiGetAlertRequest
+	@return GetAlertApiRequest
 	*/
-	GetAlert(ctx context.Context, groupId string, alertId string) AlertsApiGetAlertRequest
+	GetAlert(ctx context.Context, groupId string, alertId string) GetAlertApiRequest
 
 	// GetAlertExecute executes the request
 	//  @return AlertViewForNdsGroup
-	GetAlertExecute(r AlertsApiGetAlertRequest) (*AlertViewForNdsGroup, *http.Response, error)
+	GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
 	ListAlerts Return All Alerts from One Project
@@ -67,13 +67,13 @@ type AlertsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return AlertsApiListAlertsRequest
+	@return ListAlertsApiRequest
 	*/
-	ListAlerts(ctx context.Context, groupId string) AlertsApiListAlertsRequest
+	ListAlerts(ctx context.Context, groupId string) ListAlertsApiRequest
 
 	// ListAlertsExecute executes the request
 	//  @return PaginatedAlert
-	ListAlertsExecute(r AlertsApiListAlertsRequest) (*PaginatedAlert, *http.Response, error)
+	ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error)
 
 	/*
 	ListAlertsByAlertConfigurationId Return All Open Alerts for Alert Configuration
@@ -85,19 +85,19 @@ type AlertsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
-	@return AlertsApiListAlertsByAlertConfigurationIdRequest
+	@return ListAlertsByAlertConfigurationIdApiRequest
 	*/
-	ListAlertsByAlertConfigurationId(ctx context.Context, groupId string, alertConfigId string) AlertsApiListAlertsByAlertConfigurationIdRequest
+	ListAlertsByAlertConfigurationId(ctx context.Context, groupId string, alertConfigId string) ListAlertsByAlertConfigurationIdApiRequest
 
 	// ListAlertsByAlertConfigurationIdExecute executes the request
 	//  @return PaginatedAlert
-	ListAlertsByAlertConfigurationIdExecute(r AlertsApiListAlertsByAlertConfigurationIdRequest) (*PaginatedAlert, *http.Response, error)
+	ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error)
 }
 
 // AlertsApiService AlertsApi service
 type AlertsApiService service
 
-type AlertsApiAcknowledgeAlertRequest struct {
+type AcknowledgeAlertApiRequest struct {
 	ctx context.Context
 	ApiService AlertsApi
 	groupId string
@@ -112,12 +112,12 @@ type AcknowledgeAlertParams struct {
 }
 
 // Confirm one alert.
-func (r AlertsApiAcknowledgeAlertRequest) AlertViewForNdsGroup(alertViewForNdsGroup AlertViewForNdsGroup) AlertsApiAcknowledgeAlertRequest {
+func (r AcknowledgeAlertApiRequest) AlertViewForNdsGroup(alertViewForNdsGroup AlertViewForNdsGroup) AcknowledgeAlertApiRequest {
 	r.alertViewForNdsGroup = &alertViewForNdsGroup
 	return r
 }
 
-func (r AlertsApiAcknowledgeAlertRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
+func (r AcknowledgeAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.AcknowledgeAlertExecute(r)
 }
 
@@ -131,10 +131,10 @@ Confirms receipt of one existing alert. This alert applies to any component in o
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertId Unique 24-hexadecimal digit string that identifies the alert. Use the [/alerts](#tag/Alerts/operation/listAlerts) endpoint to retrieve all alerts to which the authenticated user has access.
- @return AlertsApiAcknowledgeAlertRequest
+ @return AcknowledgeAlertApiRequest
 */
-func (a *AlertsApiService) AcknowledgeAlert(ctx context.Context, groupId string, alertId string) AlertsApiAcknowledgeAlertRequest {
-	return AlertsApiAcknowledgeAlertRequest{
+func (a *AlertsApiService) AcknowledgeAlert(ctx context.Context, groupId string, alertId string) AcknowledgeAlertApiRequest {
+	return AcknowledgeAlertApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -144,7 +144,7 @@ func (a *AlertsApiService) AcknowledgeAlert(ctx context.Context, groupId string,
 
 // Execute executes the request
 //  @return AlertViewForNdsGroup
-func (a *AlertsApiService) AcknowledgeAlertExecute(r AlertsApiAcknowledgeAlertRequest) (*AlertViewForNdsGroup, *http.Response, error) {
+func (a *AlertsApiService) AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -244,7 +244,7 @@ func (a *AlertsApiService) AcknowledgeAlertExecute(r AlertsApiAcknowledgeAlertRe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertsApiGetAlertRequest struct {
+type GetAlertApiRequest struct {
 	ctx context.Context
 	ApiService AlertsApi
 	groupId string
@@ -256,7 +256,7 @@ type GetAlertParams struct {
 		AlertId string
 }
 
-func (r AlertsApiGetAlertRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
+func (r GetAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.GetAlertExecute(r)
 }
 
@@ -270,10 +270,10 @@ Returns one alert. This alert applies to any component in one project. You recei
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertId Unique 24-hexadecimal digit string that identifies the alert. Use the [/alerts](#tag/Alerts/operation/listAlerts) endpoint to retrieve all alerts to which the authenticated user has access.
- @return AlertsApiGetAlertRequest
+ @return GetAlertApiRequest
 */
-func (a *AlertsApiService) GetAlert(ctx context.Context, groupId string, alertId string) AlertsApiGetAlertRequest {
-	return AlertsApiGetAlertRequest{
+func (a *AlertsApiService) GetAlert(ctx context.Context, groupId string, alertId string) GetAlertApiRequest {
+	return GetAlertApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -283,7 +283,7 @@ func (a *AlertsApiService) GetAlert(ctx context.Context, groupId string, alertId
 
 // Execute executes the request
 //  @return AlertViewForNdsGroup
-func (a *AlertsApiService) GetAlertExecute(r AlertsApiGetAlertRequest) (*AlertViewForNdsGroup, *http.Response, error) {
+func (a *AlertsApiService) GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -378,7 +378,7 @@ func (a *AlertsApiService) GetAlertExecute(r AlertsApiGetAlertRequest) (*AlertVi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertsApiListAlertsRequest struct {
+type ListAlertsApiRequest struct {
 	ctx context.Context
 	ApiService AlertsApi
 	groupId string
@@ -397,30 +397,30 @@ type ListAlertsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r AlertsApiListAlertsRequest) IncludeCount(includeCount bool) AlertsApiListAlertsRequest {
+func (r ListAlertsApiRequest) IncludeCount(includeCount bool) ListAlertsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r AlertsApiListAlertsRequest) ItemsPerPage(itemsPerPage int32) AlertsApiListAlertsRequest {
+func (r ListAlertsApiRequest) ItemsPerPage(itemsPerPage int32) ListAlertsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r AlertsApiListAlertsRequest) PageNum(pageNum int32) AlertsApiListAlertsRequest {
+func (r ListAlertsApiRequest) PageNum(pageNum int32) ListAlertsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Status of the alerts to return. Omit to return all alerts in all statuses.
-func (r AlertsApiListAlertsRequest) Status(status string) AlertsApiListAlertsRequest {
+func (r ListAlertsApiRequest) Status(status string) ListAlertsApiRequest {
 	r.status = &status
 	return r
 }
 
-func (r AlertsApiListAlertsRequest) Execute() (*PaginatedAlert, *http.Response, error) {
+func (r ListAlertsApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
 	return r.ApiService.ListAlertsExecute(r)
 }
 
@@ -433,10 +433,10 @@ Returns all alerts. These alerts apply to all components in one project. You rec
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return AlertsApiListAlertsRequest
+ @return ListAlertsApiRequest
 */
-func (a *AlertsApiService) ListAlerts(ctx context.Context, groupId string) AlertsApiListAlertsRequest {
-	return AlertsApiListAlertsRequest{
+func (a *AlertsApiService) ListAlerts(ctx context.Context, groupId string) ListAlertsApiRequest {
+	return ListAlertsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -445,7 +445,7 @@ func (a *AlertsApiService) ListAlerts(ctx context.Context, groupId string) Alert
 
 // Execute executes the request
 //  @return PaginatedAlert
-func (a *AlertsApiService) ListAlertsExecute(r AlertsApiListAlertsRequest) (*PaginatedAlert, *http.Response, error) {
+func (a *AlertsApiService) ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -557,7 +557,7 @@ func (a *AlertsApiService) ListAlertsExecute(r AlertsApiListAlertsRequest) (*Pag
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AlertsApiListAlertsByAlertConfigurationIdRequest struct {
+type ListAlertsByAlertConfigurationIdApiRequest struct {
 	ctx context.Context
 	ApiService AlertsApi
 	groupId string
@@ -576,24 +576,24 @@ type ListAlertsByAlertConfigurationIdParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r AlertsApiListAlertsByAlertConfigurationIdRequest) IncludeCount(includeCount bool) AlertsApiListAlertsByAlertConfigurationIdRequest {
+func (r ListAlertsByAlertConfigurationIdApiRequest) IncludeCount(includeCount bool) ListAlertsByAlertConfigurationIdApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r AlertsApiListAlertsByAlertConfigurationIdRequest) ItemsPerPage(itemsPerPage int32) AlertsApiListAlertsByAlertConfigurationIdRequest {
+func (r ListAlertsByAlertConfigurationIdApiRequest) ItemsPerPage(itemsPerPage int32) ListAlertsByAlertConfigurationIdApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r AlertsApiListAlertsByAlertConfigurationIdRequest) PageNum(pageNum int32) AlertsApiListAlertsByAlertConfigurationIdRequest {
+func (r ListAlertsByAlertConfigurationIdApiRequest) PageNum(pageNum int32) ListAlertsByAlertConfigurationIdApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r AlertsApiListAlertsByAlertConfigurationIdRequest) Execute() (*PaginatedAlert, *http.Response, error) {
+func (r ListAlertsByAlertConfigurationIdApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
 	return r.ApiService.ListAlertsByAlertConfigurationIdExecute(r)
 }
 
@@ -607,10 +607,10 @@ Returns all open alerts that the specified alert configuration triggers. These a
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param alertConfigId Unique 24-hexadecimal digit string that identifies the alert configuration. Use the [/alertConfigs](#tag/Alert-Configurations/operation/listAlertConfigurations) endpoint to retrieve all alert configurations to which the authenticated user has access.
- @return AlertsApiListAlertsByAlertConfigurationIdRequest
+ @return ListAlertsByAlertConfigurationIdApiRequest
 */
-func (a *AlertsApiService) ListAlertsByAlertConfigurationId(ctx context.Context, groupId string, alertConfigId string) AlertsApiListAlertsByAlertConfigurationIdRequest {
-	return AlertsApiListAlertsByAlertConfigurationIdRequest{
+func (a *AlertsApiService) ListAlertsByAlertConfigurationId(ctx context.Context, groupId string, alertConfigId string) ListAlertsByAlertConfigurationIdApiRequest {
+	return ListAlertsByAlertConfigurationIdApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -620,7 +620,7 @@ func (a *AlertsApiService) ListAlertsByAlertConfigurationId(ctx context.Context,
 
 // Execute executes the request
 //  @return PaginatedAlert
-func (a *AlertsApiService) ListAlertsByAlertConfigurationIdExecute(r AlertsApiListAlertsByAlertConfigurationIdRequest) (*PaginatedAlert, *http.Response, error) {
+func (a *AlertsApiService) ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -105,7 +105,7 @@ type AcknowledgeAlertApiRequest struct {
 	alertViewForNdsGroup *AlertViewForNdsGroup
 }
 
-type AcknowledgeAlertParams struct {
+type AcknowledgeAlertApiParams struct {
 		GroupId string
 		AlertId string
 		AlertViewForNdsGroup *AlertViewForNdsGroup
@@ -251,7 +251,7 @@ type GetAlertApiRequest struct {
 	alertId string
 }
 
-type GetAlertParams struct {
+type GetAlertApiParams struct {
 		GroupId string
 		AlertId string
 }
@@ -388,7 +388,7 @@ type ListAlertsApiRequest struct {
 	status *string
 }
 
-type ListAlertsParams struct {
+type ListAlertsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -567,7 +567,7 @@ type ListAlertsByAlertConfigurationIdApiRequest struct {
 	pageNum *int32
 }
 
-type ListAlertsByAlertConfigurationIdParams struct {
+type ListAlertsByAlertConfigurationIdApiParams struct {
 		GroupId string
 		AlertConfigId string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -104,10 +104,11 @@ type AlertsApiAcknowledgeAlertRequest struct {
 	alertId string
 	alertViewForNdsGroup *AlertViewForNdsGroup
 }
+
 type AlertsApiAcknowledgeAlertQueryParams struct {
-		groupId string
-		alertId string
-		alertViewForNdsGroup *AlertViewForNdsGroup
+		GroupId string
+		AlertId string
+		AlertViewForNdsGroup *AlertViewForNdsGroup
 }
 
 // Confirm one alert.
@@ -249,9 +250,10 @@ type AlertsApiGetAlertRequest struct {
 	groupId string
 	alertId string
 }
+
 type AlertsApiGetAlertQueryParams struct {
-		groupId string
-		alertId string
+		GroupId string
+		AlertId string
 }
 
 func (r AlertsApiGetAlertRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
@@ -385,12 +387,13 @@ type AlertsApiListAlertsRequest struct {
 	pageNum *int32
 	status *string
 }
+
 type AlertsApiListAlertsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		status *string
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		Status *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -563,12 +566,13 @@ type AlertsApiListAlertsByAlertConfigurationIdRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type AlertsApiListAlertsByAlertConfigurationIdQueryParams struct {
-		groupId string
-		alertConfigId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		AlertConfigId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -104,6 +104,11 @@ type AlertsApiAcknowledgeAlertRequest struct {
 	alertId string
 	alertViewForNdsGroup *AlertViewForNdsGroup
 }
+type AlertsApiAcknowledgeAlertQueryParams struct {
+		groupId string
+		alertId string
+		alertViewForNdsGroup *AlertViewForNdsGroup
+}
 
 // Confirm one alert.
 func (r AlertsApiAcknowledgeAlertRequest) AlertViewForNdsGroup(alertViewForNdsGroup AlertViewForNdsGroup) AlertsApiAcknowledgeAlertRequest {
@@ -244,6 +249,10 @@ type AlertsApiGetAlertRequest struct {
 	groupId string
 	alertId string
 }
+type AlertsApiGetAlertQueryParams struct {
+		groupId string
+		alertId string
+}
 
 func (r AlertsApiGetAlertRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.GetAlertExecute(r)
@@ -375,6 +384,13 @@ type AlertsApiListAlertsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 	status *string
+}
+type AlertsApiListAlertsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		status *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -546,6 +562,13 @@ type AlertsApiListAlertsByAlertConfigurationIdRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type AlertsApiListAlertsByAlertConfigurationIdQueryParams struct {
+		groupId string
+		alertConfigId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -105,7 +105,7 @@ type AlertsApiAcknowledgeAlertRequest struct {
 	alertViewForNdsGroup *AlertViewForNdsGroup
 }
 
-type AlertsApiAcknowledgeAlertQueryParams struct {
+type AlertsApiAcknowledgeAlertParams struct {
 		GroupId string
 		AlertId string
 		AlertViewForNdsGroup *AlertViewForNdsGroup
@@ -251,7 +251,7 @@ type AlertsApiGetAlertRequest struct {
 	alertId string
 }
 
-type AlertsApiGetAlertQueryParams struct {
+type AlertsApiGetAlertParams struct {
 		GroupId string
 		AlertId string
 }
@@ -388,7 +388,7 @@ type AlertsApiListAlertsRequest struct {
 	status *string
 }
 
-type AlertsApiListAlertsQueryParams struct {
+type AlertsApiListAlertsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -567,7 +567,7 @@ type AlertsApiListAlertsByAlertConfigurationIdRequest struct {
 	pageNum *int32
 }
 
-type AlertsApiListAlertsByAlertConfigurationIdQueryParams struct {
+type AlertsApiListAlertsByAlertConfigurationIdParams struct {
 		GroupId string
 		AlertConfigId string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -105,7 +105,7 @@ type AlertsApiAcknowledgeAlertRequest struct {
 	alertViewForNdsGroup *AlertViewForNdsGroup
 }
 
-type AlertsApiAcknowledgeAlertParams struct {
+type AcknowledgeAlertParams struct {
 		GroupId string
 		AlertId string
 		AlertViewForNdsGroup *AlertViewForNdsGroup
@@ -251,7 +251,7 @@ type AlertsApiGetAlertRequest struct {
 	alertId string
 }
 
-type AlertsApiGetAlertParams struct {
+type GetAlertParams struct {
 		GroupId string
 		AlertId string
 }
@@ -388,7 +388,7 @@ type AlertsApiListAlertsRequest struct {
 	status *string
 }
 
-type AlertsApiListAlertsParams struct {
+type ListAlertsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -567,7 +567,7 @@ type AlertsApiListAlertsByAlertConfigurationIdRequest struct {
 	pageNum *int32
 }
 
-type AlertsApiListAlertsByAlertConfigurationIdParams struct {
+type ListAlertsByAlertConfigurationIdParams struct {
 		GroupId string
 		AlertConfigId string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -117,10 +117,11 @@ type AtlasSearchApiCreateAtlasSearchIndexRequest struct {
 	clusterName string
 	fTSIndex *FTSIndex
 }
+
 type AtlasSearchApiCreateAtlasSearchIndexQueryParams struct {
-		groupId string
-		clusterName string
-		fTSIndex *FTSIndex
+		GroupId string
+		ClusterName string
+		FTSIndex *FTSIndex
 }
 
 // Creates one Atlas Search index on the specified collection.
@@ -261,10 +262,11 @@ type AtlasSearchApiDeleteAtlasSearchIndexRequest struct {
 	clusterName string
 	indexId string
 }
+
 type AtlasSearchApiDeleteAtlasSearchIndexQueryParams struct {
-		groupId string
-		clusterName string
-		indexId string
+		GroupId string
+		ClusterName string
+		IndexId string
 }
 
 func (r AtlasSearchApiDeleteAtlasSearchIndexRequest) Execute() (*http.Response, error) {
@@ -392,10 +394,11 @@ type AtlasSearchApiGetAtlasSearchIndexRequest struct {
 	clusterName string
 	indexId string
 }
+
 type AtlasSearchApiGetAtlasSearchIndexQueryParams struct {
-		groupId string
-		clusterName string
-		indexId string
+		GroupId string
+		ClusterName string
+		IndexId string
 }
 
 func (r AtlasSearchApiGetAtlasSearchIndexRequest) Execute() (*FTSIndex, *http.Response, error) {
@@ -535,11 +538,12 @@ type AtlasSearchApiListAtlasSearchIndexesRequest struct {
 	collectionName string
 	databaseName string
 }
+
 type AtlasSearchApiListAtlasSearchIndexesQueryParams struct {
-		groupId string
-		clusterName string
-		collectionName string
-		databaseName string
+		GroupId string
+		ClusterName string
+		CollectionName string
+		DatabaseName string
 }
 
 func (r AtlasSearchApiListAtlasSearchIndexesRequest) Execute() ([]FTSIndex, *http.Response, error) {
@@ -676,11 +680,12 @@ type AtlasSearchApiUpdateAtlasSearchIndexRequest struct {
 	indexId string
 	fTSIndex *FTSIndex
 }
+
 type AtlasSearchApiUpdateAtlasSearchIndexQueryParams struct {
-		groupId string
-		clusterName string
-		indexId string
-		fTSIndex *FTSIndex
+		GroupId string
+		ClusterName string
+		IndexId string
+		FTSIndex *FTSIndex
 }
 
 // Details to update on the Atlas Search index.

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -118,7 +118,7 @@ type AtlasSearchApiCreateAtlasSearchIndexRequest struct {
 	fTSIndex *FTSIndex
 }
 
-type AtlasSearchApiCreateAtlasSearchIndexQueryParams struct {
+type AtlasSearchApiCreateAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		FTSIndex *FTSIndex
@@ -263,7 +263,7 @@ type AtlasSearchApiDeleteAtlasSearchIndexRequest struct {
 	indexId string
 }
 
-type AtlasSearchApiDeleteAtlasSearchIndexQueryParams struct {
+type AtlasSearchApiDeleteAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string
@@ -395,7 +395,7 @@ type AtlasSearchApiGetAtlasSearchIndexRequest struct {
 	indexId string
 }
 
-type AtlasSearchApiGetAtlasSearchIndexQueryParams struct {
+type AtlasSearchApiGetAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string
@@ -539,7 +539,7 @@ type AtlasSearchApiListAtlasSearchIndexesRequest struct {
 	databaseName string
 }
 
-type AtlasSearchApiListAtlasSearchIndexesQueryParams struct {
+type AtlasSearchApiListAtlasSearchIndexesParams struct {
 		GroupId string
 		ClusterName string
 		CollectionName string
@@ -681,7 +681,7 @@ type AtlasSearchApiUpdateAtlasSearchIndexRequest struct {
 	fTSIndex *FTSIndex
 }
 
-type AtlasSearchApiUpdateAtlasSearchIndexQueryParams struct {
+type AtlasSearchApiUpdateAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -30,13 +30,13 @@ type AtlasSearchApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Name of the cluster that contains the collection on which to create an Atlas Search index.
-	@return AtlasSearchApiCreateAtlasSearchIndexRequest
+	@return CreateAtlasSearchIndexApiRequest
 	*/
-	CreateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string) AtlasSearchApiCreateAtlasSearchIndexRequest
+	CreateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string) CreateAtlasSearchIndexApiRequest
 
 	// CreateAtlasSearchIndexExecute executes the request
 	//  @return FTSIndex
-	CreateAtlasSearchIndexExecute(r AtlasSearchApiCreateAtlasSearchIndexRequest) (*FTSIndex, *http.Response, error)
+	CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
 
 	/*
 	DeleteAtlasSearchIndex Remove One Atlas Search Index
@@ -47,12 +47,12 @@ type AtlasSearchApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Name of the cluster that contains the database and collection with one or more Application Search indexes.
 	@param indexId Unique 24-hexadecimal digit string that identifies the Atlas Search index. Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
-	@return AtlasSearchApiDeleteAtlasSearchIndexRequest
+	@return DeleteAtlasSearchIndexApiRequest
 	*/
-	DeleteAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) AtlasSearchApiDeleteAtlasSearchIndexRequest
+	DeleteAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) DeleteAtlasSearchIndexApiRequest
 
 	// DeleteAtlasSearchIndexExecute executes the request
-	DeleteAtlasSearchIndexExecute(r AtlasSearchApiDeleteAtlasSearchIndexRequest) (*http.Response, error)
+	DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (*http.Response, error)
 
 	/*
 	GetAtlasSearchIndex Return One Atlas Search Index
@@ -63,13 +63,13 @@ type AtlasSearchApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Name of the cluster that contains the collection with one or more Atlas Search indexes.
 	@param indexId Unique 24-hexadecimal digit string that identifies the Application Search [index](https://docs.atlas.mongodb.com/reference/atlas-search/index-definitions/). Use the [Get All Application Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Application Search indexes.
-	@return AtlasSearchApiGetAtlasSearchIndexRequest
+	@return GetAtlasSearchIndexApiRequest
 	*/
-	GetAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) AtlasSearchApiGetAtlasSearchIndexRequest
+	GetAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) GetAtlasSearchIndexApiRequest
 
 	// GetAtlasSearchIndexExecute executes the request
 	//  @return FTSIndex
-	GetAtlasSearchIndexExecute(r AtlasSearchApiGetAtlasSearchIndexRequest) (*FTSIndex, *http.Response, error)
+	GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
 
 	/*
 	ListAtlasSearchIndexes Return All Atlas Search Indexes for One Collection
@@ -81,13 +81,13 @@ type AtlasSearchApi interface {
 	@param clusterName Name of the cluster that contains the collection with one or more Atlas Search indexes.
 	@param collectionName Name of the collection that contains one or more Atlas Search indexes.
 	@param databaseName Human-readable label that identifies the database that contains the collection with one or more Atlas Search indexes.
-	@return AtlasSearchApiListAtlasSearchIndexesRequest
+	@return ListAtlasSearchIndexesApiRequest
 	*/
-	ListAtlasSearchIndexes(ctx context.Context, groupId string, clusterName string, collectionName string, databaseName string) AtlasSearchApiListAtlasSearchIndexesRequest
+	ListAtlasSearchIndexes(ctx context.Context, groupId string, clusterName string, collectionName string, databaseName string) ListAtlasSearchIndexesApiRequest
 
 	// ListAtlasSearchIndexesExecute executes the request
 	//  @return []FTSIndex
-	ListAtlasSearchIndexesExecute(r AtlasSearchApiListAtlasSearchIndexesRequest) ([]FTSIndex, *http.Response, error)
+	ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]FTSIndex, *http.Response, error)
 
 	/*
 	UpdateAtlasSearchIndex Update One Atlas Search Index
@@ -98,19 +98,19 @@ type AtlasSearchApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Name of the cluster that contains the collection whose Atlas Search index to update.
 	@param indexId Unique 24-hexadecimal digit string that identifies the Atlas Search [index](https://docs.atlas.mongodb.com/reference/atlas-search/index-definitions/). Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
-	@return AtlasSearchApiUpdateAtlasSearchIndexRequest
+	@return UpdateAtlasSearchIndexApiRequest
 	*/
-	UpdateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) AtlasSearchApiUpdateAtlasSearchIndexRequest
+	UpdateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) UpdateAtlasSearchIndexApiRequest
 
 	// UpdateAtlasSearchIndexExecute executes the request
 	//  @return FTSIndex
-	UpdateAtlasSearchIndexExecute(r AtlasSearchApiUpdateAtlasSearchIndexRequest) (*FTSIndex, *http.Response, error)
+	UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
 }
 
 // AtlasSearchApiService AtlasSearchApi service
 type AtlasSearchApiService service
 
-type AtlasSearchApiCreateAtlasSearchIndexRequest struct {
+type CreateAtlasSearchIndexApiRequest struct {
 	ctx context.Context
 	ApiService AtlasSearchApi
 	groupId string
@@ -125,12 +125,12 @@ type CreateAtlasSearchIndexParams struct {
 }
 
 // Creates one Atlas Search index on the specified collection.
-func (r AtlasSearchApiCreateAtlasSearchIndexRequest) FTSIndex(fTSIndex FTSIndex) AtlasSearchApiCreateAtlasSearchIndexRequest {
+func (r CreateAtlasSearchIndexApiRequest) FTSIndex(fTSIndex FTSIndex) CreateAtlasSearchIndexApiRequest {
 	r.fTSIndex = &fTSIndex
 	return r
 }
 
-func (r AtlasSearchApiCreateAtlasSearchIndexRequest) Execute() (*FTSIndex, *http.Response, error) {
+func (r CreateAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
 	return r.ApiService.CreateAtlasSearchIndexExecute(r)
 }
 
@@ -142,10 +142,10 @@ Creates one Atlas Search index on the specified collection. Atlas Search indexes
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Name of the cluster that contains the collection on which to create an Atlas Search index.
- @return AtlasSearchApiCreateAtlasSearchIndexRequest
+ @return CreateAtlasSearchIndexApiRequest
 */
-func (a *AtlasSearchApiService) CreateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string) AtlasSearchApiCreateAtlasSearchIndexRequest {
-	return AtlasSearchApiCreateAtlasSearchIndexRequest{
+func (a *AtlasSearchApiService) CreateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string) CreateAtlasSearchIndexApiRequest {
+	return CreateAtlasSearchIndexApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -155,7 +155,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchIndex(ctx context.Context, grou
 
 // Execute executes the request
 //  @return FTSIndex
-func (a *AtlasSearchApiService) CreateAtlasSearchIndexExecute(r AtlasSearchApiCreateAtlasSearchIndexRequest) (*FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -255,7 +255,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchIndexExecute(r AtlasSearchApiCr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AtlasSearchApiDeleteAtlasSearchIndexRequest struct {
+type DeleteAtlasSearchIndexApiRequest struct {
 	ctx context.Context
 	ApiService AtlasSearchApi
 	groupId string
@@ -269,7 +269,7 @@ type DeleteAtlasSearchIndexParams struct {
 		IndexId string
 }
 
-func (r AtlasSearchApiDeleteAtlasSearchIndexRequest) Execute() (*http.Response, error) {
+func (r DeleteAtlasSearchIndexApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteAtlasSearchIndexExecute(r)
 }
 
@@ -282,10 +282,10 @@ Removes one Atlas Search index that you identified with its unique ID. To use th
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Name of the cluster that contains the database and collection with one or more Application Search indexes.
  @param indexId Unique 24-hexadecimal digit string that identifies the Atlas Search index. Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
- @return AtlasSearchApiDeleteAtlasSearchIndexRequest
+ @return DeleteAtlasSearchIndexApiRequest
 */
-func (a *AtlasSearchApiService) DeleteAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) AtlasSearchApiDeleteAtlasSearchIndexRequest {
-	return AtlasSearchApiDeleteAtlasSearchIndexRequest{
+func (a *AtlasSearchApiService) DeleteAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) DeleteAtlasSearchIndexApiRequest {
+	return DeleteAtlasSearchIndexApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -295,7 +295,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndex(ctx context.Context, grou
 }
 
 // Execute executes the request
-func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r AtlasSearchApiDeleteAtlasSearchIndexRequest) (*http.Response, error) {
+func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -387,7 +387,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r AtlasSearchApiDe
 	return localVarHTTPResponse, nil
 }
 
-type AtlasSearchApiGetAtlasSearchIndexRequest struct {
+type GetAtlasSearchIndexApiRequest struct {
 	ctx context.Context
 	ApiService AtlasSearchApi
 	groupId string
@@ -401,7 +401,7 @@ type GetAtlasSearchIndexParams struct {
 		IndexId string
 }
 
-func (r AtlasSearchApiGetAtlasSearchIndexRequest) Execute() (*FTSIndex, *http.Response, error) {
+func (r GetAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
 	return r.ApiService.GetAtlasSearchIndexExecute(r)
 }
 
@@ -414,10 +414,10 @@ Returns one Atlas Search index in the specified project. You identify this index
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Name of the cluster that contains the collection with one or more Atlas Search indexes.
  @param indexId Unique 24-hexadecimal digit string that identifies the Application Search [index](https://docs.atlas.mongodb.com/reference/atlas-search/index-definitions/). Use the [Get All Application Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Application Search indexes.
- @return AtlasSearchApiGetAtlasSearchIndexRequest
+ @return GetAtlasSearchIndexApiRequest
 */
-func (a *AtlasSearchApiService) GetAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) AtlasSearchApiGetAtlasSearchIndexRequest {
-	return AtlasSearchApiGetAtlasSearchIndexRequest{
+func (a *AtlasSearchApiService) GetAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) GetAtlasSearchIndexApiRequest {
+	return GetAtlasSearchIndexApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -428,7 +428,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndex(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return FTSIndex
-func (a *AtlasSearchApiService) GetAtlasSearchIndexExecute(r AtlasSearchApiGetAtlasSearchIndexRequest) (*FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -530,7 +530,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndexExecute(r AtlasSearchApiGetAt
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AtlasSearchApiListAtlasSearchIndexesRequest struct {
+type ListAtlasSearchIndexesApiRequest struct {
 	ctx context.Context
 	ApiService AtlasSearchApi
 	groupId string
@@ -546,7 +546,7 @@ type ListAtlasSearchIndexesParams struct {
 		DatabaseName string
 }
 
-func (r AtlasSearchApiListAtlasSearchIndexesRequest) Execute() ([]FTSIndex, *http.Response, error) {
+func (r ListAtlasSearchIndexesApiRequest) Execute() ([]FTSIndex, *http.Response, error) {
 	return r.ApiService.ListAtlasSearchIndexesExecute(r)
 }
 
@@ -560,10 +560,10 @@ Returns all Atlas Search indexes on the specified collection. Atlas Search index
  @param clusterName Name of the cluster that contains the collection with one or more Atlas Search indexes.
  @param collectionName Name of the collection that contains one or more Atlas Search indexes.
  @param databaseName Human-readable label that identifies the database that contains the collection with one or more Atlas Search indexes.
- @return AtlasSearchApiListAtlasSearchIndexesRequest
+ @return ListAtlasSearchIndexesApiRequest
 */
-func (a *AtlasSearchApiService) ListAtlasSearchIndexes(ctx context.Context, groupId string, clusterName string, collectionName string, databaseName string) AtlasSearchApiListAtlasSearchIndexesRequest {
-	return AtlasSearchApiListAtlasSearchIndexesRequest{
+func (a *AtlasSearchApiService) ListAtlasSearchIndexes(ctx context.Context, groupId string, clusterName string, collectionName string, databaseName string) ListAtlasSearchIndexesApiRequest {
+	return ListAtlasSearchIndexesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -575,7 +575,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexes(ctx context.Context, grou
 
 // Execute executes the request
 //  @return []FTSIndex
-func (a *AtlasSearchApiService) ListAtlasSearchIndexesExecute(r AtlasSearchApiListAtlasSearchIndexesRequest) ([]FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -672,7 +672,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexesExecute(r AtlasSearchApiLi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AtlasSearchApiUpdateAtlasSearchIndexRequest struct {
+type UpdateAtlasSearchIndexApiRequest struct {
 	ctx context.Context
 	ApiService AtlasSearchApi
 	groupId string
@@ -689,12 +689,12 @@ type UpdateAtlasSearchIndexParams struct {
 }
 
 // Details to update on the Atlas Search index.
-func (r AtlasSearchApiUpdateAtlasSearchIndexRequest) FTSIndex(fTSIndex FTSIndex) AtlasSearchApiUpdateAtlasSearchIndexRequest {
+func (r UpdateAtlasSearchIndexApiRequest) FTSIndex(fTSIndex FTSIndex) UpdateAtlasSearchIndexApiRequest {
 	r.fTSIndex = &fTSIndex
 	return r
 }
 
-func (r AtlasSearchApiUpdateAtlasSearchIndexRequest) Execute() (*FTSIndex, *http.Response, error) {
+func (r UpdateAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
 	return r.ApiService.UpdateAtlasSearchIndexExecute(r)
 }
 
@@ -707,10 +707,10 @@ Updates one Atlas Search index that you identified with its unique ID. Atlas Sea
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Name of the cluster that contains the collection whose Atlas Search index to update.
  @param indexId Unique 24-hexadecimal digit string that identifies the Atlas Search [index](https://docs.atlas.mongodb.com/reference/atlas-search/index-definitions/). Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
- @return AtlasSearchApiUpdateAtlasSearchIndexRequest
+ @return UpdateAtlasSearchIndexApiRequest
 */
-func (a *AtlasSearchApiService) UpdateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) AtlasSearchApiUpdateAtlasSearchIndexRequest {
-	return AtlasSearchApiUpdateAtlasSearchIndexRequest{
+func (a *AtlasSearchApiService) UpdateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) UpdateAtlasSearchIndexApiRequest {
+	return UpdateAtlasSearchIndexApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -721,7 +721,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchIndex(ctx context.Context, grou
 
 // Execute executes the request
 //  @return FTSIndex
-func (a *AtlasSearchApiService) UpdateAtlasSearchIndexExecute(r AtlasSearchApiUpdateAtlasSearchIndexRequest) (*FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -117,6 +117,11 @@ type AtlasSearchApiCreateAtlasSearchIndexRequest struct {
 	clusterName string
 	fTSIndex *FTSIndex
 }
+type AtlasSearchApiCreateAtlasSearchIndexQueryParams struct {
+		groupId string
+		clusterName string
+		fTSIndex *FTSIndex
+}
 
 // Creates one Atlas Search index on the specified collection.
 func (r AtlasSearchApiCreateAtlasSearchIndexRequest) FTSIndex(fTSIndex FTSIndex) AtlasSearchApiCreateAtlasSearchIndexRequest {
@@ -256,6 +261,11 @@ type AtlasSearchApiDeleteAtlasSearchIndexRequest struct {
 	clusterName string
 	indexId string
 }
+type AtlasSearchApiDeleteAtlasSearchIndexQueryParams struct {
+		groupId string
+		clusterName string
+		indexId string
+}
 
 func (r AtlasSearchApiDeleteAtlasSearchIndexRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteAtlasSearchIndexExecute(r)
@@ -381,6 +391,11 @@ type AtlasSearchApiGetAtlasSearchIndexRequest struct {
 	groupId string
 	clusterName string
 	indexId string
+}
+type AtlasSearchApiGetAtlasSearchIndexQueryParams struct {
+		groupId string
+		clusterName string
+		indexId string
 }
 
 func (r AtlasSearchApiGetAtlasSearchIndexRequest) Execute() (*FTSIndex, *http.Response, error) {
@@ -520,6 +535,12 @@ type AtlasSearchApiListAtlasSearchIndexesRequest struct {
 	collectionName string
 	databaseName string
 }
+type AtlasSearchApiListAtlasSearchIndexesQueryParams struct {
+		groupId string
+		clusterName string
+		collectionName string
+		databaseName string
+}
 
 func (r AtlasSearchApiListAtlasSearchIndexesRequest) Execute() ([]FTSIndex, *http.Response, error) {
 	return r.ApiService.ListAtlasSearchIndexesExecute(r)
@@ -654,6 +675,12 @@ type AtlasSearchApiUpdateAtlasSearchIndexRequest struct {
 	clusterName string
 	indexId string
 	fTSIndex *FTSIndex
+}
+type AtlasSearchApiUpdateAtlasSearchIndexQueryParams struct {
+		groupId string
+		clusterName string
+		indexId string
+		fTSIndex *FTSIndex
 }
 
 // Details to update on the Atlas Search index.

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -118,7 +118,7 @@ type CreateAtlasSearchIndexApiRequest struct {
 	fTSIndex *FTSIndex
 }
 
-type CreateAtlasSearchIndexParams struct {
+type CreateAtlasSearchIndexApiParams struct {
 		GroupId string
 		ClusterName string
 		FTSIndex *FTSIndex
@@ -263,7 +263,7 @@ type DeleteAtlasSearchIndexApiRequest struct {
 	indexId string
 }
 
-type DeleteAtlasSearchIndexParams struct {
+type DeleteAtlasSearchIndexApiParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string
@@ -395,7 +395,7 @@ type GetAtlasSearchIndexApiRequest struct {
 	indexId string
 }
 
-type GetAtlasSearchIndexParams struct {
+type GetAtlasSearchIndexApiParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string
@@ -539,7 +539,7 @@ type ListAtlasSearchIndexesApiRequest struct {
 	databaseName string
 }
 
-type ListAtlasSearchIndexesParams struct {
+type ListAtlasSearchIndexesApiParams struct {
 		GroupId string
 		ClusterName string
 		CollectionName string
@@ -681,7 +681,7 @@ type UpdateAtlasSearchIndexApiRequest struct {
 	fTSIndex *FTSIndex
 }
 
-type UpdateAtlasSearchIndexParams struct {
+type UpdateAtlasSearchIndexApiParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -118,7 +118,7 @@ type AtlasSearchApiCreateAtlasSearchIndexRequest struct {
 	fTSIndex *FTSIndex
 }
 
-type AtlasSearchApiCreateAtlasSearchIndexParams struct {
+type CreateAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		FTSIndex *FTSIndex
@@ -263,7 +263,7 @@ type AtlasSearchApiDeleteAtlasSearchIndexRequest struct {
 	indexId string
 }
 
-type AtlasSearchApiDeleteAtlasSearchIndexParams struct {
+type DeleteAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string
@@ -395,7 +395,7 @@ type AtlasSearchApiGetAtlasSearchIndexRequest struct {
 	indexId string
 }
 
-type AtlasSearchApiGetAtlasSearchIndexParams struct {
+type GetAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string
@@ -539,7 +539,7 @@ type AtlasSearchApiListAtlasSearchIndexesRequest struct {
 	databaseName string
 }
 
-type AtlasSearchApiListAtlasSearchIndexesParams struct {
+type ListAtlasSearchIndexesParams struct {
 		GroupId string
 		ClusterName string
 		CollectionName string
@@ -681,7 +681,7 @@ type AtlasSearchApiUpdateAtlasSearchIndexRequest struct {
 	fTSIndex *FTSIndex
 }
 
-type AtlasSearchApiUpdateAtlasSearchIndexParams struct {
+type UpdateAtlasSearchIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexId string

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -61,6 +61,9 @@ type AuditingApiGetAuditingConfigurationRequest struct {
 	ApiService AuditingApi
 	groupId string
 }
+type AuditingApiGetAuditingConfigurationQueryParams struct {
+		groupId string
+}
 
 func (r AuditingApiGetAuditingConfigurationRequest) Execute() (*AuditLog, *http.Response, error) {
 	return r.ApiService.GetAuditingConfigurationExecute(r)
@@ -178,6 +181,10 @@ type AuditingApiUpdateAuditingConfigurationRequest struct {
 	ApiService AuditingApi
 	groupId string
 	auditLog *AuditLog
+}
+type AuditingApiUpdateAuditingConfigurationQueryParams struct {
+		groupId string
+		auditLog *AuditLog
 }
 
 // Updated auditing configuration for the specified project.

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -29,13 +29,13 @@ type AuditingApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return AuditingApiGetAuditingConfigurationRequest
+	@return GetAuditingConfigurationApiRequest
 	*/
-	GetAuditingConfiguration(ctx context.Context, groupId string) AuditingApiGetAuditingConfigurationRequest
+	GetAuditingConfiguration(ctx context.Context, groupId string) GetAuditingConfigurationApiRequest
 
 	// GetAuditingConfigurationExecute executes the request
 	//  @return AuditLog
-	GetAuditingConfigurationExecute(r AuditingApiGetAuditingConfigurationRequest) (*AuditLog, *http.Response, error)
+	GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 
 	/*
 	UpdateAuditingConfiguration Update Auditing Configuration for One Project
@@ -44,19 +44,19 @@ type AuditingApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return AuditingApiUpdateAuditingConfigurationRequest
+	@return UpdateAuditingConfigurationApiRequest
 	*/
-	UpdateAuditingConfiguration(ctx context.Context, groupId string) AuditingApiUpdateAuditingConfigurationRequest
+	UpdateAuditingConfiguration(ctx context.Context, groupId string) UpdateAuditingConfigurationApiRequest
 
 	// UpdateAuditingConfigurationExecute executes the request
 	//  @return AuditLog
-	UpdateAuditingConfigurationExecute(r AuditingApiUpdateAuditingConfigurationRequest) (*AuditLog, *http.Response, error)
+	UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 }
 
 // AuditingApiService AuditingApi service
 type AuditingApiService service
 
-type AuditingApiGetAuditingConfigurationRequest struct {
+type GetAuditingConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService AuditingApi
 	groupId string
@@ -66,7 +66,7 @@ type GetAuditingConfigurationParams struct {
 		GroupId string
 }
 
-func (r AuditingApiGetAuditingConfigurationRequest) Execute() (*AuditLog, *http.Response, error) {
+func (r GetAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
 	return r.ApiService.GetAuditingConfigurationExecute(r)
 }
 
@@ -77,10 +77,10 @@ Returns the auditing configuration for the specified project. The auditing confi
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return AuditingApiGetAuditingConfigurationRequest
+ @return GetAuditingConfigurationApiRequest
 */
-func (a *AuditingApiService) GetAuditingConfiguration(ctx context.Context, groupId string) AuditingApiGetAuditingConfigurationRequest {
-	return AuditingApiGetAuditingConfigurationRequest{
+func (a *AuditingApiService) GetAuditingConfiguration(ctx context.Context, groupId string) GetAuditingConfigurationApiRequest {
+	return GetAuditingConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -89,7 +89,7 @@ func (a *AuditingApiService) GetAuditingConfiguration(ctx context.Context, group
 
 // Execute executes the request
 //  @return AuditLog
-func (a *AuditingApiService) GetAuditingConfigurationExecute(r AuditingApiGetAuditingConfigurationRequest) (*AuditLog, *http.Response, error) {
+func (a *AuditingApiService) GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -177,7 +177,7 @@ func (a *AuditingApiService) GetAuditingConfigurationExecute(r AuditingApiGetAud
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AuditingApiUpdateAuditingConfigurationRequest struct {
+type UpdateAuditingConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService AuditingApi
 	groupId string
@@ -190,12 +190,12 @@ type UpdateAuditingConfigurationParams struct {
 }
 
 // Updated auditing configuration for the specified project.
-func (r AuditingApiUpdateAuditingConfigurationRequest) AuditLog(auditLog AuditLog) AuditingApiUpdateAuditingConfigurationRequest {
+func (r UpdateAuditingConfigurationApiRequest) AuditLog(auditLog AuditLog) UpdateAuditingConfigurationApiRequest {
 	r.auditLog = &auditLog
 	return r
 }
 
-func (r AuditingApiUpdateAuditingConfigurationRequest) Execute() (*AuditLog, *http.Response, error) {
+func (r UpdateAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
 	return r.ApiService.UpdateAuditingConfigurationExecute(r)
 }
 
@@ -206,10 +206,10 @@ Updates the auditing configuration for the specified project. The auditing confi
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return AuditingApiUpdateAuditingConfigurationRequest
+ @return UpdateAuditingConfigurationApiRequest
 */
-func (a *AuditingApiService) UpdateAuditingConfiguration(ctx context.Context, groupId string) AuditingApiUpdateAuditingConfigurationRequest {
-	return AuditingApiUpdateAuditingConfigurationRequest{
+func (a *AuditingApiService) UpdateAuditingConfiguration(ctx context.Context, groupId string) UpdateAuditingConfigurationApiRequest {
+	return UpdateAuditingConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -218,7 +218,7 @@ func (a *AuditingApiService) UpdateAuditingConfiguration(ctx context.Context, gr
 
 // Execute executes the request
 //  @return AuditLog
-func (a *AuditingApiService) UpdateAuditingConfigurationExecute(r AuditingApiUpdateAuditingConfigurationRequest) (*AuditLog, *http.Response, error) {
+func (a *AuditingApiService) UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -62,7 +62,7 @@ type AuditingApiGetAuditingConfigurationRequest struct {
 	groupId string
 }
 
-type AuditingApiGetAuditingConfigurationParams struct {
+type GetAuditingConfigurationParams struct {
 		GroupId string
 }
 
@@ -184,7 +184,7 @@ type AuditingApiUpdateAuditingConfigurationRequest struct {
 	auditLog *AuditLog
 }
 
-type AuditingApiUpdateAuditingConfigurationParams struct {
+type UpdateAuditingConfigurationParams struct {
 		GroupId string
 		AuditLog *AuditLog
 }

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -62,7 +62,7 @@ type GetAuditingConfigurationApiRequest struct {
 	groupId string
 }
 
-type GetAuditingConfigurationParams struct {
+type GetAuditingConfigurationApiParams struct {
 		GroupId string
 }
 
@@ -184,7 +184,7 @@ type UpdateAuditingConfigurationApiRequest struct {
 	auditLog *AuditLog
 }
 
-type UpdateAuditingConfigurationParams struct {
+type UpdateAuditingConfigurationApiParams struct {
 		GroupId string
 		AuditLog *AuditLog
 }

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -62,7 +62,7 @@ type AuditingApiGetAuditingConfigurationRequest struct {
 	groupId string
 }
 
-type AuditingApiGetAuditingConfigurationQueryParams struct {
+type AuditingApiGetAuditingConfigurationParams struct {
 		GroupId string
 }
 
@@ -184,7 +184,7 @@ type AuditingApiUpdateAuditingConfigurationRequest struct {
 	auditLog *AuditLog
 }
 
-type AuditingApiUpdateAuditingConfigurationQueryParams struct {
+type AuditingApiUpdateAuditingConfigurationParams struct {
 		GroupId string
 		AuditLog *AuditLog
 }

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -61,8 +61,9 @@ type AuditingApiGetAuditingConfigurationRequest struct {
 	ApiService AuditingApi
 	groupId string
 }
+
 type AuditingApiGetAuditingConfigurationQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r AuditingApiGetAuditingConfigurationRequest) Execute() (*AuditLog, *http.Response, error) {
@@ -182,9 +183,10 @@ type AuditingApiUpdateAuditingConfigurationRequest struct {
 	groupId string
 	auditLog *AuditLog
 }
+
 type AuditingApiUpdateAuditingConfigurationQueryParams struct {
-		groupId string
-		auditLog *AuditLog
+		GroupId string
+		AuditLog *AuditLog
 }
 
 // Updated auditing configuration for the specified project.

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -62,7 +62,7 @@ type AWSClustersDNSApiGetAWSCustomDNSRequest struct {
 	groupId string
 }
 
-type AWSClustersDNSApiGetAWSCustomDNSParams struct {
+type GetAWSCustomDNSParams struct {
 		GroupId string
 }
 
@@ -184,7 +184,7 @@ type AWSClustersDNSApiToggleAWSCustomDNSRequest struct {
 	aWSCustomDNSEnabled *AWSCustomDNSEnabled
 }
 
-type AWSClustersDNSApiToggleAWSCustomDNSParams struct {
+type ToggleAWSCustomDNSParams struct {
 		GroupId string
 		AWSCustomDNSEnabled *AWSCustomDNSEnabled
 }

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -62,7 +62,7 @@ type AWSClustersDNSApiGetAWSCustomDNSRequest struct {
 	groupId string
 }
 
-type AWSClustersDNSApiGetAWSCustomDNSQueryParams struct {
+type AWSClustersDNSApiGetAWSCustomDNSParams struct {
 		GroupId string
 }
 
@@ -184,7 +184,7 @@ type AWSClustersDNSApiToggleAWSCustomDNSRequest struct {
 	aWSCustomDNSEnabled *AWSCustomDNSEnabled
 }
 
-type AWSClustersDNSApiToggleAWSCustomDNSQueryParams struct {
+type AWSClustersDNSApiToggleAWSCustomDNSParams struct {
 		GroupId string
 		AWSCustomDNSEnabled *AWSCustomDNSEnabled
 }

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -62,7 +62,7 @@ type GetAWSCustomDNSApiRequest struct {
 	groupId string
 }
 
-type GetAWSCustomDNSParams struct {
+type GetAWSCustomDNSApiParams struct {
 		GroupId string
 }
 
@@ -184,7 +184,7 @@ type ToggleAWSCustomDNSApiRequest struct {
 	aWSCustomDNSEnabled *AWSCustomDNSEnabled
 }
 
-type ToggleAWSCustomDNSParams struct {
+type ToggleAWSCustomDNSApiParams struct {
 		GroupId string
 		AWSCustomDNSEnabled *AWSCustomDNSEnabled
 }

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -29,13 +29,13 @@ type AWSClustersDNSApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return AWSClustersDNSApiGetAWSCustomDNSRequest
+	@return GetAWSCustomDNSApiRequest
 	*/
-	GetAWSCustomDNS(ctx context.Context, groupId string) AWSClustersDNSApiGetAWSCustomDNSRequest
+	GetAWSCustomDNS(ctx context.Context, groupId string) GetAWSCustomDNSApiRequest
 
 	// GetAWSCustomDNSExecute executes the request
 	//  @return AWSCustomDNSEnabled
-	GetAWSCustomDNSExecute(r AWSClustersDNSApiGetAWSCustomDNSRequest) (*AWSCustomDNSEnabled, *http.Response, error)
+	GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 
 	/*
 	ToggleAWSCustomDNS Toggle State of One Custom DNS Configuration for Atlas Clusters on AWS
@@ -44,19 +44,19 @@ type AWSClustersDNSApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return AWSClustersDNSApiToggleAWSCustomDNSRequest
+	@return ToggleAWSCustomDNSApiRequest
 	*/
-	ToggleAWSCustomDNS(ctx context.Context, groupId string) AWSClustersDNSApiToggleAWSCustomDNSRequest
+	ToggleAWSCustomDNS(ctx context.Context, groupId string) ToggleAWSCustomDNSApiRequest
 
 	// ToggleAWSCustomDNSExecute executes the request
 	//  @return AWSCustomDNSEnabled
-	ToggleAWSCustomDNSExecute(r AWSClustersDNSApiToggleAWSCustomDNSRequest) (*AWSCustomDNSEnabled, *http.Response, error)
+	ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 }
 
 // AWSClustersDNSApiService AWSClustersDNSApi service
 type AWSClustersDNSApiService service
 
-type AWSClustersDNSApiGetAWSCustomDNSRequest struct {
+type GetAWSCustomDNSApiRequest struct {
 	ctx context.Context
 	ApiService AWSClustersDNSApi
 	groupId string
@@ -66,7 +66,7 @@ type GetAWSCustomDNSParams struct {
 		GroupId string
 }
 
-func (r AWSClustersDNSApiGetAWSCustomDNSRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
+func (r GetAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
 	return r.ApiService.GetAWSCustomDNSExecute(r)
 }
 
@@ -77,10 +77,10 @@ Returns the custom DNS configuration for AWS clusters in the specified project. 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return AWSClustersDNSApiGetAWSCustomDNSRequest
+ @return GetAWSCustomDNSApiRequest
 */
-func (a *AWSClustersDNSApiService) GetAWSCustomDNS(ctx context.Context, groupId string) AWSClustersDNSApiGetAWSCustomDNSRequest {
-	return AWSClustersDNSApiGetAWSCustomDNSRequest{
+func (a *AWSClustersDNSApiService) GetAWSCustomDNS(ctx context.Context, groupId string) GetAWSCustomDNSApiRequest {
+	return GetAWSCustomDNSApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -89,7 +89,7 @@ func (a *AWSClustersDNSApiService) GetAWSCustomDNS(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return AWSCustomDNSEnabled
-func (a *AWSClustersDNSApiService) GetAWSCustomDNSExecute(r AWSClustersDNSApiGetAWSCustomDNSRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
+func (a *AWSClustersDNSApiService) GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -177,7 +177,7 @@ func (a *AWSClustersDNSApiService) GetAWSCustomDNSExecute(r AWSClustersDNSApiGet
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type AWSClustersDNSApiToggleAWSCustomDNSRequest struct {
+type ToggleAWSCustomDNSApiRequest struct {
 	ctx context.Context
 	ApiService AWSClustersDNSApi
 	groupId string
@@ -190,12 +190,12 @@ type ToggleAWSCustomDNSParams struct {
 }
 
 // Enables or disables the custom DNS configuration for AWS clusters in the specified project.
-func (r AWSClustersDNSApiToggleAWSCustomDNSRequest) AWSCustomDNSEnabled(aWSCustomDNSEnabled AWSCustomDNSEnabled) AWSClustersDNSApiToggleAWSCustomDNSRequest {
+func (r ToggleAWSCustomDNSApiRequest) AWSCustomDNSEnabled(aWSCustomDNSEnabled AWSCustomDNSEnabled) ToggleAWSCustomDNSApiRequest {
 	r.aWSCustomDNSEnabled = &aWSCustomDNSEnabled
 	return r
 }
 
-func (r AWSClustersDNSApiToggleAWSCustomDNSRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
+func (r ToggleAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
 	return r.ApiService.ToggleAWSCustomDNSExecute(r)
 }
 
@@ -206,10 +206,10 @@ Enables or disables the custom DNS configuration for AWS clusters in the specifi
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return AWSClustersDNSApiToggleAWSCustomDNSRequest
+ @return ToggleAWSCustomDNSApiRequest
 */
-func (a *AWSClustersDNSApiService) ToggleAWSCustomDNS(ctx context.Context, groupId string) AWSClustersDNSApiToggleAWSCustomDNSRequest {
-	return AWSClustersDNSApiToggleAWSCustomDNSRequest{
+func (a *AWSClustersDNSApiService) ToggleAWSCustomDNS(ctx context.Context, groupId string) ToggleAWSCustomDNSApiRequest {
+	return ToggleAWSCustomDNSApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -218,7 +218,7 @@ func (a *AWSClustersDNSApiService) ToggleAWSCustomDNS(ctx context.Context, group
 
 // Execute executes the request
 //  @return AWSCustomDNSEnabled
-func (a *AWSClustersDNSApiService) ToggleAWSCustomDNSExecute(r AWSClustersDNSApiToggleAWSCustomDNSRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
+func (a *AWSClustersDNSApiService) ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -61,8 +61,9 @@ type AWSClustersDNSApiGetAWSCustomDNSRequest struct {
 	ApiService AWSClustersDNSApi
 	groupId string
 }
+
 type AWSClustersDNSApiGetAWSCustomDNSQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r AWSClustersDNSApiGetAWSCustomDNSRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
@@ -182,9 +183,10 @@ type AWSClustersDNSApiToggleAWSCustomDNSRequest struct {
 	groupId string
 	aWSCustomDNSEnabled *AWSCustomDNSEnabled
 }
+
 type AWSClustersDNSApiToggleAWSCustomDNSQueryParams struct {
-		groupId string
-		aWSCustomDNSEnabled *AWSCustomDNSEnabled
+		GroupId string
+		AWSCustomDNSEnabled *AWSCustomDNSEnabled
 }
 
 // Enables or disables the custom DNS configuration for AWS clusters in the specified project.

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -61,6 +61,9 @@ type AWSClustersDNSApiGetAWSCustomDNSRequest struct {
 	ApiService AWSClustersDNSApi
 	groupId string
 }
+type AWSClustersDNSApiGetAWSCustomDNSQueryParams struct {
+		groupId string
+}
 
 func (r AWSClustersDNSApiGetAWSCustomDNSRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
 	return r.ApiService.GetAWSCustomDNSExecute(r)
@@ -178,6 +181,10 @@ type AWSClustersDNSApiToggleAWSCustomDNSRequest struct {
 	ApiService AWSClustersDNSApi
 	groupId string
 	aWSCustomDNSEnabled *AWSCustomDNSEnabled
+}
+type AWSClustersDNSApiToggleAWSCustomDNSQueryParams struct {
+		groupId string
+		aWSCustomDNSEnabled *AWSCustomDNSEnabled
 }
 
 // Enables or disables the custom DNS configuration for AWS clusters in the specified project.

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -504,7 +504,7 @@ type CloudBackupsApiCancelBackupRestoreJobRequest struct {
 	restoreJobId string
 }
 
-type CloudBackupsApiCancelBackupRestoreJobParams struct {
+type CancelBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -636,7 +636,7 @@ type CloudBackupsApiCreateBackupExportJobRequest struct {
 	diskBackupExportJobRequest *DiskBackupExportJobRequest
 }
 
-type CloudBackupsApiCreateBackupExportJobParams struct {
+type CreateBackupExportJobParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupExportJobRequest *DiskBackupExportJobRequest
@@ -781,7 +781,7 @@ type CloudBackupsApiCreateBackupRestoreJobRequest struct {
 	diskBackupRestoreJob *DiskBackupRestoreJob
 }
 
-type CloudBackupsApiCreateBackupRestoreJobParams struct {
+type CreateBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupRestoreJob *DiskBackupRestoreJob
@@ -927,7 +927,7 @@ type CloudBackupsApiCreateExportBucketRequest struct {
 	diskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
 
-type CloudBackupsApiCreateExportBucketParams struct {
+type CreateExportBucketParams struct {
 		GroupId string
 		DiskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
@@ -1062,7 +1062,7 @@ type CloudBackupsApiCreateServerlessBackupRestoreJobRequest struct {
 	serverlessBackupRestoreJob *ServerlessBackupRestoreJob
 }
 
-type CloudBackupsApiCreateServerlessBackupRestoreJobParams struct {
+type CreateServerlessBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		ServerlessBackupRestoreJob *ServerlessBackupRestoreJob
@@ -1206,7 +1206,7 @@ type CloudBackupsApiDeleteAllBackupSchedulesRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiDeleteAllBackupSchedulesParams struct {
+type DeleteAllBackupSchedulesParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -1338,7 +1338,7 @@ type CloudBackupsApiDeleteExportBucketRequest struct {
 	exportBucketId string
 }
 
-type CloudBackupsApiDeleteExportBucketParams struct {
+type DeleteExportBucketParams struct {
 		GroupId string
 		ExportBucketId string
 }
@@ -1460,7 +1460,7 @@ type CloudBackupsApiDeleteReplicaSetBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiDeleteReplicaSetBackupParams struct {
+type DeleteReplicaSetBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1592,7 +1592,7 @@ type CloudBackupsApiDeleteShardedClusterBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiDeleteShardedClusterBackupParams struct {
+type DeleteShardedClusterBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1724,7 +1724,7 @@ type CloudBackupsApiGetBackupExportJobRequest struct {
 	exportId string
 }
 
-type CloudBackupsApiGetBackupExportJobParams struct {
+type GetBackupExportJobParams struct {
 		GroupId string
 		ClusterName string
 		ExportId string
@@ -1861,7 +1861,7 @@ type CloudBackupsApiGetBackupRestoreJobRequest struct {
 	restoreJobId string
 }
 
-type CloudBackupsApiGetBackupRestoreJobParams struct {
+type GetBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -2003,7 +2003,7 @@ type CloudBackupsApiGetBackupScheduleRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiGetBackupScheduleParams struct {
+type GetBackupScheduleParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -2134,7 +2134,7 @@ type CloudBackupsApiGetDataProtectionSettingsRequest struct {
 	groupId string
 }
 
-type CloudBackupsApiGetDataProtectionSettingsParams struct {
+type GetDataProtectionSettingsParams struct {
 		GroupId string
 }
 
@@ -2256,7 +2256,7 @@ type CloudBackupsApiGetExportBucketRequest struct {
 	exportBucketId string
 }
 
-type CloudBackupsApiGetExportBucketParams struct {
+type GetExportBucketParams struct {
 		GroupId string
 		ExportBucketId string
 }
@@ -2389,7 +2389,7 @@ type CloudBackupsApiGetReplicaSetBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiGetReplicaSetBackupParams struct {
+type GetReplicaSetBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2532,7 +2532,7 @@ type CloudBackupsApiGetServerlessBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiGetServerlessBackupParams struct {
+type GetServerlessBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2675,7 +2675,7 @@ type CloudBackupsApiGetServerlessBackupRestoreJobRequest struct {
 	restoreJobId string
 }
 
-type CloudBackupsApiGetServerlessBackupRestoreJobParams struct {
+type GetServerlessBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -2818,7 +2818,7 @@ type CloudBackupsApiGetShardedClusterBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiGetShardedClusterBackupParams struct {
+type GetShardedClusterBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2963,7 +2963,7 @@ type CloudBackupsApiListBackupExportJobsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListBackupExportJobsParams struct {
+type ListBackupExportJobsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3140,7 +3140,7 @@ type CloudBackupsApiListBackupRestoreJobsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListBackupRestoreJobsParams struct {
+type ListBackupRestoreJobsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3313,7 +3313,7 @@ type CloudBackupsApiListExportBucketsRequest struct {
 	groupId string
 }
 
-type CloudBackupsApiListExportBucketsParams struct {
+type ListExportBucketsParams struct {
 		GroupId string
 }
 
@@ -3438,7 +3438,7 @@ type CloudBackupsApiListReplicaSetBackupsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListReplicaSetBackupsParams struct {
+type ListReplicaSetBackupsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3612,7 +3612,7 @@ type CloudBackupsApiListServerlessBackupRestoreJobsRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiListServerlessBackupRestoreJobsParams struct {
+type ListServerlessBackupRestoreJobsParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -3747,7 +3747,7 @@ type CloudBackupsApiListServerlessBackupsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListServerlessBackupsParams struct {
+type ListServerlessBackupsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3921,7 +3921,7 @@ type CloudBackupsApiListShardedClusterBackupsRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiListShardedClusterBackupsParams struct {
+type ListShardedClusterBackupsParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -4054,7 +4054,7 @@ type CloudBackupsApiTakeSnapshotRequest struct {
 	diskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
 }
 
-type CloudBackupsApiTakeSnapshotParams struct {
+type TakeSnapshotParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
@@ -4201,7 +4201,7 @@ type CloudBackupsApiUpdateBackupScheduleRequest struct {
 	diskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
 }
 
-type CloudBackupsApiUpdateBackupScheduleParams struct {
+type UpdateBackupScheduleParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
@@ -4345,7 +4345,7 @@ type CloudBackupsApiUpdateDataProtectionSettingsRequest struct {
 	dataProtectionSettings *DataProtectionSettings
 }
 
-type CloudBackupsApiUpdateDataProtectionSettingsParams struct {
+type UpdateDataProtectionSettingsParams struct {
 		GroupId string
 		DataProtectionSettings *DataProtectionSettings
 }
@@ -4481,7 +4481,7 @@ type CloudBackupsApiUpdateSnapshotRetentionRequest struct {
 	snapshotRetention *SnapshotRetention
 }
 
-type CloudBackupsApiUpdateSnapshotRetentionParams struct {
+type UpdateSnapshotRetentionParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -503,6 +503,11 @@ type CloudBackupsApiCancelBackupRestoreJobRequest struct {
 	clusterName string
 	restoreJobId string
 }
+type CloudBackupsApiCancelBackupRestoreJobQueryParams struct {
+		groupId string
+		clusterName string
+		restoreJobId string
+}
 
 func (r CloudBackupsApiCancelBackupRestoreJobRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CancelBackupRestoreJobExecute(r)
@@ -628,6 +633,11 @@ type CloudBackupsApiCreateBackupExportJobRequest struct {
 	groupId string
 	clusterName string
 	diskBackupExportJobRequest *DiskBackupExportJobRequest
+}
+type CloudBackupsApiCreateBackupExportJobQueryParams struct {
+		groupId string
+		clusterName string
+		diskBackupExportJobRequest *DiskBackupExportJobRequest
 }
 
 // Information about the Cloud Backup Snapshot Export Job to create.
@@ -767,6 +777,11 @@ type CloudBackupsApiCreateBackupRestoreJobRequest struct {
 	groupId string
 	clusterName string
 	diskBackupRestoreJob *DiskBackupRestoreJob
+}
+type CloudBackupsApiCreateBackupRestoreJobQueryParams struct {
+		groupId string
+		clusterName string
+		diskBackupRestoreJob *DiskBackupRestoreJob
 }
 
 // Restores one snapshot of one cluster from the specified project.
@@ -908,6 +923,10 @@ type CloudBackupsApiCreateExportBucketRequest struct {
 	groupId string
 	diskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
+type CloudBackupsApiCreateExportBucketQueryParams struct {
+		groupId string
+		diskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
+}
 
 // Grants MongoDB Cloud access to the specified AWS S3 bucket.
 func (r CloudBackupsApiCreateExportBucketRequest) DiskBackupSnapshotAWSExportBucket(diskBackupSnapshotAWSExportBucket DiskBackupSnapshotAWSExportBucket) CloudBackupsApiCreateExportBucketRequest {
@@ -1037,6 +1056,11 @@ type CloudBackupsApiCreateServerlessBackupRestoreJobRequest struct {
 	groupId string
 	clusterName string
 	serverlessBackupRestoreJob *ServerlessBackupRestoreJob
+}
+type CloudBackupsApiCreateServerlessBackupRestoreJobQueryParams struct {
+		groupId string
+		clusterName string
+		serverlessBackupRestoreJob *ServerlessBackupRestoreJob
 }
 
 // Restores one snapshot of one serverless instance from the specified project.
@@ -1176,6 +1200,10 @@ type CloudBackupsApiDeleteAllBackupSchedulesRequest struct {
 	groupId string
 	clusterName string
 }
+type CloudBackupsApiDeleteAllBackupSchedulesQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r CloudBackupsApiDeleteAllBackupSchedulesRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	return r.ApiService.DeleteAllBackupSchedulesExecute(r)
@@ -1303,6 +1331,10 @@ type CloudBackupsApiDeleteExportBucketRequest struct {
 	groupId string
 	exportBucketId string
 }
+type CloudBackupsApiDeleteExportBucketQueryParams struct {
+		groupId string
+		exportBucketId string
+}
 
 func (r CloudBackupsApiDeleteExportBucketRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteExportBucketExecute(r)
@@ -1419,6 +1451,11 @@ type CloudBackupsApiDeleteReplicaSetBackupRequest struct {
 	groupId string
 	clusterName string
 	snapshotId string
+}
+type CloudBackupsApiDeleteReplicaSetBackupQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
 }
 
 func (r CloudBackupsApiDeleteReplicaSetBackupRequest) Execute() (*http.Response, error) {
@@ -1546,6 +1583,11 @@ type CloudBackupsApiDeleteShardedClusterBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+type CloudBackupsApiDeleteShardedClusterBackupQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
+}
 
 func (r CloudBackupsApiDeleteShardedClusterBackupRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteShardedClusterBackupExecute(r)
@@ -1671,6 +1713,11 @@ type CloudBackupsApiGetBackupExportJobRequest struct {
 	groupId string
 	clusterName string
 	exportId string
+}
+type CloudBackupsApiGetBackupExportJobQueryParams struct {
+		groupId string
+		clusterName string
+		exportId string
 }
 
 func (r CloudBackupsApiGetBackupExportJobRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
@@ -1802,6 +1849,11 @@ type CloudBackupsApiGetBackupRestoreJobRequest struct {
 	groupId string
 	clusterName string
 	restoreJobId string
+}
+type CloudBackupsApiGetBackupRestoreJobQueryParams struct {
+		groupId string
+		clusterName string
+		restoreJobId string
 }
 
 func (r CloudBackupsApiGetBackupRestoreJobRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
@@ -1939,6 +1991,10 @@ type CloudBackupsApiGetBackupScheduleRequest struct {
 	groupId string
 	clusterName string
 }
+type CloudBackupsApiGetBackupScheduleQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r CloudBackupsApiGetBackupScheduleRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	return r.ApiService.GetBackupScheduleExecute(r)
@@ -2065,6 +2121,9 @@ type CloudBackupsApiGetDataProtectionSettingsRequest struct {
 	ApiService CloudBackupsApi
 	groupId string
 }
+type CloudBackupsApiGetDataProtectionSettingsQueryParams struct {
+		groupId string
+}
 
 func (r CloudBackupsApiGetDataProtectionSettingsRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
 	return r.ApiService.GetDataProtectionSettingsExecute(r)
@@ -2182,6 +2241,10 @@ type CloudBackupsApiGetExportBucketRequest struct {
 	ApiService CloudBackupsApi
 	groupId string
 	exportBucketId string
+}
+type CloudBackupsApiGetExportBucketQueryParams struct {
+		groupId string
+		exportBucketId string
 }
 
 func (r CloudBackupsApiGetExportBucketRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
@@ -2310,6 +2373,11 @@ type CloudBackupsApiGetReplicaSetBackupRequest struct {
 	groupId string
 	clusterName string
 	snapshotId string
+}
+type CloudBackupsApiGetReplicaSetBackupQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
 }
 
 func (r CloudBackupsApiGetReplicaSetBackupRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
@@ -2448,6 +2516,11 @@ type CloudBackupsApiGetServerlessBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+type CloudBackupsApiGetServerlessBackupQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
+}
 
 func (r CloudBackupsApiGetServerlessBackupRequest) Execute() (*ServerlessBackupSnapshot, *http.Response, error) {
 	return r.ApiService.GetServerlessBackupExecute(r)
@@ -2585,6 +2658,11 @@ type CloudBackupsApiGetServerlessBackupRestoreJobRequest struct {
 	clusterName string
 	restoreJobId string
 }
+type CloudBackupsApiGetServerlessBackupRestoreJobQueryParams struct {
+		groupId string
+		clusterName string
+		restoreJobId string
+}
 
 func (r CloudBackupsApiGetServerlessBackupRestoreJobRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.GetServerlessBackupRestoreJobExecute(r)
@@ -2721,6 +2799,11 @@ type CloudBackupsApiGetShardedClusterBackupRequest struct {
 	groupId string
 	clusterName string
 	snapshotId string
+}
+type CloudBackupsApiGetShardedClusterBackupQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
 }
 
 func (r CloudBackupsApiGetShardedClusterBackupRequest) Execute() (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
@@ -2860,6 +2943,13 @@ type CloudBackupsApiListBackupExportJobsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type CloudBackupsApiListBackupExportJobsQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -3030,6 +3120,13 @@ type CloudBackupsApiListBackupRestoreJobsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type CloudBackupsApiListBackupRestoreJobsQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r CloudBackupsApiListBackupRestoreJobsRequest) IncludeCount(includeCount bool) CloudBackupsApiListBackupRestoreJobsRequest {
@@ -3195,6 +3292,9 @@ type CloudBackupsApiListExportBucketsRequest struct {
 	ApiService CloudBackupsApi
 	groupId string
 }
+type CloudBackupsApiListExportBucketsQueryParams struct {
+		groupId string
+}
 
 func (r CloudBackupsApiListExportBucketsRequest) Execute() (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
 	return r.ApiService.ListExportBucketsExecute(r)
@@ -3315,6 +3415,13 @@ type CloudBackupsApiListReplicaSetBackupsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type CloudBackupsApiListReplicaSetBackupsQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -3482,6 +3589,10 @@ type CloudBackupsApiListServerlessBackupRestoreJobsRequest struct {
 	groupId string
 	clusterName string
 }
+type CloudBackupsApiListServerlessBackupRestoreJobsQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r CloudBackupsApiListServerlessBackupRestoreJobsRequest) Execute() (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.ListServerlessBackupRestoreJobsExecute(r)
@@ -3611,6 +3722,13 @@ type CloudBackupsApiListServerlessBackupsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type CloudBackupsApiListServerlessBackupsQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -3778,6 +3896,10 @@ type CloudBackupsApiListShardedClusterBackupsRequest struct {
 	groupId string
 	clusterName string
 }
+type CloudBackupsApiListShardedClusterBackupsQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r CloudBackupsApiListShardedClusterBackupsRequest) Execute() (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
 	return r.ApiService.ListShardedClusterBackupsExecute(r)
@@ -3905,6 +4027,11 @@ type CloudBackupsApiTakeSnapshotRequest struct {
 	groupId string
 	clusterName string
 	diskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
+}
+type CloudBackupsApiTakeSnapshotQueryParams struct {
+		groupId string
+		clusterName string
+		diskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
 }
 
 // Takes one on-demand snapshot.
@@ -4047,6 +4174,11 @@ type CloudBackupsApiUpdateBackupScheduleRequest struct {
 	clusterName string
 	diskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
 }
+type CloudBackupsApiUpdateBackupScheduleQueryParams struct {
+		groupId string
+		clusterName string
+		diskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
+}
 
 // Updates the cloud backup schedule for one cluster within the specified project.  **Note**: In the request body, provide only the fields that you want to update.
 func (r CloudBackupsApiUpdateBackupScheduleRequest) DiskBackupSnapshotSchedule(diskBackupSnapshotSchedule DiskBackupSnapshotSchedule) CloudBackupsApiUpdateBackupScheduleRequest {
@@ -4185,6 +4317,10 @@ type CloudBackupsApiUpdateDataProtectionSettingsRequest struct {
 	groupId string
 	dataProtectionSettings *DataProtectionSettings
 }
+type CloudBackupsApiUpdateDataProtectionSettingsQueryParams struct {
+		groupId string
+		dataProtectionSettings *DataProtectionSettings
+}
 
 // The new Backup Compliance Policy settings.
 func (r CloudBackupsApiUpdateDataProtectionSettingsRequest) DataProtectionSettings(dataProtectionSettings DataProtectionSettings) CloudBackupsApiUpdateDataProtectionSettingsRequest {
@@ -4315,6 +4451,12 @@ type CloudBackupsApiUpdateSnapshotRetentionRequest struct {
 	clusterName string
 	snapshotId string
 	snapshotRetention *SnapshotRetention
+}
+type CloudBackupsApiUpdateSnapshotRetentionQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
+		snapshotRetention *SnapshotRetention
 }
 
 // Changes the expiration date for one cloud backup snapshot for one cluster in the specified project.

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -31,12 +31,12 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param restoreJobId Unique 24-hexadecimal digit string that identifies the restore job to remove.
-	@return CloudBackupsApiCancelBackupRestoreJobRequest
+	@return CancelBackupRestoreJobApiRequest
 	*/
-	CancelBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CloudBackupsApiCancelBackupRestoreJobRequest
+	CancelBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CancelBackupRestoreJobApiRequest
 
 	// CancelBackupRestoreJobExecute executes the request
-	CancelBackupRestoreJobExecute(r CloudBackupsApiCancelBackupRestoreJobRequest) (*http.Response, error)
+	CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (*http.Response, error)
 
 	/*
 	CreateBackupExportJob Create One Cloud Backup Snapshot Export Job
@@ -46,13 +46,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiCreateBackupExportJobRequest
+	@return CreateBackupExportJobApiRequest
 	*/
-	CreateBackupExportJob(ctx context.Context, groupId string, clusterName string) CloudBackupsApiCreateBackupExportJobRequest
+	CreateBackupExportJob(ctx context.Context, groupId string, clusterName string) CreateBackupExportJobApiRequest
 
 	// CreateBackupExportJobExecute executes the request
 	//  @return DiskBackupExportJob
-	CreateBackupExportJobExecute(r CloudBackupsApiCreateBackupExportJobRequest) (*DiskBackupExportJob, *http.Response, error)
+	CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
 	CreateBackupRestoreJob Restore One Snapshot of One Cluster
@@ -64,13 +64,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiCreateBackupRestoreJobRequest
+	@return CreateBackupRestoreJobApiRequest
 	*/
-	CreateBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CloudBackupsApiCreateBackupRestoreJobRequest
+	CreateBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateBackupRestoreJobApiRequest
 
 	// CreateBackupRestoreJobExecute executes the request
 	//  @return DiskBackupRestoreJob
-	CreateBackupRestoreJobExecute(r CloudBackupsApiCreateBackupRestoreJobRequest) (*DiskBackupRestoreJob, *http.Response, error)
+	CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error)
 
 	/*
 	CreateExportBucket Grant Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
@@ -79,13 +79,13 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudBackupsApiCreateExportBucketRequest
+	@return CreateExportBucketApiRequest
 	*/
-	CreateExportBucket(ctx context.Context, groupId string) CloudBackupsApiCreateExportBucketRequest
+	CreateExportBucket(ctx context.Context, groupId string) CreateExportBucketApiRequest
 
 	// CreateExportBucketExecute executes the request
 	//  @return DiskBackupSnapshotAWSExportBucket
-	CreateExportBucketExecute(r CloudBackupsApiCreateExportBucketRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
+	CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
 	CreateServerlessBackupRestoreJob Restore One Snapshot of One Serverless Instance
@@ -95,13 +95,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the serverless instance whose snapshot you want to restore.
-	@return CloudBackupsApiCreateServerlessBackupRestoreJobRequest
+	@return CreateServerlessBackupRestoreJobApiRequest
 	*/
-	CreateServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CloudBackupsApiCreateServerlessBackupRestoreJobRequest
+	CreateServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateServerlessBackupRestoreJobApiRequest
 
 	// CreateServerlessBackupRestoreJobExecute executes the request
 	//  @return ServerlessBackupRestoreJob
-	CreateServerlessBackupRestoreJobExecute(r CloudBackupsApiCreateServerlessBackupRestoreJobRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
+	CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 	DeleteAllBackupSchedules Remove All Cloud Backup Schedules
@@ -111,13 +111,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiDeleteAllBackupSchedulesRequest
+	@return DeleteAllBackupSchedulesApiRequest
 	*/
-	DeleteAllBackupSchedules(ctx context.Context, groupId string, clusterName string) CloudBackupsApiDeleteAllBackupSchedulesRequest
+	DeleteAllBackupSchedules(ctx context.Context, groupId string, clusterName string) DeleteAllBackupSchedulesApiRequest
 
 	// DeleteAllBackupSchedulesExecute executes the request
 	//  @return DiskBackupSnapshotSchedule
-	DeleteAllBackupSchedulesExecute(r CloudBackupsApiDeleteAllBackupSchedulesRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+	DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 	DeleteExportBucket Revoke Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
@@ -127,12 +127,12 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param exportBucketId Unique string that identifies the AWS S3 bucket to which you export your snapshots.
-	@return CloudBackupsApiDeleteExportBucketRequest
+	@return DeleteExportBucketApiRequest
 	*/
-	DeleteExportBucket(ctx context.Context, groupId string, exportBucketId string) CloudBackupsApiDeleteExportBucketRequest
+	DeleteExportBucket(ctx context.Context, groupId string, exportBucketId string) DeleteExportBucketApiRequest
 
 	// DeleteExportBucketExecute executes the request
-	DeleteExportBucketExecute(r CloudBackupsApiDeleteExportBucketRequest) (*http.Response, error)
+	DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (*http.Response, error)
 
 	/*
 	DeleteReplicaSetBackup Remove One Replica Set Cloud Backup
@@ -143,12 +143,12 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return CloudBackupsApiDeleteReplicaSetBackupRequest
+	@return DeleteReplicaSetBackupApiRequest
 	*/
-	DeleteReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiDeleteReplicaSetBackupRequest
+	DeleteReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteReplicaSetBackupApiRequest
 
 	// DeleteReplicaSetBackupExecute executes the request
-	DeleteReplicaSetBackupExecute(r CloudBackupsApiDeleteReplicaSetBackupRequest) (*http.Response, error)
+	DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (*http.Response, error)
 
 	/*
 	DeleteShardedClusterBackup Remove One Sharded Cluster Cloud Backup
@@ -159,12 +159,12 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return CloudBackupsApiDeleteShardedClusterBackupRequest
+	@return DeleteShardedClusterBackupApiRequest
 	*/
-	DeleteShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiDeleteShardedClusterBackupRequest
+	DeleteShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteShardedClusterBackupApiRequest
 
 	// DeleteShardedClusterBackupExecute executes the request
-	DeleteShardedClusterBackupExecute(r CloudBackupsApiDeleteShardedClusterBackupRequest) (*http.Response, error)
+	DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (*http.Response, error)
 
 	/*
 	GetBackupExportJob Return One Cloud Backup Snapshot Export Job
@@ -175,13 +175,13 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param exportId Unique string that identifies the AWS S3 bucket to which you export your snapshots.
-	@return CloudBackupsApiGetBackupExportJobRequest
+	@return GetBackupExportJobApiRequest
 	*/
-	GetBackupExportJob(ctx context.Context, groupId string, clusterName string, exportId string) CloudBackupsApiGetBackupExportJobRequest
+	GetBackupExportJob(ctx context.Context, groupId string, clusterName string, exportId string) GetBackupExportJobApiRequest
 
 	// GetBackupExportJobExecute executes the request
 	//  @return DiskBackupExportJob
-	GetBackupExportJobExecute(r CloudBackupsApiGetBackupExportJobRequest) (*DiskBackupExportJob, *http.Response, error)
+	GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
 	GetBackupRestoreJob Return One Restore Job of One Cluster
@@ -192,13 +192,13 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster with the restore jobs you want to return.
 	@param restoreJobId Unique 24-hexadecimal digit string that identifies the restore job to return.
-	@return CloudBackupsApiGetBackupRestoreJobRequest
+	@return GetBackupRestoreJobApiRequest
 	*/
-	GetBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CloudBackupsApiGetBackupRestoreJobRequest
+	GetBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) GetBackupRestoreJobApiRequest
 
 	// GetBackupRestoreJobExecute executes the request
 	//  @return DiskBackupRestoreJob
-	GetBackupRestoreJobExecute(r CloudBackupsApiGetBackupRestoreJobRequest) (*DiskBackupRestoreJob, *http.Response, error)
+	GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error)
 
 	/*
 	GetBackupSchedule Return One Cloud Backup Schedule
@@ -208,13 +208,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiGetBackupScheduleRequest
+	@return GetBackupScheduleApiRequest
 	*/
-	GetBackupSchedule(ctx context.Context, groupId string, clusterName string) CloudBackupsApiGetBackupScheduleRequest
+	GetBackupSchedule(ctx context.Context, groupId string, clusterName string) GetBackupScheduleApiRequest
 
 	// GetBackupScheduleExecute executes the request
 	//  @return DiskBackupSnapshotSchedule
-	GetBackupScheduleExecute(r CloudBackupsApiGetBackupScheduleRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+	GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 	GetDataProtectionSettings Return the Backup Compliance Policy settings
@@ -223,13 +223,13 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudBackupsApiGetDataProtectionSettingsRequest
+	@return GetDataProtectionSettingsApiRequest
 	*/
-	GetDataProtectionSettings(ctx context.Context, groupId string) CloudBackupsApiGetDataProtectionSettingsRequest
+	GetDataProtectionSettings(ctx context.Context, groupId string) GetDataProtectionSettingsApiRequest
 
 	// GetDataProtectionSettingsExecute executes the request
 	//  @return DataProtectionSettings
-	GetDataProtectionSettingsExecute(r CloudBackupsApiGetDataProtectionSettingsRequest) (*DataProtectionSettings, *http.Response, error)
+	GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error)
 
 	/*
 	GetExportBucket Return One AWS S3 Bucket Used for Cloud Backup Snapshot Exports
@@ -239,13 +239,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param exportBucketId Unique string that identifies the AWS S3 bucket to which you export your snapshots.
-	@return CloudBackupsApiGetExportBucketRequest
+	@return GetExportBucketApiRequest
 	*/
-	GetExportBucket(ctx context.Context, groupId string, exportBucketId string) CloudBackupsApiGetExportBucketRequest
+	GetExportBucket(ctx context.Context, groupId string, exportBucketId string) GetExportBucketApiRequest
 
 	// GetExportBucketExecute executes the request
 	//  @return DiskBackupSnapshotAWSExportBucket
-	GetExportBucketExecute(r CloudBackupsApiGetExportBucketRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
+	GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
 	GetReplicaSetBackup Return One Replica Set Cloud Backup
@@ -256,13 +256,13 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return CloudBackupsApiGetReplicaSetBackupRequest
+	@return GetReplicaSetBackupApiRequest
 	*/
-	GetReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiGetReplicaSetBackupRequest
+	GetReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetReplicaSetBackupApiRequest
 
 	// GetReplicaSetBackupExecute executes the request
 	//  @return DiskBackupReplicaSet
-	GetReplicaSetBackupExecute(r CloudBackupsApiGetReplicaSetBackupRequest) (*DiskBackupReplicaSet, *http.Response, error)
+	GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 
 	/*
 	GetServerlessBackup Return One Snapshot of One Serverless Instance
@@ -273,13 +273,13 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the serverless instance.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return CloudBackupsApiGetServerlessBackupRequest
+	@return GetServerlessBackupApiRequest
 	*/
-	GetServerlessBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiGetServerlessBackupRequest
+	GetServerlessBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetServerlessBackupApiRequest
 
 	// GetServerlessBackupExecute executes the request
 	//  @return ServerlessBackupSnapshot
-	GetServerlessBackupExecute(r CloudBackupsApiGetServerlessBackupRequest) (*ServerlessBackupSnapshot, *http.Response, error)
+	GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error)
 
 	/*
 	GetServerlessBackupRestoreJob Return One Restore Job for One Serverless Instance
@@ -290,13 +290,13 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the serverless instance.
 	@param restoreJobId Unique 24-hexadecimal digit string that identifies the restore job to return.
-	@return CloudBackupsApiGetServerlessBackupRestoreJobRequest
+	@return GetServerlessBackupRestoreJobApiRequest
 	*/
-	GetServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CloudBackupsApiGetServerlessBackupRestoreJobRequest
+	GetServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) GetServerlessBackupRestoreJobApiRequest
 
 	// GetServerlessBackupRestoreJobExecute executes the request
 	//  @return ServerlessBackupRestoreJob
-	GetServerlessBackupRestoreJobExecute(r CloudBackupsApiGetServerlessBackupRestoreJobRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
+	GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 	GetShardedClusterBackup Return One Sharded Cluster Cloud Backup
@@ -307,13 +307,13 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return CloudBackupsApiGetShardedClusterBackupRequest
+	@return GetShardedClusterBackupApiRequest
 	*/
-	GetShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiGetShardedClusterBackupRequest
+	GetShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetShardedClusterBackupApiRequest
 
 	// GetShardedClusterBackupExecute executes the request
 	//  @return DiskBackupShardedClusterSnapshot
-	GetShardedClusterBackupExecute(r CloudBackupsApiGetShardedClusterBackupRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error)
+	GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
 	ListBackupExportJobs Return All Cloud Backup Snapshot Export Jobs
@@ -323,13 +323,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiListBackupExportJobsRequest
+	@return ListBackupExportJobsApiRequest
 	*/
-	ListBackupExportJobs(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListBackupExportJobsRequest
+	ListBackupExportJobs(ctx context.Context, groupId string, clusterName string) ListBackupExportJobsApiRequest
 
 	// ListBackupExportJobsExecute executes the request
 	//  @return PaginatedApiAtlasDiskBackupExportJob
-	ListBackupExportJobsExecute(r CloudBackupsApiListBackupExportJobsRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error)
+	ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error)
 
 	/*
 	ListBackupRestoreJobs Return All Restore Jobs for One Cluster
@@ -339,13 +339,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster with the restore jobs you want to return.
-	@return CloudBackupsApiListBackupRestoreJobsRequest
+	@return ListBackupRestoreJobsApiRequest
 	*/
-	ListBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListBackupRestoreJobsRequest
+	ListBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListBackupRestoreJobsApiRequest
 
 	// ListBackupRestoreJobsExecute executes the request
 	//  @return PaginatedCloudBackupRestoreJob
-	ListBackupRestoreJobsExecute(r CloudBackupsApiListBackupRestoreJobsRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error)
+	ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error)
 
 	/*
 	ListExportBuckets Return All AWS S3 Buckets Used for Cloud Backup Snapshot Exports
@@ -354,13 +354,13 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudBackupsApiListExportBucketsRequest
+	@return ListExportBucketsApiRequest
 	*/
-	ListExportBuckets(ctx context.Context, groupId string) CloudBackupsApiListExportBucketsRequest
+	ListExportBuckets(ctx context.Context, groupId string) ListExportBucketsApiRequest
 
 	// ListExportBucketsExecute executes the request
 	//  @return PaginatedBackupSnapshotExportBucket
-	ListExportBucketsExecute(r CloudBackupsApiListExportBucketsRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error)
+	ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error)
 
 	/*
 	ListReplicaSetBackups Return All Replica Set Cloud Backups
@@ -370,13 +370,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiListReplicaSetBackupsRequest
+	@return ListReplicaSetBackupsApiRequest
 	*/
-	ListReplicaSetBackups(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListReplicaSetBackupsRequest
+	ListReplicaSetBackups(ctx context.Context, groupId string, clusterName string) ListReplicaSetBackupsApiRequest
 
 	// ListReplicaSetBackupsExecute executes the request
 	//  @return PaginatedCloudBackupReplicaSet
-	ListReplicaSetBackupsExecute(r CloudBackupsApiListReplicaSetBackupsRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error)
+	ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error)
 
 	/*
 	ListServerlessBackupRestoreJobs Return All Restore Jobs for One Serverless Instance
@@ -386,13 +386,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the serverless instance.
-	@return CloudBackupsApiListServerlessBackupRestoreJobsRequest
+	@return ListServerlessBackupRestoreJobsApiRequest
 	*/
-	ListServerlessBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListServerlessBackupRestoreJobsRequest
+	ListServerlessBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListServerlessBackupRestoreJobsApiRequest
 
 	// ListServerlessBackupRestoreJobsExecute executes the request
 	//  @return PaginatedApiAtlasServerlessBackupRestoreJob
-	ListServerlessBackupRestoreJobsExecute(r CloudBackupsApiListServerlessBackupRestoreJobsRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error)
+	ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 	ListServerlessBackups Return All Snapshots of One Serverless Instance
@@ -402,13 +402,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the serverless instance.
-	@return CloudBackupsApiListServerlessBackupsRequest
+	@return ListServerlessBackupsApiRequest
 	*/
-	ListServerlessBackups(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListServerlessBackupsRequest
+	ListServerlessBackups(ctx context.Context, groupId string, clusterName string) ListServerlessBackupsApiRequest
 
 	// ListServerlessBackupsExecute executes the request
 	//  @return PaginatedApiAtlasServerlessBackupSnapshot
-	ListServerlessBackupsExecute(r CloudBackupsApiListServerlessBackupsRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error)
+	ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error)
 
 	/*
 	ListShardedClusterBackups Return All Sharded Cluster Cloud Backups
@@ -418,13 +418,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiListShardedClusterBackupsRequest
+	@return ListShardedClusterBackupsApiRequest
 	*/
-	ListShardedClusterBackups(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListShardedClusterBackupsRequest
+	ListShardedClusterBackups(ctx context.Context, groupId string, clusterName string) ListShardedClusterBackupsApiRequest
 
 	// ListShardedClusterBackupsExecute executes the request
 	//  @return PaginatedCloudBackupShardedClusterSnapshot
-	ListShardedClusterBackupsExecute(r CloudBackupsApiListShardedClusterBackupsRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error)
+	ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
 	TakeSnapshot Take One On-Demand Snapshot
@@ -436,13 +436,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiTakeSnapshotRequest
+	@return TakeSnapshotApiRequest
 	*/
-	TakeSnapshot(ctx context.Context, groupId string, clusterName string) CloudBackupsApiTakeSnapshotRequest
+	TakeSnapshot(ctx context.Context, groupId string, clusterName string) TakeSnapshotApiRequest
 
 	// TakeSnapshotExecute executes the request
 	//  @return DiskBackupSnapshot
-	TakeSnapshotExecute(r CloudBackupsApiTakeSnapshotRequest) (*DiskBackupSnapshot, *http.Response, error)
+	TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error)
 
 	/*
 	UpdateBackupSchedule Update Cloud Backup Schedule for One Cluster
@@ -452,13 +452,13 @@ type CloudBackupsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return CloudBackupsApiUpdateBackupScheduleRequest
+	@return UpdateBackupScheduleApiRequest
 	*/
-	UpdateBackupSchedule(ctx context.Context, groupId string, clusterName string) CloudBackupsApiUpdateBackupScheduleRequest
+	UpdateBackupSchedule(ctx context.Context, groupId string, clusterName string) UpdateBackupScheduleApiRequest
 
 	// UpdateBackupScheduleExecute executes the request
 	//  @return DiskBackupSnapshotSchedule
-	UpdateBackupScheduleExecute(r CloudBackupsApiUpdateBackupScheduleRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+	UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 	UpdateDataProtectionSettings Update or enable the Backup Compliance Policy settings
@@ -467,13 +467,13 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudBackupsApiUpdateDataProtectionSettingsRequest
+	@return UpdateDataProtectionSettingsApiRequest
 	*/
-	UpdateDataProtectionSettings(ctx context.Context, groupId string) CloudBackupsApiUpdateDataProtectionSettingsRequest
+	UpdateDataProtectionSettings(ctx context.Context, groupId string) UpdateDataProtectionSettingsApiRequest
 
 	// UpdateDataProtectionSettingsExecute executes the request
 	//  @return DataProtectionSettings
-	UpdateDataProtectionSettingsExecute(r CloudBackupsApiUpdateDataProtectionSettingsRequest) (*DataProtectionSettings, *http.Response, error)
+	UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error)
 
 	/*
 	UpdateSnapshotRetention Change Expiration Date for One Cloud Backup
@@ -484,19 +484,19 @@ type CloudBackupsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return CloudBackupsApiUpdateSnapshotRetentionRequest
+	@return UpdateSnapshotRetentionApiRequest
 	*/
-	UpdateSnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiUpdateSnapshotRetentionRequest
+	UpdateSnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) UpdateSnapshotRetentionApiRequest
 
 	// UpdateSnapshotRetentionExecute executes the request
 	//  @return DiskBackupReplicaSet
-	UpdateSnapshotRetentionExecute(r CloudBackupsApiUpdateSnapshotRetentionRequest) (*DiskBackupReplicaSet, *http.Response, error)
+	UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 }
 
 // CloudBackupsApiService CloudBackupsApi service
 type CloudBackupsApiService service
 
-type CloudBackupsApiCancelBackupRestoreJobRequest struct {
+type CancelBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -510,7 +510,7 @@ type CancelBackupRestoreJobParams struct {
 		RestoreJobId string
 }
 
-func (r CloudBackupsApiCancelBackupRestoreJobRequest) Execute() (*http.Response, error) {
+func (r CancelBackupRestoreJobApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CancelBackupRestoreJobExecute(r)
 }
 
@@ -523,10 +523,10 @@ Cancels one cloud backup restore job of one cluster from the specified project. 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param restoreJobId Unique 24-hexadecimal digit string that identifies the restore job to remove.
- @return CloudBackupsApiCancelBackupRestoreJobRequest
+ @return CancelBackupRestoreJobApiRequest
 */
-func (a *CloudBackupsApiService) CancelBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CloudBackupsApiCancelBackupRestoreJobRequest {
-	return CloudBackupsApiCancelBackupRestoreJobRequest{
+func (a *CloudBackupsApiService) CancelBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CancelBackupRestoreJobApiRequest {
+	return CancelBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -536,7 +536,7 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJob(ctx context.Context, gro
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CloudBackupsApiCancelBackupRestoreJobRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -628,7 +628,7 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CloudBackupsApi
 	return localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiCreateBackupExportJobRequest struct {
+type CreateBackupExportJobApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -643,12 +643,12 @@ type CreateBackupExportJobParams struct {
 }
 
 // Information about the Cloud Backup Snapshot Export Job to create.
-func (r CloudBackupsApiCreateBackupExportJobRequest) DiskBackupExportJobRequest(diskBackupExportJobRequest DiskBackupExportJobRequest) CloudBackupsApiCreateBackupExportJobRequest {
+func (r CreateBackupExportJobApiRequest) DiskBackupExportJobRequest(diskBackupExportJobRequest DiskBackupExportJobRequest) CreateBackupExportJobApiRequest {
 	r.diskBackupExportJobRequest = &diskBackupExportJobRequest
 	return r
 }
 
-func (r CloudBackupsApiCreateBackupExportJobRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
+func (r CreateBackupExportJobApiRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
 	return r.ApiService.CreateBackupExportJobExecute(r)
 }
 
@@ -660,10 +660,10 @@ Exports one backup snapshot for dedicated Atlas cluster using Cloud Backups to a
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiCreateBackupExportJobRequest
+ @return CreateBackupExportJobApiRequest
 */
-func (a *CloudBackupsApiService) CreateBackupExportJob(ctx context.Context, groupId string, clusterName string) CloudBackupsApiCreateBackupExportJobRequest {
-	return CloudBackupsApiCreateBackupExportJobRequest{
+func (a *CloudBackupsApiService) CreateBackupExportJob(ctx context.Context, groupId string, clusterName string) CreateBackupExportJobApiRequest {
+	return CreateBackupExportJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -673,7 +673,7 @@ func (a *CloudBackupsApiService) CreateBackupExportJob(ctx context.Context, grou
 
 // Execute executes the request
 //  @return DiskBackupExportJob
-func (a *CloudBackupsApiService) CreateBackupExportJobExecute(r CloudBackupsApiCreateBackupExportJobRequest) (*DiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -773,7 +773,7 @@ func (a *CloudBackupsApiService) CreateBackupExportJobExecute(r CloudBackupsApiC
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiCreateBackupRestoreJobRequest struct {
+type CreateBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -788,12 +788,12 @@ type CreateBackupRestoreJobParams struct {
 }
 
 // Restores one snapshot of one cluster from the specified project.
-func (r CloudBackupsApiCreateBackupRestoreJobRequest) DiskBackupRestoreJob(diskBackupRestoreJob DiskBackupRestoreJob) CloudBackupsApiCreateBackupRestoreJobRequest {
+func (r CreateBackupRestoreJobApiRequest) DiskBackupRestoreJob(diskBackupRestoreJob DiskBackupRestoreJob) CreateBackupRestoreJobApiRequest {
 	r.diskBackupRestoreJob = &diskBackupRestoreJob
 	return r
 }
 
-func (r CloudBackupsApiCreateBackupRestoreJobRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
+func (r CreateBackupRestoreJobApiRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.CreateBackupRestoreJobExecute(r)
 }
 
@@ -807,10 +807,10 @@ Restores one snapshot of one cluster from the specified project. Atlas takes on-
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiCreateBackupRestoreJobRequest
+ @return CreateBackupRestoreJobApiRequest
 */
-func (a *CloudBackupsApiService) CreateBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CloudBackupsApiCreateBackupRestoreJobRequest {
-	return CloudBackupsApiCreateBackupRestoreJobRequest{
+func (a *CloudBackupsApiService) CreateBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateBackupRestoreJobApiRequest {
+	return CreateBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -820,7 +820,7 @@ func (a *CloudBackupsApiService) CreateBackupRestoreJob(ctx context.Context, gro
 
 // Execute executes the request
 //  @return DiskBackupRestoreJob
-func (a *CloudBackupsApiService) CreateBackupRestoreJobExecute(r CloudBackupsApiCreateBackupRestoreJobRequest) (*DiskBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -920,7 +920,7 @@ func (a *CloudBackupsApiService) CreateBackupRestoreJobExecute(r CloudBackupsApi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiCreateExportBucketRequest struct {
+type CreateExportBucketApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -933,12 +933,12 @@ type CreateExportBucketParams struct {
 }
 
 // Grants MongoDB Cloud access to the specified AWS S3 bucket.
-func (r CloudBackupsApiCreateExportBucketRequest) DiskBackupSnapshotAWSExportBucket(diskBackupSnapshotAWSExportBucket DiskBackupSnapshotAWSExportBucket) CloudBackupsApiCreateExportBucketRequest {
+func (r CreateExportBucketApiRequest) DiskBackupSnapshotAWSExportBucket(diskBackupSnapshotAWSExportBucket DiskBackupSnapshotAWSExportBucket) CreateExportBucketApiRequest {
 	r.diskBackupSnapshotAWSExportBucket = &diskBackupSnapshotAWSExportBucket
 	return r
 }
 
-func (r CloudBackupsApiCreateExportBucketRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (r CreateExportBucketApiRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	return r.ApiService.CreateExportBucketExecute(r)
 }
 
@@ -949,10 +949,10 @@ Grants MongoDB Cloud access to the specified AWS S3 bucket. This enables this bu
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudBackupsApiCreateExportBucketRequest
+ @return CreateExportBucketApiRequest
 */
-func (a *CloudBackupsApiService) CreateExportBucket(ctx context.Context, groupId string) CloudBackupsApiCreateExportBucketRequest {
-	return CloudBackupsApiCreateExportBucketRequest{
+func (a *CloudBackupsApiService) CreateExportBucket(ctx context.Context, groupId string) CreateExportBucketApiRequest {
+	return CreateExportBucketApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -961,7 +961,7 @@ func (a *CloudBackupsApiService) CreateExportBucket(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return DiskBackupSnapshotAWSExportBucket
-func (a *CloudBackupsApiService) CreateExportBucketExecute(r CloudBackupsApiCreateExportBucketRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1054,7 +1054,7 @@ func (a *CloudBackupsApiService) CreateExportBucketExecute(r CloudBackupsApiCrea
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiCreateServerlessBackupRestoreJobRequest struct {
+type CreateServerlessBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -1069,12 +1069,12 @@ type CreateServerlessBackupRestoreJobParams struct {
 }
 
 // Restores one snapshot of one serverless instance from the specified project.
-func (r CloudBackupsApiCreateServerlessBackupRestoreJobRequest) ServerlessBackupRestoreJob(serverlessBackupRestoreJob ServerlessBackupRestoreJob) CloudBackupsApiCreateServerlessBackupRestoreJobRequest {
+func (r CreateServerlessBackupRestoreJobApiRequest) ServerlessBackupRestoreJob(serverlessBackupRestoreJob ServerlessBackupRestoreJob) CreateServerlessBackupRestoreJobApiRequest {
 	r.serverlessBackupRestoreJob = &serverlessBackupRestoreJob
 	return r
 }
 
-func (r CloudBackupsApiCreateServerlessBackupRestoreJobRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (r CreateServerlessBackupRestoreJobApiRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.CreateServerlessBackupRestoreJobExecute(r)
 }
 
@@ -1086,10 +1086,10 @@ Restores one snapshot of one serverless instance from the specified project. To 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the serverless instance whose snapshot you want to restore.
- @return CloudBackupsApiCreateServerlessBackupRestoreJobRequest
+ @return CreateServerlessBackupRestoreJobApiRequest
 */
-func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CloudBackupsApiCreateServerlessBackupRestoreJobRequest {
-	return CloudBackupsApiCreateServerlessBackupRestoreJobRequest{
+func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateServerlessBackupRestoreJobApiRequest {
+	return CreateServerlessBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1099,7 +1099,7 @@ func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJob(ctx context.Co
 
 // Execute executes the request
 //  @return ServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobExecute(r CloudBackupsApiCreateServerlessBackupRestoreJobRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1199,7 +1199,7 @@ func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobExecute(r Cloud
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiDeleteAllBackupSchedulesRequest struct {
+type DeleteAllBackupSchedulesApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -1211,7 +1211,7 @@ type DeleteAllBackupSchedulesParams struct {
 		ClusterName string
 }
 
-func (r CloudBackupsApiDeleteAllBackupSchedulesRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (r DeleteAllBackupSchedulesApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	return r.ApiService.DeleteAllBackupSchedulesExecute(r)
 }
 
@@ -1223,10 +1223,10 @@ Removes all cloud backup schedules for the specified cluster. This schedule defi
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiDeleteAllBackupSchedulesRequest
+ @return DeleteAllBackupSchedulesApiRequest
 */
-func (a *CloudBackupsApiService) DeleteAllBackupSchedules(ctx context.Context, groupId string, clusterName string) CloudBackupsApiDeleteAllBackupSchedulesRequest {
-	return CloudBackupsApiDeleteAllBackupSchedulesRequest{
+func (a *CloudBackupsApiService) DeleteAllBackupSchedules(ctx context.Context, groupId string, clusterName string) DeleteAllBackupSchedulesApiRequest {
+	return DeleteAllBackupSchedulesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1236,7 +1236,7 @@ func (a *CloudBackupsApiService) DeleteAllBackupSchedules(ctx context.Context, g
 
 // Execute executes the request
 //  @return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) DeleteAllBackupSchedulesExecute(r CloudBackupsApiDeleteAllBackupSchedulesRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1331,7 +1331,7 @@ func (a *CloudBackupsApiService) DeleteAllBackupSchedulesExecute(r CloudBackupsA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiDeleteExportBucketRequest struct {
+type DeleteExportBucketApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -1343,7 +1343,7 @@ type DeleteExportBucketParams struct {
 		ExportBucketId string
 }
 
-func (r CloudBackupsApiDeleteExportBucketRequest) Execute() (*http.Response, error) {
+func (r DeleteExportBucketApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteExportBucketExecute(r)
 }
 
@@ -1355,10 +1355,10 @@ Revoke MongoDB Cloud access to the specified AWS S3 bucket. This prevents this b
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param exportBucketId Unique string that identifies the AWS S3 bucket to which you export your snapshots.
- @return CloudBackupsApiDeleteExportBucketRequest
+ @return DeleteExportBucketApiRequest
 */
-func (a *CloudBackupsApiService) DeleteExportBucket(ctx context.Context, groupId string, exportBucketId string) CloudBackupsApiDeleteExportBucketRequest {
-	return CloudBackupsApiDeleteExportBucketRequest{
+func (a *CloudBackupsApiService) DeleteExportBucket(ctx context.Context, groupId string, exportBucketId string) DeleteExportBucketApiRequest {
+	return DeleteExportBucketApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1367,7 +1367,7 @@ func (a *CloudBackupsApiService) DeleteExportBucket(ctx context.Context, groupId
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) DeleteExportBucketExecute(r CloudBackupsApiDeleteExportBucketRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1452,7 +1452,7 @@ func (a *CloudBackupsApiService) DeleteExportBucketExecute(r CloudBackupsApiDele
 	return localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiDeleteReplicaSetBackupRequest struct {
+type DeleteReplicaSetBackupApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -1466,7 +1466,7 @@ type DeleteReplicaSetBackupParams struct {
 		SnapshotId string
 }
 
-func (r CloudBackupsApiDeleteReplicaSetBackupRequest) Execute() (*http.Response, error) {
+func (r DeleteReplicaSetBackupApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteReplicaSetBackupExecute(r)
 }
 
@@ -1479,10 +1479,10 @@ Removes the specified snapshot. To use this resource, the requesting API Key mus
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return CloudBackupsApiDeleteReplicaSetBackupRequest
+ @return DeleteReplicaSetBackupApiRequest
 */
-func (a *CloudBackupsApiService) DeleteReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiDeleteReplicaSetBackupRequest {
-	return CloudBackupsApiDeleteReplicaSetBackupRequest{
+func (a *CloudBackupsApiService) DeleteReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteReplicaSetBackupApiRequest {
+	return DeleteReplicaSetBackupApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1492,7 +1492,7 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackup(ctx context.Context, gro
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r CloudBackupsApiDeleteReplicaSetBackupRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1584,7 +1584,7 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r CloudBackupsApi
 	return localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiDeleteShardedClusterBackupRequest struct {
+type DeleteShardedClusterBackupApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -1598,7 +1598,7 @@ type DeleteShardedClusterBackupParams struct {
 		SnapshotId string
 }
 
-func (r CloudBackupsApiDeleteShardedClusterBackupRequest) Execute() (*http.Response, error) {
+func (r DeleteShardedClusterBackupApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteShardedClusterBackupExecute(r)
 }
 
@@ -1611,10 +1611,10 @@ Removes one snapshot of one sharded cluster from the specified project. To use t
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return CloudBackupsApiDeleteShardedClusterBackupRequest
+ @return DeleteShardedClusterBackupApiRequest
 */
-func (a *CloudBackupsApiService) DeleteShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiDeleteShardedClusterBackupRequest {
-	return CloudBackupsApiDeleteShardedClusterBackupRequest{
+func (a *CloudBackupsApiService) DeleteShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteShardedClusterBackupApiRequest {
+	return DeleteShardedClusterBackupApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1624,7 +1624,7 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackup(ctx context.Context,
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r CloudBackupsApiDeleteShardedClusterBackupRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1716,7 +1716,7 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r CloudBackup
 	return localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetBackupExportJobRequest struct {
+type GetBackupExportJobApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -1730,7 +1730,7 @@ type GetBackupExportJobParams struct {
 		ExportId string
 }
 
-func (r CloudBackupsApiGetBackupExportJobRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
+func (r GetBackupExportJobApiRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
 	return r.ApiService.GetBackupExportJobExecute(r)
 }
 
@@ -1743,10 +1743,10 @@ Returns one Cloud Backup snapshot export job associated with the specified Atlas
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param exportId Unique string that identifies the AWS S3 bucket to which you export your snapshots.
- @return CloudBackupsApiGetBackupExportJobRequest
+ @return GetBackupExportJobApiRequest
 */
-func (a *CloudBackupsApiService) GetBackupExportJob(ctx context.Context, groupId string, clusterName string, exportId string) CloudBackupsApiGetBackupExportJobRequest {
-	return CloudBackupsApiGetBackupExportJobRequest{
+func (a *CloudBackupsApiService) GetBackupExportJob(ctx context.Context, groupId string, clusterName string, exportId string) GetBackupExportJobApiRequest {
+	return GetBackupExportJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1757,7 +1757,7 @@ func (a *CloudBackupsApiService) GetBackupExportJob(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return DiskBackupExportJob
-func (a *CloudBackupsApiService) GetBackupExportJobExecute(r CloudBackupsApiGetBackupExportJobRequest) (*DiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1853,7 +1853,7 @@ func (a *CloudBackupsApiService) GetBackupExportJobExecute(r CloudBackupsApiGetB
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetBackupRestoreJobRequest struct {
+type GetBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -1867,7 +1867,7 @@ type GetBackupRestoreJobParams struct {
 		RestoreJobId string
 }
 
-func (r CloudBackupsApiGetBackupRestoreJobRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
+func (r GetBackupRestoreJobApiRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.GetBackupRestoreJobExecute(r)
 }
 
@@ -1880,10 +1880,10 @@ Returns one cloud backup restore job for one cluster from the specified project.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster with the restore jobs you want to return.
  @param restoreJobId Unique 24-hexadecimal digit string that identifies the restore job to return.
- @return CloudBackupsApiGetBackupRestoreJobRequest
+ @return GetBackupRestoreJobApiRequest
 */
-func (a *CloudBackupsApiService) GetBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CloudBackupsApiGetBackupRestoreJobRequest {
-	return CloudBackupsApiGetBackupRestoreJobRequest{
+func (a *CloudBackupsApiService) GetBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) GetBackupRestoreJobApiRequest {
+	return GetBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1894,7 +1894,7 @@ func (a *CloudBackupsApiService) GetBackupRestoreJob(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DiskBackupRestoreJob
-func (a *CloudBackupsApiService) GetBackupRestoreJobExecute(r CloudBackupsApiGetBackupRestoreJobRequest) (*DiskBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1996,7 +1996,7 @@ func (a *CloudBackupsApiService) GetBackupRestoreJobExecute(r CloudBackupsApiGet
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetBackupScheduleRequest struct {
+type GetBackupScheduleApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2008,7 +2008,7 @@ type GetBackupScheduleParams struct {
 		ClusterName string
 }
 
-func (r CloudBackupsApiGetBackupScheduleRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (r GetBackupScheduleApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	return r.ApiService.GetBackupScheduleExecute(r)
 }
 
@@ -2020,10 +2020,10 @@ Returns the cloud backup schedule for the specified cluster within the specified
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiGetBackupScheduleRequest
+ @return GetBackupScheduleApiRequest
 */
-func (a *CloudBackupsApiService) GetBackupSchedule(ctx context.Context, groupId string, clusterName string) CloudBackupsApiGetBackupScheduleRequest {
-	return CloudBackupsApiGetBackupScheduleRequest{
+func (a *CloudBackupsApiService) GetBackupSchedule(ctx context.Context, groupId string, clusterName string) GetBackupScheduleApiRequest {
+	return GetBackupScheduleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2033,7 +2033,7 @@ func (a *CloudBackupsApiService) GetBackupSchedule(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) GetBackupScheduleExecute(r CloudBackupsApiGetBackupScheduleRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2128,7 +2128,7 @@ func (a *CloudBackupsApiService) GetBackupScheduleExecute(r CloudBackupsApiGetBa
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetDataProtectionSettingsRequest struct {
+type GetDataProtectionSettingsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2138,7 +2138,7 @@ type GetDataProtectionSettingsParams struct {
 		GroupId string
 }
 
-func (r CloudBackupsApiGetDataProtectionSettingsRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
+func (r GetDataProtectionSettingsApiRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
 	return r.ApiService.GetDataProtectionSettingsExecute(r)
 }
 
@@ -2149,10 +2149,10 @@ Returns the Backup Compliance Policy settings with the specified project. To use
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudBackupsApiGetDataProtectionSettingsRequest
+ @return GetDataProtectionSettingsApiRequest
 */
-func (a *CloudBackupsApiService) GetDataProtectionSettings(ctx context.Context, groupId string) CloudBackupsApiGetDataProtectionSettingsRequest {
-	return CloudBackupsApiGetDataProtectionSettingsRequest{
+func (a *CloudBackupsApiService) GetDataProtectionSettings(ctx context.Context, groupId string) GetDataProtectionSettingsApiRequest {
+	return GetDataProtectionSettingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2161,7 +2161,7 @@ func (a *CloudBackupsApiService) GetDataProtectionSettings(ctx context.Context, 
 
 // Execute executes the request
 //  @return DataProtectionSettings
-func (a *CloudBackupsApiService) GetDataProtectionSettingsExecute(r CloudBackupsApiGetDataProtectionSettingsRequest) (*DataProtectionSettings, *http.Response, error) {
+func (a *CloudBackupsApiService) GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2249,7 +2249,7 @@ func (a *CloudBackupsApiService) GetDataProtectionSettingsExecute(r CloudBackups
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetExportBucketRequest struct {
+type GetExportBucketApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2261,7 +2261,7 @@ type GetExportBucketParams struct {
 		ExportBucketId string
 }
 
-func (r CloudBackupsApiGetExportBucketRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (r GetExportBucketApiRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	return r.ApiService.GetExportBucketExecute(r)
 }
 
@@ -2273,10 +2273,10 @@ Returns one AWS S3 bucket associated with the specified project. To use this res
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param exportBucketId Unique string that identifies the AWS S3 bucket to which you export your snapshots.
- @return CloudBackupsApiGetExportBucketRequest
+ @return GetExportBucketApiRequest
 */
-func (a *CloudBackupsApiService) GetExportBucket(ctx context.Context, groupId string, exportBucketId string) CloudBackupsApiGetExportBucketRequest {
-	return CloudBackupsApiGetExportBucketRequest{
+func (a *CloudBackupsApiService) GetExportBucket(ctx context.Context, groupId string, exportBucketId string) GetExportBucketApiRequest {
+	return GetExportBucketApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2286,7 +2286,7 @@ func (a *CloudBackupsApiService) GetExportBucket(ctx context.Context, groupId st
 
 // Execute executes the request
 //  @return DiskBackupSnapshotAWSExportBucket
-func (a *CloudBackupsApiService) GetExportBucketExecute(r CloudBackupsApiGetExportBucketRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2381,7 +2381,7 @@ func (a *CloudBackupsApiService) GetExportBucketExecute(r CloudBackupsApiGetExpo
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetReplicaSetBackupRequest struct {
+type GetReplicaSetBackupApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2395,7 +2395,7 @@ type GetReplicaSetBackupParams struct {
 		SnapshotId string
 }
 
-func (r CloudBackupsApiGetReplicaSetBackupRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
+func (r GetReplicaSetBackupApiRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
 	return r.ApiService.GetReplicaSetBackupExecute(r)
 }
 
@@ -2408,10 +2408,10 @@ Returns one snapshot from the specified cluster. To use this resource, the reque
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return CloudBackupsApiGetReplicaSetBackupRequest
+ @return GetReplicaSetBackupApiRequest
 */
-func (a *CloudBackupsApiService) GetReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiGetReplicaSetBackupRequest {
-	return CloudBackupsApiGetReplicaSetBackupRequest{
+func (a *CloudBackupsApiService) GetReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetReplicaSetBackupApiRequest {
+	return GetReplicaSetBackupApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2422,7 +2422,7 @@ func (a *CloudBackupsApiService) GetReplicaSetBackup(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DiskBackupReplicaSet
-func (a *CloudBackupsApiService) GetReplicaSetBackupExecute(r CloudBackupsApiGetReplicaSetBackupRequest) (*DiskBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2524,7 +2524,7 @@ func (a *CloudBackupsApiService) GetReplicaSetBackupExecute(r CloudBackupsApiGet
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetServerlessBackupRequest struct {
+type GetServerlessBackupApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2538,7 +2538,7 @@ type GetServerlessBackupParams struct {
 		SnapshotId string
 }
 
-func (r CloudBackupsApiGetServerlessBackupRequest) Execute() (*ServerlessBackupSnapshot, *http.Response, error) {
+func (r GetServerlessBackupApiRequest) Execute() (*ServerlessBackupSnapshot, *http.Response, error) {
 	return r.ApiService.GetServerlessBackupExecute(r)
 }
 
@@ -2551,10 +2551,10 @@ Returns one snapshot of one serverless instance from the specified project. To u
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the serverless instance.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return CloudBackupsApiGetServerlessBackupRequest
+ @return GetServerlessBackupApiRequest
 */
-func (a *CloudBackupsApiService) GetServerlessBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiGetServerlessBackupRequest {
-	return CloudBackupsApiGetServerlessBackupRequest{
+func (a *CloudBackupsApiService) GetServerlessBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetServerlessBackupApiRequest {
+	return GetServerlessBackupApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2565,7 +2565,7 @@ func (a *CloudBackupsApiService) GetServerlessBackup(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return ServerlessBackupSnapshot
-func (a *CloudBackupsApiService) GetServerlessBackupExecute(r CloudBackupsApiGetServerlessBackupRequest) (*ServerlessBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2667,7 +2667,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupExecute(r CloudBackupsApiGet
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetServerlessBackupRestoreJobRequest struct {
+type GetServerlessBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2681,7 +2681,7 @@ type GetServerlessBackupRestoreJobParams struct {
 		RestoreJobId string
 }
 
-func (r CloudBackupsApiGetServerlessBackupRestoreJobRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (r GetServerlessBackupRestoreJobApiRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.GetServerlessBackupRestoreJobExecute(r)
 }
 
@@ -2694,10 +2694,10 @@ Returns one restore job for one serverless instance from the specified project. 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the serverless instance.
  @param restoreJobId Unique 24-hexadecimal digit string that identifies the restore job to return.
- @return CloudBackupsApiGetServerlessBackupRestoreJobRequest
+ @return GetServerlessBackupRestoreJobApiRequest
 */
-func (a *CloudBackupsApiService) GetServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CloudBackupsApiGetServerlessBackupRestoreJobRequest {
-	return CloudBackupsApiGetServerlessBackupRestoreJobRequest{
+func (a *CloudBackupsApiService) GetServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) GetServerlessBackupRestoreJobApiRequest {
+	return GetServerlessBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2708,7 +2708,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupRestoreJob(ctx context.Conte
 
 // Execute executes the request
 //  @return ServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobExecute(r CloudBackupsApiGetServerlessBackupRestoreJobRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2810,7 +2810,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobExecute(r CloudBac
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiGetShardedClusterBackupRequest struct {
+type GetShardedClusterBackupApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2824,7 +2824,7 @@ type GetShardedClusterBackupParams struct {
 		SnapshotId string
 }
 
-func (r CloudBackupsApiGetShardedClusterBackupRequest) Execute() (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
+func (r GetShardedClusterBackupApiRequest) Execute() (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
 	return r.ApiService.GetShardedClusterBackupExecute(r)
 }
 
@@ -2837,10 +2837,10 @@ Returns one snapshot of one sharded cluster from the specified project. To use t
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return CloudBackupsApiGetShardedClusterBackupRequest
+ @return GetShardedClusterBackupApiRequest
 */
-func (a *CloudBackupsApiService) GetShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiGetShardedClusterBackupRequest {
-	return CloudBackupsApiGetShardedClusterBackupRequest{
+func (a *CloudBackupsApiService) GetShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetShardedClusterBackupApiRequest {
+	return GetShardedClusterBackupApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2851,7 +2851,7 @@ func (a *CloudBackupsApiService) GetShardedClusterBackup(ctx context.Context, gr
 
 // Execute executes the request
 //  @return DiskBackupShardedClusterSnapshot
-func (a *CloudBackupsApiService) GetShardedClusterBackupExecute(r CloudBackupsApiGetShardedClusterBackupRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2953,7 +2953,7 @@ func (a *CloudBackupsApiService) GetShardedClusterBackupExecute(r CloudBackupsAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiListBackupExportJobsRequest struct {
+type ListBackupExportJobsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -2972,24 +2972,24 @@ type ListBackupExportJobsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r CloudBackupsApiListBackupExportJobsRequest) IncludeCount(includeCount bool) CloudBackupsApiListBackupExportJobsRequest {
+func (r ListBackupExportJobsApiRequest) IncludeCount(includeCount bool) ListBackupExportJobsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r CloudBackupsApiListBackupExportJobsRequest) ItemsPerPage(itemsPerPage int32) CloudBackupsApiListBackupExportJobsRequest {
+func (r ListBackupExportJobsApiRequest) ItemsPerPage(itemsPerPage int32) ListBackupExportJobsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r CloudBackupsApiListBackupExportJobsRequest) PageNum(pageNum int32) CloudBackupsApiListBackupExportJobsRequest {
+func (r ListBackupExportJobsApiRequest) PageNum(pageNum int32) ListBackupExportJobsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r CloudBackupsApiListBackupExportJobsRequest) Execute() (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
+func (r ListBackupExportJobsApiRequest) Execute() (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
 	return r.ApiService.ListBackupExportJobsExecute(r)
 }
 
@@ -3001,10 +3001,10 @@ Returns all Cloud Backup snapshot export jobs associated with the specified Atla
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiListBackupExportJobsRequest
+ @return ListBackupExportJobsApiRequest
 */
-func (a *CloudBackupsApiService) ListBackupExportJobs(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListBackupExportJobsRequest {
-	return CloudBackupsApiListBackupExportJobsRequest{
+func (a *CloudBackupsApiService) ListBackupExportJobs(ctx context.Context, groupId string, clusterName string) ListBackupExportJobsApiRequest {
+	return ListBackupExportJobsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -3014,7 +3014,7 @@ func (a *CloudBackupsApiService) ListBackupExportJobs(ctx context.Context, group
 
 // Execute executes the request
 //  @return PaginatedApiAtlasDiskBackupExportJob
-func (a *CloudBackupsApiService) ListBackupExportJobsExecute(r CloudBackupsApiListBackupExportJobsRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3130,7 +3130,7 @@ func (a *CloudBackupsApiService) ListBackupExportJobsExecute(r CloudBackupsApiLi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiListBackupRestoreJobsRequest struct {
+type ListBackupRestoreJobsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -3149,24 +3149,24 @@ type ListBackupRestoreJobsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r CloudBackupsApiListBackupRestoreJobsRequest) IncludeCount(includeCount bool) CloudBackupsApiListBackupRestoreJobsRequest {
+func (r ListBackupRestoreJobsApiRequest) IncludeCount(includeCount bool) ListBackupRestoreJobsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r CloudBackupsApiListBackupRestoreJobsRequest) ItemsPerPage(itemsPerPage int32) CloudBackupsApiListBackupRestoreJobsRequest {
+func (r ListBackupRestoreJobsApiRequest) ItemsPerPage(itemsPerPage int32) ListBackupRestoreJobsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r CloudBackupsApiListBackupRestoreJobsRequest) PageNum(pageNum int32) CloudBackupsApiListBackupRestoreJobsRequest {
+func (r ListBackupRestoreJobsApiRequest) PageNum(pageNum int32) ListBackupRestoreJobsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r CloudBackupsApiListBackupRestoreJobsRequest) Execute() (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
+func (r ListBackupRestoreJobsApiRequest) Execute() (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.ListBackupRestoreJobsExecute(r)
 }
 
@@ -3178,10 +3178,10 @@ Returns all cloud backup restore jobs for one cluster from the specified project
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster with the restore jobs you want to return.
- @return CloudBackupsApiListBackupRestoreJobsRequest
+ @return ListBackupRestoreJobsApiRequest
 */
-func (a *CloudBackupsApiService) ListBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListBackupRestoreJobsRequest {
-	return CloudBackupsApiListBackupRestoreJobsRequest{
+func (a *CloudBackupsApiService) ListBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListBackupRestoreJobsApiRequest {
+	return ListBackupRestoreJobsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -3191,7 +3191,7 @@ func (a *CloudBackupsApiService) ListBackupRestoreJobs(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedCloudBackupRestoreJob
-func (a *CloudBackupsApiService) ListBackupRestoreJobsExecute(r CloudBackupsApiListBackupRestoreJobsRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3307,7 +3307,7 @@ func (a *CloudBackupsApiService) ListBackupRestoreJobsExecute(r CloudBackupsApiL
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiListExportBucketsRequest struct {
+type ListExportBucketsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -3317,7 +3317,7 @@ type ListExportBucketsParams struct {
 		GroupId string
 }
 
-func (r CloudBackupsApiListExportBucketsRequest) Execute() (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
+func (r ListExportBucketsApiRequest) Execute() (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
 	return r.ApiService.ListExportBucketsExecute(r)
 }
 
@@ -3328,10 +3328,10 @@ Returns all AWS S3 buckets associated with the specified project. To use this re
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudBackupsApiListExportBucketsRequest
+ @return ListExportBucketsApiRequest
 */
-func (a *CloudBackupsApiService) ListExportBuckets(ctx context.Context, groupId string) CloudBackupsApiListExportBucketsRequest {
-	return CloudBackupsApiListExportBucketsRequest{
+func (a *CloudBackupsApiService) ListExportBuckets(ctx context.Context, groupId string) ListExportBucketsApiRequest {
+	return ListExportBucketsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -3340,7 +3340,7 @@ func (a *CloudBackupsApiService) ListExportBuckets(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return PaginatedBackupSnapshotExportBucket
-func (a *CloudBackupsApiService) ListExportBucketsExecute(r CloudBackupsApiListExportBucketsRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3428,7 +3428,7 @@ func (a *CloudBackupsApiService) ListExportBucketsExecute(r CloudBackupsApiListE
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiListReplicaSetBackupsRequest struct {
+type ListReplicaSetBackupsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -3447,24 +3447,24 @@ type ListReplicaSetBackupsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r CloudBackupsApiListReplicaSetBackupsRequest) IncludeCount(includeCount bool) CloudBackupsApiListReplicaSetBackupsRequest {
+func (r ListReplicaSetBackupsApiRequest) IncludeCount(includeCount bool) ListReplicaSetBackupsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r CloudBackupsApiListReplicaSetBackupsRequest) ItemsPerPage(itemsPerPage int32) CloudBackupsApiListReplicaSetBackupsRequest {
+func (r ListReplicaSetBackupsApiRequest) ItemsPerPage(itemsPerPage int32) ListReplicaSetBackupsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r CloudBackupsApiListReplicaSetBackupsRequest) PageNum(pageNum int32) CloudBackupsApiListReplicaSetBackupsRequest {
+func (r ListReplicaSetBackupsApiRequest) PageNum(pageNum int32) ListReplicaSetBackupsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r CloudBackupsApiListReplicaSetBackupsRequest) Execute() (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
+func (r ListReplicaSetBackupsApiRequest) Execute() (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
 	return r.ApiService.ListReplicaSetBackupsExecute(r)
 }
 
@@ -3476,10 +3476,10 @@ Returns all snapshots of one cluster from the specified project. To use this res
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiListReplicaSetBackupsRequest
+ @return ListReplicaSetBackupsApiRequest
 */
-func (a *CloudBackupsApiService) ListReplicaSetBackups(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListReplicaSetBackupsRequest {
-	return CloudBackupsApiListReplicaSetBackupsRequest{
+func (a *CloudBackupsApiService) ListReplicaSetBackups(ctx context.Context, groupId string, clusterName string) ListReplicaSetBackupsApiRequest {
+	return ListReplicaSetBackupsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -3489,7 +3489,7 @@ func (a *CloudBackupsApiService) ListReplicaSetBackups(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedCloudBackupReplicaSet
-func (a *CloudBackupsApiService) ListReplicaSetBackupsExecute(r CloudBackupsApiListReplicaSetBackupsRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3605,7 +3605,7 @@ func (a *CloudBackupsApiService) ListReplicaSetBackupsExecute(r CloudBackupsApiL
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiListServerlessBackupRestoreJobsRequest struct {
+type ListServerlessBackupRestoreJobsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -3617,7 +3617,7 @@ type ListServerlessBackupRestoreJobsParams struct {
 		ClusterName string
 }
 
-func (r CloudBackupsApiListServerlessBackupRestoreJobsRequest) Execute() (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
+func (r ListServerlessBackupRestoreJobsApiRequest) Execute() (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
 	return r.ApiService.ListServerlessBackupRestoreJobsExecute(r)
 }
 
@@ -3629,10 +3629,10 @@ Returns all restore jobs for one serverless instance from the specified project.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the serverless instance.
- @return CloudBackupsApiListServerlessBackupRestoreJobsRequest
+ @return ListServerlessBackupRestoreJobsApiRequest
 */
-func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListServerlessBackupRestoreJobsRequest {
-	return CloudBackupsApiListServerlessBackupRestoreJobsRequest{
+func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListServerlessBackupRestoreJobsApiRequest {
+	return ListServerlessBackupRestoreJobsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -3642,7 +3642,7 @@ func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobs(ctx context.Con
 
 // Execute executes the request
 //  @return PaginatedApiAtlasServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobsExecute(r CloudBackupsApiListServerlessBackupRestoreJobsRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3737,7 +3737,7 @@ func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobsExecute(r CloudB
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiListServerlessBackupsRequest struct {
+type ListServerlessBackupsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -3756,24 +3756,24 @@ type ListServerlessBackupsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r CloudBackupsApiListServerlessBackupsRequest) IncludeCount(includeCount bool) CloudBackupsApiListServerlessBackupsRequest {
+func (r ListServerlessBackupsApiRequest) IncludeCount(includeCount bool) ListServerlessBackupsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r CloudBackupsApiListServerlessBackupsRequest) ItemsPerPage(itemsPerPage int32) CloudBackupsApiListServerlessBackupsRequest {
+func (r ListServerlessBackupsApiRequest) ItemsPerPage(itemsPerPage int32) ListServerlessBackupsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r CloudBackupsApiListServerlessBackupsRequest) PageNum(pageNum int32) CloudBackupsApiListServerlessBackupsRequest {
+func (r ListServerlessBackupsApiRequest) PageNum(pageNum int32) ListServerlessBackupsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r CloudBackupsApiListServerlessBackupsRequest) Execute() (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
+func (r ListServerlessBackupsApiRequest) Execute() (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
 	return r.ApiService.ListServerlessBackupsExecute(r)
 }
 
@@ -3785,10 +3785,10 @@ Returns all snapshots of one serverless instance from the specified project. To 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the serverless instance.
- @return CloudBackupsApiListServerlessBackupsRequest
+ @return ListServerlessBackupsApiRequest
 */
-func (a *CloudBackupsApiService) ListServerlessBackups(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListServerlessBackupsRequest {
-	return CloudBackupsApiListServerlessBackupsRequest{
+func (a *CloudBackupsApiService) ListServerlessBackups(ctx context.Context, groupId string, clusterName string) ListServerlessBackupsApiRequest {
+	return ListServerlessBackupsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -3798,7 +3798,7 @@ func (a *CloudBackupsApiService) ListServerlessBackups(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedApiAtlasServerlessBackupSnapshot
-func (a *CloudBackupsApiService) ListServerlessBackupsExecute(r CloudBackupsApiListServerlessBackupsRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3914,7 +3914,7 @@ func (a *CloudBackupsApiService) ListServerlessBackupsExecute(r CloudBackupsApiL
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiListShardedClusterBackupsRequest struct {
+type ListShardedClusterBackupsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -3926,7 +3926,7 @@ type ListShardedClusterBackupsParams struct {
 		ClusterName string
 }
 
-func (r CloudBackupsApiListShardedClusterBackupsRequest) Execute() (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
+func (r ListShardedClusterBackupsApiRequest) Execute() (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
 	return r.ApiService.ListShardedClusterBackupsExecute(r)
 }
 
@@ -3938,10 +3938,10 @@ Returns all snapshots of one sharded cluster from the specified project. To use 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiListShardedClusterBackupsRequest
+ @return ListShardedClusterBackupsApiRequest
 */
-func (a *CloudBackupsApiService) ListShardedClusterBackups(ctx context.Context, groupId string, clusterName string) CloudBackupsApiListShardedClusterBackupsRequest {
-	return CloudBackupsApiListShardedClusterBackupsRequest{
+func (a *CloudBackupsApiService) ListShardedClusterBackups(ctx context.Context, groupId string, clusterName string) ListShardedClusterBackupsApiRequest {
+	return ListShardedClusterBackupsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -3951,7 +3951,7 @@ func (a *CloudBackupsApiService) ListShardedClusterBackups(ctx context.Context, 
 
 // Execute executes the request
 //  @return PaginatedCloudBackupShardedClusterSnapshot
-func (a *CloudBackupsApiService) ListShardedClusterBackupsExecute(r CloudBackupsApiListShardedClusterBackupsRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -4046,7 +4046,7 @@ func (a *CloudBackupsApiService) ListShardedClusterBackupsExecute(r CloudBackups
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiTakeSnapshotRequest struct {
+type TakeSnapshotApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -4061,12 +4061,12 @@ type TakeSnapshotParams struct {
 }
 
 // Takes one on-demand snapshot.
-func (r CloudBackupsApiTakeSnapshotRequest) DiskBackupOnDemandSnapshotRequest(diskBackupOnDemandSnapshotRequest DiskBackupOnDemandSnapshotRequest) CloudBackupsApiTakeSnapshotRequest {
+func (r TakeSnapshotApiRequest) DiskBackupOnDemandSnapshotRequest(diskBackupOnDemandSnapshotRequest DiskBackupOnDemandSnapshotRequest) TakeSnapshotApiRequest {
 	r.diskBackupOnDemandSnapshotRequest = &diskBackupOnDemandSnapshotRequest
 	return r
 }
 
-func (r CloudBackupsApiTakeSnapshotRequest) Execute() (*DiskBackupSnapshot, *http.Response, error) {
+func (r TakeSnapshotApiRequest) Execute() (*DiskBackupSnapshot, *http.Response, error) {
 	return r.ApiService.TakeSnapshotExecute(r)
 }
 
@@ -4080,10 +4080,10 @@ Takes one on-demand snapshot for the specified cluster. Atlas takes on-demand sn
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiTakeSnapshotRequest
+ @return TakeSnapshotApiRequest
 */
-func (a *CloudBackupsApiService) TakeSnapshot(ctx context.Context, groupId string, clusterName string) CloudBackupsApiTakeSnapshotRequest {
-	return CloudBackupsApiTakeSnapshotRequest{
+func (a *CloudBackupsApiService) TakeSnapshot(ctx context.Context, groupId string, clusterName string) TakeSnapshotApiRequest {
+	return TakeSnapshotApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -4093,7 +4093,7 @@ func (a *CloudBackupsApiService) TakeSnapshot(ctx context.Context, groupId strin
 
 // Execute executes the request
 //  @return DiskBackupSnapshot
-func (a *CloudBackupsApiService) TakeSnapshotExecute(r CloudBackupsApiTakeSnapshotRequest) (*DiskBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -4193,7 +4193,7 @@ func (a *CloudBackupsApiService) TakeSnapshotExecute(r CloudBackupsApiTakeSnapsh
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiUpdateBackupScheduleRequest struct {
+type UpdateBackupScheduleApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -4208,12 +4208,12 @@ type UpdateBackupScheduleParams struct {
 }
 
 // Updates the cloud backup schedule for one cluster within the specified project.  **Note**: In the request body, provide only the fields that you want to update.
-func (r CloudBackupsApiUpdateBackupScheduleRequest) DiskBackupSnapshotSchedule(diskBackupSnapshotSchedule DiskBackupSnapshotSchedule) CloudBackupsApiUpdateBackupScheduleRequest {
+func (r UpdateBackupScheduleApiRequest) DiskBackupSnapshotSchedule(diskBackupSnapshotSchedule DiskBackupSnapshotSchedule) UpdateBackupScheduleApiRequest {
 	r.diskBackupSnapshotSchedule = &diskBackupSnapshotSchedule
 	return r
 }
 
-func (r CloudBackupsApiUpdateBackupScheduleRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (r UpdateBackupScheduleApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	return r.ApiService.UpdateBackupScheduleExecute(r)
 }
 
@@ -4225,10 +4225,10 @@ Updates the cloud backup schedule for one cluster within the specified project. 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return CloudBackupsApiUpdateBackupScheduleRequest
+ @return UpdateBackupScheduleApiRequest
 */
-func (a *CloudBackupsApiService) UpdateBackupSchedule(ctx context.Context, groupId string, clusterName string) CloudBackupsApiUpdateBackupScheduleRequest {
-	return CloudBackupsApiUpdateBackupScheduleRequest{
+func (a *CloudBackupsApiService) UpdateBackupSchedule(ctx context.Context, groupId string, clusterName string) UpdateBackupScheduleApiRequest {
+	return UpdateBackupScheduleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -4238,7 +4238,7 @@ func (a *CloudBackupsApiService) UpdateBackupSchedule(ctx context.Context, group
 
 // Execute executes the request
 //  @return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) UpdateBackupScheduleExecute(r CloudBackupsApiUpdateBackupScheduleRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -4338,7 +4338,7 @@ func (a *CloudBackupsApiService) UpdateBackupScheduleExecute(r CloudBackupsApiUp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiUpdateDataProtectionSettingsRequest struct {
+type UpdateDataProtectionSettingsApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -4351,12 +4351,12 @@ type UpdateDataProtectionSettingsParams struct {
 }
 
 // The new Backup Compliance Policy settings.
-func (r CloudBackupsApiUpdateDataProtectionSettingsRequest) DataProtectionSettings(dataProtectionSettings DataProtectionSettings) CloudBackupsApiUpdateDataProtectionSettingsRequest {
+func (r UpdateDataProtectionSettingsApiRequest) DataProtectionSettings(dataProtectionSettings DataProtectionSettings) UpdateDataProtectionSettingsApiRequest {
 	r.dataProtectionSettings = &dataProtectionSettings
 	return r
 }
 
-func (r CloudBackupsApiUpdateDataProtectionSettingsRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
+func (r UpdateDataProtectionSettingsApiRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
 	return r.ApiService.UpdateDataProtectionSettingsExecute(r)
 }
 
@@ -4367,10 +4367,10 @@ Updates the Backup Compliance Policy settings for the specified project. To use 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudBackupsApiUpdateDataProtectionSettingsRequest
+ @return UpdateDataProtectionSettingsApiRequest
 */
-func (a *CloudBackupsApiService) UpdateDataProtectionSettings(ctx context.Context, groupId string) CloudBackupsApiUpdateDataProtectionSettingsRequest {
-	return CloudBackupsApiUpdateDataProtectionSettingsRequest{
+func (a *CloudBackupsApiService) UpdateDataProtectionSettings(ctx context.Context, groupId string) UpdateDataProtectionSettingsApiRequest {
+	return UpdateDataProtectionSettingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -4379,7 +4379,7 @@ func (a *CloudBackupsApiService) UpdateDataProtectionSettings(ctx context.Contex
 
 // Execute executes the request
 //  @return DataProtectionSettings
-func (a *CloudBackupsApiService) UpdateDataProtectionSettingsExecute(r CloudBackupsApiUpdateDataProtectionSettingsRequest) (*DataProtectionSettings, *http.Response, error) {
+func (a *CloudBackupsApiService) UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}
@@ -4472,7 +4472,7 @@ func (a *CloudBackupsApiService) UpdateDataProtectionSettingsExecute(r CloudBack
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudBackupsApiUpdateSnapshotRetentionRequest struct {
+type UpdateSnapshotRetentionApiRequest struct {
 	ctx context.Context
 	ApiService CloudBackupsApi
 	groupId string
@@ -4489,12 +4489,12 @@ type UpdateSnapshotRetentionParams struct {
 }
 
 // Changes the expiration date for one cloud backup snapshot for one cluster in the specified project.
-func (r CloudBackupsApiUpdateSnapshotRetentionRequest) SnapshotRetention(snapshotRetention SnapshotRetention) CloudBackupsApiUpdateSnapshotRetentionRequest {
+func (r UpdateSnapshotRetentionApiRequest) SnapshotRetention(snapshotRetention SnapshotRetention) UpdateSnapshotRetentionApiRequest {
 	r.snapshotRetention = &snapshotRetention
 	return r
 }
 
-func (r CloudBackupsApiUpdateSnapshotRetentionRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
+func (r UpdateSnapshotRetentionApiRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
 	return r.ApiService.UpdateSnapshotRetentionExecute(r)
 }
 
@@ -4507,10 +4507,10 @@ Changes the expiration date for one cloud backup snapshot for one cluster in the
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return CloudBackupsApiUpdateSnapshotRetentionRequest
+ @return UpdateSnapshotRetentionApiRequest
 */
-func (a *CloudBackupsApiService) UpdateSnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) CloudBackupsApiUpdateSnapshotRetentionRequest {
-	return CloudBackupsApiUpdateSnapshotRetentionRequest{
+func (a *CloudBackupsApiService) UpdateSnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) UpdateSnapshotRetentionApiRequest {
+	return UpdateSnapshotRetentionApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -4521,7 +4521,7 @@ func (a *CloudBackupsApiService) UpdateSnapshotRetention(ctx context.Context, gr
 
 // Execute executes the request
 //  @return DiskBackupReplicaSet
-func (a *CloudBackupsApiService) UpdateSnapshotRetentionExecute(r CloudBackupsApiUpdateSnapshotRetentionRequest) (*DiskBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -504,7 +504,7 @@ type CloudBackupsApiCancelBackupRestoreJobRequest struct {
 	restoreJobId string
 }
 
-type CloudBackupsApiCancelBackupRestoreJobQueryParams struct {
+type CloudBackupsApiCancelBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -636,7 +636,7 @@ type CloudBackupsApiCreateBackupExportJobRequest struct {
 	diskBackupExportJobRequest *DiskBackupExportJobRequest
 }
 
-type CloudBackupsApiCreateBackupExportJobQueryParams struct {
+type CloudBackupsApiCreateBackupExportJobParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupExportJobRequest *DiskBackupExportJobRequest
@@ -781,7 +781,7 @@ type CloudBackupsApiCreateBackupRestoreJobRequest struct {
 	diskBackupRestoreJob *DiskBackupRestoreJob
 }
 
-type CloudBackupsApiCreateBackupRestoreJobQueryParams struct {
+type CloudBackupsApiCreateBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupRestoreJob *DiskBackupRestoreJob
@@ -927,7 +927,7 @@ type CloudBackupsApiCreateExportBucketRequest struct {
 	diskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
 
-type CloudBackupsApiCreateExportBucketQueryParams struct {
+type CloudBackupsApiCreateExportBucketParams struct {
 		GroupId string
 		DiskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
@@ -1062,7 +1062,7 @@ type CloudBackupsApiCreateServerlessBackupRestoreJobRequest struct {
 	serverlessBackupRestoreJob *ServerlessBackupRestoreJob
 }
 
-type CloudBackupsApiCreateServerlessBackupRestoreJobQueryParams struct {
+type CloudBackupsApiCreateServerlessBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		ServerlessBackupRestoreJob *ServerlessBackupRestoreJob
@@ -1206,7 +1206,7 @@ type CloudBackupsApiDeleteAllBackupSchedulesRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiDeleteAllBackupSchedulesQueryParams struct {
+type CloudBackupsApiDeleteAllBackupSchedulesParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -1338,7 +1338,7 @@ type CloudBackupsApiDeleteExportBucketRequest struct {
 	exportBucketId string
 }
 
-type CloudBackupsApiDeleteExportBucketQueryParams struct {
+type CloudBackupsApiDeleteExportBucketParams struct {
 		GroupId string
 		ExportBucketId string
 }
@@ -1460,7 +1460,7 @@ type CloudBackupsApiDeleteReplicaSetBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiDeleteReplicaSetBackupQueryParams struct {
+type CloudBackupsApiDeleteReplicaSetBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1592,7 +1592,7 @@ type CloudBackupsApiDeleteShardedClusterBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiDeleteShardedClusterBackupQueryParams struct {
+type CloudBackupsApiDeleteShardedClusterBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1724,7 +1724,7 @@ type CloudBackupsApiGetBackupExportJobRequest struct {
 	exportId string
 }
 
-type CloudBackupsApiGetBackupExportJobQueryParams struct {
+type CloudBackupsApiGetBackupExportJobParams struct {
 		GroupId string
 		ClusterName string
 		ExportId string
@@ -1861,7 +1861,7 @@ type CloudBackupsApiGetBackupRestoreJobRequest struct {
 	restoreJobId string
 }
 
-type CloudBackupsApiGetBackupRestoreJobQueryParams struct {
+type CloudBackupsApiGetBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -2003,7 +2003,7 @@ type CloudBackupsApiGetBackupScheduleRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiGetBackupScheduleQueryParams struct {
+type CloudBackupsApiGetBackupScheduleParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -2134,7 +2134,7 @@ type CloudBackupsApiGetDataProtectionSettingsRequest struct {
 	groupId string
 }
 
-type CloudBackupsApiGetDataProtectionSettingsQueryParams struct {
+type CloudBackupsApiGetDataProtectionSettingsParams struct {
 		GroupId string
 }
 
@@ -2256,7 +2256,7 @@ type CloudBackupsApiGetExportBucketRequest struct {
 	exportBucketId string
 }
 
-type CloudBackupsApiGetExportBucketQueryParams struct {
+type CloudBackupsApiGetExportBucketParams struct {
 		GroupId string
 		ExportBucketId string
 }
@@ -2389,7 +2389,7 @@ type CloudBackupsApiGetReplicaSetBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiGetReplicaSetBackupQueryParams struct {
+type CloudBackupsApiGetReplicaSetBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2532,7 +2532,7 @@ type CloudBackupsApiGetServerlessBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiGetServerlessBackupQueryParams struct {
+type CloudBackupsApiGetServerlessBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2675,7 +2675,7 @@ type CloudBackupsApiGetServerlessBackupRestoreJobRequest struct {
 	restoreJobId string
 }
 
-type CloudBackupsApiGetServerlessBackupRestoreJobQueryParams struct {
+type CloudBackupsApiGetServerlessBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -2818,7 +2818,7 @@ type CloudBackupsApiGetShardedClusterBackupRequest struct {
 	snapshotId string
 }
 
-type CloudBackupsApiGetShardedClusterBackupQueryParams struct {
+type CloudBackupsApiGetShardedClusterBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2963,7 +2963,7 @@ type CloudBackupsApiListBackupExportJobsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListBackupExportJobsQueryParams struct {
+type CloudBackupsApiListBackupExportJobsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3140,7 +3140,7 @@ type CloudBackupsApiListBackupRestoreJobsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListBackupRestoreJobsQueryParams struct {
+type CloudBackupsApiListBackupRestoreJobsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3313,7 +3313,7 @@ type CloudBackupsApiListExportBucketsRequest struct {
 	groupId string
 }
 
-type CloudBackupsApiListExportBucketsQueryParams struct {
+type CloudBackupsApiListExportBucketsParams struct {
 		GroupId string
 }
 
@@ -3438,7 +3438,7 @@ type CloudBackupsApiListReplicaSetBackupsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListReplicaSetBackupsQueryParams struct {
+type CloudBackupsApiListReplicaSetBackupsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3612,7 +3612,7 @@ type CloudBackupsApiListServerlessBackupRestoreJobsRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiListServerlessBackupRestoreJobsQueryParams struct {
+type CloudBackupsApiListServerlessBackupRestoreJobsParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -3747,7 +3747,7 @@ type CloudBackupsApiListServerlessBackupsRequest struct {
 	pageNum *int32
 }
 
-type CloudBackupsApiListServerlessBackupsQueryParams struct {
+type CloudBackupsApiListServerlessBackupsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3921,7 +3921,7 @@ type CloudBackupsApiListShardedClusterBackupsRequest struct {
 	clusterName string
 }
 
-type CloudBackupsApiListShardedClusterBackupsQueryParams struct {
+type CloudBackupsApiListShardedClusterBackupsParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -4054,7 +4054,7 @@ type CloudBackupsApiTakeSnapshotRequest struct {
 	diskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
 }
 
-type CloudBackupsApiTakeSnapshotQueryParams struct {
+type CloudBackupsApiTakeSnapshotParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
@@ -4201,7 +4201,7 @@ type CloudBackupsApiUpdateBackupScheduleRequest struct {
 	diskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
 }
 
-type CloudBackupsApiUpdateBackupScheduleQueryParams struct {
+type CloudBackupsApiUpdateBackupScheduleParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
@@ -4345,7 +4345,7 @@ type CloudBackupsApiUpdateDataProtectionSettingsRequest struct {
 	dataProtectionSettings *DataProtectionSettings
 }
 
-type CloudBackupsApiUpdateDataProtectionSettingsQueryParams struct {
+type CloudBackupsApiUpdateDataProtectionSettingsParams struct {
 		GroupId string
 		DataProtectionSettings *DataProtectionSettings
 }
@@ -4481,7 +4481,7 @@ type CloudBackupsApiUpdateSnapshotRetentionRequest struct {
 	snapshotRetention *SnapshotRetention
 }
 
-type CloudBackupsApiUpdateSnapshotRetentionQueryParams struct {
+type CloudBackupsApiUpdateSnapshotRetentionParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -503,10 +503,11 @@ type CloudBackupsApiCancelBackupRestoreJobRequest struct {
 	clusterName string
 	restoreJobId string
 }
+
 type CloudBackupsApiCancelBackupRestoreJobQueryParams struct {
-		groupId string
-		clusterName string
-		restoreJobId string
+		GroupId string
+		ClusterName string
+		RestoreJobId string
 }
 
 func (r CloudBackupsApiCancelBackupRestoreJobRequest) Execute() (*http.Response, error) {
@@ -634,10 +635,11 @@ type CloudBackupsApiCreateBackupExportJobRequest struct {
 	clusterName string
 	diskBackupExportJobRequest *DiskBackupExportJobRequest
 }
+
 type CloudBackupsApiCreateBackupExportJobQueryParams struct {
-		groupId string
-		clusterName string
-		diskBackupExportJobRequest *DiskBackupExportJobRequest
+		GroupId string
+		ClusterName string
+		DiskBackupExportJobRequest *DiskBackupExportJobRequest
 }
 
 // Information about the Cloud Backup Snapshot Export Job to create.
@@ -778,10 +780,11 @@ type CloudBackupsApiCreateBackupRestoreJobRequest struct {
 	clusterName string
 	diskBackupRestoreJob *DiskBackupRestoreJob
 }
+
 type CloudBackupsApiCreateBackupRestoreJobQueryParams struct {
-		groupId string
-		clusterName string
-		diskBackupRestoreJob *DiskBackupRestoreJob
+		GroupId string
+		ClusterName string
+		DiskBackupRestoreJob *DiskBackupRestoreJob
 }
 
 // Restores one snapshot of one cluster from the specified project.
@@ -923,9 +926,10 @@ type CloudBackupsApiCreateExportBucketRequest struct {
 	groupId string
 	diskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
+
 type CloudBackupsApiCreateExportBucketQueryParams struct {
-		groupId string
-		diskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
+		GroupId string
+		DiskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
 
 // Grants MongoDB Cloud access to the specified AWS S3 bucket.
@@ -1057,10 +1061,11 @@ type CloudBackupsApiCreateServerlessBackupRestoreJobRequest struct {
 	clusterName string
 	serverlessBackupRestoreJob *ServerlessBackupRestoreJob
 }
+
 type CloudBackupsApiCreateServerlessBackupRestoreJobQueryParams struct {
-		groupId string
-		clusterName string
-		serverlessBackupRestoreJob *ServerlessBackupRestoreJob
+		GroupId string
+		ClusterName string
+		ServerlessBackupRestoreJob *ServerlessBackupRestoreJob
 }
 
 // Restores one snapshot of one serverless instance from the specified project.
@@ -1200,9 +1205,10 @@ type CloudBackupsApiDeleteAllBackupSchedulesRequest struct {
 	groupId string
 	clusterName string
 }
+
 type CloudBackupsApiDeleteAllBackupSchedulesQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r CloudBackupsApiDeleteAllBackupSchedulesRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
@@ -1331,9 +1337,10 @@ type CloudBackupsApiDeleteExportBucketRequest struct {
 	groupId string
 	exportBucketId string
 }
+
 type CloudBackupsApiDeleteExportBucketQueryParams struct {
-		groupId string
-		exportBucketId string
+		GroupId string
+		ExportBucketId string
 }
 
 func (r CloudBackupsApiDeleteExportBucketRequest) Execute() (*http.Response, error) {
@@ -1452,10 +1459,11 @@ type CloudBackupsApiDeleteReplicaSetBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type CloudBackupsApiDeleteReplicaSetBackupQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r CloudBackupsApiDeleteReplicaSetBackupRequest) Execute() (*http.Response, error) {
@@ -1583,10 +1591,11 @@ type CloudBackupsApiDeleteShardedClusterBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type CloudBackupsApiDeleteShardedClusterBackupQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r CloudBackupsApiDeleteShardedClusterBackupRequest) Execute() (*http.Response, error) {
@@ -1714,10 +1723,11 @@ type CloudBackupsApiGetBackupExportJobRequest struct {
 	clusterName string
 	exportId string
 }
+
 type CloudBackupsApiGetBackupExportJobQueryParams struct {
-		groupId string
-		clusterName string
-		exportId string
+		GroupId string
+		ClusterName string
+		ExportId string
 }
 
 func (r CloudBackupsApiGetBackupExportJobRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
@@ -1850,10 +1860,11 @@ type CloudBackupsApiGetBackupRestoreJobRequest struct {
 	clusterName string
 	restoreJobId string
 }
+
 type CloudBackupsApiGetBackupRestoreJobQueryParams struct {
-		groupId string
-		clusterName string
-		restoreJobId string
+		GroupId string
+		ClusterName string
+		RestoreJobId string
 }
 
 func (r CloudBackupsApiGetBackupRestoreJobRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
@@ -1991,9 +2002,10 @@ type CloudBackupsApiGetBackupScheduleRequest struct {
 	groupId string
 	clusterName string
 }
+
 type CloudBackupsApiGetBackupScheduleQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r CloudBackupsApiGetBackupScheduleRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
@@ -2121,8 +2133,9 @@ type CloudBackupsApiGetDataProtectionSettingsRequest struct {
 	ApiService CloudBackupsApi
 	groupId string
 }
+
 type CloudBackupsApiGetDataProtectionSettingsQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r CloudBackupsApiGetDataProtectionSettingsRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
@@ -2242,9 +2255,10 @@ type CloudBackupsApiGetExportBucketRequest struct {
 	groupId string
 	exportBucketId string
 }
+
 type CloudBackupsApiGetExportBucketQueryParams struct {
-		groupId string
-		exportBucketId string
+		GroupId string
+		ExportBucketId string
 }
 
 func (r CloudBackupsApiGetExportBucketRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
@@ -2374,10 +2388,11 @@ type CloudBackupsApiGetReplicaSetBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type CloudBackupsApiGetReplicaSetBackupQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r CloudBackupsApiGetReplicaSetBackupRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
@@ -2516,10 +2531,11 @@ type CloudBackupsApiGetServerlessBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type CloudBackupsApiGetServerlessBackupQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r CloudBackupsApiGetServerlessBackupRequest) Execute() (*ServerlessBackupSnapshot, *http.Response, error) {
@@ -2658,10 +2674,11 @@ type CloudBackupsApiGetServerlessBackupRestoreJobRequest struct {
 	clusterName string
 	restoreJobId string
 }
+
 type CloudBackupsApiGetServerlessBackupRestoreJobQueryParams struct {
-		groupId string
-		clusterName string
-		restoreJobId string
+		GroupId string
+		ClusterName string
+		RestoreJobId string
 }
 
 func (r CloudBackupsApiGetServerlessBackupRestoreJobRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
@@ -2800,10 +2817,11 @@ type CloudBackupsApiGetShardedClusterBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type CloudBackupsApiGetShardedClusterBackupQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r CloudBackupsApiGetShardedClusterBackupRequest) Execute() (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
@@ -2944,12 +2962,13 @@ type CloudBackupsApiListBackupExportJobsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type CloudBackupsApiListBackupExportJobsQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -3120,12 +3139,13 @@ type CloudBackupsApiListBackupRestoreJobsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type CloudBackupsApiListBackupRestoreJobsQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -3292,8 +3312,9 @@ type CloudBackupsApiListExportBucketsRequest struct {
 	ApiService CloudBackupsApi
 	groupId string
 }
+
 type CloudBackupsApiListExportBucketsQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r CloudBackupsApiListExportBucketsRequest) Execute() (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
@@ -3416,12 +3437,13 @@ type CloudBackupsApiListReplicaSetBackupsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type CloudBackupsApiListReplicaSetBackupsQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -3589,9 +3611,10 @@ type CloudBackupsApiListServerlessBackupRestoreJobsRequest struct {
 	groupId string
 	clusterName string
 }
+
 type CloudBackupsApiListServerlessBackupRestoreJobsQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r CloudBackupsApiListServerlessBackupRestoreJobsRequest) Execute() (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
@@ -3723,12 +3746,13 @@ type CloudBackupsApiListServerlessBackupsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type CloudBackupsApiListServerlessBackupsQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -3896,9 +3920,10 @@ type CloudBackupsApiListShardedClusterBackupsRequest struct {
 	groupId string
 	clusterName string
 }
+
 type CloudBackupsApiListShardedClusterBackupsQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r CloudBackupsApiListShardedClusterBackupsRequest) Execute() (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
@@ -4028,10 +4053,11 @@ type CloudBackupsApiTakeSnapshotRequest struct {
 	clusterName string
 	diskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
 }
+
 type CloudBackupsApiTakeSnapshotQueryParams struct {
-		groupId string
-		clusterName string
-		diskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
+		GroupId string
+		ClusterName string
+		DiskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
 }
 
 // Takes one on-demand snapshot.
@@ -4174,10 +4200,11 @@ type CloudBackupsApiUpdateBackupScheduleRequest struct {
 	clusterName string
 	diskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
 }
+
 type CloudBackupsApiUpdateBackupScheduleQueryParams struct {
-		groupId string
-		clusterName string
-		diskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
+		GroupId string
+		ClusterName string
+		DiskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
 }
 
 // Updates the cloud backup schedule for one cluster within the specified project.  **Note**: In the request body, provide only the fields that you want to update.
@@ -4317,9 +4344,10 @@ type CloudBackupsApiUpdateDataProtectionSettingsRequest struct {
 	groupId string
 	dataProtectionSettings *DataProtectionSettings
 }
+
 type CloudBackupsApiUpdateDataProtectionSettingsQueryParams struct {
-		groupId string
-		dataProtectionSettings *DataProtectionSettings
+		GroupId string
+		DataProtectionSettings *DataProtectionSettings
 }
 
 // The new Backup Compliance Policy settings.
@@ -4452,11 +4480,12 @@ type CloudBackupsApiUpdateSnapshotRetentionRequest struct {
 	snapshotId string
 	snapshotRetention *SnapshotRetention
 }
+
 type CloudBackupsApiUpdateSnapshotRetentionQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
-		snapshotRetention *SnapshotRetention
+		GroupId string
+		ClusterName string
+		SnapshotId string
+		SnapshotRetention *SnapshotRetention
 }
 
 // Changes the expiration date for one cloud backup snapshot for one cluster in the specified project.

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -504,7 +504,7 @@ type CancelBackupRestoreJobApiRequest struct {
 	restoreJobId string
 }
 
-type CancelBackupRestoreJobParams struct {
+type CancelBackupRestoreJobApiParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -636,7 +636,7 @@ type CreateBackupExportJobApiRequest struct {
 	diskBackupExportJobRequest *DiskBackupExportJobRequest
 }
 
-type CreateBackupExportJobParams struct {
+type CreateBackupExportJobApiParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupExportJobRequest *DiskBackupExportJobRequest
@@ -781,7 +781,7 @@ type CreateBackupRestoreJobApiRequest struct {
 	diskBackupRestoreJob *DiskBackupRestoreJob
 }
 
-type CreateBackupRestoreJobParams struct {
+type CreateBackupRestoreJobApiParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupRestoreJob *DiskBackupRestoreJob
@@ -927,7 +927,7 @@ type CreateExportBucketApiRequest struct {
 	diskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
 
-type CreateExportBucketParams struct {
+type CreateExportBucketApiParams struct {
 		GroupId string
 		DiskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
@@ -1062,7 +1062,7 @@ type CreateServerlessBackupRestoreJobApiRequest struct {
 	serverlessBackupRestoreJob *ServerlessBackupRestoreJob
 }
 
-type CreateServerlessBackupRestoreJobParams struct {
+type CreateServerlessBackupRestoreJobApiParams struct {
 		GroupId string
 		ClusterName string
 		ServerlessBackupRestoreJob *ServerlessBackupRestoreJob
@@ -1206,7 +1206,7 @@ type DeleteAllBackupSchedulesApiRequest struct {
 	clusterName string
 }
 
-type DeleteAllBackupSchedulesParams struct {
+type DeleteAllBackupSchedulesApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -1338,7 +1338,7 @@ type DeleteExportBucketApiRequest struct {
 	exportBucketId string
 }
 
-type DeleteExportBucketParams struct {
+type DeleteExportBucketApiParams struct {
 		GroupId string
 		ExportBucketId string
 }
@@ -1460,7 +1460,7 @@ type DeleteReplicaSetBackupApiRequest struct {
 	snapshotId string
 }
 
-type DeleteReplicaSetBackupParams struct {
+type DeleteReplicaSetBackupApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1592,7 +1592,7 @@ type DeleteShardedClusterBackupApiRequest struct {
 	snapshotId string
 }
 
-type DeleteShardedClusterBackupParams struct {
+type DeleteShardedClusterBackupApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1724,7 +1724,7 @@ type GetBackupExportJobApiRequest struct {
 	exportId string
 }
 
-type GetBackupExportJobParams struct {
+type GetBackupExportJobApiParams struct {
 		GroupId string
 		ClusterName string
 		ExportId string
@@ -1861,7 +1861,7 @@ type GetBackupRestoreJobApiRequest struct {
 	restoreJobId string
 }
 
-type GetBackupRestoreJobParams struct {
+type GetBackupRestoreJobApiParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -2003,7 +2003,7 @@ type GetBackupScheduleApiRequest struct {
 	clusterName string
 }
 
-type GetBackupScheduleParams struct {
+type GetBackupScheduleApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -2134,7 +2134,7 @@ type GetDataProtectionSettingsApiRequest struct {
 	groupId string
 }
 
-type GetDataProtectionSettingsParams struct {
+type GetDataProtectionSettingsApiParams struct {
 		GroupId string
 }
 
@@ -2256,7 +2256,7 @@ type GetExportBucketApiRequest struct {
 	exportBucketId string
 }
 
-type GetExportBucketParams struct {
+type GetExportBucketApiParams struct {
 		GroupId string
 		ExportBucketId string
 }
@@ -2389,7 +2389,7 @@ type GetReplicaSetBackupApiRequest struct {
 	snapshotId string
 }
 
-type GetReplicaSetBackupParams struct {
+type GetReplicaSetBackupApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2532,7 +2532,7 @@ type GetServerlessBackupApiRequest struct {
 	snapshotId string
 }
 
-type GetServerlessBackupParams struct {
+type GetServerlessBackupApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2675,7 +2675,7 @@ type GetServerlessBackupRestoreJobApiRequest struct {
 	restoreJobId string
 }
 
-type GetServerlessBackupRestoreJobParams struct {
+type GetServerlessBackupRestoreJobApiParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJobId string
@@ -2818,7 +2818,7 @@ type GetShardedClusterBackupApiRequest struct {
 	snapshotId string
 }
 
-type GetShardedClusterBackupParams struct {
+type GetShardedClusterBackupApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -2963,7 +2963,7 @@ type ListBackupExportJobsApiRequest struct {
 	pageNum *int32
 }
 
-type ListBackupExportJobsParams struct {
+type ListBackupExportJobsApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3140,7 +3140,7 @@ type ListBackupRestoreJobsApiRequest struct {
 	pageNum *int32
 }
 
-type ListBackupRestoreJobsParams struct {
+type ListBackupRestoreJobsApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3313,7 +3313,7 @@ type ListExportBucketsApiRequest struct {
 	groupId string
 }
 
-type ListExportBucketsParams struct {
+type ListExportBucketsApiParams struct {
 		GroupId string
 }
 
@@ -3438,7 +3438,7 @@ type ListReplicaSetBackupsApiRequest struct {
 	pageNum *int32
 }
 
-type ListReplicaSetBackupsParams struct {
+type ListReplicaSetBackupsApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3612,7 +3612,7 @@ type ListServerlessBackupRestoreJobsApiRequest struct {
 	clusterName string
 }
 
-type ListServerlessBackupRestoreJobsParams struct {
+type ListServerlessBackupRestoreJobsApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -3747,7 +3747,7 @@ type ListServerlessBackupsApiRequest struct {
 	pageNum *int32
 }
 
-type ListServerlessBackupsParams struct {
+type ListServerlessBackupsApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -3921,7 +3921,7 @@ type ListShardedClusterBackupsApiRequest struct {
 	clusterName string
 }
 
-type ListShardedClusterBackupsParams struct {
+type ListShardedClusterBackupsApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -4054,7 +4054,7 @@ type TakeSnapshotApiRequest struct {
 	diskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
 }
 
-type TakeSnapshotParams struct {
+type TakeSnapshotApiParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
@@ -4201,7 +4201,7 @@ type UpdateBackupScheduleApiRequest struct {
 	diskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
 }
 
-type UpdateBackupScheduleParams struct {
+type UpdateBackupScheduleApiParams struct {
 		GroupId string
 		ClusterName string
 		DiskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
@@ -4345,7 +4345,7 @@ type UpdateDataProtectionSettingsApiRequest struct {
 	dataProtectionSettings *DataProtectionSettings
 }
 
-type UpdateDataProtectionSettingsParams struct {
+type UpdateDataProtectionSettingsApiParams struct {
 		GroupId string
 		DataProtectionSettings *DataProtectionSettings
 }
@@ -4481,7 +4481,7 @@ type UpdateSnapshotRetentionApiRequest struct {
 	snapshotRetention *SnapshotRetention
 }
 
-type UpdateSnapshotRetentionParams struct {
+type UpdateSnapshotRetentionApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -158,7 +158,7 @@ type CloudMigrationServiceApiCreateLinkTokenRequest struct {
 	targetOrgRequest *TargetOrgRequest
 }
 
-type CloudMigrationServiceApiCreateLinkTokenQueryParams struct {
+type CloudMigrationServiceApiCreateLinkTokenParams struct {
 		OrgId string
 		TargetOrgRequest *TargetOrgRequest
 }
@@ -292,7 +292,7 @@ type CloudMigrationServiceApiCreatePushMigrationRequest struct {
 	liveMigrationRequest *LiveMigrationRequest
 }
 
-type CloudMigrationServiceApiCreatePushMigrationQueryParams struct {
+type CloudMigrationServiceApiCreatePushMigrationParams struct {
 		GroupId string
 		LiveMigrationRequest *LiveMigrationRequest
 }
@@ -430,7 +430,7 @@ type CloudMigrationServiceApiCutoverMigrationRequest struct {
 	liveMigrationId string
 }
 
-type CloudMigrationServiceApiCutoverMigrationQueryParams struct {
+type CloudMigrationServiceApiCutoverMigrationParams struct {
 		GroupId string
 		LiveMigrationId string
 }
@@ -550,7 +550,7 @@ type CloudMigrationServiceApiDeleteLinkTokenRequest struct {
 	orgId string
 }
 
-type CloudMigrationServiceApiDeleteLinkTokenQueryParams struct {
+type CloudMigrationServiceApiDeleteLinkTokenParams struct {
 		OrgId string
 }
 
@@ -661,7 +661,7 @@ type CloudMigrationServiceApiGetPushMigrationRequest struct {
 	liveMigrationId string
 }
 
-type CloudMigrationServiceApiGetPushMigrationQueryParams struct {
+type CloudMigrationServiceApiGetPushMigrationParams struct {
 		GroupId string
 		LiveMigrationId string
 }
@@ -793,7 +793,7 @@ type CloudMigrationServiceApiGetValidationStatusRequest struct {
 	validationId string
 }
 
-type CloudMigrationServiceApiGetValidationStatusQueryParams struct {
+type CloudMigrationServiceApiGetValidationStatusParams struct {
 		GroupId string
 		ValidationId string
 }
@@ -924,7 +924,7 @@ type CloudMigrationServiceApiListSourceProjectsRequest struct {
 	orgId string
 }
 
-type CloudMigrationServiceApiListSourceProjectsQueryParams struct {
+type CloudMigrationServiceApiListSourceProjectsParams struct {
 		OrgId string
 }
 
@@ -1046,7 +1046,7 @@ type CloudMigrationServiceApiValidateMigrationRequest struct {
 	liveMigrationRequest *LiveMigrationRequest
 }
 
-type CloudMigrationServiceApiValidateMigrationQueryParams struct {
+type CloudMigrationServiceApiValidateMigrationParams struct {
 		GroupId string
 		LiveMigrationRequest *LiveMigrationRequest
 }

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -157,6 +157,10 @@ type CloudMigrationServiceApiCreateLinkTokenRequest struct {
 	orgId string
 	targetOrgRequest *TargetOrgRequest
 }
+type CloudMigrationServiceApiCreateLinkTokenQueryParams struct {
+		orgId string
+		targetOrgRequest *TargetOrgRequest
+}
 
 // IP address access list entries associated with the migration.
 func (r CloudMigrationServiceApiCreateLinkTokenRequest) TargetOrgRequest(targetOrgRequest TargetOrgRequest) CloudMigrationServiceApiCreateLinkTokenRequest {
@@ -285,6 +289,10 @@ type CloudMigrationServiceApiCreatePushMigrationRequest struct {
 	ApiService CloudMigrationServiceApi
 	groupId string
 	liveMigrationRequest *LiveMigrationRequest
+}
+type CloudMigrationServiceApiCreatePushMigrationQueryParams struct {
+		groupId string
+		liveMigrationRequest *LiveMigrationRequest
 }
 
 // One migration to be created.
@@ -419,6 +427,10 @@ type CloudMigrationServiceApiCutoverMigrationRequest struct {
 	groupId string
 	liveMigrationId string
 }
+type CloudMigrationServiceApiCutoverMigrationQueryParams struct {
+		groupId string
+		liveMigrationId string
+}
 
 func (r CloudMigrationServiceApiCutoverMigrationRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CutoverMigrationExecute(r)
@@ -534,6 +546,9 @@ type CloudMigrationServiceApiDeleteLinkTokenRequest struct {
 	ApiService CloudMigrationServiceApi
 	orgId string
 }
+type CloudMigrationServiceApiDeleteLinkTokenQueryParams struct {
+		orgId string
+}
 
 func (r CloudMigrationServiceApiDeleteLinkTokenRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLinkTokenExecute(r)
@@ -640,6 +655,10 @@ type CloudMigrationServiceApiGetPushMigrationRequest struct {
 	ApiService CloudMigrationServiceApi
 	groupId string
 	liveMigrationId string
+}
+type CloudMigrationServiceApiGetPushMigrationQueryParams struct {
+		groupId string
+		liveMigrationId string
 }
 
 func (r CloudMigrationServiceApiGetPushMigrationRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
@@ -768,6 +787,10 @@ type CloudMigrationServiceApiGetValidationStatusRequest struct {
 	groupId string
 	validationId string
 }
+type CloudMigrationServiceApiGetValidationStatusQueryParams struct {
+		groupId string
+		validationId string
+}
 
 func (r CloudMigrationServiceApiGetValidationStatusRequest) Execute() (*Validation, *http.Response, error) {
 	return r.ApiService.GetValidationStatusExecute(r)
@@ -894,6 +917,9 @@ type CloudMigrationServiceApiListSourceProjectsRequest struct {
 	ApiService CloudMigrationServiceApi
 	orgId string
 }
+type CloudMigrationServiceApiListSourceProjectsQueryParams struct {
+		orgId string
+}
 
 func (r CloudMigrationServiceApiListSourceProjectsRequest) Execute() ([]AvailableProject, *http.Response, error) {
 	return r.ApiService.ListSourceProjectsExecute(r)
@@ -1011,6 +1037,10 @@ type CloudMigrationServiceApiValidateMigrationRequest struct {
 	ApiService CloudMigrationServiceApi
 	groupId string
 	liveMigrationRequest *LiveMigrationRequest
+}
+type CloudMigrationServiceApiValidateMigrationQueryParams struct {
+		groupId string
+		liveMigrationRequest *LiveMigrationRequest
 }
 
 // One migration to be validated.

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -29,13 +29,13 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return CloudMigrationServiceApiCreateLinkTokenRequest
+	@return CreateLinkTokenApiRequest
 	*/
-	CreateLinkToken(ctx context.Context, orgId string) CloudMigrationServiceApiCreateLinkTokenRequest
+	CreateLinkToken(ctx context.Context, orgId string) CreateLinkTokenApiRequest
 
 	// CreateLinkTokenExecute executes the request
 	//  @return TargetOrg
-	CreateLinkTokenExecute(r CloudMigrationServiceApiCreateLinkTokenRequest) (*TargetOrg, *http.Response, error)
+	CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error)
 
 	/*
 	CreatePushMigration Migrate One Local Managed Cluster to MongoDB Atlas
@@ -48,13 +48,13 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudMigrationServiceApiCreatePushMigrationRequest
+	@return CreatePushMigrationApiRequest
 	*/
-	CreatePushMigration(ctx context.Context, groupId string) CloudMigrationServiceApiCreatePushMigrationRequest
+	CreatePushMigration(ctx context.Context, groupId string) CreatePushMigrationApiRequest
 
 	// CreatePushMigrationExecute executes the request
 	//  @return LiveMigrationResponse
-	CreatePushMigrationExecute(r CloudMigrationServiceApiCreatePushMigrationRequest) (*LiveMigrationResponse, *http.Response, error)
+	CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
 	CutoverMigration Cut Over the Migrated Cluster
@@ -64,12 +64,12 @@ type CloudMigrationServiceApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param liveMigrationId Unique 24-hexadecimal digit string that identifies the migration.
-	@return CloudMigrationServiceApiCutoverMigrationRequest
+	@return CutoverMigrationApiRequest
 	*/
-	CutoverMigration(ctx context.Context, groupId string, liveMigrationId string) CloudMigrationServiceApiCutoverMigrationRequest
+	CutoverMigration(ctx context.Context, groupId string, liveMigrationId string) CutoverMigrationApiRequest
 
 	// CutoverMigrationExecute executes the request
-	CutoverMigrationExecute(r CloudMigrationServiceApiCutoverMigrationRequest) (*http.Response, error)
+	CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error)
 
 	/*
 	DeleteLinkToken Remove One Link-Token
@@ -78,12 +78,12 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return CloudMigrationServiceApiDeleteLinkTokenRequest
+	@return DeleteLinkTokenApiRequest
 	*/
-	DeleteLinkToken(ctx context.Context, orgId string) CloudMigrationServiceApiDeleteLinkTokenRequest
+	DeleteLinkToken(ctx context.Context, orgId string) DeleteLinkTokenApiRequest
 
 	// DeleteLinkTokenExecute executes the request
-	DeleteLinkTokenExecute(r CloudMigrationServiceApiDeleteLinkTokenRequest) (*http.Response, error)
+	DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (*http.Response, error)
 
 	/*
 	GetPushMigration Return One Migration Job
@@ -93,13 +93,13 @@ type CloudMigrationServiceApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param liveMigrationId Unique 24-hexadecimal digit string that identifies the migration.
-	@return CloudMigrationServiceApiGetPushMigrationRequest
+	@return GetPushMigrationApiRequest
 	*/
-	GetPushMigration(ctx context.Context, groupId string, liveMigrationId string) CloudMigrationServiceApiGetPushMigrationRequest
+	GetPushMigration(ctx context.Context, groupId string, liveMigrationId string) GetPushMigrationApiRequest
 
 	// GetPushMigrationExecute executes the request
 	//  @return LiveMigrationResponse
-	GetPushMigrationExecute(r CloudMigrationServiceApiGetPushMigrationRequest) (*LiveMigrationResponse, *http.Response, error)
+	GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
 	GetValidationStatus Return One Migration Validation Job
@@ -109,13 +109,13 @@ type CloudMigrationServiceApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param validationId Unique 24-hexadecimal digit string that identifies the validation job.
-	@return CloudMigrationServiceApiGetValidationStatusRequest
+	@return GetValidationStatusApiRequest
 	*/
-	GetValidationStatus(ctx context.Context, groupId string, validationId string) CloudMigrationServiceApiGetValidationStatusRequest
+	GetValidationStatus(ctx context.Context, groupId string, validationId string) GetValidationStatusApiRequest
 
 	// GetValidationStatusExecute executes the request
 	//  @return Validation
-	GetValidationStatusExecute(r CloudMigrationServiceApiGetValidationStatusRequest) (*Validation, *http.Response, error)
+	GetValidationStatusExecute(r GetValidationStatusApiRequest) (*Validation, *http.Response, error)
 
 	/*
 	ListSourceProjects Return All Projects Available for Migration
@@ -124,13 +124,13 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return CloudMigrationServiceApiListSourceProjectsRequest
+	@return ListSourceProjectsApiRequest
 	*/
-	ListSourceProjects(ctx context.Context, orgId string) CloudMigrationServiceApiListSourceProjectsRequest
+	ListSourceProjects(ctx context.Context, orgId string) ListSourceProjectsApiRequest
 
 	// ListSourceProjectsExecute executes the request
 	//  @return []AvailableProject
-	ListSourceProjectsExecute(r CloudMigrationServiceApiListSourceProjectsRequest) ([]AvailableProject, *http.Response, error)
+	ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]AvailableProject, *http.Response, error)
 
 	/*
 	ValidateMigration Validate One Migration Request
@@ -139,19 +139,19 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudMigrationServiceApiValidateMigrationRequest
+	@return ValidateMigrationApiRequest
 	*/
-	ValidateMigration(ctx context.Context, groupId string) CloudMigrationServiceApiValidateMigrationRequest
+	ValidateMigration(ctx context.Context, groupId string) ValidateMigrationApiRequest
 
 	// ValidateMigrationExecute executes the request
 	//  @return Validation
-	ValidateMigrationExecute(r CloudMigrationServiceApiValidateMigrationRequest) (*Validation, *http.Response, error)
+	ValidateMigrationExecute(r ValidateMigrationApiRequest) (*Validation, *http.Response, error)
 }
 
 // CloudMigrationServiceApiService CloudMigrationServiceApi service
 type CloudMigrationServiceApiService service
 
-type CloudMigrationServiceApiCreateLinkTokenRequest struct {
+type CreateLinkTokenApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	orgId string
@@ -164,12 +164,12 @@ type CreateLinkTokenParams struct {
 }
 
 // IP address access list entries associated with the migration.
-func (r CloudMigrationServiceApiCreateLinkTokenRequest) TargetOrgRequest(targetOrgRequest TargetOrgRequest) CloudMigrationServiceApiCreateLinkTokenRequest {
+func (r CreateLinkTokenApiRequest) TargetOrgRequest(targetOrgRequest TargetOrgRequest) CreateLinkTokenApiRequest {
 	r.targetOrgRequest = &targetOrgRequest
 	return r
 }
 
-func (r CloudMigrationServiceApiCreateLinkTokenRequest) Execute() (*TargetOrg, *http.Response, error) {
+func (r CreateLinkTokenApiRequest) Execute() (*TargetOrg, *http.Response, error) {
 	return r.ApiService.CreateLinkTokenExecute(r)
 }
 
@@ -180,10 +180,10 @@ Create one link-token that contains all the information required to complete the
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return CloudMigrationServiceApiCreateLinkTokenRequest
+ @return CreateLinkTokenApiRequest
 */
-func (a *CloudMigrationServiceApiService) CreateLinkToken(ctx context.Context, orgId string) CloudMigrationServiceApiCreateLinkTokenRequest {
-	return CloudMigrationServiceApiCreateLinkTokenRequest{
+func (a *CloudMigrationServiceApiService) CreateLinkToken(ctx context.Context, orgId string) CreateLinkTokenApiRequest {
+	return CreateLinkTokenApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -192,7 +192,7 @@ func (a *CloudMigrationServiceApiService) CreateLinkToken(ctx context.Context, o
 
 // Execute executes the request
 //  @return TargetOrg
-func (a *CloudMigrationServiceApiService) CreateLinkTokenExecute(r CloudMigrationServiceApiCreateLinkTokenRequest) (*TargetOrg, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -285,7 +285,7 @@ func (a *CloudMigrationServiceApiService) CreateLinkTokenExecute(r CloudMigratio
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudMigrationServiceApiCreatePushMigrationRequest struct {
+type CreatePushMigrationApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	groupId string
@@ -298,12 +298,12 @@ type CreatePushMigrationParams struct {
 }
 
 // One migration to be created.
-func (r CloudMigrationServiceApiCreatePushMigrationRequest) LiveMigrationRequest(liveMigrationRequest LiveMigrationRequest) CloudMigrationServiceApiCreatePushMigrationRequest {
+func (r CreatePushMigrationApiRequest) LiveMigrationRequest(liveMigrationRequest LiveMigrationRequest) CreatePushMigrationApiRequest {
 	r.liveMigrationRequest = &liveMigrationRequest
 	return r
 }
 
-func (r CloudMigrationServiceApiCreatePushMigrationRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
+func (r CreatePushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
 	return r.ApiService.CreatePushMigrationExecute(r)
 }
 
@@ -318,10 +318,10 @@ Migrate one cluster that Cloud or Ops Manager manages to MongoDB Atlas.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudMigrationServiceApiCreatePushMigrationRequest
+ @return CreatePushMigrationApiRequest
 */
-func (a *CloudMigrationServiceApiService) CreatePushMigration(ctx context.Context, groupId string) CloudMigrationServiceApiCreatePushMigrationRequest {
-	return CloudMigrationServiceApiCreatePushMigrationRequest{
+func (a *CloudMigrationServiceApiService) CreatePushMigration(ctx context.Context, groupId string) CreatePushMigrationApiRequest {
+	return CreatePushMigrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -330,7 +330,7 @@ func (a *CloudMigrationServiceApiService) CreatePushMigration(ctx context.Contex
 
 // Execute executes the request
 //  @return LiveMigrationResponse
-func (a *CloudMigrationServiceApiService) CreatePushMigrationExecute(r CloudMigrationServiceApiCreatePushMigrationRequest) (*LiveMigrationResponse, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -423,7 +423,7 @@ func (a *CloudMigrationServiceApiService) CreatePushMigrationExecute(r CloudMigr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudMigrationServiceApiCutoverMigrationRequest struct {
+type CutoverMigrationApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	groupId string
@@ -435,7 +435,7 @@ type CutoverMigrationParams struct {
 		LiveMigrationId string
 }
 
-func (r CloudMigrationServiceApiCutoverMigrationRequest) Execute() (*http.Response, error) {
+func (r CutoverMigrationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CutoverMigrationExecute(r)
 }
 
@@ -447,10 +447,10 @@ Cut over the migrated cluster to MongoDB Atlas. Confirm when the cut over comple
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param liveMigrationId Unique 24-hexadecimal digit string that identifies the migration.
- @return CloudMigrationServiceApiCutoverMigrationRequest
+ @return CutoverMigrationApiRequest
 */
-func (a *CloudMigrationServiceApiService) CutoverMigration(ctx context.Context, groupId string, liveMigrationId string) CloudMigrationServiceApiCutoverMigrationRequest {
-	return CloudMigrationServiceApiCutoverMigrationRequest{
+func (a *CloudMigrationServiceApiService) CutoverMigration(ctx context.Context, groupId string, liveMigrationId string) CutoverMigrationApiRequest {
+	return CutoverMigrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -459,7 +459,7 @@ func (a *CloudMigrationServiceApiService) CutoverMigration(ctx context.Context, 
 }
 
 // Execute executes the request
-func (a *CloudMigrationServiceApiService) CutoverMigrationExecute(r CloudMigrationServiceApiCutoverMigrationRequest) (*http.Response, error) {
+func (a *CloudMigrationServiceApiService) CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}
@@ -544,7 +544,7 @@ func (a *CloudMigrationServiceApiService) CutoverMigrationExecute(r CloudMigrati
 	return localVarHTTPResponse, nil
 }
 
-type CloudMigrationServiceApiDeleteLinkTokenRequest struct {
+type DeleteLinkTokenApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	orgId string
@@ -554,7 +554,7 @@ type DeleteLinkTokenParams struct {
 		OrgId string
 }
 
-func (r CloudMigrationServiceApiDeleteLinkTokenRequest) Execute() (*http.Response, error) {
+func (r DeleteLinkTokenApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLinkTokenExecute(r)
 }
 
@@ -565,10 +565,10 @@ Remove one organization link and its associated public API key. MongoDB Atlas us
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return CloudMigrationServiceApiDeleteLinkTokenRequest
+ @return DeleteLinkTokenApiRequest
 */
-func (a *CloudMigrationServiceApiService) DeleteLinkToken(ctx context.Context, orgId string) CloudMigrationServiceApiDeleteLinkTokenRequest {
-	return CloudMigrationServiceApiDeleteLinkTokenRequest{
+func (a *CloudMigrationServiceApiService) DeleteLinkToken(ctx context.Context, orgId string) DeleteLinkTokenApiRequest {
+	return DeleteLinkTokenApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -576,7 +576,7 @@ func (a *CloudMigrationServiceApiService) DeleteLinkToken(ctx context.Context, o
 }
 
 // Execute executes the request
-func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r CloudMigrationServiceApiDeleteLinkTokenRequest) (*http.Response, error) {
+func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -654,7 +654,7 @@ func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r CloudMigratio
 	return localVarHTTPResponse, nil
 }
 
-type CloudMigrationServiceApiGetPushMigrationRequest struct {
+type GetPushMigrationApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	groupId string
@@ -666,7 +666,7 @@ type GetPushMigrationParams struct {
 		LiveMigrationId string
 }
 
-func (r CloudMigrationServiceApiGetPushMigrationRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
+func (r GetPushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
 	return r.ApiService.GetPushMigrationExecute(r)
 }
 
@@ -678,10 +678,10 @@ Return details of one cluster migration job. Each push live migration job uses o
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param liveMigrationId Unique 24-hexadecimal digit string that identifies the migration.
- @return CloudMigrationServiceApiGetPushMigrationRequest
+ @return GetPushMigrationApiRequest
 */
-func (a *CloudMigrationServiceApiService) GetPushMigration(ctx context.Context, groupId string, liveMigrationId string) CloudMigrationServiceApiGetPushMigrationRequest {
-	return CloudMigrationServiceApiGetPushMigrationRequest{
+func (a *CloudMigrationServiceApiService) GetPushMigration(ctx context.Context, groupId string, liveMigrationId string) GetPushMigrationApiRequest {
+	return GetPushMigrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -691,7 +691,7 @@ func (a *CloudMigrationServiceApiService) GetPushMigration(ctx context.Context, 
 
 // Execute executes the request
 //  @return LiveMigrationResponse
-func (a *CloudMigrationServiceApiService) GetPushMigrationExecute(r CloudMigrationServiceApiGetPushMigrationRequest) (*LiveMigrationResponse, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -786,7 +786,7 @@ func (a *CloudMigrationServiceApiService) GetPushMigrationExecute(r CloudMigrati
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudMigrationServiceApiGetValidationStatusRequest struct {
+type GetValidationStatusApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	groupId string
@@ -798,7 +798,7 @@ type GetValidationStatusParams struct {
 		ValidationId string
 }
 
-func (r CloudMigrationServiceApiGetValidationStatusRequest) Execute() (*Validation, *http.Response, error) {
+func (r GetValidationStatusApiRequest) Execute() (*Validation, *http.Response, error) {
 	return r.ApiService.GetValidationStatusExecute(r)
 }
 
@@ -810,10 +810,10 @@ Return the status of one migration validation job. Your API Key must have the Or
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param validationId Unique 24-hexadecimal digit string that identifies the validation job.
- @return CloudMigrationServiceApiGetValidationStatusRequest
+ @return GetValidationStatusApiRequest
 */
-func (a *CloudMigrationServiceApiService) GetValidationStatus(ctx context.Context, groupId string, validationId string) CloudMigrationServiceApiGetValidationStatusRequest {
-	return CloudMigrationServiceApiGetValidationStatusRequest{
+func (a *CloudMigrationServiceApiService) GetValidationStatus(ctx context.Context, groupId string, validationId string) GetValidationStatusApiRequest {
+	return GetValidationStatusApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -823,7 +823,7 @@ func (a *CloudMigrationServiceApiService) GetValidationStatus(ctx context.Contex
 
 // Execute executes the request
 //  @return Validation
-func (a *CloudMigrationServiceApiService) GetValidationStatusExecute(r CloudMigrationServiceApiGetValidationStatusRequest) (*Validation, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) GetValidationStatusExecute(r GetValidationStatusApiRequest) (*Validation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -918,7 +918,7 @@ func (a *CloudMigrationServiceApiService) GetValidationStatusExecute(r CloudMigr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudMigrationServiceApiListSourceProjectsRequest struct {
+type ListSourceProjectsApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	orgId string
@@ -928,7 +928,7 @@ type ListSourceProjectsParams struct {
 		OrgId string
 }
 
-func (r CloudMigrationServiceApiListSourceProjectsRequest) Execute() ([]AvailableProject, *http.Response, error) {
+func (r ListSourceProjectsApiRequest) Execute() ([]AvailableProject, *http.Response, error) {
 	return r.ApiService.ListSourceProjectsExecute(r)
 }
 
@@ -939,10 +939,10 @@ Return all projects that you can migrate to the specified organization.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return CloudMigrationServiceApiListSourceProjectsRequest
+ @return ListSourceProjectsApiRequest
 */
-func (a *CloudMigrationServiceApiService) ListSourceProjects(ctx context.Context, orgId string) CloudMigrationServiceApiListSourceProjectsRequest {
-	return CloudMigrationServiceApiListSourceProjectsRequest{
+func (a *CloudMigrationServiceApiService) ListSourceProjects(ctx context.Context, orgId string) ListSourceProjectsApiRequest {
+	return ListSourceProjectsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -951,7 +951,7 @@ func (a *CloudMigrationServiceApiService) ListSourceProjects(ctx context.Context
 
 // Execute executes the request
 //  @return []AvailableProject
-func (a *CloudMigrationServiceApiService) ListSourceProjectsExecute(r CloudMigrationServiceApiListSourceProjectsRequest) ([]AvailableProject, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]AvailableProject, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1039,7 +1039,7 @@ func (a *CloudMigrationServiceApiService) ListSourceProjectsExecute(r CloudMigra
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudMigrationServiceApiValidateMigrationRequest struct {
+type ValidateMigrationApiRequest struct {
 	ctx context.Context
 	ApiService CloudMigrationServiceApi
 	groupId string
@@ -1052,12 +1052,12 @@ type ValidateMigrationParams struct {
 }
 
 // One migration to be validated.
-func (r CloudMigrationServiceApiValidateMigrationRequest) LiveMigrationRequest(liveMigrationRequest LiveMigrationRequest) CloudMigrationServiceApiValidateMigrationRequest {
+func (r ValidateMigrationApiRequest) LiveMigrationRequest(liveMigrationRequest LiveMigrationRequest) ValidateMigrationApiRequest {
 	r.liveMigrationRequest = &liveMigrationRequest
 	return r
 }
 
-func (r CloudMigrationServiceApiValidateMigrationRequest) Execute() (*Validation, *http.Response, error) {
+func (r ValidateMigrationApiRequest) Execute() (*Validation, *http.Response, error) {
 	return r.ApiService.ValidateMigrationExecute(r)
 }
 
@@ -1068,10 +1068,10 @@ Verifies whether the provided credentials, available disk space, MongoDB version
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudMigrationServiceApiValidateMigrationRequest
+ @return ValidateMigrationApiRequest
 */
-func (a *CloudMigrationServiceApiService) ValidateMigration(ctx context.Context, groupId string) CloudMigrationServiceApiValidateMigrationRequest {
-	return CloudMigrationServiceApiValidateMigrationRequest{
+func (a *CloudMigrationServiceApiService) ValidateMigration(ctx context.Context, groupId string) ValidateMigrationApiRequest {
+	return ValidateMigrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1080,7 +1080,7 @@ func (a *CloudMigrationServiceApiService) ValidateMigration(ctx context.Context,
 
 // Execute executes the request
 //  @return Validation
-func (a *CloudMigrationServiceApiService) ValidateMigrationExecute(r CloudMigrationServiceApiValidateMigrationRequest) (*Validation, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) ValidateMigrationExecute(r ValidateMigrationApiRequest) (*Validation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -157,9 +157,10 @@ type CloudMigrationServiceApiCreateLinkTokenRequest struct {
 	orgId string
 	targetOrgRequest *TargetOrgRequest
 }
+
 type CloudMigrationServiceApiCreateLinkTokenQueryParams struct {
-		orgId string
-		targetOrgRequest *TargetOrgRequest
+		OrgId string
+		TargetOrgRequest *TargetOrgRequest
 }
 
 // IP address access list entries associated with the migration.
@@ -290,9 +291,10 @@ type CloudMigrationServiceApiCreatePushMigrationRequest struct {
 	groupId string
 	liveMigrationRequest *LiveMigrationRequest
 }
+
 type CloudMigrationServiceApiCreatePushMigrationQueryParams struct {
-		groupId string
-		liveMigrationRequest *LiveMigrationRequest
+		GroupId string
+		LiveMigrationRequest *LiveMigrationRequest
 }
 
 // One migration to be created.
@@ -427,9 +429,10 @@ type CloudMigrationServiceApiCutoverMigrationRequest struct {
 	groupId string
 	liveMigrationId string
 }
+
 type CloudMigrationServiceApiCutoverMigrationQueryParams struct {
-		groupId string
-		liveMigrationId string
+		GroupId string
+		LiveMigrationId string
 }
 
 func (r CloudMigrationServiceApiCutoverMigrationRequest) Execute() (*http.Response, error) {
@@ -546,8 +549,9 @@ type CloudMigrationServiceApiDeleteLinkTokenRequest struct {
 	ApiService CloudMigrationServiceApi
 	orgId string
 }
+
 type CloudMigrationServiceApiDeleteLinkTokenQueryParams struct {
-		orgId string
+		OrgId string
 }
 
 func (r CloudMigrationServiceApiDeleteLinkTokenRequest) Execute() (*http.Response, error) {
@@ -656,9 +660,10 @@ type CloudMigrationServiceApiGetPushMigrationRequest struct {
 	groupId string
 	liveMigrationId string
 }
+
 type CloudMigrationServiceApiGetPushMigrationQueryParams struct {
-		groupId string
-		liveMigrationId string
+		GroupId string
+		LiveMigrationId string
 }
 
 func (r CloudMigrationServiceApiGetPushMigrationRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
@@ -787,9 +792,10 @@ type CloudMigrationServiceApiGetValidationStatusRequest struct {
 	groupId string
 	validationId string
 }
+
 type CloudMigrationServiceApiGetValidationStatusQueryParams struct {
-		groupId string
-		validationId string
+		GroupId string
+		ValidationId string
 }
 
 func (r CloudMigrationServiceApiGetValidationStatusRequest) Execute() (*Validation, *http.Response, error) {
@@ -917,8 +923,9 @@ type CloudMigrationServiceApiListSourceProjectsRequest struct {
 	ApiService CloudMigrationServiceApi
 	orgId string
 }
+
 type CloudMigrationServiceApiListSourceProjectsQueryParams struct {
-		orgId string
+		OrgId string
 }
 
 func (r CloudMigrationServiceApiListSourceProjectsRequest) Execute() ([]AvailableProject, *http.Response, error) {
@@ -1038,9 +1045,10 @@ type CloudMigrationServiceApiValidateMigrationRequest struct {
 	groupId string
 	liveMigrationRequest *LiveMigrationRequest
 }
+
 type CloudMigrationServiceApiValidateMigrationQueryParams struct {
-		groupId string
-		liveMigrationRequest *LiveMigrationRequest
+		GroupId string
+		LiveMigrationRequest *LiveMigrationRequest
 }
 
 // One migration to be validated.

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -158,7 +158,7 @@ type CloudMigrationServiceApiCreateLinkTokenRequest struct {
 	targetOrgRequest *TargetOrgRequest
 }
 
-type CloudMigrationServiceApiCreateLinkTokenParams struct {
+type CreateLinkTokenParams struct {
 		OrgId string
 		TargetOrgRequest *TargetOrgRequest
 }
@@ -292,7 +292,7 @@ type CloudMigrationServiceApiCreatePushMigrationRequest struct {
 	liveMigrationRequest *LiveMigrationRequest
 }
 
-type CloudMigrationServiceApiCreatePushMigrationParams struct {
+type CreatePushMigrationParams struct {
 		GroupId string
 		LiveMigrationRequest *LiveMigrationRequest
 }
@@ -430,7 +430,7 @@ type CloudMigrationServiceApiCutoverMigrationRequest struct {
 	liveMigrationId string
 }
 
-type CloudMigrationServiceApiCutoverMigrationParams struct {
+type CutoverMigrationParams struct {
 		GroupId string
 		LiveMigrationId string
 }
@@ -550,7 +550,7 @@ type CloudMigrationServiceApiDeleteLinkTokenRequest struct {
 	orgId string
 }
 
-type CloudMigrationServiceApiDeleteLinkTokenParams struct {
+type DeleteLinkTokenParams struct {
 		OrgId string
 }
 
@@ -661,7 +661,7 @@ type CloudMigrationServiceApiGetPushMigrationRequest struct {
 	liveMigrationId string
 }
 
-type CloudMigrationServiceApiGetPushMigrationParams struct {
+type GetPushMigrationParams struct {
 		GroupId string
 		LiveMigrationId string
 }
@@ -793,7 +793,7 @@ type CloudMigrationServiceApiGetValidationStatusRequest struct {
 	validationId string
 }
 
-type CloudMigrationServiceApiGetValidationStatusParams struct {
+type GetValidationStatusParams struct {
 		GroupId string
 		ValidationId string
 }
@@ -924,7 +924,7 @@ type CloudMigrationServiceApiListSourceProjectsRequest struct {
 	orgId string
 }
 
-type CloudMigrationServiceApiListSourceProjectsParams struct {
+type ListSourceProjectsParams struct {
 		OrgId string
 }
 
@@ -1046,7 +1046,7 @@ type CloudMigrationServiceApiValidateMigrationRequest struct {
 	liveMigrationRequest *LiveMigrationRequest
 }
 
-type CloudMigrationServiceApiValidateMigrationParams struct {
+type ValidateMigrationParams struct {
 		GroupId string
 		LiveMigrationRequest *LiveMigrationRequest
 }

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -158,7 +158,7 @@ type CreateLinkTokenApiRequest struct {
 	targetOrgRequest *TargetOrgRequest
 }
 
-type CreateLinkTokenParams struct {
+type CreateLinkTokenApiParams struct {
 		OrgId string
 		TargetOrgRequest *TargetOrgRequest
 }
@@ -292,7 +292,7 @@ type CreatePushMigrationApiRequest struct {
 	liveMigrationRequest *LiveMigrationRequest
 }
 
-type CreatePushMigrationParams struct {
+type CreatePushMigrationApiParams struct {
 		GroupId string
 		LiveMigrationRequest *LiveMigrationRequest
 }
@@ -430,7 +430,7 @@ type CutoverMigrationApiRequest struct {
 	liveMigrationId string
 }
 
-type CutoverMigrationParams struct {
+type CutoverMigrationApiParams struct {
 		GroupId string
 		LiveMigrationId string
 }
@@ -550,7 +550,7 @@ type DeleteLinkTokenApiRequest struct {
 	orgId string
 }
 
-type DeleteLinkTokenParams struct {
+type DeleteLinkTokenApiParams struct {
 		OrgId string
 }
 
@@ -661,7 +661,7 @@ type GetPushMigrationApiRequest struct {
 	liveMigrationId string
 }
 
-type GetPushMigrationParams struct {
+type GetPushMigrationApiParams struct {
 		GroupId string
 		LiveMigrationId string
 }
@@ -793,7 +793,7 @@ type GetValidationStatusApiRequest struct {
 	validationId string
 }
 
-type GetValidationStatusParams struct {
+type GetValidationStatusApiParams struct {
 		GroupId string
 		ValidationId string
 }
@@ -924,7 +924,7 @@ type ListSourceProjectsApiRequest struct {
 	orgId string
 }
 
-type ListSourceProjectsParams struct {
+type ListSourceProjectsApiParams struct {
 		OrgId string
 }
 
@@ -1046,7 +1046,7 @@ type ValidateMigrationApiRequest struct {
 	liveMigrationRequest *LiveMigrationRequest
 }
 
-type ValidateMigrationParams struct {
+type ValidateMigrationApiParams struct {
 		GroupId string
 		LiveMigrationRequest *LiveMigrationRequest
 }

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -114,7 +114,7 @@ type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest struct {
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
 
-type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleQueryParams struct {
+type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleParams struct {
 		GroupId string
 		RoleId string
 		CloudProviderAccessRole *CloudProviderAccessRole
@@ -258,7 +258,7 @@ type CloudProviderAccessApiCreateCloudProviderAccessRoleRequest struct {
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
 
-type CloudProviderAccessApiCreateCloudProviderAccessRoleQueryParams struct {
+type CloudProviderAccessApiCreateCloudProviderAccessRoleParams struct {
 		GroupId string
 		CloudProviderAccessRole *CloudProviderAccessRole
 }
@@ -395,7 +395,7 @@ type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest struct {
 	roleId string
 }
 
-type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleQueryParams struct {
+type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleParams struct {
 		GroupId string
 		CloudProvider string
 		RoleId string
@@ -520,7 +520,7 @@ type CloudProviderAccessApiGetCloudProviderAccessRoleRequest struct {
 	roleId string
 }
 
-type CloudProviderAccessApiGetCloudProviderAccessRoleQueryParams struct {
+type CloudProviderAccessApiGetCloudProviderAccessRoleParams struct {
 		GroupId string
 		RoleId string
 }
@@ -651,7 +651,7 @@ type CloudProviderAccessApiListCloudProviderAccessRolesRequest struct {
 	groupId string
 }
 
-type CloudProviderAccessApiListCloudProviderAccessRolesQueryParams struct {
+type CloudProviderAccessApiListCloudProviderAccessRolesParams struct {
 		GroupId string
 }
 

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -113,6 +113,11 @@ type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest struct {
 	roleId string
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
+type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleQueryParams struct {
+		groupId string
+		roleId string
+		cloudProviderAccessRole *CloudProviderAccessRole
+}
 
 // Grants access to the specified project for the specified AWS IAM role.
 func (r CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest {
@@ -251,6 +256,10 @@ type CloudProviderAccessApiCreateCloudProviderAccessRoleRequest struct {
 	groupId string
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
+type CloudProviderAccessApiCreateCloudProviderAccessRoleQueryParams struct {
+		groupId string
+		cloudProviderAccessRole *CloudProviderAccessRole
+}
 
 // Creates one AWS IAM role.
 func (r CloudProviderAccessApiCreateCloudProviderAccessRoleRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) CloudProviderAccessApiCreateCloudProviderAccessRoleRequest {
@@ -383,6 +392,11 @@ type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest struct {
 	cloudProvider string
 	roleId string
 }
+type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleQueryParams struct {
+		groupId string
+		cloudProvider string
+		roleId string
+}
 
 func (r CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeauthorizeCloudProviderAccessRoleExecute(r)
@@ -501,6 +515,10 @@ type CloudProviderAccessApiGetCloudProviderAccessRoleRequest struct {
 	ApiService CloudProviderAccessApi
 	groupId string
 	roleId string
+}
+type CloudProviderAccessApiGetCloudProviderAccessRoleQueryParams struct {
+		groupId string
+		roleId string
 }
 
 func (r CloudProviderAccessApiGetCloudProviderAccessRoleRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
@@ -627,6 +645,9 @@ type CloudProviderAccessApiListCloudProviderAccessRolesRequest struct {
 	ctx context.Context
 	ApiService CloudProviderAccessApi
 	groupId string
+}
+type CloudProviderAccessApiListCloudProviderAccessRolesQueryParams struct {
+		groupId string
 }
 
 func (r CloudProviderAccessApiListCloudProviderAccessRolesRequest) Execute() (*CloudProviderAccess, *http.Response, error) {

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -114,7 +114,7 @@ type AuthorizeCloudProviderAccessRoleApiRequest struct {
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
 
-type AuthorizeCloudProviderAccessRoleParams struct {
+type AuthorizeCloudProviderAccessRoleApiParams struct {
 		GroupId string
 		RoleId string
 		CloudProviderAccessRole *CloudProviderAccessRole
@@ -258,7 +258,7 @@ type CreateCloudProviderAccessRoleApiRequest struct {
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
 
-type CreateCloudProviderAccessRoleParams struct {
+type CreateCloudProviderAccessRoleApiParams struct {
 		GroupId string
 		CloudProviderAccessRole *CloudProviderAccessRole
 }
@@ -395,7 +395,7 @@ type DeauthorizeCloudProviderAccessRoleApiRequest struct {
 	roleId string
 }
 
-type DeauthorizeCloudProviderAccessRoleParams struct {
+type DeauthorizeCloudProviderAccessRoleApiParams struct {
 		GroupId string
 		CloudProvider string
 		RoleId string
@@ -520,7 +520,7 @@ type GetCloudProviderAccessRoleApiRequest struct {
 	roleId string
 }
 
-type GetCloudProviderAccessRoleParams struct {
+type GetCloudProviderAccessRoleApiParams struct {
 		GroupId string
 		RoleId string
 }
@@ -651,7 +651,7 @@ type ListCloudProviderAccessRolesApiRequest struct {
 	groupId string
 }
 
-type ListCloudProviderAccessRolesParams struct {
+type ListCloudProviderAccessRolesApiParams struct {
 		GroupId string
 }
 

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -114,7 +114,7 @@ type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest struct {
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
 
-type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleParams struct {
+type AuthorizeCloudProviderAccessRoleParams struct {
 		GroupId string
 		RoleId string
 		CloudProviderAccessRole *CloudProviderAccessRole
@@ -258,7 +258,7 @@ type CloudProviderAccessApiCreateCloudProviderAccessRoleRequest struct {
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
 
-type CloudProviderAccessApiCreateCloudProviderAccessRoleParams struct {
+type CreateCloudProviderAccessRoleParams struct {
 		GroupId string
 		CloudProviderAccessRole *CloudProviderAccessRole
 }
@@ -395,7 +395,7 @@ type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest struct {
 	roleId string
 }
 
-type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleParams struct {
+type DeauthorizeCloudProviderAccessRoleParams struct {
 		GroupId string
 		CloudProvider string
 		RoleId string
@@ -520,7 +520,7 @@ type CloudProviderAccessApiGetCloudProviderAccessRoleRequest struct {
 	roleId string
 }
 
-type CloudProviderAccessApiGetCloudProviderAccessRoleParams struct {
+type GetCloudProviderAccessRoleParams struct {
 		GroupId string
 		RoleId string
 }
@@ -651,7 +651,7 @@ type CloudProviderAccessApiListCloudProviderAccessRolesRequest struct {
 	groupId string
 }
 
-type CloudProviderAccessApiListCloudProviderAccessRolesParams struct {
+type ListCloudProviderAccessRolesParams struct {
 		GroupId string
 }
 

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -113,10 +113,11 @@ type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest struct {
 	roleId string
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
+
 type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleQueryParams struct {
-		groupId string
-		roleId string
-		cloudProviderAccessRole *CloudProviderAccessRole
+		GroupId string
+		RoleId string
+		CloudProviderAccessRole *CloudProviderAccessRole
 }
 
 // Grants access to the specified project for the specified AWS IAM role.
@@ -256,9 +257,10 @@ type CloudProviderAccessApiCreateCloudProviderAccessRoleRequest struct {
 	groupId string
 	cloudProviderAccessRole *CloudProviderAccessRole
 }
+
 type CloudProviderAccessApiCreateCloudProviderAccessRoleQueryParams struct {
-		groupId string
-		cloudProviderAccessRole *CloudProviderAccessRole
+		GroupId string
+		CloudProviderAccessRole *CloudProviderAccessRole
 }
 
 // Creates one AWS IAM role.
@@ -392,10 +394,11 @@ type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest struct {
 	cloudProvider string
 	roleId string
 }
+
 type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleQueryParams struct {
-		groupId string
-		cloudProvider string
-		roleId string
+		GroupId string
+		CloudProvider string
+		RoleId string
 }
 
 func (r CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest) Execute() (*http.Response, error) {
@@ -516,9 +519,10 @@ type CloudProviderAccessApiGetCloudProviderAccessRoleRequest struct {
 	groupId string
 	roleId string
 }
+
 type CloudProviderAccessApiGetCloudProviderAccessRoleQueryParams struct {
-		groupId string
-		roleId string
+		GroupId string
+		RoleId string
 }
 
 func (r CloudProviderAccessApiGetCloudProviderAccessRoleRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
@@ -646,8 +650,9 @@ type CloudProviderAccessApiListCloudProviderAccessRolesRequest struct {
 	ApiService CloudProviderAccessApi
 	groupId string
 }
+
 type CloudProviderAccessApiListCloudProviderAccessRolesQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r CloudProviderAccessApiListCloudProviderAccessRolesRequest) Execute() (*CloudProviderAccess, *http.Response, error) {

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -30,13 +30,13 @@ type CloudProviderAccessApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param roleId Unique 24-hexadecimal digit string that identifies the role.
-	@return CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest
+	@return AuthorizeCloudProviderAccessRoleApiRequest
 	*/
-	AuthorizeCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest
+	AuthorizeCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) AuthorizeCloudProviderAccessRoleApiRequest
 
 	// AuthorizeCloudProviderAccessRoleExecute executes the request
 	//  @return CloudProviderAccessRole
-	AuthorizeCloudProviderAccessRoleExecute(r CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest) (*CloudProviderAccessRole, *http.Response, error)
+	AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
 	CreateCloudProviderAccessRole Create One Cloud Provider Access Role
@@ -47,13 +47,13 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudProviderAccessApiCreateCloudProviderAccessRoleRequest
+	@return CreateCloudProviderAccessRoleApiRequest
 	*/
-	CreateCloudProviderAccessRole(ctx context.Context, groupId string) CloudProviderAccessApiCreateCloudProviderAccessRoleRequest
+	CreateCloudProviderAccessRole(ctx context.Context, groupId string) CreateCloudProviderAccessRoleApiRequest
 
 	// CreateCloudProviderAccessRoleExecute executes the request
 	//  @return CloudProviderAccessRole
-	CreateCloudProviderAccessRoleExecute(r CloudProviderAccessApiCreateCloudProviderAccessRoleRequest) (*CloudProviderAccessRole, *http.Response, error)
+	CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
 	DeauthorizeCloudProviderAccessRole Deauthorize One Cloud Provider Access Role
@@ -64,12 +64,12 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param cloudProvider Human-readable label that identifies the cloud provider of the role to deauthorize.
 	@param roleId Unique 24-hexadecimal digit string that identifies the role.
-	@return CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest
+	@return DeauthorizeCloudProviderAccessRoleApiRequest
 	*/
-	DeauthorizeCloudProviderAccessRole(ctx context.Context, groupId string, cloudProvider string, roleId string) CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest
+	DeauthorizeCloudProviderAccessRole(ctx context.Context, groupId string, cloudProvider string, roleId string) DeauthorizeCloudProviderAccessRoleApiRequest
 
 	// DeauthorizeCloudProviderAccessRoleExecute executes the request
-	DeauthorizeCloudProviderAccessRoleExecute(r CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest) (*http.Response, error)
+	DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error)
 
 	/*
 	GetCloudProviderAccessRole Return specified Cloud Provider Access Role
@@ -79,13 +79,13 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param roleId Unique 24-hexadecimal digit string that identifies the role.
-	@return CloudProviderAccessApiGetCloudProviderAccessRoleRequest
+	@return GetCloudProviderAccessRoleApiRequest
 	*/
-	GetCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) CloudProviderAccessApiGetCloudProviderAccessRoleRequest
+	GetCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) GetCloudProviderAccessRoleApiRequest
 
 	// GetCloudProviderAccessRoleExecute executes the request
 	//  @return CloudProviderAccess
-	GetCloudProviderAccessRoleExecute(r CloudProviderAccessApiGetCloudProviderAccessRoleRequest) (*CloudProviderAccess, *http.Response, error)
+	GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccess, *http.Response, error)
 
 	/*
 	ListCloudProviderAccessRoles Return All Cloud Provider Access Roles
@@ -94,19 +94,19 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CloudProviderAccessApiListCloudProviderAccessRolesRequest
+	@return ListCloudProviderAccessRolesApiRequest
 	*/
-	ListCloudProviderAccessRoles(ctx context.Context, groupId string) CloudProviderAccessApiListCloudProviderAccessRolesRequest
+	ListCloudProviderAccessRoles(ctx context.Context, groupId string) ListCloudProviderAccessRolesApiRequest
 
 	// ListCloudProviderAccessRolesExecute executes the request
 	//  @return CloudProviderAccess
-	ListCloudProviderAccessRolesExecute(r CloudProviderAccessApiListCloudProviderAccessRolesRequest) (*CloudProviderAccess, *http.Response, error)
+	ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccess, *http.Response, error)
 }
 
 // CloudProviderAccessApiService CloudProviderAccessApi service
 type CloudProviderAccessApiService service
 
-type CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest struct {
+type AuthorizeCloudProviderAccessRoleApiRequest struct {
 	ctx context.Context
 	ApiService CloudProviderAccessApi
 	groupId string
@@ -121,12 +121,12 @@ type AuthorizeCloudProviderAccessRoleParams struct {
 }
 
 // Grants access to the specified project for the specified AWS IAM role.
-func (r CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest {
+func (r AuthorizeCloudProviderAccessRoleApiRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) AuthorizeCloudProviderAccessRoleApiRequest {
 	r.cloudProviderAccessRole = &cloudProviderAccessRole
 	return r
 }
 
-func (r CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
+func (r AuthorizeCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
 	return r.ApiService.AuthorizeCloudProviderAccessRoleExecute(r)
 }
 
@@ -138,10 +138,10 @@ Grants access to the specified project for the specified Amazon Web Services (AW
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param roleId Unique 24-hexadecimal digit string that identifies the role.
- @return CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest
+ @return AuthorizeCloudProviderAccessRoleApiRequest
 */
-func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest {
-	return CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest{
+func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) AuthorizeCloudProviderAccessRoleApiRequest {
+	return AuthorizeCloudProviderAccessRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -151,7 +151,7 @@ func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRole(ctx con
 
 // Execute executes the request
 //  @return CloudProviderAccessRole
-func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleExecute(r CloudProviderAccessApiAuthorizeCloudProviderAccessRoleRequest) (*CloudProviderAccessRole, *http.Response, error) {
+func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -251,7 +251,7 @@ func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleExecute(
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudProviderAccessApiCreateCloudProviderAccessRoleRequest struct {
+type CreateCloudProviderAccessRoleApiRequest struct {
 	ctx context.Context
 	ApiService CloudProviderAccessApi
 	groupId string
@@ -264,12 +264,12 @@ type CreateCloudProviderAccessRoleParams struct {
 }
 
 // Creates one AWS IAM role.
-func (r CloudProviderAccessApiCreateCloudProviderAccessRoleRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) CloudProviderAccessApiCreateCloudProviderAccessRoleRequest {
+func (r CreateCloudProviderAccessRoleApiRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) CreateCloudProviderAccessRoleApiRequest {
 	r.cloudProviderAccessRole = &cloudProviderAccessRole
 	return r
 }
 
-func (r CloudProviderAccessApiCreateCloudProviderAccessRoleRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
+func (r CreateCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
 	return r.ApiService.CreateCloudProviderAccessRoleExecute(r)
 }
 
@@ -282,10 +282,10 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudProviderAccessApiCreateCloudProviderAccessRoleRequest
+ @return CreateCloudProviderAccessRoleApiRequest
 */
-func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRole(ctx context.Context, groupId string) CloudProviderAccessApiCreateCloudProviderAccessRoleRequest {
-	return CloudProviderAccessApiCreateCloudProviderAccessRoleRequest{
+func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRole(ctx context.Context, groupId string) CreateCloudProviderAccessRoleApiRequest {
+	return CreateCloudProviderAccessRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -294,7 +294,7 @@ func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRole(ctx contex
 
 // Execute executes the request
 //  @return CloudProviderAccessRole
-func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleExecute(r CloudProviderAccessApiCreateCloudProviderAccessRoleRequest) (*CloudProviderAccessRole, *http.Response, error) {
+func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -387,7 +387,7 @@ func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleExecute(r C
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest struct {
+type DeauthorizeCloudProviderAccessRoleApiRequest struct {
 	ctx context.Context
 	ApiService CloudProviderAccessApi
 	groupId string
@@ -401,7 +401,7 @@ type DeauthorizeCloudProviderAccessRoleParams struct {
 		RoleId string
 }
 
-func (r CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest) Execute() (*http.Response, error) {
+func (r DeauthorizeCloudProviderAccessRoleApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeauthorizeCloudProviderAccessRoleExecute(r)
 }
 
@@ -414,10 +414,10 @@ Revokes access to the specified project for the specified AWS IAM role. To use t
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param cloudProvider Human-readable label that identifies the cloud provider of the role to deauthorize.
  @param roleId Unique 24-hexadecimal digit string that identifies the role.
- @return CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest
+ @return DeauthorizeCloudProviderAccessRoleApiRequest
 */
-func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRole(ctx context.Context, groupId string, cloudProvider string, roleId string) CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest {
-	return CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest{
+func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRole(ctx context.Context, groupId string, cloudProvider string, roleId string) DeauthorizeCloudProviderAccessRoleApiRequest {
+	return DeauthorizeCloudProviderAccessRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -427,7 +427,7 @@ func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRole(ctx c
 }
 
 // Execute executes the request
-func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleExecute(r CloudProviderAccessApiDeauthorizeCloudProviderAccessRoleRequest) (*http.Response, error) {
+func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -513,7 +513,7 @@ func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleExecut
 	return localVarHTTPResponse, nil
 }
 
-type CloudProviderAccessApiGetCloudProviderAccessRoleRequest struct {
+type GetCloudProviderAccessRoleApiRequest struct {
 	ctx context.Context
 	ApiService CloudProviderAccessApi
 	groupId string
@@ -525,7 +525,7 @@ type GetCloudProviderAccessRoleParams struct {
 		RoleId string
 }
 
-func (r CloudProviderAccessApiGetCloudProviderAccessRoleRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
+func (r GetCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
 	return r.ApiService.GetCloudProviderAccessRoleExecute(r)
 }
 
@@ -537,10 +537,10 @@ Returns the Amazon Web Services (AWS) Identity and Access Management (IAM) role 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param roleId Unique 24-hexadecimal digit string that identifies the role.
- @return CloudProviderAccessApiGetCloudProviderAccessRoleRequest
+ @return GetCloudProviderAccessRoleApiRequest
 */
-func (a *CloudProviderAccessApiService) GetCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) CloudProviderAccessApiGetCloudProviderAccessRoleRequest {
-	return CloudProviderAccessApiGetCloudProviderAccessRoleRequest{
+func (a *CloudProviderAccessApiService) GetCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) GetCloudProviderAccessRoleApiRequest {
+	return GetCloudProviderAccessRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -550,7 +550,7 @@ func (a *CloudProviderAccessApiService) GetCloudProviderAccessRole(ctx context.C
 
 // Execute executes the request
 //  @return CloudProviderAccess
-func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleExecute(r CloudProviderAccessApiGetCloudProviderAccessRoleRequest) (*CloudProviderAccess, *http.Response, error) {
+func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -645,7 +645,7 @@ func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleExecute(r Clou
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CloudProviderAccessApiListCloudProviderAccessRolesRequest struct {
+type ListCloudProviderAccessRolesApiRequest struct {
 	ctx context.Context
 	ApiService CloudProviderAccessApi
 	groupId string
@@ -655,7 +655,7 @@ type ListCloudProviderAccessRolesParams struct {
 		GroupId string
 }
 
-func (r CloudProviderAccessApiListCloudProviderAccessRolesRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
+func (r ListCloudProviderAccessRolesApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
 	return r.ApiService.ListCloudProviderAccessRolesExecute(r)
 }
 
@@ -666,10 +666,10 @@ Returns all Amazon Web Services (AWS) Identity and Access Management (IAM) roles
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CloudProviderAccessApiListCloudProviderAccessRolesRequest
+ @return ListCloudProviderAccessRolesApiRequest
 */
-func (a *CloudProviderAccessApiService) ListCloudProviderAccessRoles(ctx context.Context, groupId string) CloudProviderAccessApiListCloudProviderAccessRolesRequest {
-	return CloudProviderAccessApiListCloudProviderAccessRolesRequest{
+func (a *CloudProviderAccessApiService) ListCloudProviderAccessRoles(ctx context.Context, groupId string) ListCloudProviderAccessRolesApiRequest {
+	return ListCloudProviderAccessRolesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -678,7 +678,7 @@ func (a *CloudProviderAccessApiService) ListCloudProviderAccessRoles(ctx context
 
 // Execute executes the request
 //  @return CloudProviderAccess
-func (a *CloudProviderAccessApiService) ListCloudProviderAccessRolesExecute(r CloudProviderAccessApiListCloudProviderAccessRolesRequest) (*CloudProviderAccess, *http.Response, error) {
+func (a *CloudProviderAccessApiService) ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -30,13 +30,13 @@ type ClusterOutageSimulationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster that is undergoing outage simulation.
-	@return ClusterOutageSimulationApiEndOutageSimulationRequest
+	@return EndOutageSimulationApiRequest
 	*/
-	EndOutageSimulation(ctx context.Context, groupId string, clusterName string) ClusterOutageSimulationApiEndOutageSimulationRequest
+	EndOutageSimulation(ctx context.Context, groupId string, clusterName string) EndOutageSimulationApiRequest
 
 	// EndOutageSimulationExecute executes the request
 	//  @return ClusterOutageSimulation
-	EndOutageSimulationExecute(r ClusterOutageSimulationApiEndOutageSimulationRequest) (*ClusterOutageSimulation, *http.Response, error)
+	EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
 	GetOutageSimulation Return One Outage Simulation
@@ -46,13 +46,13 @@ type ClusterOutageSimulationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster that is undergoing outage simulation.
-	@return ClusterOutageSimulationApiGetOutageSimulationRequest
+	@return GetOutageSimulationApiRequest
 	*/
-	GetOutageSimulation(ctx context.Context, groupId string, clusterName string) ClusterOutageSimulationApiGetOutageSimulationRequest
+	GetOutageSimulation(ctx context.Context, groupId string, clusterName string) GetOutageSimulationApiRequest
 
 	// GetOutageSimulationExecute executes the request
 	//  @return ClusterOutageSimulation
-	GetOutageSimulationExecute(r ClusterOutageSimulationApiGetOutageSimulationRequest) (*ClusterOutageSimulation, *http.Response, error)
+	GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
 	StartOutageSimulation Start an Outage Simulation
@@ -62,19 +62,19 @@ type ClusterOutageSimulationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster to undergo an outage simulation.
-	@return ClusterOutageSimulationApiStartOutageSimulationRequest
+	@return StartOutageSimulationApiRequest
 	*/
-	StartOutageSimulation(ctx context.Context, groupId string, clusterName string) ClusterOutageSimulationApiStartOutageSimulationRequest
+	StartOutageSimulation(ctx context.Context, groupId string, clusterName string) StartOutageSimulationApiRequest
 
 	// StartOutageSimulationExecute executes the request
 	//  @return ClusterOutageSimulation
-	StartOutageSimulationExecute(r ClusterOutageSimulationApiStartOutageSimulationRequest) (*ClusterOutageSimulation, *http.Response, error)
+	StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 }
 
 // ClusterOutageSimulationApiService ClusterOutageSimulationApi service
 type ClusterOutageSimulationApiService service
 
-type ClusterOutageSimulationApiEndOutageSimulationRequest struct {
+type EndOutageSimulationApiRequest struct {
 	ctx context.Context
 	ApiService ClusterOutageSimulationApi
 	groupId string
@@ -86,7 +86,7 @@ type EndOutageSimulationParams struct {
 		ClusterName string
 }
 
-func (r ClusterOutageSimulationApiEndOutageSimulationRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
+func (r EndOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
 	return r.ApiService.EndOutageSimulationExecute(r)
 }
 
@@ -98,10 +98,10 @@ Ends a cluster outage simulation.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster that is undergoing outage simulation.
- @return ClusterOutageSimulationApiEndOutageSimulationRequest
+ @return EndOutageSimulationApiRequest
 */
-func (a *ClusterOutageSimulationApiService) EndOutageSimulation(ctx context.Context, groupId string, clusterName string) ClusterOutageSimulationApiEndOutageSimulationRequest {
-	return ClusterOutageSimulationApiEndOutageSimulationRequest{
+func (a *ClusterOutageSimulationApiService) EndOutageSimulation(ctx context.Context, groupId string, clusterName string) EndOutageSimulationApiRequest {
+	return EndOutageSimulationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -111,7 +111,7 @@ func (a *ClusterOutageSimulationApiService) EndOutageSimulation(ctx context.Cont
 
 // Execute executes the request
 //  @return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) EndOutageSimulationExecute(r ClusterOutageSimulationApiEndOutageSimulationRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -206,7 +206,7 @@ func (a *ClusterOutageSimulationApiService) EndOutageSimulationExecute(r Cluster
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClusterOutageSimulationApiGetOutageSimulationRequest struct {
+type GetOutageSimulationApiRequest struct {
 	ctx context.Context
 	ApiService ClusterOutageSimulationApi
 	groupId string
@@ -218,7 +218,7 @@ type GetOutageSimulationParams struct {
 		ClusterName string
 }
 
-func (r ClusterOutageSimulationApiGetOutageSimulationRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
+func (r GetOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
 	return r.ApiService.GetOutageSimulationExecute(r)
 }
 
@@ -230,10 +230,10 @@ Returns one outage simulation for one cluster.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster that is undergoing outage simulation.
- @return ClusterOutageSimulationApiGetOutageSimulationRequest
+ @return GetOutageSimulationApiRequest
 */
-func (a *ClusterOutageSimulationApiService) GetOutageSimulation(ctx context.Context, groupId string, clusterName string) ClusterOutageSimulationApiGetOutageSimulationRequest {
-	return ClusterOutageSimulationApiGetOutageSimulationRequest{
+func (a *ClusterOutageSimulationApiService) GetOutageSimulation(ctx context.Context, groupId string, clusterName string) GetOutageSimulationApiRequest {
+	return GetOutageSimulationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -243,7 +243,7 @@ func (a *ClusterOutageSimulationApiService) GetOutageSimulation(ctx context.Cont
 
 // Execute executes the request
 //  @return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) GetOutageSimulationExecute(r ClusterOutageSimulationApiGetOutageSimulationRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -338,7 +338,7 @@ func (a *ClusterOutageSimulationApiService) GetOutageSimulationExecute(r Cluster
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClusterOutageSimulationApiStartOutageSimulationRequest struct {
+type StartOutageSimulationApiRequest struct {
 	ctx context.Context
 	ApiService ClusterOutageSimulationApi
 	groupId string
@@ -353,12 +353,12 @@ type StartOutageSimulationParams struct {
 }
 
 // Describes the outage simulation.
-func (r ClusterOutageSimulationApiStartOutageSimulationRequest) ClusterOutageSimulation(clusterOutageSimulation ClusterOutageSimulation) ClusterOutageSimulationApiStartOutageSimulationRequest {
+func (r StartOutageSimulationApiRequest) ClusterOutageSimulation(clusterOutageSimulation ClusterOutageSimulation) StartOutageSimulationApiRequest {
 	r.clusterOutageSimulation = &clusterOutageSimulation
 	return r
 }
 
-func (r ClusterOutageSimulationApiStartOutageSimulationRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
+func (r StartOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
 	return r.ApiService.StartOutageSimulationExecute(r)
 }
 
@@ -370,10 +370,10 @@ Starts a cluster outage simulation.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster to undergo an outage simulation.
- @return ClusterOutageSimulationApiStartOutageSimulationRequest
+ @return StartOutageSimulationApiRequest
 */
-func (a *ClusterOutageSimulationApiService) StartOutageSimulation(ctx context.Context, groupId string, clusterName string) ClusterOutageSimulationApiStartOutageSimulationRequest {
-	return ClusterOutageSimulationApiStartOutageSimulationRequest{
+func (a *ClusterOutageSimulationApiService) StartOutageSimulation(ctx context.Context, groupId string, clusterName string) StartOutageSimulationApiRequest {
+	return StartOutageSimulationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -383,7 +383,7 @@ func (a *ClusterOutageSimulationApiService) StartOutageSimulation(ctx context.Co
 
 // Execute executes the request
 //  @return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) StartOutageSimulationExecute(r ClusterOutageSimulationApiStartOutageSimulationRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -81,7 +81,7 @@ type EndOutageSimulationApiRequest struct {
 	clusterName string
 }
 
-type EndOutageSimulationParams struct {
+type EndOutageSimulationApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -213,7 +213,7 @@ type GetOutageSimulationApiRequest struct {
 	clusterName string
 }
 
-type GetOutageSimulationParams struct {
+type GetOutageSimulationApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -346,7 +346,7 @@ type StartOutageSimulationApiRequest struct {
 	clusterOutageSimulation *ClusterOutageSimulation
 }
 
-type StartOutageSimulationParams struct {
+type StartOutageSimulationApiParams struct {
 		GroupId string
 		ClusterName string
 		ClusterOutageSimulation *ClusterOutageSimulation

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -80,6 +80,10 @@ type ClusterOutageSimulationApiEndOutageSimulationRequest struct {
 	groupId string
 	clusterName string
 }
+type ClusterOutageSimulationApiEndOutageSimulationQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r ClusterOutageSimulationApiEndOutageSimulationRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
 	return r.ApiService.EndOutageSimulationExecute(r)
@@ -206,6 +210,10 @@ type ClusterOutageSimulationApiGetOutageSimulationRequest struct {
 	ApiService ClusterOutageSimulationApi
 	groupId string
 	clusterName string
+}
+type ClusterOutageSimulationApiGetOutageSimulationQueryParams struct {
+		groupId string
+		clusterName string
 }
 
 func (r ClusterOutageSimulationApiGetOutageSimulationRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
@@ -334,6 +342,11 @@ type ClusterOutageSimulationApiStartOutageSimulationRequest struct {
 	groupId string
 	clusterName string
 	clusterOutageSimulation *ClusterOutageSimulation
+}
+type ClusterOutageSimulationApiStartOutageSimulationQueryParams struct {
+		groupId string
+		clusterName string
+		clusterOutageSimulation *ClusterOutageSimulation
 }
 
 // Describes the outage simulation.

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -80,9 +80,10 @@ type ClusterOutageSimulationApiEndOutageSimulationRequest struct {
 	groupId string
 	clusterName string
 }
+
 type ClusterOutageSimulationApiEndOutageSimulationQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r ClusterOutageSimulationApiEndOutageSimulationRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
@@ -211,9 +212,10 @@ type ClusterOutageSimulationApiGetOutageSimulationRequest struct {
 	groupId string
 	clusterName string
 }
+
 type ClusterOutageSimulationApiGetOutageSimulationQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r ClusterOutageSimulationApiGetOutageSimulationRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
@@ -343,10 +345,11 @@ type ClusterOutageSimulationApiStartOutageSimulationRequest struct {
 	clusterName string
 	clusterOutageSimulation *ClusterOutageSimulation
 }
+
 type ClusterOutageSimulationApiStartOutageSimulationQueryParams struct {
-		groupId string
-		clusterName string
-		clusterOutageSimulation *ClusterOutageSimulation
+		GroupId string
+		ClusterName string
+		ClusterOutageSimulation *ClusterOutageSimulation
 }
 
 // Describes the outage simulation.

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -81,7 +81,7 @@ type ClusterOutageSimulationApiEndOutageSimulationRequest struct {
 	clusterName string
 }
 
-type ClusterOutageSimulationApiEndOutageSimulationParams struct {
+type EndOutageSimulationParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -213,7 +213,7 @@ type ClusterOutageSimulationApiGetOutageSimulationRequest struct {
 	clusterName string
 }
 
-type ClusterOutageSimulationApiGetOutageSimulationParams struct {
+type GetOutageSimulationParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -346,7 +346,7 @@ type ClusterOutageSimulationApiStartOutageSimulationRequest struct {
 	clusterOutageSimulation *ClusterOutageSimulation
 }
 
-type ClusterOutageSimulationApiStartOutageSimulationParams struct {
+type StartOutageSimulationParams struct {
 		GroupId string
 		ClusterName string
 		ClusterOutageSimulation *ClusterOutageSimulation

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -81,7 +81,7 @@ type ClusterOutageSimulationApiEndOutageSimulationRequest struct {
 	clusterName string
 }
 
-type ClusterOutageSimulationApiEndOutageSimulationQueryParams struct {
+type ClusterOutageSimulationApiEndOutageSimulationParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -213,7 +213,7 @@ type ClusterOutageSimulationApiGetOutageSimulationRequest struct {
 	clusterName string
 }
 
-type ClusterOutageSimulationApiGetOutageSimulationQueryParams struct {
+type ClusterOutageSimulationApiGetOutageSimulationParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -346,7 +346,7 @@ type ClusterOutageSimulationApiStartOutageSimulationRequest struct {
 	clusterOutageSimulation *ClusterOutageSimulation
 }
 
-type ClusterOutageSimulationApiStartOutageSimulationQueryParams struct {
+type ClusterOutageSimulationApiStartOutageSimulationParams struct {
 		GroupId string
 		ClusterName string
 		ClusterOutageSimulation *ClusterOutageSimulation

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -31,13 +31,13 @@ type ClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return ClustersApiGetClusterAdvancedConfigurationRequest
+	@return GetClusterAdvancedConfigurationApiRequest
 	*/
-	GetClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) ClustersApiGetClusterAdvancedConfigurationRequest
+	GetClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) GetClusterAdvancedConfigurationApiRequest
 
 	// GetClusterAdvancedConfigurationExecute executes the request
 	//  @return ClusterDescriptionProcessArgs
-	GetClusterAdvancedConfigurationExecute(r ClustersApiGetClusterAdvancedConfigurationRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
+	GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
 	GetClusterStatus Return Status of All Cluster Operations
@@ -47,13 +47,13 @@ type ClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return ClustersApiGetClusterStatusRequest
+	@return GetClusterStatusApiRequest
 	*/
-	GetClusterStatus(ctx context.Context, groupId string, clusterName string) ClustersApiGetClusterStatusRequest
+	GetClusterStatus(ctx context.Context, groupId string, clusterName string) GetClusterStatusApiRequest
 
 	// GetClusterStatusExecute executes the request
 	//  @return ClusterStatus
-	GetClusterStatusExecute(r ClustersApiGetClusterStatusRequest) (*ClusterStatus, *http.Response, error)
+	GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error)
 
 	/*
 	GetSampleDatasetLoadStatus Check Status of Cluster Sample Dataset Request
@@ -63,13 +63,13 @@ type ClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param sampleDatasetId Unique 24-hexadecimal digit string that identifies the loaded sample dataset.
-	@return ClustersApiGetSampleDatasetLoadStatusRequest
+	@return GetSampleDatasetLoadStatusApiRequest
 	*/
-	GetSampleDatasetLoadStatus(ctx context.Context, groupId string, sampleDatasetId string) ClustersApiGetSampleDatasetLoadStatusRequest
+	GetSampleDatasetLoadStatus(ctx context.Context, groupId string, sampleDatasetId string) GetSampleDatasetLoadStatusApiRequest
 
 	// GetSampleDatasetLoadStatusExecute executes the request
 	//  @return SampleDatasetStatus
-	GetSampleDatasetLoadStatusExecute(r ClustersApiGetSampleDatasetLoadStatusRequest) (*SampleDatasetStatus, *http.Response, error)
+	GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error)
 
 	/*
 	ListCloudProviderRegions Return All Cloud Provider Regions
@@ -78,13 +78,13 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ClustersApiListCloudProviderRegionsRequest
+	@return ListCloudProviderRegionsApiRequest
 	*/
-	ListCloudProviderRegions(ctx context.Context, groupId string) ClustersApiListCloudProviderRegionsRequest
+	ListCloudProviderRegions(ctx context.Context, groupId string) ListCloudProviderRegionsApiRequest
 
 	// ListCloudProviderRegionsExecute executes the request
 	//  @return PaginatedApiAtlasProviderRegions
-	ListCloudProviderRegionsExecute(r ClustersApiListCloudProviderRegionsRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error)
+	ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error)
 
 	/*
 	ListClustersForAllProjects Return All Authorized Clusters in All Projects
@@ -92,13 +92,13 @@ type ClustersApi interface {
 	Returns the details for all clusters in all projects to which you have access. Clusters contain a group of hosts that maintain the same data set. The response does not include multi-cloud clusters. To use this resource, the requesting API Key can have any cluster-level role. This resource doesn't require the API Key to have an Access List.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ClustersApiListClustersForAllProjectsRequest
+	@return ListClustersForAllProjectsApiRequest
 	*/
-	ListClustersForAllProjects(ctx context.Context) ClustersApiListClustersForAllProjectsRequest
+	ListClustersForAllProjects(ctx context.Context) ListClustersForAllProjectsApiRequest
 
 	// ListClustersForAllProjectsExecute executes the request
 	//  @return PaginatedOrgGroup
-	ListClustersForAllProjectsExecute(r ClustersApiListClustersForAllProjectsRequest) (*PaginatedOrgGroup, *http.Response, error)
+	ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error)
 
 	/*
 	LoadSampleDataset Load Sample Dataset Request into Cluster
@@ -108,13 +108,13 @@ type ClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param name Human-readable label that identifies the cluster into which you load the sample dataset.
-	@return ClustersApiLoadSampleDatasetRequest
+	@return LoadSampleDatasetApiRequest
 	*/
-	LoadSampleDataset(ctx context.Context, groupId string, name string) ClustersApiLoadSampleDatasetRequest
+	LoadSampleDataset(ctx context.Context, groupId string, name string) LoadSampleDatasetApiRequest
 
 	// LoadSampleDatasetExecute executes the request
 	//  @return []SampleDatasetStatus
-	LoadSampleDatasetExecute(r ClustersApiLoadSampleDatasetRequest) ([]SampleDatasetStatus, *http.Response, error)
+	LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) ([]SampleDatasetStatus, *http.Response, error)
 
 	/*
 	UpdateClusterAdvancedConfiguration Update Advanced Configuration Options for One Cluster
@@ -124,13 +124,13 @@ type ClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return ClustersApiUpdateClusterAdvancedConfigurationRequest
+	@return UpdateClusterAdvancedConfigurationApiRequest
 	*/
-	UpdateClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) ClustersApiUpdateClusterAdvancedConfigurationRequest
+	UpdateClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) UpdateClusterAdvancedConfigurationApiRequest
 
 	// UpdateClusterAdvancedConfigurationExecute executes the request
 	//  @return ClusterDescriptionProcessArgs
-	UpdateClusterAdvancedConfigurationExecute(r ClustersApiUpdateClusterAdvancedConfigurationRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
+	UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
 	UpgradeSharedCluster Upgrade One Shared-tier Cluster
@@ -139,13 +139,13 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ClustersApiUpgradeSharedClusterRequest
+	@return UpgradeSharedClusterApiRequest
 	*/
-	UpgradeSharedCluster(ctx context.Context, groupId string) ClustersApiUpgradeSharedClusterRequest
+	UpgradeSharedCluster(ctx context.Context, groupId string) UpgradeSharedClusterApiRequest
 
 	// UpgradeSharedClusterExecute executes the request
 	//  @return LegacyClusterDescription
-	UpgradeSharedClusterExecute(r ClustersApiUpgradeSharedClusterRequest) (*LegacyClusterDescription, *http.Response, error)
+	UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyClusterDescription, *http.Response, error)
 
 	/*
 	UpgradeSharedClusterToServerless Upgrades One Shared-Tier Cluster to the Serverless Instance
@@ -154,19 +154,19 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ClustersApiUpgradeSharedClusterToServerlessRequest
+	@return UpgradeSharedClusterToServerlessApiRequest
 	*/
-	UpgradeSharedClusterToServerless(ctx context.Context, groupId string) ClustersApiUpgradeSharedClusterToServerlessRequest
+	UpgradeSharedClusterToServerless(ctx context.Context, groupId string) UpgradeSharedClusterToServerlessApiRequest
 
 	// UpgradeSharedClusterToServerlessExecute executes the request
 	//  @return ServerlessInstanceDescription
-	UpgradeSharedClusterToServerlessExecute(r ClustersApiUpgradeSharedClusterToServerlessRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 
 // ClustersApiService ClustersApi service
 type ClustersApiService service
 
-type ClustersApiGetClusterAdvancedConfigurationRequest struct {
+type GetClusterAdvancedConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -178,7 +178,7 @@ type GetClusterAdvancedConfigurationParams struct {
 		ClusterName string
 }
 
-func (r ClustersApiGetClusterAdvancedConfigurationRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (r GetClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	return r.ApiService.GetClusterAdvancedConfigurationExecute(r)
 }
 
@@ -190,10 +190,10 @@ Returns the advanced configuration details for one cluster in the specified proj
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return ClustersApiGetClusterAdvancedConfigurationRequest
+ @return GetClusterAdvancedConfigurationApiRequest
 */
-func (a *ClustersApiService) GetClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) ClustersApiGetClusterAdvancedConfigurationRequest {
-	return ClustersApiGetClusterAdvancedConfigurationRequest{
+func (a *ClustersApiService) GetClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) GetClusterAdvancedConfigurationApiRequest {
+	return GetClusterAdvancedConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -203,7 +203,7 @@ func (a *ClustersApiService) GetClusterAdvancedConfiguration(ctx context.Context
 
 // Execute executes the request
 //  @return ClusterDescriptionProcessArgs
-func (a *ClustersApiService) GetClusterAdvancedConfigurationExecute(r ClustersApiGetClusterAdvancedConfigurationRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (a *ClustersApiService) GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -298,7 +298,7 @@ func (a *ClustersApiService) GetClusterAdvancedConfigurationExecute(r ClustersAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiGetClusterStatusRequest struct {
+type GetClusterStatusApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -310,7 +310,7 @@ type GetClusterStatusParams struct {
 		ClusterName string
 }
 
-func (r ClustersApiGetClusterStatusRequest) Execute() (*ClusterStatus, *http.Response, error) {
+func (r GetClusterStatusApiRequest) Execute() (*ClusterStatus, *http.Response, error) {
 	return r.ApiService.GetClusterStatusExecute(r)
 }
 
@@ -322,10 +322,10 @@ Returns the status of all changes that you made to the specified cluster in the 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return ClustersApiGetClusterStatusRequest
+ @return GetClusterStatusApiRequest
 */
-func (a *ClustersApiService) GetClusterStatus(ctx context.Context, groupId string, clusterName string) ClustersApiGetClusterStatusRequest {
-	return ClustersApiGetClusterStatusRequest{
+func (a *ClustersApiService) GetClusterStatus(ctx context.Context, groupId string, clusterName string) GetClusterStatusApiRequest {
+	return GetClusterStatusApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -335,7 +335,7 @@ func (a *ClustersApiService) GetClusterStatus(ctx context.Context, groupId strin
 
 // Execute executes the request
 //  @return ClusterStatus
-func (a *ClustersApiService) GetClusterStatusExecute(r ClustersApiGetClusterStatusRequest) (*ClusterStatus, *http.Response, error) {
+func (a *ClustersApiService) GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -430,7 +430,7 @@ func (a *ClustersApiService) GetClusterStatusExecute(r ClustersApiGetClusterStat
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiGetSampleDatasetLoadStatusRequest struct {
+type GetSampleDatasetLoadStatusApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -442,7 +442,7 @@ type GetSampleDatasetLoadStatusParams struct {
 		SampleDatasetId string
 }
 
-func (r ClustersApiGetSampleDatasetLoadStatusRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
+func (r GetSampleDatasetLoadStatusApiRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
 	return r.ApiService.GetSampleDatasetLoadStatusExecute(r)
 }
 
@@ -454,10 +454,10 @@ Checks the progress of loading the sample dataset into one cluster. To use this 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param sampleDatasetId Unique 24-hexadecimal digit string that identifies the loaded sample dataset.
- @return ClustersApiGetSampleDatasetLoadStatusRequest
+ @return GetSampleDatasetLoadStatusApiRequest
 */
-func (a *ClustersApiService) GetSampleDatasetLoadStatus(ctx context.Context, groupId string, sampleDatasetId string) ClustersApiGetSampleDatasetLoadStatusRequest {
-	return ClustersApiGetSampleDatasetLoadStatusRequest{
+func (a *ClustersApiService) GetSampleDatasetLoadStatus(ctx context.Context, groupId string, sampleDatasetId string) GetSampleDatasetLoadStatusApiRequest {
+	return GetSampleDatasetLoadStatusApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -467,7 +467,7 @@ func (a *ClustersApiService) GetSampleDatasetLoadStatus(ctx context.Context, gro
 
 // Execute executes the request
 //  @return SampleDatasetStatus
-func (a *ClustersApiService) GetSampleDatasetLoadStatusExecute(r ClustersApiGetSampleDatasetLoadStatusRequest) (*SampleDatasetStatus, *http.Response, error) {
+func (a *ClustersApiService) GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -562,7 +562,7 @@ func (a *ClustersApiService) GetSampleDatasetLoadStatusExecute(r ClustersApiGetS
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiListCloudProviderRegionsRequest struct {
+type ListCloudProviderRegionsApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -583,36 +583,36 @@ type ListCloudProviderRegionsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ClustersApiListCloudProviderRegionsRequest) IncludeCount(includeCount bool) ClustersApiListCloudProviderRegionsRequest {
+func (r ListCloudProviderRegionsApiRequest) IncludeCount(includeCount bool) ListCloudProviderRegionsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ClustersApiListCloudProviderRegionsRequest) ItemsPerPage(itemsPerPage int32) ClustersApiListCloudProviderRegionsRequest {
+func (r ListCloudProviderRegionsApiRequest) ItemsPerPage(itemsPerPage int32) ListCloudProviderRegionsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ClustersApiListCloudProviderRegionsRequest) PageNum(pageNum int32) ClustersApiListCloudProviderRegionsRequest {
+func (r ListCloudProviderRegionsApiRequest) PageNum(pageNum int32) ListCloudProviderRegionsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Cloud providers whose regions to retrieve. When you specify multiple providers, the response can return only tiers and regions that support multi-cloud clusters.
-func (r ClustersApiListCloudProviderRegionsRequest) Providers(providers []string) ClustersApiListCloudProviderRegionsRequest {
+func (r ListCloudProviderRegionsApiRequest) Providers(providers []string) ListCloudProviderRegionsApiRequest {
 	r.providers = &providers
 	return r
 }
 
 // Cluster tier for which to retrieve the regions.
-func (r ClustersApiListCloudProviderRegionsRequest) Tier(tier string) ClustersApiListCloudProviderRegionsRequest {
+func (r ListCloudProviderRegionsApiRequest) Tier(tier string) ListCloudProviderRegionsApiRequest {
 	r.tier = &tier
 	return r
 }
 
-func (r ClustersApiListCloudProviderRegionsRequest) Execute() (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
+func (r ListCloudProviderRegionsApiRequest) Execute() (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
 	return r.ApiService.ListCloudProviderRegionsExecute(r)
 }
 
@@ -623,10 +623,10 @@ Returns the list of regions available for the specified cloud provider at the sp
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ClustersApiListCloudProviderRegionsRequest
+ @return ListCloudProviderRegionsApiRequest
 */
-func (a *ClustersApiService) ListCloudProviderRegions(ctx context.Context, groupId string) ClustersApiListCloudProviderRegionsRequest {
-	return ClustersApiListCloudProviderRegionsRequest{
+func (a *ClustersApiService) ListCloudProviderRegions(ctx context.Context, groupId string) ListCloudProviderRegionsApiRequest {
+	return ListCloudProviderRegionsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -635,7 +635,7 @@ func (a *ClustersApiService) ListCloudProviderRegions(ctx context.Context, group
 
 // Execute executes the request
 //  @return PaginatedApiAtlasProviderRegions
-func (a *ClustersApiService) ListCloudProviderRegionsExecute(r ClustersApiListCloudProviderRegionsRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
+func (a *ClustersApiService) ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -758,7 +758,7 @@ func (a *ClustersApiService) ListCloudProviderRegionsExecute(r ClustersApiListCl
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiListClustersForAllProjectsRequest struct {
+type ListClustersForAllProjectsApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	includeCount *bool
@@ -773,24 +773,24 @@ type ListClustersForAllProjectsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ClustersApiListClustersForAllProjectsRequest) IncludeCount(includeCount bool) ClustersApiListClustersForAllProjectsRequest {
+func (r ListClustersForAllProjectsApiRequest) IncludeCount(includeCount bool) ListClustersForAllProjectsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ClustersApiListClustersForAllProjectsRequest) ItemsPerPage(itemsPerPage int32) ClustersApiListClustersForAllProjectsRequest {
+func (r ListClustersForAllProjectsApiRequest) ItemsPerPage(itemsPerPage int32) ListClustersForAllProjectsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ClustersApiListClustersForAllProjectsRequest) PageNum(pageNum int32) ClustersApiListClustersForAllProjectsRequest {
+func (r ListClustersForAllProjectsApiRequest) PageNum(pageNum int32) ListClustersForAllProjectsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ClustersApiListClustersForAllProjectsRequest) Execute() (*PaginatedOrgGroup, *http.Response, error) {
+func (r ListClustersForAllProjectsApiRequest) Execute() (*PaginatedOrgGroup, *http.Response, error) {
 	return r.ApiService.ListClustersForAllProjectsExecute(r)
 }
 
@@ -800,10 +800,10 @@ ListClustersForAllProjects Return All Authorized Clusters in All Projects
 Returns the details for all clusters in all projects to which you have access. Clusters contain a group of hosts that maintain the same data set. The response does not include multi-cloud clusters. To use this resource, the requesting API Key can have any cluster-level role. This resource doesn't require the API Key to have an Access List.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ClustersApiListClustersForAllProjectsRequest
+ @return ListClustersForAllProjectsApiRequest
 */
-func (a *ClustersApiService) ListClustersForAllProjects(ctx context.Context) ClustersApiListClustersForAllProjectsRequest {
-	return ClustersApiListClustersForAllProjectsRequest{
+func (a *ClustersApiService) ListClustersForAllProjects(ctx context.Context) ListClustersForAllProjectsApiRequest {
+	return ListClustersForAllProjectsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -811,7 +811,7 @@ func (a *ClustersApiService) ListClustersForAllProjects(ctx context.Context) Clu
 
 // Execute executes the request
 //  @return PaginatedOrgGroup
-func (a *ClustersApiService) ListClustersForAllProjectsExecute(r ClustersApiListClustersForAllProjectsRequest) (*PaginatedOrgGroup, *http.Response, error) {
+func (a *ClustersApiService) ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -913,7 +913,7 @@ func (a *ClustersApiService) ListClustersForAllProjectsExecute(r ClustersApiList
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiLoadSampleDatasetRequest struct {
+type LoadSampleDatasetApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -928,12 +928,12 @@ type LoadSampleDatasetParams struct {
 }
 
 // Cluster into which to load the sample dataset.
-func (r ClustersApiLoadSampleDatasetRequest) SampleDatasetStatus(sampleDatasetStatus SampleDatasetStatus) ClustersApiLoadSampleDatasetRequest {
+func (r LoadSampleDatasetApiRequest) SampleDatasetStatus(sampleDatasetStatus SampleDatasetStatus) LoadSampleDatasetApiRequest {
 	r.sampleDatasetStatus = &sampleDatasetStatus
 	return r
 }
 
-func (r ClustersApiLoadSampleDatasetRequest) Execute() ([]SampleDatasetStatus, *http.Response, error) {
+func (r LoadSampleDatasetApiRequest) Execute() ([]SampleDatasetStatus, *http.Response, error) {
 	return r.ApiService.LoadSampleDatasetExecute(r)
 }
 
@@ -945,10 +945,10 @@ Requests loading the MongoDB sample dataset into the specified cluster. To use t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param name Human-readable label that identifies the cluster into which you load the sample dataset.
- @return ClustersApiLoadSampleDatasetRequest
+ @return LoadSampleDatasetApiRequest
 */
-func (a *ClustersApiService) LoadSampleDataset(ctx context.Context, groupId string, name string) ClustersApiLoadSampleDatasetRequest {
-	return ClustersApiLoadSampleDatasetRequest{
+func (a *ClustersApiService) LoadSampleDataset(ctx context.Context, groupId string, name string) LoadSampleDatasetApiRequest {
+	return LoadSampleDatasetApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -958,7 +958,7 @@ func (a *ClustersApiService) LoadSampleDataset(ctx context.Context, groupId stri
 
 // Execute executes the request
 //  @return []SampleDatasetStatus
-func (a *ClustersApiService) LoadSampleDatasetExecute(r ClustersApiLoadSampleDatasetRequest) ([]SampleDatasetStatus, *http.Response, error) {
+func (a *ClustersApiService) LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) ([]SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1058,7 +1058,7 @@ func (a *ClustersApiService) LoadSampleDatasetExecute(r ClustersApiLoadSampleDat
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiUpdateClusterAdvancedConfigurationRequest struct {
+type UpdateClusterAdvancedConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -1073,12 +1073,12 @@ type UpdateClusterAdvancedConfigurationParams struct {
 }
 
 // Advanced configuration details to add for one cluster in the specified project.
-func (r ClustersApiUpdateClusterAdvancedConfigurationRequest) ClusterDescriptionProcessArgs(clusterDescriptionProcessArgs ClusterDescriptionProcessArgs) ClustersApiUpdateClusterAdvancedConfigurationRequest {
+func (r UpdateClusterAdvancedConfigurationApiRequest) ClusterDescriptionProcessArgs(clusterDescriptionProcessArgs ClusterDescriptionProcessArgs) UpdateClusterAdvancedConfigurationApiRequest {
 	r.clusterDescriptionProcessArgs = &clusterDescriptionProcessArgs
 	return r
 }
 
-func (r ClustersApiUpdateClusterAdvancedConfigurationRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (r UpdateClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	return r.ApiService.UpdateClusterAdvancedConfigurationExecute(r)
 }
 
@@ -1090,10 +1090,10 @@ Updates the advanced configuration details for one cluster in the specified proj
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return ClustersApiUpdateClusterAdvancedConfigurationRequest
+ @return UpdateClusterAdvancedConfigurationApiRequest
 */
-func (a *ClustersApiService) UpdateClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) ClustersApiUpdateClusterAdvancedConfigurationRequest {
-	return ClustersApiUpdateClusterAdvancedConfigurationRequest{
+func (a *ClustersApiService) UpdateClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) UpdateClusterAdvancedConfigurationApiRequest {
+	return UpdateClusterAdvancedConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1103,7 +1103,7 @@ func (a *ClustersApiService) UpdateClusterAdvancedConfiguration(ctx context.Cont
 
 // Execute executes the request
 //  @return ClusterDescriptionProcessArgs
-func (a *ClustersApiService) UpdateClusterAdvancedConfigurationExecute(r ClustersApiUpdateClusterAdvancedConfigurationRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (a *ClustersApiService) UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1203,7 +1203,7 @@ func (a *ClustersApiService) UpdateClusterAdvancedConfigurationExecute(r Cluster
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiUpgradeSharedClusterRequest struct {
+type UpgradeSharedClusterApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -1216,12 +1216,12 @@ type UpgradeSharedClusterParams struct {
 }
 
 // Details of the shared-tier cluster upgrade in the specified project.
-func (r ClustersApiUpgradeSharedClusterRequest) LegacyClusterDescription(legacyClusterDescription LegacyClusterDescription) ClustersApiUpgradeSharedClusterRequest {
+func (r UpgradeSharedClusterApiRequest) LegacyClusterDescription(legacyClusterDescription LegacyClusterDescription) UpgradeSharedClusterApiRequest {
 	r.legacyClusterDescription = &legacyClusterDescription
 	return r
 }
 
-func (r ClustersApiUpgradeSharedClusterRequest) Execute() (*LegacyClusterDescription, *http.Response, error) {
+func (r UpgradeSharedClusterApiRequest) Execute() (*LegacyClusterDescription, *http.Response, error) {
 	return r.ApiService.UpgradeSharedClusterExecute(r)
 }
 
@@ -1232,10 +1232,10 @@ Upgrades a shared-tier cluster in the specified project. To use this resource, t
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ClustersApiUpgradeSharedClusterRequest
+ @return UpgradeSharedClusterApiRequest
 */
-func (a *ClustersApiService) UpgradeSharedCluster(ctx context.Context, groupId string) ClustersApiUpgradeSharedClusterRequest {
-	return ClustersApiUpgradeSharedClusterRequest{
+func (a *ClustersApiService) UpgradeSharedCluster(ctx context.Context, groupId string) UpgradeSharedClusterApiRequest {
+	return UpgradeSharedClusterApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1244,7 +1244,7 @@ func (a *ClustersApiService) UpgradeSharedCluster(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return LegacyClusterDescription
-func (a *ClustersApiService) UpgradeSharedClusterExecute(r ClustersApiUpgradeSharedClusterRequest) (*LegacyClusterDescription, *http.Response, error) {
+func (a *ClustersApiService) UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyClusterDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1337,7 +1337,7 @@ func (a *ClustersApiService) UpgradeSharedClusterExecute(r ClustersApiUpgradeSha
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ClustersApiUpgradeSharedClusterToServerlessRequest struct {
+type UpgradeSharedClusterToServerlessApiRequest struct {
 	ctx context.Context
 	ApiService ClustersApi
 	groupId string
@@ -1350,12 +1350,12 @@ type UpgradeSharedClusterToServerlessParams struct {
 }
 
 // Details of the shared-tier cluster upgrade in the specified project.
-func (r ClustersApiUpgradeSharedClusterToServerlessRequest) ServerlessInstanceDescription(serverlessInstanceDescription ServerlessInstanceDescription) ClustersApiUpgradeSharedClusterToServerlessRequest {
+func (r UpgradeSharedClusterToServerlessApiRequest) ServerlessInstanceDescription(serverlessInstanceDescription ServerlessInstanceDescription) UpgradeSharedClusterToServerlessApiRequest {
 	r.serverlessInstanceDescription = &serverlessInstanceDescription
 	return r
 }
 
-func (r ClustersApiUpgradeSharedClusterToServerlessRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
+func (r UpgradeSharedClusterToServerlessApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.UpgradeSharedClusterToServerlessExecute(r)
 }
 
@@ -1366,10 +1366,10 @@ Upgrades a shared-tier cluster to a serverless instance in the specified project
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ClustersApiUpgradeSharedClusterToServerlessRequest
+ @return UpgradeSharedClusterToServerlessApiRequest
 */
-func (a *ClustersApiService) UpgradeSharedClusterToServerless(ctx context.Context, groupId string) ClustersApiUpgradeSharedClusterToServerlessRequest {
-	return ClustersApiUpgradeSharedClusterToServerlessRequest{
+func (a *ClustersApiService) UpgradeSharedClusterToServerless(ctx context.Context, groupId string) UpgradeSharedClusterToServerlessApiRequest {
+	return UpgradeSharedClusterToServerlessApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1378,7 +1378,7 @@ func (a *ClustersApiService) UpgradeSharedClusterToServerless(ctx context.Contex
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ClustersApiService) UpgradeSharedClusterToServerlessExecute(r ClustersApiUpgradeSharedClusterToServerlessRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ClustersApiService) UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -172,6 +172,10 @@ type ClustersApiGetClusterAdvancedConfigurationRequest struct {
 	groupId string
 	clusterName string
 }
+type ClustersApiGetClusterAdvancedConfigurationQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r ClustersApiGetClusterAdvancedConfigurationRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	return r.ApiService.GetClusterAdvancedConfigurationExecute(r)
@@ -299,6 +303,10 @@ type ClustersApiGetClusterStatusRequest struct {
 	groupId string
 	clusterName string
 }
+type ClustersApiGetClusterStatusQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r ClustersApiGetClusterStatusRequest) Execute() (*ClusterStatus, *http.Response, error) {
 	return r.ApiService.GetClusterStatusExecute(r)
@@ -425,6 +433,10 @@ type ClustersApiGetSampleDatasetLoadStatusRequest struct {
 	ApiService ClustersApi
 	groupId string
 	sampleDatasetId string
+}
+type ClustersApiGetSampleDatasetLoadStatusQueryParams struct {
+		groupId string
+		sampleDatasetId string
 }
 
 func (r ClustersApiGetSampleDatasetLoadStatusRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
@@ -556,6 +568,14 @@ type ClustersApiListCloudProviderRegionsRequest struct {
 	pageNum *int32
 	providers *[]string
 	tier *string
+}
+type ClustersApiListCloudProviderRegionsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		providers *[]string
+		tier *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -741,6 +761,11 @@ type ClustersApiListClustersForAllProjectsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type ClustersApiListClustersForAllProjectsQueryParams struct {
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ClustersApiListClustersForAllProjectsRequest) IncludeCount(includeCount bool) ClustersApiListClustersForAllProjectsRequest {
@@ -890,6 +915,11 @@ type ClustersApiLoadSampleDatasetRequest struct {
 	name string
 	sampleDatasetStatus *SampleDatasetStatus
 }
+type ClustersApiLoadSampleDatasetQueryParams struct {
+		groupId string
+		name string
+		sampleDatasetStatus *SampleDatasetStatus
+}
 
 // Cluster into which to load the sample dataset.
 func (r ClustersApiLoadSampleDatasetRequest) SampleDatasetStatus(sampleDatasetStatus SampleDatasetStatus) ClustersApiLoadSampleDatasetRequest {
@@ -1029,6 +1059,11 @@ type ClustersApiUpdateClusterAdvancedConfigurationRequest struct {
 	clusterName string
 	clusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
 }
+type ClustersApiUpdateClusterAdvancedConfigurationQueryParams struct {
+		groupId string
+		clusterName string
+		clusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
+}
 
 // Advanced configuration details to add for one cluster in the specified project.
 func (r ClustersApiUpdateClusterAdvancedConfigurationRequest) ClusterDescriptionProcessArgs(clusterDescriptionProcessArgs ClusterDescriptionProcessArgs) ClustersApiUpdateClusterAdvancedConfigurationRequest {
@@ -1167,6 +1202,10 @@ type ClustersApiUpgradeSharedClusterRequest struct {
 	groupId string
 	legacyClusterDescription *LegacyClusterDescription
 }
+type ClustersApiUpgradeSharedClusterQueryParams struct {
+		groupId string
+		legacyClusterDescription *LegacyClusterDescription
+}
 
 // Details of the shared-tier cluster upgrade in the specified project.
 func (r ClustersApiUpgradeSharedClusterRequest) LegacyClusterDescription(legacyClusterDescription LegacyClusterDescription) ClustersApiUpgradeSharedClusterRequest {
@@ -1295,6 +1334,10 @@ type ClustersApiUpgradeSharedClusterToServerlessRequest struct {
 	ApiService ClustersApi
 	groupId string
 	serverlessInstanceDescription *ServerlessInstanceDescription
+}
+type ClustersApiUpgradeSharedClusterToServerlessQueryParams struct {
+		groupId string
+		serverlessInstanceDescription *ServerlessInstanceDescription
 }
 
 // Details of the shared-tier cluster upgrade in the specified project.

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -173,7 +173,7 @@ type ClustersApiGetClusterAdvancedConfigurationRequest struct {
 	clusterName string
 }
 
-type ClustersApiGetClusterAdvancedConfigurationQueryParams struct {
+type ClustersApiGetClusterAdvancedConfigurationParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -305,7 +305,7 @@ type ClustersApiGetClusterStatusRequest struct {
 	clusterName string
 }
 
-type ClustersApiGetClusterStatusQueryParams struct {
+type ClustersApiGetClusterStatusParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -437,7 +437,7 @@ type ClustersApiGetSampleDatasetLoadStatusRequest struct {
 	sampleDatasetId string
 }
 
-type ClustersApiGetSampleDatasetLoadStatusQueryParams struct {
+type ClustersApiGetSampleDatasetLoadStatusParams struct {
 		GroupId string
 		SampleDatasetId string
 }
@@ -573,7 +573,7 @@ type ClustersApiListCloudProviderRegionsRequest struct {
 	tier *string
 }
 
-type ClustersApiListCloudProviderRegionsQueryParams struct {
+type ClustersApiListCloudProviderRegionsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -766,7 +766,7 @@ type ClustersApiListClustersForAllProjectsRequest struct {
 	pageNum *int32
 }
 
-type ClustersApiListClustersForAllProjectsQueryParams struct {
+type ClustersApiListClustersForAllProjectsParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -921,7 +921,7 @@ type ClustersApiLoadSampleDatasetRequest struct {
 	sampleDatasetStatus *SampleDatasetStatus
 }
 
-type ClustersApiLoadSampleDatasetQueryParams struct {
+type ClustersApiLoadSampleDatasetParams struct {
 		GroupId string
 		Name string
 		SampleDatasetStatus *SampleDatasetStatus
@@ -1066,7 +1066,7 @@ type ClustersApiUpdateClusterAdvancedConfigurationRequest struct {
 	clusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
 }
 
-type ClustersApiUpdateClusterAdvancedConfigurationQueryParams struct {
+type ClustersApiUpdateClusterAdvancedConfigurationParams struct {
 		GroupId string
 		ClusterName string
 		ClusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
@@ -1210,7 +1210,7 @@ type ClustersApiUpgradeSharedClusterRequest struct {
 	legacyClusterDescription *LegacyClusterDescription
 }
 
-type ClustersApiUpgradeSharedClusterQueryParams struct {
+type ClustersApiUpgradeSharedClusterParams struct {
 		GroupId string
 		LegacyClusterDescription *LegacyClusterDescription
 }
@@ -1344,7 +1344,7 @@ type ClustersApiUpgradeSharedClusterToServerlessRequest struct {
 	serverlessInstanceDescription *ServerlessInstanceDescription
 }
 
-type ClustersApiUpgradeSharedClusterToServerlessQueryParams struct {
+type ClustersApiUpgradeSharedClusterToServerlessParams struct {
 		GroupId string
 		ServerlessInstanceDescription *ServerlessInstanceDescription
 }

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -173,7 +173,7 @@ type ClustersApiGetClusterAdvancedConfigurationRequest struct {
 	clusterName string
 }
 
-type ClustersApiGetClusterAdvancedConfigurationParams struct {
+type GetClusterAdvancedConfigurationParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -305,7 +305,7 @@ type ClustersApiGetClusterStatusRequest struct {
 	clusterName string
 }
 
-type ClustersApiGetClusterStatusParams struct {
+type GetClusterStatusParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -437,7 +437,7 @@ type ClustersApiGetSampleDatasetLoadStatusRequest struct {
 	sampleDatasetId string
 }
 
-type ClustersApiGetSampleDatasetLoadStatusParams struct {
+type GetSampleDatasetLoadStatusParams struct {
 		GroupId string
 		SampleDatasetId string
 }
@@ -573,7 +573,7 @@ type ClustersApiListCloudProviderRegionsRequest struct {
 	tier *string
 }
 
-type ClustersApiListCloudProviderRegionsParams struct {
+type ListCloudProviderRegionsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -766,7 +766,7 @@ type ClustersApiListClustersForAllProjectsRequest struct {
 	pageNum *int32
 }
 
-type ClustersApiListClustersForAllProjectsParams struct {
+type ListClustersForAllProjectsParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -921,7 +921,7 @@ type ClustersApiLoadSampleDatasetRequest struct {
 	sampleDatasetStatus *SampleDatasetStatus
 }
 
-type ClustersApiLoadSampleDatasetParams struct {
+type LoadSampleDatasetParams struct {
 		GroupId string
 		Name string
 		SampleDatasetStatus *SampleDatasetStatus
@@ -1066,7 +1066,7 @@ type ClustersApiUpdateClusterAdvancedConfigurationRequest struct {
 	clusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
 }
 
-type ClustersApiUpdateClusterAdvancedConfigurationParams struct {
+type UpdateClusterAdvancedConfigurationParams struct {
 		GroupId string
 		ClusterName string
 		ClusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
@@ -1210,7 +1210,7 @@ type ClustersApiUpgradeSharedClusterRequest struct {
 	legacyClusterDescription *LegacyClusterDescription
 }
 
-type ClustersApiUpgradeSharedClusterParams struct {
+type UpgradeSharedClusterParams struct {
 		GroupId string
 		LegacyClusterDescription *LegacyClusterDescription
 }
@@ -1344,7 +1344,7 @@ type ClustersApiUpgradeSharedClusterToServerlessRequest struct {
 	serverlessInstanceDescription *ServerlessInstanceDescription
 }
 
-type ClustersApiUpgradeSharedClusterToServerlessParams struct {
+type UpgradeSharedClusterToServerlessParams struct {
 		GroupId string
 		ServerlessInstanceDescription *ServerlessInstanceDescription
 }

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -173,7 +173,7 @@ type GetClusterAdvancedConfigurationApiRequest struct {
 	clusterName string
 }
 
-type GetClusterAdvancedConfigurationParams struct {
+type GetClusterAdvancedConfigurationApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -305,7 +305,7 @@ type GetClusterStatusApiRequest struct {
 	clusterName string
 }
 
-type GetClusterStatusParams struct {
+type GetClusterStatusApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -437,7 +437,7 @@ type GetSampleDatasetLoadStatusApiRequest struct {
 	sampleDatasetId string
 }
 
-type GetSampleDatasetLoadStatusParams struct {
+type GetSampleDatasetLoadStatusApiParams struct {
 		GroupId string
 		SampleDatasetId string
 }
@@ -573,7 +573,7 @@ type ListCloudProviderRegionsApiRequest struct {
 	tier *string
 }
 
-type ListCloudProviderRegionsParams struct {
+type ListCloudProviderRegionsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -766,7 +766,7 @@ type ListClustersForAllProjectsApiRequest struct {
 	pageNum *int32
 }
 
-type ListClustersForAllProjectsParams struct {
+type ListClustersForAllProjectsApiParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -921,7 +921,7 @@ type LoadSampleDatasetApiRequest struct {
 	sampleDatasetStatus *SampleDatasetStatus
 }
 
-type LoadSampleDatasetParams struct {
+type LoadSampleDatasetApiParams struct {
 		GroupId string
 		Name string
 		SampleDatasetStatus *SampleDatasetStatus
@@ -1066,7 +1066,7 @@ type UpdateClusterAdvancedConfigurationApiRequest struct {
 	clusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
 }
 
-type UpdateClusterAdvancedConfigurationParams struct {
+type UpdateClusterAdvancedConfigurationApiParams struct {
 		GroupId string
 		ClusterName string
 		ClusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
@@ -1210,7 +1210,7 @@ type UpgradeSharedClusterApiRequest struct {
 	legacyClusterDescription *LegacyClusterDescription
 }
 
-type UpgradeSharedClusterParams struct {
+type UpgradeSharedClusterApiParams struct {
 		GroupId string
 		LegacyClusterDescription *LegacyClusterDescription
 }
@@ -1344,7 +1344,7 @@ type UpgradeSharedClusterToServerlessApiRequest struct {
 	serverlessInstanceDescription *ServerlessInstanceDescription
 }
 
-type UpgradeSharedClusterToServerlessParams struct {
+type UpgradeSharedClusterToServerlessApiParams struct {
 		GroupId string
 		ServerlessInstanceDescription *ServerlessInstanceDescription
 }

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -172,9 +172,10 @@ type ClustersApiGetClusterAdvancedConfigurationRequest struct {
 	groupId string
 	clusterName string
 }
+
 type ClustersApiGetClusterAdvancedConfigurationQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r ClustersApiGetClusterAdvancedConfigurationRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
@@ -303,9 +304,10 @@ type ClustersApiGetClusterStatusRequest struct {
 	groupId string
 	clusterName string
 }
+
 type ClustersApiGetClusterStatusQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r ClustersApiGetClusterStatusRequest) Execute() (*ClusterStatus, *http.Response, error) {
@@ -434,9 +436,10 @@ type ClustersApiGetSampleDatasetLoadStatusRequest struct {
 	groupId string
 	sampleDatasetId string
 }
+
 type ClustersApiGetSampleDatasetLoadStatusQueryParams struct {
-		groupId string
-		sampleDatasetId string
+		GroupId string
+		SampleDatasetId string
 }
 
 func (r ClustersApiGetSampleDatasetLoadStatusRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
@@ -569,13 +572,14 @@ type ClustersApiListCloudProviderRegionsRequest struct {
 	providers *[]string
 	tier *string
 }
+
 type ClustersApiListCloudProviderRegionsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		providers *[]string
-		tier *string
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		Providers *[]string
+		Tier *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -761,10 +765,11 @@ type ClustersApiListClustersForAllProjectsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ClustersApiListClustersForAllProjectsQueryParams struct {
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -915,10 +920,11 @@ type ClustersApiLoadSampleDatasetRequest struct {
 	name string
 	sampleDatasetStatus *SampleDatasetStatus
 }
+
 type ClustersApiLoadSampleDatasetQueryParams struct {
-		groupId string
-		name string
-		sampleDatasetStatus *SampleDatasetStatus
+		GroupId string
+		Name string
+		SampleDatasetStatus *SampleDatasetStatus
 }
 
 // Cluster into which to load the sample dataset.
@@ -1059,10 +1065,11 @@ type ClustersApiUpdateClusterAdvancedConfigurationRequest struct {
 	clusterName string
 	clusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
 }
+
 type ClustersApiUpdateClusterAdvancedConfigurationQueryParams struct {
-		groupId string
-		clusterName string
-		clusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
+		GroupId string
+		ClusterName string
+		ClusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
 }
 
 // Advanced configuration details to add for one cluster in the specified project.
@@ -1202,9 +1209,10 @@ type ClustersApiUpgradeSharedClusterRequest struct {
 	groupId string
 	legacyClusterDescription *LegacyClusterDescription
 }
+
 type ClustersApiUpgradeSharedClusterQueryParams struct {
-		groupId string
-		legacyClusterDescription *LegacyClusterDescription
+		GroupId string
+		LegacyClusterDescription *LegacyClusterDescription
 }
 
 // Details of the shared-tier cluster upgrade in the specified project.
@@ -1335,9 +1343,10 @@ type ClustersApiUpgradeSharedClusterToServerlessRequest struct {
 	groupId string
 	serverlessInstanceDescription *ServerlessInstanceDescription
 }
+
 type ClustersApiUpgradeSharedClusterToServerlessQueryParams struct {
-		groupId string
-		serverlessInstanceDescription *ServerlessInstanceDescription
+		GroupId string
+		ServerlessInstanceDescription *ServerlessInstanceDescription
 }
 
 // Details of the shared-tier cluster upgrade in the specified project.

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -110,7 +110,7 @@ type CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest struct {
 	customDBRole *CustomDBRole
 }
 
-type CustomDatabaseRolesApiCreateCustomDatabaseRoleParams struct {
+type CreateCustomDatabaseRoleParams struct {
 		GroupId string
 		CustomDBRole *CustomDBRole
 }
@@ -244,7 +244,7 @@ type CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest struct {
 	roleName string
 }
 
-type CustomDatabaseRolesApiDeleteCustomDatabaseRoleParams struct {
+type DeleteCustomDatabaseRoleParams struct {
 		GroupId string
 		RoleName string
 }
@@ -359,7 +359,7 @@ type CustomDatabaseRolesApiGetCustomDatabaseRoleRequest struct {
 	roleName string
 }
 
-type CustomDatabaseRolesApiGetCustomDatabaseRoleParams struct {
+type GetCustomDatabaseRoleParams struct {
 		GroupId string
 		RoleName string
 }
@@ -484,7 +484,7 @@ type CustomDatabaseRolesApiListCustomDatabaseRolesRequest struct {
 	groupId string
 }
 
-type CustomDatabaseRolesApiListCustomDatabaseRolesParams struct {
+type ListCustomDatabaseRolesParams struct {
 		GroupId string
 }
 
@@ -607,7 +607,7 @@ type CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest struct {
 	updateCustomDBRole *UpdateCustomDBRole
 }
 
-type CustomDatabaseRolesApiUpdateCustomDatabaseRoleParams struct {
+type UpdateCustomDatabaseRoleParams struct {
 		GroupId string
 		RoleName string
 		UpdateCustomDBRole *UpdateCustomDBRole

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -29,13 +29,13 @@ type CustomDatabaseRolesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest
+	@return CreateCustomDatabaseRoleApiRequest
 	*/
-	CreateCustomDatabaseRole(ctx context.Context, groupId string) CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest
+	CreateCustomDatabaseRole(ctx context.Context, groupId string) CreateCustomDatabaseRoleApiRequest
 
 	// CreateCustomDatabaseRoleExecute executes the request
 	//  @return CustomDBRole
-	CreateCustomDatabaseRoleExecute(r CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest) (*CustomDBRole, *http.Response, error)
+	CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
 
 	/*
 	DeleteCustomDatabaseRole Remove One Custom Role from One Project
@@ -45,12 +45,12 @@ type CustomDatabaseRolesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param roleName Human-readable label that identifies the role for the request. This name must be unique for this custom role in this project.
-	@return CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest
+	@return DeleteCustomDatabaseRoleApiRequest
 	*/
-	DeleteCustomDatabaseRole(ctx context.Context, groupId string, roleName string) CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest
+	DeleteCustomDatabaseRole(ctx context.Context, groupId string, roleName string) DeleteCustomDatabaseRoleApiRequest
 
 	// DeleteCustomDatabaseRoleExecute executes the request
-	DeleteCustomDatabaseRoleExecute(r CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest) (*http.Response, error)
+	DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error)
 
 	/*
 	GetCustomDatabaseRole Return One Custom Role in One Project
@@ -60,13 +60,13 @@ type CustomDatabaseRolesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param roleName Human-readable label that identifies the role for the request. This name must be unique for this custom role in this project.
-	@return CustomDatabaseRolesApiGetCustomDatabaseRoleRequest
+	@return GetCustomDatabaseRoleApiRequest
 	*/
-	GetCustomDatabaseRole(ctx context.Context, groupId string, roleName string) CustomDatabaseRolesApiGetCustomDatabaseRoleRequest
+	GetCustomDatabaseRole(ctx context.Context, groupId string, roleName string) GetCustomDatabaseRoleApiRequest
 
 	// GetCustomDatabaseRoleExecute executes the request
 	//  @return CustomDBRole
-	GetCustomDatabaseRoleExecute(r CustomDatabaseRolesApiGetCustomDatabaseRoleRequest) (*CustomDBRole, *http.Response, error)
+	GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
 
 	/*
 	ListCustomDatabaseRoles Return All Custom Roles in One Project
@@ -75,13 +75,13 @@ type CustomDatabaseRolesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return CustomDatabaseRolesApiListCustomDatabaseRolesRequest
+	@return ListCustomDatabaseRolesApiRequest
 	*/
-	ListCustomDatabaseRoles(ctx context.Context, groupId string) CustomDatabaseRolesApiListCustomDatabaseRolesRequest
+	ListCustomDatabaseRoles(ctx context.Context, groupId string) ListCustomDatabaseRolesApiRequest
 
 	// ListCustomDatabaseRolesExecute executes the request
 	//  @return []CustomDBRole
-	ListCustomDatabaseRolesExecute(r CustomDatabaseRolesApiListCustomDatabaseRolesRequest) ([]CustomDBRole, *http.Response, error)
+	ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]CustomDBRole, *http.Response, error)
 
 	/*
 	UpdateCustomDatabaseRole Update One Custom Role in One Project
@@ -91,19 +91,19 @@ type CustomDatabaseRolesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param roleName Human-readable label that identifies the role for the request. This name must beunique for this custom role in this project.
-	@return CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest
+	@return UpdateCustomDatabaseRoleApiRequest
 	*/
-	UpdateCustomDatabaseRole(ctx context.Context, groupId string, roleName string) CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest
+	UpdateCustomDatabaseRole(ctx context.Context, groupId string, roleName string) UpdateCustomDatabaseRoleApiRequest
 
 	// UpdateCustomDatabaseRoleExecute executes the request
 	//  @return CustomDBRole
-	UpdateCustomDatabaseRoleExecute(r CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest) (*CustomDBRole, *http.Response, error)
+	UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
 }
 
 // CustomDatabaseRolesApiService CustomDatabaseRolesApi service
 type CustomDatabaseRolesApiService service
 
-type CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest struct {
+type CreateCustomDatabaseRoleApiRequest struct {
 	ctx context.Context
 	ApiService CustomDatabaseRolesApi
 	groupId string
@@ -116,12 +116,12 @@ type CreateCustomDatabaseRoleParams struct {
 }
 
 // Creates one custom role in the specified project.
-func (r CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest) CustomDBRole(customDBRole CustomDBRole) CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest {
+func (r CreateCustomDatabaseRoleApiRequest) CustomDBRole(customDBRole CustomDBRole) CreateCustomDatabaseRoleApiRequest {
 	r.customDBRole = &customDBRole
 	return r
 }
 
-func (r CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest) Execute() (*CustomDBRole, *http.Response, error) {
+func (r CreateCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
 	return r.ApiService.CreateCustomDatabaseRoleExecute(r)
 }
 
@@ -132,10 +132,10 @@ Creates one custom role in the specified project. To use this resource, the requ
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest
+ @return CreateCustomDatabaseRoleApiRequest
 */
-func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRole(ctx context.Context, groupId string) CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest {
-	return CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest{
+func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRole(ctx context.Context, groupId string) CreateCustomDatabaseRoleApiRequest {
+	return CreateCustomDatabaseRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -144,7 +144,7 @@ func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRole(ctx context.Con
 
 // Execute executes the request
 //  @return CustomDBRole
-func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleExecute(r CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest) (*CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -237,7 +237,7 @@ func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleExecute(r Custom
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest struct {
+type DeleteCustomDatabaseRoleApiRequest struct {
 	ctx context.Context
 	ApiService CustomDatabaseRolesApi
 	groupId string
@@ -249,7 +249,7 @@ type DeleteCustomDatabaseRoleParams struct {
 		RoleName string
 }
 
-func (r CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest) Execute() (*http.Response, error) {
+func (r DeleteCustomDatabaseRoleApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteCustomDatabaseRoleExecute(r)
 }
 
@@ -261,10 +261,10 @@ Removes one custom role from the specified project. You can't remove a custom ro
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param roleName Human-readable label that identifies the role for the request. This name must be unique for this custom role in this project.
- @return CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest
+ @return DeleteCustomDatabaseRoleApiRequest
 */
-func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRole(ctx context.Context, groupId string, roleName string) CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest {
-	return CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest{
+func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRole(ctx context.Context, groupId string, roleName string) DeleteCustomDatabaseRoleApiRequest {
+	return DeleteCustomDatabaseRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -273,7 +273,7 @@ func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRole(ctx context.Con
 }
 
 // Execute executes the request
-func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleExecute(r CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest) (*http.Response, error) {
+func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -352,7 +352,7 @@ func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleExecute(r Custom
 	return localVarHTTPResponse, nil
 }
 
-type CustomDatabaseRolesApiGetCustomDatabaseRoleRequest struct {
+type GetCustomDatabaseRoleApiRequest struct {
 	ctx context.Context
 	ApiService CustomDatabaseRolesApi
 	groupId string
@@ -364,7 +364,7 @@ type GetCustomDatabaseRoleParams struct {
 		RoleName string
 }
 
-func (r CustomDatabaseRolesApiGetCustomDatabaseRoleRequest) Execute() (*CustomDBRole, *http.Response, error) {
+func (r GetCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
 	return r.ApiService.GetCustomDatabaseRoleExecute(r)
 }
 
@@ -376,10 +376,10 @@ Returns one custom role for the specified project. To use this resource, the req
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param roleName Human-readable label that identifies the role for the request. This name must be unique for this custom role in this project.
- @return CustomDatabaseRolesApiGetCustomDatabaseRoleRequest
+ @return GetCustomDatabaseRoleApiRequest
 */
-func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRole(ctx context.Context, groupId string, roleName string) CustomDatabaseRolesApiGetCustomDatabaseRoleRequest {
-	return CustomDatabaseRolesApiGetCustomDatabaseRoleRequest{
+func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRole(ctx context.Context, groupId string, roleName string) GetCustomDatabaseRoleApiRequest {
+	return GetCustomDatabaseRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -389,7 +389,7 @@ func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRole(ctx context.Contex
 
 // Execute executes the request
 //  @return CustomDBRole
-func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleExecute(r CustomDatabaseRolesApiGetCustomDatabaseRoleRequest) (*CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -478,7 +478,7 @@ func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleExecute(r CustomDat
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CustomDatabaseRolesApiListCustomDatabaseRolesRequest struct {
+type ListCustomDatabaseRolesApiRequest struct {
 	ctx context.Context
 	ApiService CustomDatabaseRolesApi
 	groupId string
@@ -488,7 +488,7 @@ type ListCustomDatabaseRolesParams struct {
 		GroupId string
 }
 
-func (r CustomDatabaseRolesApiListCustomDatabaseRolesRequest) Execute() ([]CustomDBRole, *http.Response, error) {
+func (r ListCustomDatabaseRolesApiRequest) Execute() ([]CustomDBRole, *http.Response, error) {
 	return r.ApiService.ListCustomDatabaseRolesExecute(r)
 }
 
@@ -499,10 +499,10 @@ Returns all custom roles for the specified project. To use this resource, the re
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return CustomDatabaseRolesApiListCustomDatabaseRolesRequest
+ @return ListCustomDatabaseRolesApiRequest
 */
-func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRoles(ctx context.Context, groupId string) CustomDatabaseRolesApiListCustomDatabaseRolesRequest {
-	return CustomDatabaseRolesApiListCustomDatabaseRolesRequest{
+func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRoles(ctx context.Context, groupId string) ListCustomDatabaseRolesApiRequest {
+	return ListCustomDatabaseRolesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -511,7 +511,7 @@ func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRoles(ctx context.Cont
 
 // Execute executes the request
 //  @return []CustomDBRole
-func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesExecute(r CustomDatabaseRolesApiListCustomDatabaseRolesRequest) ([]CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -599,7 +599,7 @@ func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesExecute(r CustomD
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest struct {
+type UpdateCustomDatabaseRoleApiRequest struct {
 	ctx context.Context
 	ApiService CustomDatabaseRolesApi
 	groupId string
@@ -614,12 +614,12 @@ type UpdateCustomDatabaseRoleParams struct {
 }
 
 // Updates one custom role in the specified project.
-func (r CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest) UpdateCustomDBRole(updateCustomDBRole UpdateCustomDBRole) CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest {
+func (r UpdateCustomDatabaseRoleApiRequest) UpdateCustomDBRole(updateCustomDBRole UpdateCustomDBRole) UpdateCustomDatabaseRoleApiRequest {
 	r.updateCustomDBRole = &updateCustomDBRole
 	return r
 }
 
-func (r CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest) Execute() (*CustomDBRole, *http.Response, error) {
+func (r UpdateCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
 	return r.ApiService.UpdateCustomDatabaseRoleExecute(r)
 }
 
@@ -631,10 +631,10 @@ Updates one custom role in the specified project. To use this resource, the requ
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param roleName Human-readable label that identifies the role for the request. This name must beunique for this custom role in this project.
- @return CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest
+ @return UpdateCustomDatabaseRoleApiRequest
 */
-func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRole(ctx context.Context, groupId string, roleName string) CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest {
-	return CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest{
+func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRole(ctx context.Context, groupId string, roleName string) UpdateCustomDatabaseRoleApiRequest {
+	return UpdateCustomDatabaseRoleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -644,7 +644,7 @@ func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRole(ctx context.Con
 
 // Execute executes the request
 //  @return CustomDBRole
-func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRoleExecute(r CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest) (*CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -109,9 +109,10 @@ type CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest struct {
 	groupId string
 	customDBRole *CustomDBRole
 }
+
 type CustomDatabaseRolesApiCreateCustomDatabaseRoleQueryParams struct {
-		groupId string
-		customDBRole *CustomDBRole
+		GroupId string
+		CustomDBRole *CustomDBRole
 }
 
 // Creates one custom role in the specified project.
@@ -242,9 +243,10 @@ type CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest struct {
 	groupId string
 	roleName string
 }
+
 type CustomDatabaseRolesApiDeleteCustomDatabaseRoleQueryParams struct {
-		groupId string
-		roleName string
+		GroupId string
+		RoleName string
 }
 
 func (r CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest) Execute() (*http.Response, error) {
@@ -356,9 +358,10 @@ type CustomDatabaseRolesApiGetCustomDatabaseRoleRequest struct {
 	groupId string
 	roleName string
 }
+
 type CustomDatabaseRolesApiGetCustomDatabaseRoleQueryParams struct {
-		groupId string
-		roleName string
+		GroupId string
+		RoleName string
 }
 
 func (r CustomDatabaseRolesApiGetCustomDatabaseRoleRequest) Execute() (*CustomDBRole, *http.Response, error) {
@@ -480,8 +483,9 @@ type CustomDatabaseRolesApiListCustomDatabaseRolesRequest struct {
 	ApiService CustomDatabaseRolesApi
 	groupId string
 }
+
 type CustomDatabaseRolesApiListCustomDatabaseRolesQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r CustomDatabaseRolesApiListCustomDatabaseRolesRequest) Execute() ([]CustomDBRole, *http.Response, error) {
@@ -602,10 +606,11 @@ type CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest struct {
 	roleName string
 	updateCustomDBRole *UpdateCustomDBRole
 }
+
 type CustomDatabaseRolesApiUpdateCustomDatabaseRoleQueryParams struct {
-		groupId string
-		roleName string
-		updateCustomDBRole *UpdateCustomDBRole
+		GroupId string
+		RoleName string
+		UpdateCustomDBRole *UpdateCustomDBRole
 }
 
 // Updates one custom role in the specified project.

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -110,7 +110,7 @@ type CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest struct {
 	customDBRole *CustomDBRole
 }
 
-type CustomDatabaseRolesApiCreateCustomDatabaseRoleQueryParams struct {
+type CustomDatabaseRolesApiCreateCustomDatabaseRoleParams struct {
 		GroupId string
 		CustomDBRole *CustomDBRole
 }
@@ -244,7 +244,7 @@ type CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest struct {
 	roleName string
 }
 
-type CustomDatabaseRolesApiDeleteCustomDatabaseRoleQueryParams struct {
+type CustomDatabaseRolesApiDeleteCustomDatabaseRoleParams struct {
 		GroupId string
 		RoleName string
 }
@@ -359,7 +359,7 @@ type CustomDatabaseRolesApiGetCustomDatabaseRoleRequest struct {
 	roleName string
 }
 
-type CustomDatabaseRolesApiGetCustomDatabaseRoleQueryParams struct {
+type CustomDatabaseRolesApiGetCustomDatabaseRoleParams struct {
 		GroupId string
 		RoleName string
 }
@@ -484,7 +484,7 @@ type CustomDatabaseRolesApiListCustomDatabaseRolesRequest struct {
 	groupId string
 }
 
-type CustomDatabaseRolesApiListCustomDatabaseRolesQueryParams struct {
+type CustomDatabaseRolesApiListCustomDatabaseRolesParams struct {
 		GroupId string
 }
 
@@ -607,7 +607,7 @@ type CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest struct {
 	updateCustomDBRole *UpdateCustomDBRole
 }
 
-type CustomDatabaseRolesApiUpdateCustomDatabaseRoleQueryParams struct {
+type CustomDatabaseRolesApiUpdateCustomDatabaseRoleParams struct {
 		GroupId string
 		RoleName string
 		UpdateCustomDBRole *UpdateCustomDBRole

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -110,7 +110,7 @@ type CreateCustomDatabaseRoleApiRequest struct {
 	customDBRole *CustomDBRole
 }
 
-type CreateCustomDatabaseRoleParams struct {
+type CreateCustomDatabaseRoleApiParams struct {
 		GroupId string
 		CustomDBRole *CustomDBRole
 }
@@ -244,7 +244,7 @@ type DeleteCustomDatabaseRoleApiRequest struct {
 	roleName string
 }
 
-type DeleteCustomDatabaseRoleParams struct {
+type DeleteCustomDatabaseRoleApiParams struct {
 		GroupId string
 		RoleName string
 }
@@ -359,7 +359,7 @@ type GetCustomDatabaseRoleApiRequest struct {
 	roleName string
 }
 
-type GetCustomDatabaseRoleParams struct {
+type GetCustomDatabaseRoleApiParams struct {
 		GroupId string
 		RoleName string
 }
@@ -484,7 +484,7 @@ type ListCustomDatabaseRolesApiRequest struct {
 	groupId string
 }
 
-type ListCustomDatabaseRolesParams struct {
+type ListCustomDatabaseRolesApiParams struct {
 		GroupId string
 }
 
@@ -607,7 +607,7 @@ type UpdateCustomDatabaseRoleApiRequest struct {
 	updateCustomDBRole *UpdateCustomDBRole
 }
 
-type UpdateCustomDatabaseRoleParams struct {
+type UpdateCustomDatabaseRoleApiParams struct {
 		GroupId string
 		RoleName string
 		UpdateCustomDBRole *UpdateCustomDBRole

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -109,6 +109,10 @@ type CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest struct {
 	groupId string
 	customDBRole *CustomDBRole
 }
+type CustomDatabaseRolesApiCreateCustomDatabaseRoleQueryParams struct {
+		groupId string
+		customDBRole *CustomDBRole
+}
 
 // Creates one custom role in the specified project.
 func (r CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest) CustomDBRole(customDBRole CustomDBRole) CustomDatabaseRolesApiCreateCustomDatabaseRoleRequest {
@@ -238,6 +242,10 @@ type CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest struct {
 	groupId string
 	roleName string
 }
+type CustomDatabaseRolesApiDeleteCustomDatabaseRoleQueryParams struct {
+		groupId string
+		roleName string
+}
 
 func (r CustomDatabaseRolesApiDeleteCustomDatabaseRoleRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteCustomDatabaseRoleExecute(r)
@@ -347,6 +355,10 @@ type CustomDatabaseRolesApiGetCustomDatabaseRoleRequest struct {
 	ApiService CustomDatabaseRolesApi
 	groupId string
 	roleName string
+}
+type CustomDatabaseRolesApiGetCustomDatabaseRoleQueryParams struct {
+		groupId string
+		roleName string
 }
 
 func (r CustomDatabaseRolesApiGetCustomDatabaseRoleRequest) Execute() (*CustomDBRole, *http.Response, error) {
@@ -468,6 +480,9 @@ type CustomDatabaseRolesApiListCustomDatabaseRolesRequest struct {
 	ApiService CustomDatabaseRolesApi
 	groupId string
 }
+type CustomDatabaseRolesApiListCustomDatabaseRolesQueryParams struct {
+		groupId string
+}
 
 func (r CustomDatabaseRolesApiListCustomDatabaseRolesRequest) Execute() ([]CustomDBRole, *http.Response, error) {
 	return r.ApiService.ListCustomDatabaseRolesExecute(r)
@@ -586,6 +601,11 @@ type CustomDatabaseRolesApiUpdateCustomDatabaseRoleRequest struct {
 	groupId string
 	roleName string
 	updateCustomDBRole *UpdateCustomDBRole
+}
+type CustomDatabaseRolesApiUpdateCustomDatabaseRoleQueryParams struct {
+		groupId string
+		roleName string
+		updateCustomDBRole *UpdateCustomDBRole
 }
 
 // Updates one custom role in the specified project.

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -271,6 +271,10 @@ type DataFederationApiCreateDataFederationPrivateEndpointRequest struct {
 	groupId string
 	privateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
+type DataFederationApiCreateDataFederationPrivateEndpointQueryParams struct {
+		groupId string
+		privateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
+}
 
 // Private endpoint for Federated Database Instances and Online Archives to add to the specified project.
 func (r DataFederationApiCreateDataFederationPrivateEndpointRequest) PrivateNetworkEndpointIdEntry(privateNetworkEndpointIdEntry PrivateNetworkEndpointIdEntry) DataFederationApiCreateDataFederationPrivateEndpointRequest {
@@ -419,6 +423,11 @@ type DataFederationApiCreateFederatedDatabaseRequest struct {
 	dataLakeTenant *DataLakeTenant
 	skipRoleValidation *bool
 }
+type DataFederationApiCreateFederatedDatabaseQueryParams struct {
+		groupId string
+		dataLakeTenant *DataLakeTenant
+		skipRoleValidation *bool
+}
 
 // Details to create one federated database instance in the specified project.
 func (r DataFederationApiCreateFederatedDatabaseRequest) DataLakeTenant(dataLakeTenant DataLakeTenant) DataFederationApiCreateFederatedDatabaseRequest {
@@ -563,6 +572,12 @@ type DataFederationApiCreateOneDataFederationQueryLimitRequest struct {
 	limitName string
 	dataFederationTenantQueryLimit *DataFederationTenantQueryLimit
 }
+type DataFederationApiCreateOneDataFederationQueryLimitQueryParams struct {
+		groupId string
+		tenantName string
+		limitName string
+		dataFederationTenantQueryLimit *DataFederationTenantQueryLimit
+}
 
 // Creates or updates one query limit for one federated database instance.
 func (r DataFederationApiCreateOneDataFederationQueryLimitRequest) DataFederationTenantQueryLimit(dataFederationTenantQueryLimit DataFederationTenantQueryLimit) DataFederationApiCreateOneDataFederationQueryLimitRequest {
@@ -698,6 +713,10 @@ type DataFederationApiDeleteDataFederationPrivateEndpointRequest struct {
 	groupId string
 	endpointId string
 }
+type DataFederationApiDeleteDataFederationPrivateEndpointQueryParams struct {
+		groupId string
+		endpointId string
+}
 
 func (r DataFederationApiDeleteDataFederationPrivateEndpointRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteDataFederationPrivateEndpointExecute(r)
@@ -814,6 +833,10 @@ type DataFederationApiDeleteFederatedDatabaseRequest struct {
 	groupId string
 	tenantName string
 }
+type DataFederationApiDeleteFederatedDatabaseQueryParams struct {
+		groupId string
+		tenantName string
+}
 
 func (r DataFederationApiDeleteFederatedDatabaseRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteFederatedDatabaseExecute(r)
@@ -924,6 +947,11 @@ type DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest struct {
 	groupId string
 	tenantName string
 	limitName string
+}
+type DataFederationApiDeleteOneDataFederationInstanceQueryLimitQueryParams struct {
+		groupId string
+		tenantName string
+		limitName string
 }
 
 func (r DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest) Execute() (*http.Response, error) {
@@ -1039,6 +1067,12 @@ type DataFederationApiDownloadFederatedDatabaseQueryLogsRequest struct {
 	tenantName string
 	endDate *int64
 	startDate *int64
+}
+type DataFederationApiDownloadFederatedDatabaseQueryLogsQueryParams struct {
+		groupId string
+		tenantName string
+		endDate *int64
+		startDate *int64
 }
 
 // Timestamp that specifies the end point for the range of log messages to download.  MongoDB Cloud expresses this timestamp in the number of seconds that have elapsed since the UNIX epoch.
@@ -1179,6 +1213,10 @@ type DataFederationApiGetDataFederationPrivateEndpointRequest struct {
 	groupId string
 	endpointId string
 }
+type DataFederationApiGetDataFederationPrivateEndpointQueryParams struct {
+		groupId string
+		endpointId string
+}
 
 func (r DataFederationApiGetDataFederationPrivateEndpointRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	return r.ApiService.GetDataFederationPrivateEndpointExecute(r)
@@ -1306,6 +1344,10 @@ type DataFederationApiGetFederatedDatabaseRequest struct {
 	groupId string
 	tenantName string
 }
+type DataFederationApiGetFederatedDatabaseQueryParams struct {
+		groupId string
+		tenantName string
+}
 
 func (r DataFederationApiGetFederatedDatabaseRequest) Execute() (*DataLakeTenant, *http.Response, error) {
 	return r.ApiService.GetFederatedDatabaseExecute(r)
@@ -1426,6 +1468,9 @@ type DataFederationApiListDataFederationPrivateEndpointsRequest struct {
 	ApiService DataFederationApi
 	groupId string
 }
+type DataFederationApiListDataFederationPrivateEndpointsQueryParams struct {
+		groupId string
+}
 
 func (r DataFederationApiListDataFederationPrivateEndpointsRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	return r.ApiService.ListDataFederationPrivateEndpointsExecute(r)
@@ -1543,6 +1588,10 @@ type DataFederationApiListFederatedDatabasesRequest struct {
 	ApiService DataFederationApi
 	groupId string
 	type_ *string
+}
+type DataFederationApiListFederatedDatabasesQueryParams struct {
+		groupId string
+		type_ *string
 }
 
 // Type of Federated Database Instances to return.
@@ -1676,6 +1725,11 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitRequest struct {
 	tenantName string
 	limitName string
 }
+type DataFederationApiReturnFederatedDatabaseQueryLimitQueryParams struct {
+		groupId string
+		tenantName string
+		limitName string
+}
 
 func (r DataFederationApiReturnFederatedDatabaseQueryLimitRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	return r.ApiService.ReturnFederatedDatabaseQueryLimitExecute(r)
@@ -1800,6 +1854,10 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitsRequest struct {
 	groupId string
 	tenantName string
 }
+type DataFederationApiReturnFederatedDatabaseQueryLimitsQueryParams struct {
+		groupId string
+		tenantName string
+}
 
 func (r DataFederationApiReturnFederatedDatabaseQueryLimitsRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	return r.ApiService.ReturnFederatedDatabaseQueryLimitsExecute(r)
@@ -1922,6 +1980,12 @@ type DataFederationApiUpdateFederatedDatabaseRequest struct {
 	tenantName string
 	skipRoleValidation *bool
 	dataLakeTenant *DataLakeTenant
+}
+type DataFederationApiUpdateFederatedDatabaseQueryParams struct {
+		groupId string
+		tenantName string
+		skipRoleValidation *bool
+		dataLakeTenant *DataLakeTenant
 }
 
 // Flag that indicates whether this request should check if the requesting IAM role can read from the S3 bucket. AWS checks if the role can list the objects in the bucket before writing to it. Some IAM roles only need write permissions. This flag allows you to skip that check.

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -272,7 +272,7 @@ type CreateDataFederationPrivateEndpointApiRequest struct {
 	privateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
 
-type CreateDataFederationPrivateEndpointParams struct {
+type CreateDataFederationPrivateEndpointApiParams struct {
 		GroupId string
 		PrivateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
@@ -425,7 +425,7 @@ type CreateFederatedDatabaseApiRequest struct {
 	skipRoleValidation *bool
 }
 
-type CreateFederatedDatabaseParams struct {
+type CreateFederatedDatabaseApiParams struct {
 		GroupId string
 		DataLakeTenant *DataLakeTenant
 		SkipRoleValidation *bool
@@ -575,7 +575,7 @@ type CreateOneDataFederationQueryLimitApiRequest struct {
 	dataFederationTenantQueryLimit *DataFederationTenantQueryLimit
 }
 
-type CreateOneDataFederationQueryLimitParams struct {
+type CreateOneDataFederationQueryLimitApiParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -717,7 +717,7 @@ type DeleteDataFederationPrivateEndpointApiRequest struct {
 	endpointId string
 }
 
-type DeleteDataFederationPrivateEndpointParams struct {
+type DeleteDataFederationPrivateEndpointApiParams struct {
 		GroupId string
 		EndpointId string
 }
@@ -838,7 +838,7 @@ type DeleteFederatedDatabaseApiRequest struct {
 	tenantName string
 }
 
-type DeleteFederatedDatabaseParams struct {
+type DeleteFederatedDatabaseApiParams struct {
 		GroupId string
 		TenantName string
 }
@@ -954,7 +954,7 @@ type DeleteOneDataFederationInstanceQueryLimitApiRequest struct {
 	limitName string
 }
 
-type DeleteOneDataFederationInstanceQueryLimitParams struct {
+type DeleteOneDataFederationInstanceQueryLimitApiParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -1075,7 +1075,7 @@ type DownloadFederatedDatabaseQueryLogsApiRequest struct {
 	startDate *int64
 }
 
-type DownloadFederatedDatabaseQueryLogsParams struct {
+type DownloadFederatedDatabaseQueryLogsApiParams struct {
 		GroupId string
 		TenantName string
 		EndDate *int64
@@ -1221,7 +1221,7 @@ type GetDataFederationPrivateEndpointApiRequest struct {
 	endpointId string
 }
 
-type GetDataFederationPrivateEndpointParams struct {
+type GetDataFederationPrivateEndpointApiParams struct {
 		GroupId string
 		EndpointId string
 }
@@ -1353,7 +1353,7 @@ type GetFederatedDatabaseApiRequest struct {
 	tenantName string
 }
 
-type GetFederatedDatabaseParams struct {
+type GetFederatedDatabaseApiParams struct {
 		GroupId string
 		TenantName string
 }
@@ -1478,7 +1478,7 @@ type ListDataFederationPrivateEndpointsApiRequest struct {
 	groupId string
 }
 
-type ListDataFederationPrivateEndpointsParams struct {
+type ListDataFederationPrivateEndpointsApiParams struct {
 		GroupId string
 }
 
@@ -1600,7 +1600,7 @@ type ListFederatedDatabasesApiRequest struct {
 	type_ *string
 }
 
-type ListFederatedDatabasesParams struct {
+type ListFederatedDatabasesApiParams struct {
 		GroupId string
 		Type_ *string
 }
@@ -1737,7 +1737,7 @@ type ReturnFederatedDatabaseQueryLimitApiRequest struct {
 	limitName string
 }
 
-type ReturnFederatedDatabaseQueryLimitParams struct {
+type ReturnFederatedDatabaseQueryLimitApiParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -1867,7 +1867,7 @@ type ReturnFederatedDatabaseQueryLimitsApiRequest struct {
 	tenantName string
 }
 
-type ReturnFederatedDatabaseQueryLimitsParams struct {
+type ReturnFederatedDatabaseQueryLimitsApiParams struct {
 		GroupId string
 		TenantName string
 }
@@ -1995,7 +1995,7 @@ type UpdateFederatedDatabaseApiRequest struct {
 	dataLakeTenant *DataLakeTenant
 }
 
-type UpdateFederatedDatabaseParams struct {
+type UpdateFederatedDatabaseApiParams struct {
 		GroupId string
 		TenantName string
 		SkipRoleValidation *bool

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -48,13 +48,13 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DataFederationApiCreateDataFederationPrivateEndpointRequest
+	@return CreateDataFederationPrivateEndpointApiRequest
 	*/
-	CreateDataFederationPrivateEndpoint(ctx context.Context, groupId string) DataFederationApiCreateDataFederationPrivateEndpointRequest
+	CreateDataFederationPrivateEndpoint(ctx context.Context, groupId string) CreateDataFederationPrivateEndpointApiRequest
 
 	// CreateDataFederationPrivateEndpointExecute executes the request
 	//  @return []PrivateNetworkEndpointIdEntry
-	CreateDataFederationPrivateEndpointExecute(r DataFederationApiCreateDataFederationPrivateEndpointRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
+	CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 	CreateFederatedDatabase Create One Federated Database Instance in One Project
@@ -63,13 +63,13 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DataFederationApiCreateFederatedDatabaseRequest
+	@return CreateFederatedDatabaseApiRequest
 	*/
-	CreateFederatedDatabase(ctx context.Context, groupId string) DataFederationApiCreateFederatedDatabaseRequest
+	CreateFederatedDatabase(ctx context.Context, groupId string) CreateFederatedDatabaseApiRequest
 
 	// CreateFederatedDatabaseExecute executes the request
 	//  @return DataLakeTenant
-	CreateFederatedDatabaseExecute(r DataFederationApiCreateFederatedDatabaseRequest) (*DataLakeTenant, *http.Response, error)
+	CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
 	CreateOneDataFederationQueryLimit Configure One Query Limit for One Federated Database Instance
@@ -80,13 +80,13 @@ type DataFederationApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the federated database instance to which the query limit applies.
 	@param limitName Human-readable label that identifies this data federation instance limit.  | Limit Name | Description | Default | | --- | --- | --- | | bytesProcessed.query | Limit on the number of bytes processed during a single data federation query | N/A | | bytesProcessed.daily | Limit on the number of bytes processed for the data federation instance for the current day | N/A | | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A | | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A | 
-	@return DataFederationApiCreateOneDataFederationQueryLimitRequest
+	@return CreateOneDataFederationQueryLimitApiRequest
 	*/
-	CreateOneDataFederationQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DataFederationApiCreateOneDataFederationQueryLimitRequest
+	CreateOneDataFederationQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) CreateOneDataFederationQueryLimitApiRequest
 
 	// CreateOneDataFederationQueryLimitExecute executes the request
 	//  @return []DataFederationTenantQueryLimit
-	CreateOneDataFederationQueryLimitExecute(r DataFederationApiCreateOneDataFederationQueryLimitRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
+	CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 	DeleteDataFederationPrivateEndpoint Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
@@ -96,12 +96,12 @@ type DataFederationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param endpointId Unique 22-character alphanumeric string that identifies the private endpoint to remove. Atlas Data Federation supports AWS private endpoints using the AWS PrivateLink feature.
-	@return DataFederationApiDeleteDataFederationPrivateEndpointRequest
+	@return DeleteDataFederationPrivateEndpointApiRequest
 	*/
-	DeleteDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) DataFederationApiDeleteDataFederationPrivateEndpointRequest
+	DeleteDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) DeleteDataFederationPrivateEndpointApiRequest
 
 	// DeleteDataFederationPrivateEndpointExecute executes the request
-	DeleteDataFederationPrivateEndpointExecute(r DataFederationApiDeleteDataFederationPrivateEndpointRequest) (*http.Response, error)
+	DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (*http.Response, error)
 
 	/*
 	DeleteFederatedDatabase Remove One Federated Database Instance from One Project
@@ -111,12 +111,12 @@ type DataFederationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the federated database instance to remove.
-	@return DataFederationApiDeleteFederatedDatabaseRequest
+	@return DeleteFederatedDatabaseApiRequest
 	*/
-	DeleteFederatedDatabase(ctx context.Context, groupId string, tenantName string) DataFederationApiDeleteFederatedDatabaseRequest
+	DeleteFederatedDatabase(ctx context.Context, groupId string, tenantName string) DeleteFederatedDatabaseApiRequest
 
 	// DeleteFederatedDatabaseExecute executes the request
-	DeleteFederatedDatabaseExecute(r DataFederationApiDeleteFederatedDatabaseRequest) (*http.Response, error)
+	DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (*http.Response, error)
 
 	/*
 	DeleteOneDataFederationInstanceQueryLimit Delete One Query Limit For One Federated Database Instance
@@ -127,12 +127,12 @@ type DataFederationApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the federated database instance to which the query limit applies.
 	@param limitName Human-readable label that identifies this data federation instance limit.  | Limit Name | Description | Default | | --- | --- | --- | | bytesProcessed.query | Limit on the number of bytes processed during a single data federation query | N/A | | bytesProcessed.daily | Limit on the number of bytes processed for the data federation instance for the current day | N/A | | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A | | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A | 
-	@return DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest
+	@return DeleteOneDataFederationInstanceQueryLimitApiRequest
 	*/
-	DeleteOneDataFederationInstanceQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest
+	DeleteOneDataFederationInstanceQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DeleteOneDataFederationInstanceQueryLimitApiRequest
 
 	// DeleteOneDataFederationInstanceQueryLimitExecute executes the request
-	DeleteOneDataFederationInstanceQueryLimitExecute(r DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest) (*http.Response, error)
+	DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (*http.Response, error)
 
 	/*
 	DownloadFederatedDatabaseQueryLogs Download Query Logs for One Federated Database Instance
@@ -142,13 +142,13 @@ type DataFederationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the federated database instance for which you want to download query logs.
-	@return DataFederationApiDownloadFederatedDatabaseQueryLogsRequest
+	@return DownloadFederatedDatabaseQueryLogsApiRequest
 	*/
-	DownloadFederatedDatabaseQueryLogs(ctx context.Context, groupId string, tenantName string) DataFederationApiDownloadFederatedDatabaseQueryLogsRequest
+	DownloadFederatedDatabaseQueryLogs(ctx context.Context, groupId string, tenantName string) DownloadFederatedDatabaseQueryLogsApiRequest
 
 	// DownloadFederatedDatabaseQueryLogsExecute executes the request
 	//  @return *os.File
-	DownloadFederatedDatabaseQueryLogsExecute(r DataFederationApiDownloadFederatedDatabaseQueryLogsRequest) (*os.File, *http.Response, error)
+	DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error)
 
 	/*
 	GetDataFederationPrivateEndpoint Return One Federated Database Instance and Online Archive Private Endpoint in One Project
@@ -158,13 +158,13 @@ type DataFederationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param endpointId Unique 22-character alphanumeric string that identifies the private endpoint to return. Atlas Data Federation supports AWS private endpoints using the AWS PrivateLink feature.
-	@return DataFederationApiGetDataFederationPrivateEndpointRequest
+	@return GetDataFederationPrivateEndpointApiRequest
 	*/
-	GetDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) DataFederationApiGetDataFederationPrivateEndpointRequest
+	GetDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) GetDataFederationPrivateEndpointApiRequest
 
 	// GetDataFederationPrivateEndpointExecute executes the request
 	//  @return PrivateNetworkEndpointIdEntry
-	GetDataFederationPrivateEndpointExecute(r DataFederationApiGetDataFederationPrivateEndpointRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error)
+	GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 	GetFederatedDatabase Return One Federated Database Instance in One Project
@@ -174,13 +174,13 @@ type DataFederationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the Federated Database to return.
-	@return DataFederationApiGetFederatedDatabaseRequest
+	@return GetFederatedDatabaseApiRequest
 	*/
-	GetFederatedDatabase(ctx context.Context, groupId string, tenantName string) DataFederationApiGetFederatedDatabaseRequest
+	GetFederatedDatabase(ctx context.Context, groupId string, tenantName string) GetFederatedDatabaseApiRequest
 
 	// GetFederatedDatabaseExecute executes the request
 	//  @return DataLakeTenant
-	GetFederatedDatabaseExecute(r DataFederationApiGetFederatedDatabaseRequest) (*DataLakeTenant, *http.Response, error)
+	GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
 	ListDataFederationPrivateEndpoints Return All Federated Database Instance and Online Archive Private Endpoints in One Project
@@ -189,13 +189,13 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DataFederationApiListDataFederationPrivateEndpointsRequest
+	@return ListDataFederationPrivateEndpointsApiRequest
 	*/
-	ListDataFederationPrivateEndpoints(ctx context.Context, groupId string) DataFederationApiListDataFederationPrivateEndpointsRequest
+	ListDataFederationPrivateEndpoints(ctx context.Context, groupId string) ListDataFederationPrivateEndpointsApiRequest
 
 	// ListDataFederationPrivateEndpointsExecute executes the request
 	//  @return []PrivateNetworkEndpointIdEntry
-	ListDataFederationPrivateEndpointsExecute(r DataFederationApiListDataFederationPrivateEndpointsRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
+	ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 	ListFederatedDatabases Return All Federated Database Instances in One Project
@@ -204,13 +204,13 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DataFederationApiListFederatedDatabasesRequest
+	@return ListFederatedDatabasesApiRequest
 	*/
-	ListFederatedDatabases(ctx context.Context, groupId string) DataFederationApiListFederatedDatabasesRequest
+	ListFederatedDatabases(ctx context.Context, groupId string) ListFederatedDatabasesApiRequest
 
 	// ListFederatedDatabasesExecute executes the request
 	//  @return []DataLakeTenant
-	ListFederatedDatabasesExecute(r DataFederationApiListFederatedDatabasesRequest) ([]DataLakeTenant, *http.Response, error)
+	ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error)
 
 	/*
 	ReturnFederatedDatabaseQueryLimit Return One Federated Database Instance Query Limit for One Project
@@ -221,13 +221,13 @@ type DataFederationApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the federated database instance to which the query limit applies.
 	@param limitName Human-readable label that identifies this data federation instance limit.  | Limit Name | Description | Default | | --- | --- | --- | | bytesProcessed.query | Limit on the number of bytes processed during a single data federation query | N/A | | bytesProcessed.daily | Limit on the number of bytes processed for the data federation instance for the current day | N/A | | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A | | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A | 
-	@return DataFederationApiReturnFederatedDatabaseQueryLimitRequest
+	@return ReturnFederatedDatabaseQueryLimitApiRequest
 	*/
-	ReturnFederatedDatabaseQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DataFederationApiReturnFederatedDatabaseQueryLimitRequest
+	ReturnFederatedDatabaseQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) ReturnFederatedDatabaseQueryLimitApiRequest
 
 	// ReturnFederatedDatabaseQueryLimitExecute executes the request
 	//  @return []DataFederationTenantQueryLimit
-	ReturnFederatedDatabaseQueryLimitExecute(r DataFederationApiReturnFederatedDatabaseQueryLimitRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
+	ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 	ReturnFederatedDatabaseQueryLimits Return All Query Limits for One Federated Database Instance
@@ -237,13 +237,13 @@ type DataFederationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the federated database instance for which you want to retrieve query limits.
-	@return DataFederationApiReturnFederatedDatabaseQueryLimitsRequest
+	@return ReturnFederatedDatabaseQueryLimitsApiRequest
 	*/
-	ReturnFederatedDatabaseQueryLimits(ctx context.Context, groupId string, tenantName string) DataFederationApiReturnFederatedDatabaseQueryLimitsRequest
+	ReturnFederatedDatabaseQueryLimits(ctx context.Context, groupId string, tenantName string) ReturnFederatedDatabaseQueryLimitsApiRequest
 
 	// ReturnFederatedDatabaseQueryLimitsExecute executes the request
 	//  @return []DataFederationTenantQueryLimit
-	ReturnFederatedDatabaseQueryLimitsExecute(r DataFederationApiReturnFederatedDatabaseQueryLimitsRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
+	ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 	UpdateFederatedDatabase Update One Federated Database Instance in One Project
@@ -253,19 +253,19 @@ type DataFederationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param tenantName Human-readable label that identifies the federated database instance to update.
-	@return DataFederationApiUpdateFederatedDatabaseRequest
+	@return UpdateFederatedDatabaseApiRequest
 	*/
-	UpdateFederatedDatabase(ctx context.Context, groupId string, tenantName string) DataFederationApiUpdateFederatedDatabaseRequest
+	UpdateFederatedDatabase(ctx context.Context, groupId string, tenantName string) UpdateFederatedDatabaseApiRequest
 
 	// UpdateFederatedDatabaseExecute executes the request
 	//  @return DataLakeTenant
-	UpdateFederatedDatabaseExecute(r DataFederationApiUpdateFederatedDatabaseRequest) (*DataLakeTenant, *http.Response, error)
+	UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 }
 
 // DataFederationApiService DataFederationApi service
 type DataFederationApiService service
 
-type DataFederationApiCreateDataFederationPrivateEndpointRequest struct {
+type CreateDataFederationPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -278,12 +278,12 @@ type CreateDataFederationPrivateEndpointParams struct {
 }
 
 // Private endpoint for Federated Database Instances and Online Archives to add to the specified project.
-func (r DataFederationApiCreateDataFederationPrivateEndpointRequest) PrivateNetworkEndpointIdEntry(privateNetworkEndpointIdEntry PrivateNetworkEndpointIdEntry) DataFederationApiCreateDataFederationPrivateEndpointRequest {
+func (r CreateDataFederationPrivateEndpointApiRequest) PrivateNetworkEndpointIdEntry(privateNetworkEndpointIdEntry PrivateNetworkEndpointIdEntry) CreateDataFederationPrivateEndpointApiRequest {
 	r.privateNetworkEndpointIdEntry = &privateNetworkEndpointIdEntry
 	return r
 }
 
-func (r DataFederationApiCreateDataFederationPrivateEndpointRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (r CreateDataFederationPrivateEndpointApiRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	return r.ApiService.CreateDataFederationPrivateEndpointExecute(r)
 }
 
@@ -312,10 +312,10 @@ Adds one private endpoint for Federated Database Instances and Online Archives t
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DataFederationApiCreateDataFederationPrivateEndpointRequest
+ @return CreateDataFederationPrivateEndpointApiRequest
 */
-func (a *DataFederationApiService) CreateDataFederationPrivateEndpoint(ctx context.Context, groupId string) DataFederationApiCreateDataFederationPrivateEndpointRequest {
-	return DataFederationApiCreateDataFederationPrivateEndpointRequest{
+func (a *DataFederationApiService) CreateDataFederationPrivateEndpoint(ctx context.Context, groupId string) CreateDataFederationPrivateEndpointApiRequest {
+	return CreateDataFederationPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -324,7 +324,7 @@ func (a *DataFederationApiService) CreateDataFederationPrivateEndpoint(ctx conte
 
 // Execute executes the request
 //  @return []PrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) CreateDataFederationPrivateEndpointExecute(r DataFederationApiCreateDataFederationPrivateEndpointRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -417,7 +417,7 @@ func (a *DataFederationApiService) CreateDataFederationPrivateEndpointExecute(r 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiCreateFederatedDatabaseRequest struct {
+type CreateFederatedDatabaseApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -432,18 +432,18 @@ type CreateFederatedDatabaseParams struct {
 }
 
 // Details to create one federated database instance in the specified project.
-func (r DataFederationApiCreateFederatedDatabaseRequest) DataLakeTenant(dataLakeTenant DataLakeTenant) DataFederationApiCreateFederatedDatabaseRequest {
+func (r CreateFederatedDatabaseApiRequest) DataLakeTenant(dataLakeTenant DataLakeTenant) CreateFederatedDatabaseApiRequest {
 	r.dataLakeTenant = &dataLakeTenant
 	return r
 }
 
 // Flag that indicates whether this request should check if the requesting IAM role can read from the S3 bucket. AWS checks if the role can list the objects in the bucket before writing to it. Some IAM roles only need write permissions. This flag allows you to skip that check.
-func (r DataFederationApiCreateFederatedDatabaseRequest) SkipRoleValidation(skipRoleValidation bool) DataFederationApiCreateFederatedDatabaseRequest {
+func (r CreateFederatedDatabaseApiRequest) SkipRoleValidation(skipRoleValidation bool) CreateFederatedDatabaseApiRequest {
 	r.skipRoleValidation = &skipRoleValidation
 	return r
 }
 
-func (r DataFederationApiCreateFederatedDatabaseRequest) Execute() (*DataLakeTenant, *http.Response, error) {
+func (r CreateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
 	return r.ApiService.CreateFederatedDatabaseExecute(r)
 }
 
@@ -454,10 +454,10 @@ Creates one federated database instance in the specified project. To use this re
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DataFederationApiCreateFederatedDatabaseRequest
+ @return CreateFederatedDatabaseApiRequest
 */
-func (a *DataFederationApiService) CreateFederatedDatabase(ctx context.Context, groupId string) DataFederationApiCreateFederatedDatabaseRequest {
-	return DataFederationApiCreateFederatedDatabaseRequest{
+func (a *DataFederationApiService) CreateFederatedDatabase(ctx context.Context, groupId string) CreateFederatedDatabaseApiRequest {
+	return CreateFederatedDatabaseApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -466,7 +466,7 @@ func (a *DataFederationApiService) CreateFederatedDatabase(ctx context.Context, 
 
 // Execute executes the request
 //  @return DataLakeTenant
-func (a *DataFederationApiService) CreateFederatedDatabaseExecute(r DataFederationApiCreateFederatedDatabaseRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -566,7 +566,7 @@ func (a *DataFederationApiService) CreateFederatedDatabaseExecute(r DataFederati
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiCreateOneDataFederationQueryLimitRequest struct {
+type CreateOneDataFederationQueryLimitApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -583,12 +583,12 @@ type CreateOneDataFederationQueryLimitParams struct {
 }
 
 // Creates or updates one query limit for one federated database instance.
-func (r DataFederationApiCreateOneDataFederationQueryLimitRequest) DataFederationTenantQueryLimit(dataFederationTenantQueryLimit DataFederationTenantQueryLimit) DataFederationApiCreateOneDataFederationQueryLimitRequest {
+func (r CreateOneDataFederationQueryLimitApiRequest) DataFederationTenantQueryLimit(dataFederationTenantQueryLimit DataFederationTenantQueryLimit) CreateOneDataFederationQueryLimitApiRequest {
 	r.dataFederationTenantQueryLimit = &dataFederationTenantQueryLimit
 	return r
 }
 
-func (r DataFederationApiCreateOneDataFederationQueryLimitRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (r CreateOneDataFederationQueryLimitApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	return r.ApiService.CreateOneDataFederationQueryLimitExecute(r)
 }
 
@@ -601,10 +601,10 @@ Creates or updates one query limit for one federated database instance. To use t
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the federated database instance to which the query limit applies.
  @param limitName Human-readable label that identifies this data federation instance limit.  | Limit Name | Description | Default | | --- | --- | --- | | bytesProcessed.query | Limit on the number of bytes processed during a single data federation query | N/A | | bytesProcessed.daily | Limit on the number of bytes processed for the data federation instance for the current day | N/A | | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A | | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A | 
- @return DataFederationApiCreateOneDataFederationQueryLimitRequest
+ @return CreateOneDataFederationQueryLimitApiRequest
 */
-func (a *DataFederationApiService) CreateOneDataFederationQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DataFederationApiCreateOneDataFederationQueryLimitRequest {
-	return DataFederationApiCreateOneDataFederationQueryLimitRequest{
+func (a *DataFederationApiService) CreateOneDataFederationQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) CreateOneDataFederationQueryLimitApiRequest {
+	return CreateOneDataFederationQueryLimitApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -615,7 +615,7 @@ func (a *DataFederationApiService) CreateOneDataFederationQueryLimit(ctx context
 
 // Execute executes the request
 //  @return []DataFederationTenantQueryLimit
-func (a *DataFederationApiService) CreateOneDataFederationQueryLimitExecute(r DataFederationApiCreateOneDataFederationQueryLimitRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -710,7 +710,7 @@ func (a *DataFederationApiService) CreateOneDataFederationQueryLimitExecute(r Da
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiDeleteDataFederationPrivateEndpointRequest struct {
+type DeleteDataFederationPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -722,7 +722,7 @@ type DeleteDataFederationPrivateEndpointParams struct {
 		EndpointId string
 }
 
-func (r DataFederationApiDeleteDataFederationPrivateEndpointRequest) Execute() (*http.Response, error) {
+func (r DeleteDataFederationPrivateEndpointApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteDataFederationPrivateEndpointExecute(r)
 }
 
@@ -734,10 +734,10 @@ Removes one private endpoint for Federated Database Instances and Online Archive
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param endpointId Unique 22-character alphanumeric string that identifies the private endpoint to remove. Atlas Data Federation supports AWS private endpoints using the AWS PrivateLink feature.
- @return DataFederationApiDeleteDataFederationPrivateEndpointRequest
+ @return DeleteDataFederationPrivateEndpointApiRequest
 */
-func (a *DataFederationApiService) DeleteDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) DataFederationApiDeleteDataFederationPrivateEndpointRequest {
-	return DataFederationApiDeleteDataFederationPrivateEndpointRequest{
+func (a *DataFederationApiService) DeleteDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) DeleteDataFederationPrivateEndpointApiRequest {
+	return DeleteDataFederationPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -746,7 +746,7 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpoint(ctx conte
 }
 
 // Execute executes the request
-func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r DataFederationApiDeleteDataFederationPrivateEndpointRequest) (*http.Response, error) {
+func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -831,7 +831,7 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r 
 	return localVarHTTPResponse, nil
 }
 
-type DataFederationApiDeleteFederatedDatabaseRequest struct {
+type DeleteFederatedDatabaseApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -843,7 +843,7 @@ type DeleteFederatedDatabaseParams struct {
 		TenantName string
 }
 
-func (r DataFederationApiDeleteFederatedDatabaseRequest) Execute() (*http.Response, error) {
+func (r DeleteFederatedDatabaseApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteFederatedDatabaseExecute(r)
 }
 
@@ -855,10 +855,10 @@ Removes one federated database instance from the specified project. To use this 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the federated database instance to remove.
- @return DataFederationApiDeleteFederatedDatabaseRequest
+ @return DeleteFederatedDatabaseApiRequest
 */
-func (a *DataFederationApiService) DeleteFederatedDatabase(ctx context.Context, groupId string, tenantName string) DataFederationApiDeleteFederatedDatabaseRequest {
-	return DataFederationApiDeleteFederatedDatabaseRequest{
+func (a *DataFederationApiService) DeleteFederatedDatabase(ctx context.Context, groupId string, tenantName string) DeleteFederatedDatabaseApiRequest {
+	return DeleteFederatedDatabaseApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -867,7 +867,7 @@ func (a *DataFederationApiService) DeleteFederatedDatabase(ctx context.Context, 
 }
 
 // Execute executes the request
-func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DataFederationApiDeleteFederatedDatabaseRequest) (*http.Response, error) {
+func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -946,7 +946,7 @@ func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DataFederati
 	return localVarHTTPResponse, nil
 }
 
-type DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest struct {
+type DeleteOneDataFederationInstanceQueryLimitApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -960,7 +960,7 @@ type DeleteOneDataFederationInstanceQueryLimitParams struct {
 		LimitName string
 }
 
-func (r DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest) Execute() (*http.Response, error) {
+func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOneDataFederationInstanceQueryLimitExecute(r)
 }
 
@@ -973,10 +973,10 @@ Deletes one query limit for one federated database instance. To use this resourc
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the federated database instance to which the query limit applies.
  @param limitName Human-readable label that identifies this data federation instance limit.  | Limit Name | Description | Default | | --- | --- | --- | | bytesProcessed.query | Limit on the number of bytes processed during a single data federation query | N/A | | bytesProcessed.daily | Limit on the number of bytes processed for the data federation instance for the current day | N/A | | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A | | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A | 
- @return DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest
+ @return DeleteOneDataFederationInstanceQueryLimitApiRequest
 */
-func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest {
-	return DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest{
+func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DeleteOneDataFederationInstanceQueryLimitApiRequest {
+	return DeleteOneDataFederationInstanceQueryLimitApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -986,7 +986,7 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimit(ctx
 }
 
 // Execute executes the request
-func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExecute(r DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest) (*http.Response, error) {
+func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1066,7 +1066,7 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExec
 	return localVarHTTPResponse, nil
 }
 
-type DataFederationApiDownloadFederatedDatabaseQueryLogsRequest struct {
+type DownloadFederatedDatabaseQueryLogsApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -1083,18 +1083,18 @@ type DownloadFederatedDatabaseQueryLogsParams struct {
 }
 
 // Timestamp that specifies the end point for the range of log messages to download.  MongoDB Cloud expresses this timestamp in the number of seconds that have elapsed since the UNIX epoch.
-func (r DataFederationApiDownloadFederatedDatabaseQueryLogsRequest) EndDate(endDate int64) DataFederationApiDownloadFederatedDatabaseQueryLogsRequest {
+func (r DownloadFederatedDatabaseQueryLogsApiRequest) EndDate(endDate int64) DownloadFederatedDatabaseQueryLogsApiRequest {
 	r.endDate = &endDate
 	return r
 }
 
 // Timestamp that specifies the starting point for the range of log messages to download. MongoDB Cloud expresses this timestamp in the number of seconds that have elapsed since the UNIX epoch.
-func (r DataFederationApiDownloadFederatedDatabaseQueryLogsRequest) StartDate(startDate int64) DataFederationApiDownloadFederatedDatabaseQueryLogsRequest {
+func (r DownloadFederatedDatabaseQueryLogsApiRequest) StartDate(startDate int64) DownloadFederatedDatabaseQueryLogsApiRequest {
 	r.startDate = &startDate
 	return r
 }
 
-func (r DataFederationApiDownloadFederatedDatabaseQueryLogsRequest) Execute() (*os.File, *http.Response, error) {
+func (r DownloadFederatedDatabaseQueryLogsApiRequest) Execute() (*os.File, *http.Response, error) {
 	return r.ApiService.DownloadFederatedDatabaseQueryLogsExecute(r)
 }
 
@@ -1106,10 +1106,10 @@ Downloads the query logs for the specified federated database instance. To use t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the federated database instance for which you want to download query logs.
- @return DataFederationApiDownloadFederatedDatabaseQueryLogsRequest
+ @return DownloadFederatedDatabaseQueryLogsApiRequest
 */
-func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogs(ctx context.Context, groupId string, tenantName string) DataFederationApiDownloadFederatedDatabaseQueryLogsRequest {
-	return DataFederationApiDownloadFederatedDatabaseQueryLogsRequest{
+func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogs(ctx context.Context, groupId string, tenantName string) DownloadFederatedDatabaseQueryLogsApiRequest {
+	return DownloadFederatedDatabaseQueryLogsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1119,7 +1119,7 @@ func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogs(ctx contex
 
 // Execute executes the request
 //  @return *os.File
-func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogsExecute(r DataFederationApiDownloadFederatedDatabaseQueryLogsRequest) (*os.File, *http.Response, error) {
+func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1214,7 +1214,7 @@ func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogsExecute(r D
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiGetDataFederationPrivateEndpointRequest struct {
+type GetDataFederationPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -1226,7 +1226,7 @@ type GetDataFederationPrivateEndpointParams struct {
 		EndpointId string
 }
 
-func (r DataFederationApiGetDataFederationPrivateEndpointRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (r GetDataFederationPrivateEndpointApiRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	return r.ApiService.GetDataFederationPrivateEndpointExecute(r)
 }
 
@@ -1238,10 +1238,10 @@ Returns the specified private endpoint for Federated Database Instances or Onlin
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param endpointId Unique 22-character alphanumeric string that identifies the private endpoint to return. Atlas Data Federation supports AWS private endpoints using the AWS PrivateLink feature.
- @return DataFederationApiGetDataFederationPrivateEndpointRequest
+ @return GetDataFederationPrivateEndpointApiRequest
 */
-func (a *DataFederationApiService) GetDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) DataFederationApiGetDataFederationPrivateEndpointRequest {
-	return DataFederationApiGetDataFederationPrivateEndpointRequest{
+func (a *DataFederationApiService) GetDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) GetDataFederationPrivateEndpointApiRequest {
+	return GetDataFederationPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1251,7 +1251,7 @@ func (a *DataFederationApiService) GetDataFederationPrivateEndpoint(ctx context.
 
 // Execute executes the request
 //  @return PrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) GetDataFederationPrivateEndpointExecute(r DataFederationApiGetDataFederationPrivateEndpointRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1346,7 +1346,7 @@ func (a *DataFederationApiService) GetDataFederationPrivateEndpointExecute(r Dat
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiGetFederatedDatabaseRequest struct {
+type GetFederatedDatabaseApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -1358,7 +1358,7 @@ type GetFederatedDatabaseParams struct {
 		TenantName string
 }
 
-func (r DataFederationApiGetFederatedDatabaseRequest) Execute() (*DataLakeTenant, *http.Response, error) {
+func (r GetFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
 	return r.ApiService.GetFederatedDatabaseExecute(r)
 }
 
@@ -1370,10 +1370,10 @@ Returns the details of one federated database instance within the specified proj
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the Federated Database to return.
- @return DataFederationApiGetFederatedDatabaseRequest
+ @return GetFederatedDatabaseApiRequest
 */
-func (a *DataFederationApiService) GetFederatedDatabase(ctx context.Context, groupId string, tenantName string) DataFederationApiGetFederatedDatabaseRequest {
-	return DataFederationApiGetFederatedDatabaseRequest{
+func (a *DataFederationApiService) GetFederatedDatabase(ctx context.Context, groupId string, tenantName string) GetFederatedDatabaseApiRequest {
+	return GetFederatedDatabaseApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1383,7 +1383,7 @@ func (a *DataFederationApiService) GetFederatedDatabase(ctx context.Context, gro
 
 // Execute executes the request
 //  @return DataLakeTenant
-func (a *DataFederationApiService) GetFederatedDatabaseExecute(r DataFederationApiGetFederatedDatabaseRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1472,7 +1472,7 @@ func (a *DataFederationApiService) GetFederatedDatabaseExecute(r DataFederationA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiListDataFederationPrivateEndpointsRequest struct {
+type ListDataFederationPrivateEndpointsApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -1482,7 +1482,7 @@ type ListDataFederationPrivateEndpointsParams struct {
 		GroupId string
 }
 
-func (r DataFederationApiListDataFederationPrivateEndpointsRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (r ListDataFederationPrivateEndpointsApiRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	return r.ApiService.ListDataFederationPrivateEndpointsExecute(r)
 }
 
@@ -1493,10 +1493,10 @@ Returns all private endpoints for Federated Database Instances and Online Archiv
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DataFederationApiListDataFederationPrivateEndpointsRequest
+ @return ListDataFederationPrivateEndpointsApiRequest
 */
-func (a *DataFederationApiService) ListDataFederationPrivateEndpoints(ctx context.Context, groupId string) DataFederationApiListDataFederationPrivateEndpointsRequest {
-	return DataFederationApiListDataFederationPrivateEndpointsRequest{
+func (a *DataFederationApiService) ListDataFederationPrivateEndpoints(ctx context.Context, groupId string) ListDataFederationPrivateEndpointsApiRequest {
+	return ListDataFederationPrivateEndpointsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1505,7 +1505,7 @@ func (a *DataFederationApiService) ListDataFederationPrivateEndpoints(ctx contex
 
 // Execute executes the request
 //  @return []PrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) ListDataFederationPrivateEndpointsExecute(r DataFederationApiListDataFederationPrivateEndpointsRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1593,7 +1593,7 @@ func (a *DataFederationApiService) ListDataFederationPrivateEndpointsExecute(r D
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiListFederatedDatabasesRequest struct {
+type ListFederatedDatabasesApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -1606,12 +1606,12 @@ type ListFederatedDatabasesParams struct {
 }
 
 // Type of Federated Database Instances to return.
-func (r DataFederationApiListFederatedDatabasesRequest) Type_(type_ string) DataFederationApiListFederatedDatabasesRequest {
+func (r ListFederatedDatabasesApiRequest) Type_(type_ string) ListFederatedDatabasesApiRequest {
 	r.type_ = &type_
 	return r
 }
 
-func (r DataFederationApiListFederatedDatabasesRequest) Execute() ([]DataLakeTenant, *http.Response, error) {
+func (r ListFederatedDatabasesApiRequest) Execute() ([]DataLakeTenant, *http.Response, error) {
 	return r.ApiService.ListFederatedDatabasesExecute(r)
 }
 
@@ -1622,10 +1622,10 @@ Returns the details of all federated database instances in the specified project
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DataFederationApiListFederatedDatabasesRequest
+ @return ListFederatedDatabasesApiRequest
 */
-func (a *DataFederationApiService) ListFederatedDatabases(ctx context.Context, groupId string) DataFederationApiListFederatedDatabasesRequest {
-	return DataFederationApiListFederatedDatabasesRequest{
+func (a *DataFederationApiService) ListFederatedDatabases(ctx context.Context, groupId string) ListFederatedDatabasesApiRequest {
+	return ListFederatedDatabasesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1634,7 +1634,7 @@ func (a *DataFederationApiService) ListFederatedDatabases(ctx context.Context, g
 
 // Execute executes the request
 //  @return []DataLakeTenant
-func (a *DataFederationApiService) ListFederatedDatabasesExecute(r DataFederationApiListFederatedDatabasesRequest) ([]DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1729,7 +1729,7 @@ func (a *DataFederationApiService) ListFederatedDatabasesExecute(r DataFederatio
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiReturnFederatedDatabaseQueryLimitRequest struct {
+type ReturnFederatedDatabaseQueryLimitApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -1743,7 +1743,7 @@ type ReturnFederatedDatabaseQueryLimitParams struct {
 		LimitName string
 }
 
-func (r DataFederationApiReturnFederatedDatabaseQueryLimitRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (r ReturnFederatedDatabaseQueryLimitApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	return r.ApiService.ReturnFederatedDatabaseQueryLimitExecute(r)
 }
 
@@ -1756,10 +1756,10 @@ Returns the details of one query limit for the specified federated database inst
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the federated database instance to which the query limit applies.
  @param limitName Human-readable label that identifies this data federation instance limit.  | Limit Name | Description | Default | | --- | --- | --- | | bytesProcessed.query | Limit on the number of bytes processed during a single data federation query | N/A | | bytesProcessed.daily | Limit on the number of bytes processed for the data federation instance for the current day | N/A | | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A | | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A | 
- @return DataFederationApiReturnFederatedDatabaseQueryLimitRequest
+ @return ReturnFederatedDatabaseQueryLimitApiRequest
 */
-func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DataFederationApiReturnFederatedDatabaseQueryLimitRequest {
-	return DataFederationApiReturnFederatedDatabaseQueryLimitRequest{
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) ReturnFederatedDatabaseQueryLimitApiRequest {
+	return ReturnFederatedDatabaseQueryLimitApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1770,7 +1770,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimit(ctx context
 
 // Execute executes the request
 //  @return []DataFederationTenantQueryLimit
-func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitExecute(r DataFederationApiReturnFederatedDatabaseQueryLimitRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1860,7 +1860,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitExecute(r Da
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiReturnFederatedDatabaseQueryLimitsRequest struct {
+type ReturnFederatedDatabaseQueryLimitsApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -1872,7 +1872,7 @@ type ReturnFederatedDatabaseQueryLimitsParams struct {
 		TenantName string
 }
 
-func (r DataFederationApiReturnFederatedDatabaseQueryLimitsRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (r ReturnFederatedDatabaseQueryLimitsApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	return r.ApiService.ReturnFederatedDatabaseQueryLimitsExecute(r)
 }
 
@@ -1884,10 +1884,10 @@ Returns query limits for a federated databases instance in the specified project
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the federated database instance for which you want to retrieve query limits.
- @return DataFederationApiReturnFederatedDatabaseQueryLimitsRequest
+ @return ReturnFederatedDatabaseQueryLimitsApiRequest
 */
-func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimits(ctx context.Context, groupId string, tenantName string) DataFederationApiReturnFederatedDatabaseQueryLimitsRequest {
-	return DataFederationApiReturnFederatedDatabaseQueryLimitsRequest{
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimits(ctx context.Context, groupId string, tenantName string) ReturnFederatedDatabaseQueryLimitsApiRequest {
+	return ReturnFederatedDatabaseQueryLimitsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1897,7 +1897,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimits(ctx contex
 
 // Execute executes the request
 //  @return []DataFederationTenantQueryLimit
-func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsExecute(r DataFederationApiReturnFederatedDatabaseQueryLimitsRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1986,7 +1986,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsExecute(r D
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataFederationApiUpdateFederatedDatabaseRequest struct {
+type UpdateFederatedDatabaseApiRequest struct {
 	ctx context.Context
 	ApiService DataFederationApi
 	groupId string
@@ -2003,18 +2003,18 @@ type UpdateFederatedDatabaseParams struct {
 }
 
 // Flag that indicates whether this request should check if the requesting IAM role can read from the S3 bucket. AWS checks if the role can list the objects in the bucket before writing to it. Some IAM roles only need write permissions. This flag allows you to skip that check.
-func (r DataFederationApiUpdateFederatedDatabaseRequest) SkipRoleValidation(skipRoleValidation bool) DataFederationApiUpdateFederatedDatabaseRequest {
+func (r UpdateFederatedDatabaseApiRequest) SkipRoleValidation(skipRoleValidation bool) UpdateFederatedDatabaseApiRequest {
 	r.skipRoleValidation = &skipRoleValidation
 	return r
 }
 
 // Details of one Federated Database to update in the specified project.
-func (r DataFederationApiUpdateFederatedDatabaseRequest) DataLakeTenant(dataLakeTenant DataLakeTenant) DataFederationApiUpdateFederatedDatabaseRequest {
+func (r UpdateFederatedDatabaseApiRequest) DataLakeTenant(dataLakeTenant DataLakeTenant) UpdateFederatedDatabaseApiRequest {
 	r.dataLakeTenant = &dataLakeTenant
 	return r
 }
 
-func (r DataFederationApiUpdateFederatedDatabaseRequest) Execute() (*DataLakeTenant, *http.Response, error) {
+func (r UpdateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
 	return r.ApiService.UpdateFederatedDatabaseExecute(r)
 }
 
@@ -2026,10 +2026,10 @@ Updates the details of one federated database instance in the specified project.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param tenantName Human-readable label that identifies the federated database instance to update.
- @return DataFederationApiUpdateFederatedDatabaseRequest
+ @return UpdateFederatedDatabaseApiRequest
 */
-func (a *DataFederationApiService) UpdateFederatedDatabase(ctx context.Context, groupId string, tenantName string) DataFederationApiUpdateFederatedDatabaseRequest {
-	return DataFederationApiUpdateFederatedDatabaseRequest{
+func (a *DataFederationApiService) UpdateFederatedDatabase(ctx context.Context, groupId string, tenantName string) UpdateFederatedDatabaseApiRequest {
+	return UpdateFederatedDatabaseApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2039,7 +2039,7 @@ func (a *DataFederationApiService) UpdateFederatedDatabase(ctx context.Context, 
 
 // Execute executes the request
 //  @return DataLakeTenant
-func (a *DataFederationApiService) UpdateFederatedDatabaseExecute(r DataFederationApiUpdateFederatedDatabaseRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -272,7 +272,7 @@ type DataFederationApiCreateDataFederationPrivateEndpointRequest struct {
 	privateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
 
-type DataFederationApiCreateDataFederationPrivateEndpointParams struct {
+type CreateDataFederationPrivateEndpointParams struct {
 		GroupId string
 		PrivateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
@@ -425,7 +425,7 @@ type DataFederationApiCreateFederatedDatabaseRequest struct {
 	skipRoleValidation *bool
 }
 
-type DataFederationApiCreateFederatedDatabaseParams struct {
+type CreateFederatedDatabaseParams struct {
 		GroupId string
 		DataLakeTenant *DataLakeTenant
 		SkipRoleValidation *bool
@@ -575,7 +575,7 @@ type DataFederationApiCreateOneDataFederationQueryLimitRequest struct {
 	dataFederationTenantQueryLimit *DataFederationTenantQueryLimit
 }
 
-type DataFederationApiCreateOneDataFederationQueryLimitParams struct {
+type CreateOneDataFederationQueryLimitParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -717,7 +717,7 @@ type DataFederationApiDeleteDataFederationPrivateEndpointRequest struct {
 	endpointId string
 }
 
-type DataFederationApiDeleteDataFederationPrivateEndpointParams struct {
+type DeleteDataFederationPrivateEndpointParams struct {
 		GroupId string
 		EndpointId string
 }
@@ -838,7 +838,7 @@ type DataFederationApiDeleteFederatedDatabaseRequest struct {
 	tenantName string
 }
 
-type DataFederationApiDeleteFederatedDatabaseParams struct {
+type DeleteFederatedDatabaseParams struct {
 		GroupId string
 		TenantName string
 }
@@ -954,7 +954,7 @@ type DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest struct {
 	limitName string
 }
 
-type DataFederationApiDeleteOneDataFederationInstanceQueryLimitParams struct {
+type DeleteOneDataFederationInstanceQueryLimitParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -1075,7 +1075,7 @@ type DataFederationApiDownloadFederatedDatabaseQueryLogsRequest struct {
 	startDate *int64
 }
 
-type DataFederationApiDownloadFederatedDatabaseQueryLogsParams struct {
+type DownloadFederatedDatabaseQueryLogsParams struct {
 		GroupId string
 		TenantName string
 		EndDate *int64
@@ -1221,7 +1221,7 @@ type DataFederationApiGetDataFederationPrivateEndpointRequest struct {
 	endpointId string
 }
 
-type DataFederationApiGetDataFederationPrivateEndpointParams struct {
+type GetDataFederationPrivateEndpointParams struct {
 		GroupId string
 		EndpointId string
 }
@@ -1353,7 +1353,7 @@ type DataFederationApiGetFederatedDatabaseRequest struct {
 	tenantName string
 }
 
-type DataFederationApiGetFederatedDatabaseParams struct {
+type GetFederatedDatabaseParams struct {
 		GroupId string
 		TenantName string
 }
@@ -1478,7 +1478,7 @@ type DataFederationApiListDataFederationPrivateEndpointsRequest struct {
 	groupId string
 }
 
-type DataFederationApiListDataFederationPrivateEndpointsParams struct {
+type ListDataFederationPrivateEndpointsParams struct {
 		GroupId string
 }
 
@@ -1600,7 +1600,7 @@ type DataFederationApiListFederatedDatabasesRequest struct {
 	type_ *string
 }
 
-type DataFederationApiListFederatedDatabasesParams struct {
+type ListFederatedDatabasesParams struct {
 		GroupId string
 		Type_ *string
 }
@@ -1737,7 +1737,7 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitRequest struct {
 	limitName string
 }
 
-type DataFederationApiReturnFederatedDatabaseQueryLimitParams struct {
+type ReturnFederatedDatabaseQueryLimitParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -1867,7 +1867,7 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitsRequest struct {
 	tenantName string
 }
 
-type DataFederationApiReturnFederatedDatabaseQueryLimitsParams struct {
+type ReturnFederatedDatabaseQueryLimitsParams struct {
 		GroupId string
 		TenantName string
 }
@@ -1995,7 +1995,7 @@ type DataFederationApiUpdateFederatedDatabaseRequest struct {
 	dataLakeTenant *DataLakeTenant
 }
 
-type DataFederationApiUpdateFederatedDatabaseParams struct {
+type UpdateFederatedDatabaseParams struct {
 		GroupId string
 		TenantName string
 		SkipRoleValidation *bool

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -271,9 +271,10 @@ type DataFederationApiCreateDataFederationPrivateEndpointRequest struct {
 	groupId string
 	privateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
+
 type DataFederationApiCreateDataFederationPrivateEndpointQueryParams struct {
-		groupId string
-		privateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
+		GroupId string
+		PrivateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
 
 // Private endpoint for Federated Database Instances and Online Archives to add to the specified project.
@@ -423,10 +424,11 @@ type DataFederationApiCreateFederatedDatabaseRequest struct {
 	dataLakeTenant *DataLakeTenant
 	skipRoleValidation *bool
 }
+
 type DataFederationApiCreateFederatedDatabaseQueryParams struct {
-		groupId string
-		dataLakeTenant *DataLakeTenant
-		skipRoleValidation *bool
+		GroupId string
+		DataLakeTenant *DataLakeTenant
+		SkipRoleValidation *bool
 }
 
 // Details to create one federated database instance in the specified project.
@@ -572,11 +574,12 @@ type DataFederationApiCreateOneDataFederationQueryLimitRequest struct {
 	limitName string
 	dataFederationTenantQueryLimit *DataFederationTenantQueryLimit
 }
+
 type DataFederationApiCreateOneDataFederationQueryLimitQueryParams struct {
-		groupId string
-		tenantName string
-		limitName string
-		dataFederationTenantQueryLimit *DataFederationTenantQueryLimit
+		GroupId string
+		TenantName string
+		LimitName string
+		DataFederationTenantQueryLimit *DataFederationTenantQueryLimit
 }
 
 // Creates or updates one query limit for one federated database instance.
@@ -713,9 +716,10 @@ type DataFederationApiDeleteDataFederationPrivateEndpointRequest struct {
 	groupId string
 	endpointId string
 }
+
 type DataFederationApiDeleteDataFederationPrivateEndpointQueryParams struct {
-		groupId string
-		endpointId string
+		GroupId string
+		EndpointId string
 }
 
 func (r DataFederationApiDeleteDataFederationPrivateEndpointRequest) Execute() (*http.Response, error) {
@@ -833,9 +837,10 @@ type DataFederationApiDeleteFederatedDatabaseRequest struct {
 	groupId string
 	tenantName string
 }
+
 type DataFederationApiDeleteFederatedDatabaseQueryParams struct {
-		groupId string
-		tenantName string
+		GroupId string
+		TenantName string
 }
 
 func (r DataFederationApiDeleteFederatedDatabaseRequest) Execute() (*http.Response, error) {
@@ -948,10 +953,11 @@ type DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest struct {
 	tenantName string
 	limitName string
 }
+
 type DataFederationApiDeleteOneDataFederationInstanceQueryLimitQueryParams struct {
-		groupId string
-		tenantName string
-		limitName string
+		GroupId string
+		TenantName string
+		LimitName string
 }
 
 func (r DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest) Execute() (*http.Response, error) {
@@ -1068,11 +1074,12 @@ type DataFederationApiDownloadFederatedDatabaseQueryLogsRequest struct {
 	endDate *int64
 	startDate *int64
 }
+
 type DataFederationApiDownloadFederatedDatabaseQueryLogsQueryParams struct {
-		groupId string
-		tenantName string
-		endDate *int64
-		startDate *int64
+		GroupId string
+		TenantName string
+		EndDate *int64
+		StartDate *int64
 }
 
 // Timestamp that specifies the end point for the range of log messages to download.  MongoDB Cloud expresses this timestamp in the number of seconds that have elapsed since the UNIX epoch.
@@ -1213,9 +1220,10 @@ type DataFederationApiGetDataFederationPrivateEndpointRequest struct {
 	groupId string
 	endpointId string
 }
+
 type DataFederationApiGetDataFederationPrivateEndpointQueryParams struct {
-		groupId string
-		endpointId string
+		GroupId string
+		EndpointId string
 }
 
 func (r DataFederationApiGetDataFederationPrivateEndpointRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
@@ -1344,9 +1352,10 @@ type DataFederationApiGetFederatedDatabaseRequest struct {
 	groupId string
 	tenantName string
 }
+
 type DataFederationApiGetFederatedDatabaseQueryParams struct {
-		groupId string
-		tenantName string
+		GroupId string
+		TenantName string
 }
 
 func (r DataFederationApiGetFederatedDatabaseRequest) Execute() (*DataLakeTenant, *http.Response, error) {
@@ -1468,8 +1477,9 @@ type DataFederationApiListDataFederationPrivateEndpointsRequest struct {
 	ApiService DataFederationApi
 	groupId string
 }
+
 type DataFederationApiListDataFederationPrivateEndpointsQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r DataFederationApiListDataFederationPrivateEndpointsRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
@@ -1589,9 +1599,10 @@ type DataFederationApiListFederatedDatabasesRequest struct {
 	groupId string
 	type_ *string
 }
+
 type DataFederationApiListFederatedDatabasesQueryParams struct {
-		groupId string
-		type_ *string
+		GroupId string
+		Type_ *string
 }
 
 // Type of Federated Database Instances to return.
@@ -1725,10 +1736,11 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitRequest struct {
 	tenantName string
 	limitName string
 }
+
 type DataFederationApiReturnFederatedDatabaseQueryLimitQueryParams struct {
-		groupId string
-		tenantName string
-		limitName string
+		GroupId string
+		TenantName string
+		LimitName string
 }
 
 func (r DataFederationApiReturnFederatedDatabaseQueryLimitRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
@@ -1854,9 +1866,10 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitsRequest struct {
 	groupId string
 	tenantName string
 }
+
 type DataFederationApiReturnFederatedDatabaseQueryLimitsQueryParams struct {
-		groupId string
-		tenantName string
+		GroupId string
+		TenantName string
 }
 
 func (r DataFederationApiReturnFederatedDatabaseQueryLimitsRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
@@ -1981,11 +1994,12 @@ type DataFederationApiUpdateFederatedDatabaseRequest struct {
 	skipRoleValidation *bool
 	dataLakeTenant *DataLakeTenant
 }
+
 type DataFederationApiUpdateFederatedDatabaseQueryParams struct {
-		groupId string
-		tenantName string
-		skipRoleValidation *bool
-		dataLakeTenant *DataLakeTenant
+		GroupId string
+		TenantName string
+		SkipRoleValidation *bool
+		DataLakeTenant *DataLakeTenant
 }
 
 // Flag that indicates whether this request should check if the requesting IAM role can read from the S3 bucket. AWS checks if the role can list the objects in the bucket before writing to it. Some IAM roles only need write permissions. This flag allows you to skip that check.

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -272,7 +272,7 @@ type DataFederationApiCreateDataFederationPrivateEndpointRequest struct {
 	privateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
 
-type DataFederationApiCreateDataFederationPrivateEndpointQueryParams struct {
+type DataFederationApiCreateDataFederationPrivateEndpointParams struct {
 		GroupId string
 		PrivateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
@@ -425,7 +425,7 @@ type DataFederationApiCreateFederatedDatabaseRequest struct {
 	skipRoleValidation *bool
 }
 
-type DataFederationApiCreateFederatedDatabaseQueryParams struct {
+type DataFederationApiCreateFederatedDatabaseParams struct {
 		GroupId string
 		DataLakeTenant *DataLakeTenant
 		SkipRoleValidation *bool
@@ -575,7 +575,7 @@ type DataFederationApiCreateOneDataFederationQueryLimitRequest struct {
 	dataFederationTenantQueryLimit *DataFederationTenantQueryLimit
 }
 
-type DataFederationApiCreateOneDataFederationQueryLimitQueryParams struct {
+type DataFederationApiCreateOneDataFederationQueryLimitParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -717,7 +717,7 @@ type DataFederationApiDeleteDataFederationPrivateEndpointRequest struct {
 	endpointId string
 }
 
-type DataFederationApiDeleteDataFederationPrivateEndpointQueryParams struct {
+type DataFederationApiDeleteDataFederationPrivateEndpointParams struct {
 		GroupId string
 		EndpointId string
 }
@@ -838,7 +838,7 @@ type DataFederationApiDeleteFederatedDatabaseRequest struct {
 	tenantName string
 }
 
-type DataFederationApiDeleteFederatedDatabaseQueryParams struct {
+type DataFederationApiDeleteFederatedDatabaseParams struct {
 		GroupId string
 		TenantName string
 }
@@ -954,7 +954,7 @@ type DataFederationApiDeleteOneDataFederationInstanceQueryLimitRequest struct {
 	limitName string
 }
 
-type DataFederationApiDeleteOneDataFederationInstanceQueryLimitQueryParams struct {
+type DataFederationApiDeleteOneDataFederationInstanceQueryLimitParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -1075,7 +1075,7 @@ type DataFederationApiDownloadFederatedDatabaseQueryLogsRequest struct {
 	startDate *int64
 }
 
-type DataFederationApiDownloadFederatedDatabaseQueryLogsQueryParams struct {
+type DataFederationApiDownloadFederatedDatabaseQueryLogsParams struct {
 		GroupId string
 		TenantName string
 		EndDate *int64
@@ -1221,7 +1221,7 @@ type DataFederationApiGetDataFederationPrivateEndpointRequest struct {
 	endpointId string
 }
 
-type DataFederationApiGetDataFederationPrivateEndpointQueryParams struct {
+type DataFederationApiGetDataFederationPrivateEndpointParams struct {
 		GroupId string
 		EndpointId string
 }
@@ -1353,7 +1353,7 @@ type DataFederationApiGetFederatedDatabaseRequest struct {
 	tenantName string
 }
 
-type DataFederationApiGetFederatedDatabaseQueryParams struct {
+type DataFederationApiGetFederatedDatabaseParams struct {
 		GroupId string
 		TenantName string
 }
@@ -1478,7 +1478,7 @@ type DataFederationApiListDataFederationPrivateEndpointsRequest struct {
 	groupId string
 }
 
-type DataFederationApiListDataFederationPrivateEndpointsQueryParams struct {
+type DataFederationApiListDataFederationPrivateEndpointsParams struct {
 		GroupId string
 }
 
@@ -1600,7 +1600,7 @@ type DataFederationApiListFederatedDatabasesRequest struct {
 	type_ *string
 }
 
-type DataFederationApiListFederatedDatabasesQueryParams struct {
+type DataFederationApiListFederatedDatabasesParams struct {
 		GroupId string
 		Type_ *string
 }
@@ -1737,7 +1737,7 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitRequest struct {
 	limitName string
 }
 
-type DataFederationApiReturnFederatedDatabaseQueryLimitQueryParams struct {
+type DataFederationApiReturnFederatedDatabaseQueryLimitParams struct {
 		GroupId string
 		TenantName string
 		LimitName string
@@ -1867,7 +1867,7 @@ type DataFederationApiReturnFederatedDatabaseQueryLimitsRequest struct {
 	tenantName string
 }
 
-type DataFederationApiReturnFederatedDatabaseQueryLimitsQueryParams struct {
+type DataFederationApiReturnFederatedDatabaseQueryLimitsParams struct {
 		GroupId string
 		TenantName string
 }
@@ -1995,7 +1995,7 @@ type DataFederationApiUpdateFederatedDatabaseRequest struct {
 	dataLakeTenant *DataLakeTenant
 }
 
-type DataFederationApiUpdateFederatedDatabaseQueryParams struct {
+type DataFederationApiUpdateFederatedDatabaseParams struct {
 		GroupId string
 		TenantName string
 		SkipRoleValidation *bool

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -240,7 +240,7 @@ type DataLakePipelinesApiCreatePipelineRequest struct {
 	ingestionPipeline *IngestionPipeline
 }
 
-type DataLakePipelinesApiCreatePipelineParams struct {
+type CreatePipelineParams struct {
 		GroupId string
 		IngestionPipeline *IngestionPipeline
 }
@@ -374,7 +374,7 @@ type DataLakePipelinesApiDeletePipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiDeletePipelineParams struct {
+type DeletePipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -496,7 +496,7 @@ type DataLakePipelinesApiDeletePipelineRunDatasetRequest struct {
 	pipelineRunId string
 }
 
-type DataLakePipelinesApiDeletePipelineRunDatasetParams struct {
+type DeletePipelineRunDatasetParams struct {
 		GroupId string
 		PipelineName string
 		PipelineRunId string
@@ -627,7 +627,7 @@ type DataLakePipelinesApiGetPipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiGetPipelineParams struct {
+type GetPipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -760,7 +760,7 @@ type DataLakePipelinesApiGetPipelineRunRequest struct {
 	pipelineRunId string
 }
 
-type DataLakePipelinesApiGetPipelineRunParams struct {
+type GetPipelineRunParams struct {
 		GroupId string
 		PipelineName string
 		PipelineRunId string
@@ -906,7 +906,7 @@ type DataLakePipelinesApiListPipelineRunsRequest struct {
 	createdBefore *time.Time
 }
 
-type DataLakePipelinesApiListPipelineRunsParams struct {
+type ListPipelineRunsParams struct {
 		GroupId string
 		PipelineName string
 		IncludeCount *bool
@@ -1090,7 +1090,7 @@ type DataLakePipelinesApiListPipelineSchedulesRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiListPipelineSchedulesParams struct {
+type ListPipelineSchedulesParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1226,7 +1226,7 @@ type DataLakePipelinesApiListPipelineSnapshotsRequest struct {
 	completedAfter *time.Time
 }
 
-type DataLakePipelinesApiListPipelineSnapshotsParams struct {
+type ListPipelineSnapshotsParams struct {
 		GroupId string
 		PipelineName string
 		IncludeCount *bool
@@ -1409,7 +1409,7 @@ type DataLakePipelinesApiListPipelinesRequest struct {
 	groupId string
 }
 
-type DataLakePipelinesApiListPipelinesParams struct {
+type ListPipelinesParams struct {
 		GroupId string
 }
 
@@ -1531,7 +1531,7 @@ type DataLakePipelinesApiPausePipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiPausePipelineParams struct {
+type PausePipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1663,7 +1663,7 @@ type DataLakePipelinesApiResumePipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiResumePipelineParams struct {
+type ResumePipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1796,7 +1796,7 @@ type DataLakePipelinesApiTriggerSnapshotIngestionRequest struct {
 	triggerIngestionRequest *TriggerIngestionRequest
 }
 
-type DataLakePipelinesApiTriggerSnapshotIngestionParams struct {
+type TriggerSnapshotIngestionParams struct {
 		GroupId string
 		PipelineName string
 		TriggerIngestionRequest *TriggerIngestionRequest
@@ -1941,7 +1941,7 @@ type DataLakePipelinesApiUpdatePipelineRequest struct {
 	ingestionPipeline *IngestionPipeline
 }
 
-type DataLakePipelinesApiUpdatePipelineParams struct {
+type UpdatePipelineParams struct {
 		GroupId string
 		PipelineName string
 		IngestionPipeline *IngestionPipeline

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -239,9 +239,10 @@ type DataLakePipelinesApiCreatePipelineRequest struct {
 	groupId string
 	ingestionPipeline *IngestionPipeline
 }
+
 type DataLakePipelinesApiCreatePipelineQueryParams struct {
-		groupId string
-		ingestionPipeline *IngestionPipeline
+		GroupId string
+		IngestionPipeline *IngestionPipeline
 }
 
 // Creates one Data Lake Pipeline.
@@ -372,9 +373,10 @@ type DataLakePipelinesApiDeletePipelineRequest struct {
 	groupId string
 	pipelineName string
 }
+
 type DataLakePipelinesApiDeletePipelineQueryParams struct {
-		groupId string
-		pipelineName string
+		GroupId string
+		PipelineName string
 }
 
 func (r DataLakePipelinesApiDeletePipelineRequest) Execute() (*http.Response, error) {
@@ -493,10 +495,11 @@ type DataLakePipelinesApiDeletePipelineRunDatasetRequest struct {
 	pipelineName string
 	pipelineRunId string
 }
+
 type DataLakePipelinesApiDeletePipelineRunDatasetQueryParams struct {
-		groupId string
-		pipelineName string
-		pipelineRunId string
+		GroupId string
+		PipelineName string
+		PipelineRunId string
 }
 
 func (r DataLakePipelinesApiDeletePipelineRunDatasetRequest) Execute() (*http.Response, error) {
@@ -623,9 +626,10 @@ type DataLakePipelinesApiGetPipelineRequest struct {
 	groupId string
 	pipelineName string
 }
+
 type DataLakePipelinesApiGetPipelineQueryParams struct {
-		groupId string
-		pipelineName string
+		GroupId string
+		PipelineName string
 }
 
 func (r DataLakePipelinesApiGetPipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
@@ -755,10 +759,11 @@ type DataLakePipelinesApiGetPipelineRunRequest struct {
 	pipelineName string
 	pipelineRunId string
 }
+
 type DataLakePipelinesApiGetPipelineRunQueryParams struct {
-		groupId string
-		pipelineName string
-		pipelineRunId string
+		GroupId string
+		PipelineName string
+		PipelineRunId string
 }
 
 func (r DataLakePipelinesApiGetPipelineRunRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
@@ -900,13 +905,14 @@ type DataLakePipelinesApiListPipelineRunsRequest struct {
 	pageNum *int32
 	createdBefore *time.Time
 }
+
 type DataLakePipelinesApiListPipelineRunsQueryParams struct {
-		groupId string
-		pipelineName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		createdBefore *time.Time
+		GroupId string
+		PipelineName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		CreatedBefore *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1083,9 +1089,10 @@ type DataLakePipelinesApiListPipelineSchedulesRequest struct {
 	groupId string
 	pipelineName string
 }
+
 type DataLakePipelinesApiListPipelineSchedulesQueryParams struct {
-		groupId string
-		pipelineName string
+		GroupId string
+		PipelineName string
 }
 
 func (r DataLakePipelinesApiListPipelineSchedulesRequest) Execute() ([]PolicyItem, *http.Response, error) {
@@ -1218,13 +1225,14 @@ type DataLakePipelinesApiListPipelineSnapshotsRequest struct {
 	pageNum *int32
 	completedAfter *time.Time
 }
+
 type DataLakePipelinesApiListPipelineSnapshotsQueryParams struct {
-		groupId string
-		pipelineName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		completedAfter *time.Time
+		GroupId string
+		PipelineName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		CompletedAfter *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1400,8 +1408,9 @@ type DataLakePipelinesApiListPipelinesRequest struct {
 	ApiService DataLakePipelinesApi
 	groupId string
 }
+
 type DataLakePipelinesApiListPipelinesQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r DataLakePipelinesApiListPipelinesRequest) Execute() ([]IngestionPipeline, *http.Response, error) {
@@ -1521,9 +1530,10 @@ type DataLakePipelinesApiPausePipelineRequest struct {
 	groupId string
 	pipelineName string
 }
+
 type DataLakePipelinesApiPausePipelineQueryParams struct {
-		groupId string
-		pipelineName string
+		GroupId string
+		PipelineName string
 }
 
 func (r DataLakePipelinesApiPausePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
@@ -1652,9 +1662,10 @@ type DataLakePipelinesApiResumePipelineRequest struct {
 	groupId string
 	pipelineName string
 }
+
 type DataLakePipelinesApiResumePipelineQueryParams struct {
-		groupId string
-		pipelineName string
+		GroupId string
+		PipelineName string
 }
 
 func (r DataLakePipelinesApiResumePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
@@ -1784,10 +1795,11 @@ type DataLakePipelinesApiTriggerSnapshotIngestionRequest struct {
 	pipelineName string
 	triggerIngestionRequest *TriggerIngestionRequest
 }
+
 type DataLakePipelinesApiTriggerSnapshotIngestionQueryParams struct {
-		groupId string
-		pipelineName string
-		triggerIngestionRequest *TriggerIngestionRequest
+		GroupId string
+		PipelineName string
+		TriggerIngestionRequest *TriggerIngestionRequest
 }
 
 // Triggers a single ingestion run of a snapshot.
@@ -1928,10 +1940,11 @@ type DataLakePipelinesApiUpdatePipelineRequest struct {
 	pipelineName string
 	ingestionPipeline *IngestionPipeline
 }
+
 type DataLakePipelinesApiUpdatePipelineQueryParams struct {
-		groupId string
-		pipelineName string
-		ingestionPipeline *IngestionPipeline
+		GroupId string
+		PipelineName string
+		IngestionPipeline *IngestionPipeline
 }
 
 // Updates one Data Lake Pipeline.

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -240,7 +240,7 @@ type DataLakePipelinesApiCreatePipelineRequest struct {
 	ingestionPipeline *IngestionPipeline
 }
 
-type DataLakePipelinesApiCreatePipelineQueryParams struct {
+type DataLakePipelinesApiCreatePipelineParams struct {
 		GroupId string
 		IngestionPipeline *IngestionPipeline
 }
@@ -374,7 +374,7 @@ type DataLakePipelinesApiDeletePipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiDeletePipelineQueryParams struct {
+type DataLakePipelinesApiDeletePipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -496,7 +496,7 @@ type DataLakePipelinesApiDeletePipelineRunDatasetRequest struct {
 	pipelineRunId string
 }
 
-type DataLakePipelinesApiDeletePipelineRunDatasetQueryParams struct {
+type DataLakePipelinesApiDeletePipelineRunDatasetParams struct {
 		GroupId string
 		PipelineName string
 		PipelineRunId string
@@ -627,7 +627,7 @@ type DataLakePipelinesApiGetPipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiGetPipelineQueryParams struct {
+type DataLakePipelinesApiGetPipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -760,7 +760,7 @@ type DataLakePipelinesApiGetPipelineRunRequest struct {
 	pipelineRunId string
 }
 
-type DataLakePipelinesApiGetPipelineRunQueryParams struct {
+type DataLakePipelinesApiGetPipelineRunParams struct {
 		GroupId string
 		PipelineName string
 		PipelineRunId string
@@ -906,7 +906,7 @@ type DataLakePipelinesApiListPipelineRunsRequest struct {
 	createdBefore *time.Time
 }
 
-type DataLakePipelinesApiListPipelineRunsQueryParams struct {
+type DataLakePipelinesApiListPipelineRunsParams struct {
 		GroupId string
 		PipelineName string
 		IncludeCount *bool
@@ -1090,7 +1090,7 @@ type DataLakePipelinesApiListPipelineSchedulesRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiListPipelineSchedulesQueryParams struct {
+type DataLakePipelinesApiListPipelineSchedulesParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1226,7 +1226,7 @@ type DataLakePipelinesApiListPipelineSnapshotsRequest struct {
 	completedAfter *time.Time
 }
 
-type DataLakePipelinesApiListPipelineSnapshotsQueryParams struct {
+type DataLakePipelinesApiListPipelineSnapshotsParams struct {
 		GroupId string
 		PipelineName string
 		IncludeCount *bool
@@ -1409,7 +1409,7 @@ type DataLakePipelinesApiListPipelinesRequest struct {
 	groupId string
 }
 
-type DataLakePipelinesApiListPipelinesQueryParams struct {
+type DataLakePipelinesApiListPipelinesParams struct {
 		GroupId string
 }
 
@@ -1531,7 +1531,7 @@ type DataLakePipelinesApiPausePipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiPausePipelineQueryParams struct {
+type DataLakePipelinesApiPausePipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1663,7 +1663,7 @@ type DataLakePipelinesApiResumePipelineRequest struct {
 	pipelineName string
 }
 
-type DataLakePipelinesApiResumePipelineQueryParams struct {
+type DataLakePipelinesApiResumePipelineParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1796,7 +1796,7 @@ type DataLakePipelinesApiTriggerSnapshotIngestionRequest struct {
 	triggerIngestionRequest *TriggerIngestionRequest
 }
 
-type DataLakePipelinesApiTriggerSnapshotIngestionQueryParams struct {
+type DataLakePipelinesApiTriggerSnapshotIngestionParams struct {
 		GroupId string
 		PipelineName string
 		TriggerIngestionRequest *TriggerIngestionRequest
@@ -1941,7 +1941,7 @@ type DataLakePipelinesApiUpdatePipelineRequest struct {
 	ingestionPipeline *IngestionPipeline
 }
 
-type DataLakePipelinesApiUpdatePipelineQueryParams struct {
+type DataLakePipelinesApiUpdatePipelineParams struct {
 		GroupId string
 		PipelineName string
 		IngestionPipeline *IngestionPipeline

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -240,7 +240,7 @@ type CreatePipelineApiRequest struct {
 	ingestionPipeline *IngestionPipeline
 }
 
-type CreatePipelineParams struct {
+type CreatePipelineApiParams struct {
 		GroupId string
 		IngestionPipeline *IngestionPipeline
 }
@@ -374,7 +374,7 @@ type DeletePipelineApiRequest struct {
 	pipelineName string
 }
 
-type DeletePipelineParams struct {
+type DeletePipelineApiParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -496,7 +496,7 @@ type DeletePipelineRunDatasetApiRequest struct {
 	pipelineRunId string
 }
 
-type DeletePipelineRunDatasetParams struct {
+type DeletePipelineRunDatasetApiParams struct {
 		GroupId string
 		PipelineName string
 		PipelineRunId string
@@ -627,7 +627,7 @@ type GetPipelineApiRequest struct {
 	pipelineName string
 }
 
-type GetPipelineParams struct {
+type GetPipelineApiParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -760,7 +760,7 @@ type GetPipelineRunApiRequest struct {
 	pipelineRunId string
 }
 
-type GetPipelineRunParams struct {
+type GetPipelineRunApiParams struct {
 		GroupId string
 		PipelineName string
 		PipelineRunId string
@@ -906,7 +906,7 @@ type ListPipelineRunsApiRequest struct {
 	createdBefore *time.Time
 }
 
-type ListPipelineRunsParams struct {
+type ListPipelineRunsApiParams struct {
 		GroupId string
 		PipelineName string
 		IncludeCount *bool
@@ -1090,7 +1090,7 @@ type ListPipelineSchedulesApiRequest struct {
 	pipelineName string
 }
 
-type ListPipelineSchedulesParams struct {
+type ListPipelineSchedulesApiParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1226,7 +1226,7 @@ type ListPipelineSnapshotsApiRequest struct {
 	completedAfter *time.Time
 }
 
-type ListPipelineSnapshotsParams struct {
+type ListPipelineSnapshotsApiParams struct {
 		GroupId string
 		PipelineName string
 		IncludeCount *bool
@@ -1409,7 +1409,7 @@ type ListPipelinesApiRequest struct {
 	groupId string
 }
 
-type ListPipelinesParams struct {
+type ListPipelinesApiParams struct {
 		GroupId string
 }
 
@@ -1531,7 +1531,7 @@ type PausePipelineApiRequest struct {
 	pipelineName string
 }
 
-type PausePipelineParams struct {
+type PausePipelineApiParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1663,7 +1663,7 @@ type ResumePipelineApiRequest struct {
 	pipelineName string
 }
 
-type ResumePipelineParams struct {
+type ResumePipelineApiParams struct {
 		GroupId string
 		PipelineName string
 }
@@ -1796,7 +1796,7 @@ type TriggerSnapshotIngestionApiRequest struct {
 	triggerIngestionRequest *TriggerIngestionRequest
 }
 
-type TriggerSnapshotIngestionParams struct {
+type TriggerSnapshotIngestionApiParams struct {
 		GroupId string
 		PipelineName string
 		TriggerIngestionRequest *TriggerIngestionRequest
@@ -1941,7 +1941,7 @@ type UpdatePipelineApiRequest struct {
 	ingestionPipeline *IngestionPipeline
 }
 
-type UpdatePipelineParams struct {
+type UpdatePipelineApiParams struct {
 		GroupId string
 		PipelineName string
 		IngestionPipeline *IngestionPipeline

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -30,13 +30,13 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DataLakePipelinesApiCreatePipelineRequest
+	@return CreatePipelineApiRequest
 	*/
-	CreatePipeline(ctx context.Context, groupId string) DataLakePipelinesApiCreatePipelineRequest
+	CreatePipeline(ctx context.Context, groupId string) CreatePipelineApiRequest
 
 	// CreatePipelineExecute executes the request
 	//  @return IngestionPipeline
-	CreatePipelineExecute(r DataLakePipelinesApiCreatePipelineRequest) (*IngestionPipeline, *http.Response, error)
+	CreatePipelineExecute(r CreatePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	DeletePipeline Remove One Data Lake Pipeline
@@ -46,12 +46,12 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiDeletePipelineRequest
+	@return DeletePipelineApiRequest
 	*/
-	DeletePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiDeletePipelineRequest
+	DeletePipeline(ctx context.Context, groupId string, pipelineName string) DeletePipelineApiRequest
 
 	// DeletePipelineExecute executes the request
-	DeletePipelineExecute(r DataLakePipelinesApiDeletePipelineRequest) (*http.Response, error)
+	DeletePipelineExecute(r DeletePipelineApiRequest) (*http.Response, error)
 
 	/*
 	DeletePipelineRunDataset Delete Pipeline Run Dataset
@@ -62,12 +62,12 @@ type DataLakePipelinesApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
 	@param pipelineRunId Unique 24-hexadecimal character string that identifies a Data Lake Pipeline run.
-	@return DataLakePipelinesApiDeletePipelineRunDatasetRequest
+	@return DeletePipelineRunDatasetApiRequest
 	*/
-	DeletePipelineRunDataset(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) DataLakePipelinesApiDeletePipelineRunDatasetRequest
+	DeletePipelineRunDataset(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) DeletePipelineRunDatasetApiRequest
 
 	// DeletePipelineRunDatasetExecute executes the request
-	DeletePipelineRunDatasetExecute(r DataLakePipelinesApiDeletePipelineRunDatasetRequest) (*http.Response, error)
+	DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (*http.Response, error)
 
 	/*
 	GetPipeline Return One Data Lake Pipeline
@@ -77,13 +77,13 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiGetPipelineRequest
+	@return GetPipelineApiRequest
 	*/
-	GetPipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiGetPipelineRequest
+	GetPipeline(ctx context.Context, groupId string, pipelineName string) GetPipelineApiRequest
 
 	// GetPipelineExecute executes the request
 	//  @return IngestionPipeline
-	GetPipelineExecute(r DataLakePipelinesApiGetPipelineRequest) (*IngestionPipeline, *http.Response, error)
+	GetPipelineExecute(r GetPipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	GetPipelineRun Return One Data Lake Pipeline Run
@@ -94,13 +94,13 @@ type DataLakePipelinesApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
 	@param pipelineRunId Unique 24-hexadecimal character string that identifies a Data Lake Pipeline run.
-	@return DataLakePipelinesApiGetPipelineRunRequest
+	@return GetPipelineRunApiRequest
 	*/
-	GetPipelineRun(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) DataLakePipelinesApiGetPipelineRunRequest
+	GetPipelineRun(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) GetPipelineRunApiRequest
 
 	// GetPipelineRunExecute executes the request
 	//  @return IngestionPipelineRun
-	GetPipelineRunExecute(r DataLakePipelinesApiGetPipelineRunRequest) (*IngestionPipelineRun, *http.Response, error)
+	GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
 	ListPipelineRuns Return All Data Lake Pipeline Runs from One Project
@@ -110,13 +110,13 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiListPipelineRunsRequest
+	@return ListPipelineRunsApiRequest
 	*/
-	ListPipelineRuns(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiListPipelineRunsRequest
+	ListPipelineRuns(ctx context.Context, groupId string, pipelineName string) ListPipelineRunsApiRequest
 
 	// ListPipelineRunsExecute executes the request
 	//  @return PaginatedPipelineRun
-	ListPipelineRunsExecute(r DataLakePipelinesApiListPipelineRunsRequest) (*PaginatedPipelineRun, *http.Response, error)
+	ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error)
 
 	/*
 	ListPipelineSchedules Return Available Ingestion Schedules for One Data Lake Pipeline
@@ -126,13 +126,13 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiListPipelineSchedulesRequest
+	@return ListPipelineSchedulesApiRequest
 	*/
-	ListPipelineSchedules(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiListPipelineSchedulesRequest
+	ListPipelineSchedules(ctx context.Context, groupId string, pipelineName string) ListPipelineSchedulesApiRequest
 
 	// ListPipelineSchedulesExecute executes the request
 	//  @return []PolicyItem
-	ListPipelineSchedulesExecute(r DataLakePipelinesApiListPipelineSchedulesRequest) ([]PolicyItem, *http.Response, error)
+	ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]PolicyItem, *http.Response, error)
 
 	/*
 	ListPipelineSnapshots Return Available Backup Snapshots for One Data Lake Pipeline
@@ -142,13 +142,13 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiListPipelineSnapshotsRequest
+	@return ListPipelineSnapshotsApiRequest
 	*/
-	ListPipelineSnapshots(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiListPipelineSnapshotsRequest
+	ListPipelineSnapshots(ctx context.Context, groupId string, pipelineName string) ListPipelineSnapshotsApiRequest
 
 	// ListPipelineSnapshotsExecute executes the request
 	//  @return PaginatedBackupSnapshot
-	ListPipelineSnapshotsExecute(r DataLakePipelinesApiListPipelineSnapshotsRequest) (*PaginatedBackupSnapshot, *http.Response, error)
+	ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error)
 
 	/*
 	ListPipelines Return All Data Lake Pipelines from One Project
@@ -157,13 +157,13 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DataLakePipelinesApiListPipelinesRequest
+	@return ListPipelinesApiRequest
 	*/
-	ListPipelines(ctx context.Context, groupId string) DataLakePipelinesApiListPipelinesRequest
+	ListPipelines(ctx context.Context, groupId string) ListPipelinesApiRequest
 
 	// ListPipelinesExecute executes the request
 	//  @return []IngestionPipeline
-	ListPipelinesExecute(r DataLakePipelinesApiListPipelinesRequest) ([]IngestionPipeline, *http.Response, error)
+	ListPipelinesExecute(r ListPipelinesApiRequest) ([]IngestionPipeline, *http.Response, error)
 
 	/*
 	PausePipeline Pause One Data Lake Pipeline
@@ -173,13 +173,13 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiPausePipelineRequest
+	@return PausePipelineApiRequest
 	*/
-	PausePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiPausePipelineRequest
+	PausePipeline(ctx context.Context, groupId string, pipelineName string) PausePipelineApiRequest
 
 	// PausePipelineExecute executes the request
 	//  @return IngestionPipeline
-	PausePipelineExecute(r DataLakePipelinesApiPausePipelineRequest) (*IngestionPipeline, *http.Response, error)
+	PausePipelineExecute(r PausePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	ResumePipeline Resume One Data Lake Pipeline
@@ -189,13 +189,13 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiResumePipelineRequest
+	@return ResumePipelineApiRequest
 	*/
-	ResumePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiResumePipelineRequest
+	ResumePipeline(ctx context.Context, groupId string, pipelineName string) ResumePipelineApiRequest
 
 	// ResumePipelineExecute executes the request
 	//  @return IngestionPipeline
-	ResumePipelineExecute(r DataLakePipelinesApiResumePipelineRequest) (*IngestionPipeline, *http.Response, error)
+	ResumePipelineExecute(r ResumePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	TriggerSnapshotIngestion Trigger on demand snapshot ingestion
@@ -205,13 +205,13 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiTriggerSnapshotIngestionRequest
+	@return TriggerSnapshotIngestionApiRequest
 	*/
-	TriggerSnapshotIngestion(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiTriggerSnapshotIngestionRequest
+	TriggerSnapshotIngestion(ctx context.Context, groupId string, pipelineName string) TriggerSnapshotIngestionApiRequest
 
 	// TriggerSnapshotIngestionExecute executes the request
 	//  @return IngestionPipelineRun
-	TriggerSnapshotIngestionExecute(r DataLakePipelinesApiTriggerSnapshotIngestionRequest) (*IngestionPipelineRun, *http.Response, error)
+	TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
 	UpdatePipeline Update One Data Lake Pipeline
@@ -221,19 +221,19 @@ type DataLakePipelinesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param pipelineName Human-readable label that identifies the Data Lake Pipeline.
-	@return DataLakePipelinesApiUpdatePipelineRequest
+	@return UpdatePipelineApiRequest
 	*/
-	UpdatePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiUpdatePipelineRequest
+	UpdatePipeline(ctx context.Context, groupId string, pipelineName string) UpdatePipelineApiRequest
 
 	// UpdatePipelineExecute executes the request
 	//  @return IngestionPipeline
-	UpdatePipelineExecute(r DataLakePipelinesApiUpdatePipelineRequest) (*IngestionPipeline, *http.Response, error)
+	UpdatePipelineExecute(r UpdatePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 }
 
 // DataLakePipelinesApiService DataLakePipelinesApi service
 type DataLakePipelinesApiService service
 
-type DataLakePipelinesApiCreatePipelineRequest struct {
+type CreatePipelineApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -246,12 +246,12 @@ type CreatePipelineParams struct {
 }
 
 // Creates one Data Lake Pipeline.
-func (r DataLakePipelinesApiCreatePipelineRequest) IngestionPipeline(ingestionPipeline IngestionPipeline) DataLakePipelinesApiCreatePipelineRequest {
+func (r CreatePipelineApiRequest) IngestionPipeline(ingestionPipeline IngestionPipeline) CreatePipelineApiRequest {
 	r.ingestionPipeline = &ingestionPipeline
 	return r
 }
 
-func (r DataLakePipelinesApiCreatePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+func (r CreatePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.CreatePipelineExecute(r)
 }
 
@@ -262,10 +262,10 @@ Creates one Data Lake Pipeline.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DataLakePipelinesApiCreatePipelineRequest
+ @return CreatePipelineApiRequest
 */
-func (a *DataLakePipelinesApiService) CreatePipeline(ctx context.Context, groupId string) DataLakePipelinesApiCreatePipelineRequest {
-	return DataLakePipelinesApiCreatePipelineRequest{
+func (a *DataLakePipelinesApiService) CreatePipeline(ctx context.Context, groupId string) CreatePipelineApiRequest {
+	return CreatePipelineApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -274,7 +274,7 @@ func (a *DataLakePipelinesApiService) CreatePipeline(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) CreatePipelineExecute(r DataLakePipelinesApiCreatePipelineRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) CreatePipelineExecute(r CreatePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -367,7 +367,7 @@ func (a *DataLakePipelinesApiService) CreatePipelineExecute(r DataLakePipelinesA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiDeletePipelineRequest struct {
+type DeletePipelineApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -379,7 +379,7 @@ type DeletePipelineParams struct {
 		PipelineName string
 }
 
-func (r DataLakePipelinesApiDeletePipelineRequest) Execute() (*http.Response, error) {
+func (r DeletePipelineApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePipelineExecute(r)
 }
 
@@ -391,10 +391,10 @@ Removes one Data Lake Pipeline.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiDeletePipelineRequest
+ @return DeletePipelineApiRequest
 */
-func (a *DataLakePipelinesApiService) DeletePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiDeletePipelineRequest {
-	return DataLakePipelinesApiDeletePipelineRequest{
+func (a *DataLakePipelinesApiService) DeletePipeline(ctx context.Context, groupId string, pipelineName string) DeletePipelineApiRequest {
+	return DeletePipelineApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -403,7 +403,7 @@ func (a *DataLakePipelinesApiService) DeletePipeline(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DataLakePipelinesApiDeletePipelineRequest) (*http.Response, error) {
+func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DeletePipelineApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -488,7 +488,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DataLakePipelinesA
 	return localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiDeletePipelineRunDatasetRequest struct {
+type DeletePipelineRunDatasetApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -502,7 +502,7 @@ type DeletePipelineRunDatasetParams struct {
 		PipelineRunId string
 }
 
-func (r DataLakePipelinesApiDeletePipelineRunDatasetRequest) Execute() (*http.Response, error) {
+func (r DeletePipelineRunDatasetApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePipelineRunDatasetExecute(r)
 }
 
@@ -515,10 +515,10 @@ Deletes dataset that Atlas generated during the specified pipeline run.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
  @param pipelineRunId Unique 24-hexadecimal character string that identifies a Data Lake Pipeline run.
- @return DataLakePipelinesApiDeletePipelineRunDatasetRequest
+ @return DeletePipelineRunDatasetApiRequest
 */
-func (a *DataLakePipelinesApiService) DeletePipelineRunDataset(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) DataLakePipelinesApiDeletePipelineRunDatasetRequest {
-	return DataLakePipelinesApiDeletePipelineRunDatasetRequest{
+func (a *DataLakePipelinesApiService) DeletePipelineRunDataset(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) DeletePipelineRunDatasetApiRequest {
+	return DeletePipelineRunDatasetApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -528,7 +528,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDataset(ctx context.Conte
 }
 
 // Execute executes the request
-func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DataLakePipelinesApiDeletePipelineRunDatasetRequest) (*http.Response, error) {
+func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -620,7 +620,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DataLake
 	return localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiGetPipelineRequest struct {
+type GetPipelineApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -632,7 +632,7 @@ type GetPipelineParams struct {
 		PipelineName string
 }
 
-func (r DataLakePipelinesApiGetPipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+func (r GetPipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.GetPipelineExecute(r)
 }
 
@@ -644,10 +644,10 @@ Returns the details of one Data Lake Pipeline within the specified project. To u
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiGetPipelineRequest
+ @return GetPipelineApiRequest
 */
-func (a *DataLakePipelinesApiService) GetPipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiGetPipelineRequest {
-	return DataLakePipelinesApiGetPipelineRequest{
+func (a *DataLakePipelinesApiService) GetPipeline(ctx context.Context, groupId string, pipelineName string) GetPipelineApiRequest {
+	return GetPipelineApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -657,7 +657,7 @@ func (a *DataLakePipelinesApiService) GetPipeline(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) GetPipelineExecute(r DataLakePipelinesApiGetPipelineRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) GetPipelineExecute(r GetPipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -752,7 +752,7 @@ func (a *DataLakePipelinesApiService) GetPipelineExecute(r DataLakePipelinesApiG
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiGetPipelineRunRequest struct {
+type GetPipelineRunApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -766,7 +766,7 @@ type GetPipelineRunParams struct {
 		PipelineRunId string
 }
 
-func (r DataLakePipelinesApiGetPipelineRunRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
+func (r GetPipelineRunApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
 	return r.ApiService.GetPipelineRunExecute(r)
 }
 
@@ -779,10 +779,10 @@ Returns the details of one Data Lake Pipeline run within the specified project. 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
  @param pipelineRunId Unique 24-hexadecimal character string that identifies a Data Lake Pipeline run.
- @return DataLakePipelinesApiGetPipelineRunRequest
+ @return GetPipelineRunApiRequest
 */
-func (a *DataLakePipelinesApiService) GetPipelineRun(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) DataLakePipelinesApiGetPipelineRunRequest {
-	return DataLakePipelinesApiGetPipelineRunRequest{
+func (a *DataLakePipelinesApiService) GetPipelineRun(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) GetPipelineRunApiRequest {
+	return GetPipelineRunApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -793,7 +793,7 @@ func (a *DataLakePipelinesApiService) GetPipelineRun(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipelineRun
-func (a *DataLakePipelinesApiService) GetPipelineRunExecute(r DataLakePipelinesApiGetPipelineRunRequest) (*IngestionPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -895,7 +895,7 @@ func (a *DataLakePipelinesApiService) GetPipelineRunExecute(r DataLakePipelinesA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiListPipelineRunsRequest struct {
+type ListPipelineRunsApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -916,30 +916,30 @@ type ListPipelineRunsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r DataLakePipelinesApiListPipelineRunsRequest) IncludeCount(includeCount bool) DataLakePipelinesApiListPipelineRunsRequest {
+func (r ListPipelineRunsApiRequest) IncludeCount(includeCount bool) ListPipelineRunsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r DataLakePipelinesApiListPipelineRunsRequest) ItemsPerPage(itemsPerPage int32) DataLakePipelinesApiListPipelineRunsRequest {
+func (r ListPipelineRunsApiRequest) ItemsPerPage(itemsPerPage int32) ListPipelineRunsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r DataLakePipelinesApiListPipelineRunsRequest) PageNum(pageNum int32) DataLakePipelinesApiListPipelineRunsRequest {
+func (r ListPipelineRunsApiRequest) PageNum(pageNum int32) ListPipelineRunsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // If specified, Atlas returns only Data Lake Pipeline runs initiated before this time and date.
-func (r DataLakePipelinesApiListPipelineRunsRequest) CreatedBefore(createdBefore time.Time) DataLakePipelinesApiListPipelineRunsRequest {
+func (r ListPipelineRunsApiRequest) CreatedBefore(createdBefore time.Time) ListPipelineRunsApiRequest {
 	r.createdBefore = &createdBefore
 	return r
 }
 
-func (r DataLakePipelinesApiListPipelineRunsRequest) Execute() (*PaginatedPipelineRun, *http.Response, error) {
+func (r ListPipelineRunsApiRequest) Execute() (*PaginatedPipelineRun, *http.Response, error) {
 	return r.ApiService.ListPipelineRunsExecute(r)
 }
 
@@ -951,10 +951,10 @@ Returns a list of past Data Lake Pipeline runs. To use this resource, the reques
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiListPipelineRunsRequest
+ @return ListPipelineRunsApiRequest
 */
-func (a *DataLakePipelinesApiService) ListPipelineRuns(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiListPipelineRunsRequest {
-	return DataLakePipelinesApiListPipelineRunsRequest{
+func (a *DataLakePipelinesApiService) ListPipelineRuns(ctx context.Context, groupId string, pipelineName string) ListPipelineRunsApiRequest {
+	return ListPipelineRunsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -964,7 +964,7 @@ func (a *DataLakePipelinesApiService) ListPipelineRuns(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedPipelineRun
-func (a *DataLakePipelinesApiService) ListPipelineRunsExecute(r DataLakePipelinesApiListPipelineRunsRequest) (*PaginatedPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1083,7 +1083,7 @@ func (a *DataLakePipelinesApiService) ListPipelineRunsExecute(r DataLakePipeline
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiListPipelineSchedulesRequest struct {
+type ListPipelineSchedulesApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -1095,7 +1095,7 @@ type ListPipelineSchedulesParams struct {
 		PipelineName string
 }
 
-func (r DataLakePipelinesApiListPipelineSchedulesRequest) Execute() ([]PolicyItem, *http.Response, error) {
+func (r ListPipelineSchedulesApiRequest) Execute() ([]PolicyItem, *http.Response, error) {
 	return r.ApiService.ListPipelineSchedulesExecute(r)
 }
 
@@ -1107,10 +1107,10 @@ Returns a list of backup schedule policy items that you can use as a Data Lake P
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiListPipelineSchedulesRequest
+ @return ListPipelineSchedulesApiRequest
 */
-func (a *DataLakePipelinesApiService) ListPipelineSchedules(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiListPipelineSchedulesRequest {
-	return DataLakePipelinesApiListPipelineSchedulesRequest{
+func (a *DataLakePipelinesApiService) ListPipelineSchedules(ctx context.Context, groupId string, pipelineName string) ListPipelineSchedulesApiRequest {
+	return ListPipelineSchedulesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1120,7 +1120,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSchedules(ctx context.Context,
 
 // Execute executes the request
 //  @return []PolicyItem
-func (a *DataLakePipelinesApiService) ListPipelineSchedulesExecute(r DataLakePipelinesApiListPipelineSchedulesRequest) ([]PolicyItem, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]PolicyItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1215,7 +1215,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSchedulesExecute(r DataLakePip
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiListPipelineSnapshotsRequest struct {
+type ListPipelineSnapshotsApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -1236,30 +1236,30 @@ type ListPipelineSnapshotsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r DataLakePipelinesApiListPipelineSnapshotsRequest) IncludeCount(includeCount bool) DataLakePipelinesApiListPipelineSnapshotsRequest {
+func (r ListPipelineSnapshotsApiRequest) IncludeCount(includeCount bool) ListPipelineSnapshotsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r DataLakePipelinesApiListPipelineSnapshotsRequest) ItemsPerPage(itemsPerPage int32) DataLakePipelinesApiListPipelineSnapshotsRequest {
+func (r ListPipelineSnapshotsApiRequest) ItemsPerPage(itemsPerPage int32) ListPipelineSnapshotsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r DataLakePipelinesApiListPipelineSnapshotsRequest) PageNum(pageNum int32) DataLakePipelinesApiListPipelineSnapshotsRequest {
+func (r ListPipelineSnapshotsApiRequest) PageNum(pageNum int32) ListPipelineSnapshotsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Date and time after which MongoDB Cloud created the snapshot. If specified, MongoDB Cloud returns available backup snapshots created after this time and date only. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-func (r DataLakePipelinesApiListPipelineSnapshotsRequest) CompletedAfter(completedAfter time.Time) DataLakePipelinesApiListPipelineSnapshotsRequest {
+func (r ListPipelineSnapshotsApiRequest) CompletedAfter(completedAfter time.Time) ListPipelineSnapshotsApiRequest {
 	r.completedAfter = &completedAfter
 	return r
 }
 
-func (r DataLakePipelinesApiListPipelineSnapshotsRequest) Execute() (*PaginatedBackupSnapshot, *http.Response, error) {
+func (r ListPipelineSnapshotsApiRequest) Execute() (*PaginatedBackupSnapshot, *http.Response, error) {
 	return r.ApiService.ListPipelineSnapshotsExecute(r)
 }
 
@@ -1271,10 +1271,10 @@ Returns a list of backup snapshots that you can use to trigger an on demand pipe
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiListPipelineSnapshotsRequest
+ @return ListPipelineSnapshotsApiRequest
 */
-func (a *DataLakePipelinesApiService) ListPipelineSnapshots(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiListPipelineSnapshotsRequest {
-	return DataLakePipelinesApiListPipelineSnapshotsRequest{
+func (a *DataLakePipelinesApiService) ListPipelineSnapshots(ctx context.Context, groupId string, pipelineName string) ListPipelineSnapshotsApiRequest {
+	return ListPipelineSnapshotsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1284,7 +1284,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSnapshots(ctx context.Context,
 
 // Execute executes the request
 //  @return PaginatedBackupSnapshot
-func (a *DataLakePipelinesApiService) ListPipelineSnapshotsExecute(r DataLakePipelinesApiListPipelineSnapshotsRequest) (*PaginatedBackupSnapshot, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1403,7 +1403,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSnapshotsExecute(r DataLakePip
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiListPipelinesRequest struct {
+type ListPipelinesApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -1413,7 +1413,7 @@ type ListPipelinesParams struct {
 		GroupId string
 }
 
-func (r DataLakePipelinesApiListPipelinesRequest) Execute() ([]IngestionPipeline, *http.Response, error) {
+func (r ListPipelinesApiRequest) Execute() ([]IngestionPipeline, *http.Response, error) {
 	return r.ApiService.ListPipelinesExecute(r)
 }
 
@@ -1424,10 +1424,10 @@ Returns a list of Data Lake Pipelines. To use this resource, the requesting API 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DataLakePipelinesApiListPipelinesRequest
+ @return ListPipelinesApiRequest
 */
-func (a *DataLakePipelinesApiService) ListPipelines(ctx context.Context, groupId string) DataLakePipelinesApiListPipelinesRequest {
-	return DataLakePipelinesApiListPipelinesRequest{
+func (a *DataLakePipelinesApiService) ListPipelines(ctx context.Context, groupId string) ListPipelinesApiRequest {
+	return ListPipelinesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1436,7 +1436,7 @@ func (a *DataLakePipelinesApiService) ListPipelines(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return []IngestionPipeline
-func (a *DataLakePipelinesApiService) ListPipelinesExecute(r DataLakePipelinesApiListPipelinesRequest) ([]IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ListPipelinesExecute(r ListPipelinesApiRequest) ([]IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1524,7 +1524,7 @@ func (a *DataLakePipelinesApiService) ListPipelinesExecute(r DataLakePipelinesAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiPausePipelineRequest struct {
+type PausePipelineApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -1536,7 +1536,7 @@ type PausePipelineParams struct {
 		PipelineName string
 }
 
-func (r DataLakePipelinesApiPausePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+func (r PausePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.PausePipelineExecute(r)
 }
 
@@ -1548,10 +1548,10 @@ Pauses ingestion for a Data Lake Pipeline within the specified project. To use t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiPausePipelineRequest
+ @return PausePipelineApiRequest
 */
-func (a *DataLakePipelinesApiService) PausePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiPausePipelineRequest {
-	return DataLakePipelinesApiPausePipelineRequest{
+func (a *DataLakePipelinesApiService) PausePipeline(ctx context.Context, groupId string, pipelineName string) PausePipelineApiRequest {
+	return PausePipelineApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1561,7 +1561,7 @@ func (a *DataLakePipelinesApiService) PausePipeline(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) PausePipelineExecute(r DataLakePipelinesApiPausePipelineRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) PausePipelineExecute(r PausePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1656,7 +1656,7 @@ func (a *DataLakePipelinesApiService) PausePipelineExecute(r DataLakePipelinesAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiResumePipelineRequest struct {
+type ResumePipelineApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -1668,7 +1668,7 @@ type ResumePipelineParams struct {
 		PipelineName string
 }
 
-func (r DataLakePipelinesApiResumePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+func (r ResumePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.ResumePipelineExecute(r)
 }
 
@@ -1680,10 +1680,10 @@ Resumes ingestion for a Data Lake Pipeline within the specified project. To use 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiResumePipelineRequest
+ @return ResumePipelineApiRequest
 */
-func (a *DataLakePipelinesApiService) ResumePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiResumePipelineRequest {
-	return DataLakePipelinesApiResumePipelineRequest{
+func (a *DataLakePipelinesApiService) ResumePipeline(ctx context.Context, groupId string, pipelineName string) ResumePipelineApiRequest {
+	return ResumePipelineApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1693,7 +1693,7 @@ func (a *DataLakePipelinesApiService) ResumePipeline(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) ResumePipelineExecute(r DataLakePipelinesApiResumePipelineRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) ResumePipelineExecute(r ResumePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1788,7 +1788,7 @@ func (a *DataLakePipelinesApiService) ResumePipelineExecute(r DataLakePipelinesA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiTriggerSnapshotIngestionRequest struct {
+type TriggerSnapshotIngestionApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -1803,12 +1803,12 @@ type TriggerSnapshotIngestionParams struct {
 }
 
 // Triggers a single ingestion run of a snapshot.
-func (r DataLakePipelinesApiTriggerSnapshotIngestionRequest) TriggerIngestionRequest(triggerIngestionRequest TriggerIngestionRequest) DataLakePipelinesApiTriggerSnapshotIngestionRequest {
+func (r TriggerSnapshotIngestionApiRequest) TriggerIngestionRequest(triggerIngestionRequest TriggerIngestionRequest) TriggerSnapshotIngestionApiRequest {
 	r.triggerIngestionRequest = &triggerIngestionRequest
 	return r
 }
 
-func (r DataLakePipelinesApiTriggerSnapshotIngestionRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
+func (r TriggerSnapshotIngestionApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
 	return r.ApiService.TriggerSnapshotIngestionExecute(r)
 }
 
@@ -1820,10 +1820,10 @@ Triggers a Data Lake Pipeline ingestion of a specified snapshot.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiTriggerSnapshotIngestionRequest
+ @return TriggerSnapshotIngestionApiRequest
 */
-func (a *DataLakePipelinesApiService) TriggerSnapshotIngestion(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiTriggerSnapshotIngestionRequest {
-	return DataLakePipelinesApiTriggerSnapshotIngestionRequest{
+func (a *DataLakePipelinesApiService) TriggerSnapshotIngestion(ctx context.Context, groupId string, pipelineName string) TriggerSnapshotIngestionApiRequest {
+	return TriggerSnapshotIngestionApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1833,7 +1833,7 @@ func (a *DataLakePipelinesApiService) TriggerSnapshotIngestion(ctx context.Conte
 
 // Execute executes the request
 //  @return IngestionPipelineRun
-func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionExecute(r DataLakePipelinesApiTriggerSnapshotIngestionRequest) (*IngestionPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1933,7 +1933,7 @@ func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionExecute(r DataLake
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DataLakePipelinesApiUpdatePipelineRequest struct {
+type UpdatePipelineApiRequest struct {
 	ctx context.Context
 	ApiService DataLakePipelinesApi
 	groupId string
@@ -1948,12 +1948,12 @@ type UpdatePipelineParams struct {
 }
 
 // Updates one Data Lake Pipeline.
-func (r DataLakePipelinesApiUpdatePipelineRequest) IngestionPipeline(ingestionPipeline IngestionPipeline) DataLakePipelinesApiUpdatePipelineRequest {
+func (r UpdatePipelineApiRequest) IngestionPipeline(ingestionPipeline IngestionPipeline) UpdatePipelineApiRequest {
 	r.ingestionPipeline = &ingestionPipeline
 	return r
 }
 
-func (r DataLakePipelinesApiUpdatePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+func (r UpdatePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.UpdatePipelineExecute(r)
 }
 
@@ -1965,10 +1965,10 @@ Updates one Data Lake Pipeline.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param pipelineName Human-readable label that identifies the Data Lake Pipeline.
- @return DataLakePipelinesApiUpdatePipelineRequest
+ @return UpdatePipelineApiRequest
 */
-func (a *DataLakePipelinesApiService) UpdatePipeline(ctx context.Context, groupId string, pipelineName string) DataLakePipelinesApiUpdatePipelineRequest {
-	return DataLakePipelinesApiUpdatePipelineRequest{
+func (a *DataLakePipelinesApiService) UpdatePipeline(ctx context.Context, groupId string, pipelineName string) UpdatePipelineApiRequest {
+	return UpdatePipelineApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1978,7 +1978,7 @@ func (a *DataLakePipelinesApiService) UpdatePipeline(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) UpdatePipelineExecute(r DataLakePipelinesApiUpdatePipelineRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) UpdatePipelineExecute(r UpdatePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -239,6 +239,10 @@ type DataLakePipelinesApiCreatePipelineRequest struct {
 	groupId string
 	ingestionPipeline *IngestionPipeline
 }
+type DataLakePipelinesApiCreatePipelineQueryParams struct {
+		groupId string
+		ingestionPipeline *IngestionPipeline
+}
 
 // Creates one Data Lake Pipeline.
 func (r DataLakePipelinesApiCreatePipelineRequest) IngestionPipeline(ingestionPipeline IngestionPipeline) DataLakePipelinesApiCreatePipelineRequest {
@@ -368,6 +372,10 @@ type DataLakePipelinesApiDeletePipelineRequest struct {
 	groupId string
 	pipelineName string
 }
+type DataLakePipelinesApiDeletePipelineQueryParams struct {
+		groupId string
+		pipelineName string
+}
 
 func (r DataLakePipelinesApiDeletePipelineRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePipelineExecute(r)
@@ -484,6 +492,11 @@ type DataLakePipelinesApiDeletePipelineRunDatasetRequest struct {
 	groupId string
 	pipelineName string
 	pipelineRunId string
+}
+type DataLakePipelinesApiDeletePipelineRunDatasetQueryParams struct {
+		groupId string
+		pipelineName string
+		pipelineRunId string
 }
 
 func (r DataLakePipelinesApiDeletePipelineRunDatasetRequest) Execute() (*http.Response, error) {
@@ -609,6 +622,10 @@ type DataLakePipelinesApiGetPipelineRequest struct {
 	ApiService DataLakePipelinesApi
 	groupId string
 	pipelineName string
+}
+type DataLakePipelinesApiGetPipelineQueryParams struct {
+		groupId string
+		pipelineName string
 }
 
 func (r DataLakePipelinesApiGetPipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
@@ -737,6 +754,11 @@ type DataLakePipelinesApiGetPipelineRunRequest struct {
 	groupId string
 	pipelineName string
 	pipelineRunId string
+}
+type DataLakePipelinesApiGetPipelineRunQueryParams struct {
+		groupId string
+		pipelineName string
+		pipelineRunId string
 }
 
 func (r DataLakePipelinesApiGetPipelineRunRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
@@ -877,6 +899,14 @@ type DataLakePipelinesApiListPipelineRunsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 	createdBefore *time.Time
+}
+type DataLakePipelinesApiListPipelineRunsQueryParams struct {
+		groupId string
+		pipelineName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		createdBefore *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1053,6 +1083,10 @@ type DataLakePipelinesApiListPipelineSchedulesRequest struct {
 	groupId string
 	pipelineName string
 }
+type DataLakePipelinesApiListPipelineSchedulesQueryParams struct {
+		groupId string
+		pipelineName string
+}
 
 func (r DataLakePipelinesApiListPipelineSchedulesRequest) Execute() ([]PolicyItem, *http.Response, error) {
 	return r.ApiService.ListPipelineSchedulesExecute(r)
@@ -1183,6 +1217,14 @@ type DataLakePipelinesApiListPipelineSnapshotsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 	completedAfter *time.Time
+}
+type DataLakePipelinesApiListPipelineSnapshotsQueryParams struct {
+		groupId string
+		pipelineName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		completedAfter *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1358,6 +1400,9 @@ type DataLakePipelinesApiListPipelinesRequest struct {
 	ApiService DataLakePipelinesApi
 	groupId string
 }
+type DataLakePipelinesApiListPipelinesQueryParams struct {
+		groupId string
+}
 
 func (r DataLakePipelinesApiListPipelinesRequest) Execute() ([]IngestionPipeline, *http.Response, error) {
 	return r.ApiService.ListPipelinesExecute(r)
@@ -1475,6 +1520,10 @@ type DataLakePipelinesApiPausePipelineRequest struct {
 	ApiService DataLakePipelinesApi
 	groupId string
 	pipelineName string
+}
+type DataLakePipelinesApiPausePipelineQueryParams struct {
+		groupId string
+		pipelineName string
 }
 
 func (r DataLakePipelinesApiPausePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
@@ -1603,6 +1652,10 @@ type DataLakePipelinesApiResumePipelineRequest struct {
 	groupId string
 	pipelineName string
 }
+type DataLakePipelinesApiResumePipelineQueryParams struct {
+		groupId string
+		pipelineName string
+}
 
 func (r DataLakePipelinesApiResumePipelineRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.ResumePipelineExecute(r)
@@ -1730,6 +1783,11 @@ type DataLakePipelinesApiTriggerSnapshotIngestionRequest struct {
 	groupId string
 	pipelineName string
 	triggerIngestionRequest *TriggerIngestionRequest
+}
+type DataLakePipelinesApiTriggerSnapshotIngestionQueryParams struct {
+		groupId string
+		pipelineName string
+		triggerIngestionRequest *TriggerIngestionRequest
 }
 
 // Triggers a single ingestion run of a snapshot.
@@ -1869,6 +1927,11 @@ type DataLakePipelinesApiUpdatePipelineRequest struct {
 	groupId string
 	pipelineName string
 	ingestionPipeline *IngestionPipeline
+}
+type DataLakePipelinesApiUpdatePipelineQueryParams struct {
+		groupId string
+		pipelineName string
+		ingestionPipeline *IngestionPipeline
 }
 
 // Updates one Data Lake Pipeline.

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -113,7 +113,7 @@ type CreateDatabaseUserApiRequest struct {
 	databaseUser *DatabaseUser
 }
 
-type CreateDatabaseUserParams struct {
+type CreateDatabaseUserApiParams struct {
 		GroupId string
 		DatabaseUser *DatabaseUser
 }
@@ -248,7 +248,7 @@ type DeleteDatabaseUserApiRequest struct {
 	username string
 }
 
-type DeleteDatabaseUserParams struct {
+type DeleteDatabaseUserApiParams struct {
 		GroupId string
 		DatabaseName string
 		Username string
@@ -368,7 +368,7 @@ type GetDatabaseUserApiRequest struct {
 	username string
 }
 
-type GetDatabaseUserParams struct {
+type GetDatabaseUserApiParams struct {
 		GroupId string
 		DatabaseName string
 		Username string
@@ -500,7 +500,7 @@ type ListDatabaseUsersApiRequest struct {
 	pageNum *int32
 }
 
-type ListDatabaseUsersParams struct {
+type ListDatabaseUsersApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -666,7 +666,7 @@ type UpdateDatabaseUserApiRequest struct {
 	databaseUser *DatabaseUser
 }
 
-type UpdateDatabaseUserParams struct {
+type UpdateDatabaseUserApiParams struct {
 		GroupId string
 		DatabaseName string
 		Username string

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -113,7 +113,7 @@ type DatabaseUsersApiCreateDatabaseUserRequest struct {
 	databaseUser *DatabaseUser
 }
 
-type DatabaseUsersApiCreateDatabaseUserParams struct {
+type CreateDatabaseUserParams struct {
 		GroupId string
 		DatabaseUser *DatabaseUser
 }
@@ -248,7 +248,7 @@ type DatabaseUsersApiDeleteDatabaseUserRequest struct {
 	username string
 }
 
-type DatabaseUsersApiDeleteDatabaseUserParams struct {
+type DeleteDatabaseUserParams struct {
 		GroupId string
 		DatabaseName string
 		Username string
@@ -368,7 +368,7 @@ type DatabaseUsersApiGetDatabaseUserRequest struct {
 	username string
 }
 
-type DatabaseUsersApiGetDatabaseUserParams struct {
+type GetDatabaseUserParams struct {
 		GroupId string
 		DatabaseName string
 		Username string
@@ -500,7 +500,7 @@ type DatabaseUsersApiListDatabaseUsersRequest struct {
 	pageNum *int32
 }
 
-type DatabaseUsersApiListDatabaseUsersParams struct {
+type ListDatabaseUsersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -666,7 +666,7 @@ type DatabaseUsersApiUpdateDatabaseUserRequest struct {
 	databaseUser *DatabaseUser
 }
 
-type DatabaseUsersApiUpdateDatabaseUserParams struct {
+type UpdateDatabaseUserParams struct {
 		GroupId string
 		DatabaseName string
 		Username string

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -112,9 +112,10 @@ type DatabaseUsersApiCreateDatabaseUserRequest struct {
 	groupId string
 	databaseUser *DatabaseUser
 }
+
 type DatabaseUsersApiCreateDatabaseUserQueryParams struct {
-		groupId string
-		databaseUser *DatabaseUser
+		GroupId string
+		DatabaseUser *DatabaseUser
 }
 
 // Creates one database user in the specified project.
@@ -246,10 +247,11 @@ type DatabaseUsersApiDeleteDatabaseUserRequest struct {
 	databaseName string
 	username string
 }
+
 type DatabaseUsersApiDeleteDatabaseUserQueryParams struct {
-		groupId string
-		databaseName string
-		username string
+		GroupId string
+		DatabaseName string
+		Username string
 }
 
 func (r DatabaseUsersApiDeleteDatabaseUserRequest) Execute() (*http.Response, error) {
@@ -365,10 +367,11 @@ type DatabaseUsersApiGetDatabaseUserRequest struct {
 	databaseName string
 	username string
 }
+
 type DatabaseUsersApiGetDatabaseUserQueryParams struct {
-		groupId string
-		databaseName string
-		username string
+		GroupId string
+		DatabaseName string
+		Username string
 }
 
 func (r DatabaseUsersApiGetDatabaseUserRequest) Execute() (*DatabaseUser, *http.Response, error) {
@@ -496,11 +499,12 @@ type DatabaseUsersApiListDatabaseUsersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type DatabaseUsersApiListDatabaseUsersQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -661,11 +665,12 @@ type DatabaseUsersApiUpdateDatabaseUserRequest struct {
 	username string
 	databaseUser *DatabaseUser
 }
+
 type DatabaseUsersApiUpdateDatabaseUserQueryParams struct {
-		groupId string
-		databaseName string
-		username string
-		databaseUser *DatabaseUser
+		GroupId string
+		DatabaseName string
+		Username string
+		DatabaseUser *DatabaseUser
 }
 
 // Updates one database user that belongs to the specified project.

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -113,7 +113,7 @@ type DatabaseUsersApiCreateDatabaseUserRequest struct {
 	databaseUser *DatabaseUser
 }
 
-type DatabaseUsersApiCreateDatabaseUserQueryParams struct {
+type DatabaseUsersApiCreateDatabaseUserParams struct {
 		GroupId string
 		DatabaseUser *DatabaseUser
 }
@@ -248,7 +248,7 @@ type DatabaseUsersApiDeleteDatabaseUserRequest struct {
 	username string
 }
 
-type DatabaseUsersApiDeleteDatabaseUserQueryParams struct {
+type DatabaseUsersApiDeleteDatabaseUserParams struct {
 		GroupId string
 		DatabaseName string
 		Username string
@@ -368,7 +368,7 @@ type DatabaseUsersApiGetDatabaseUserRequest struct {
 	username string
 }
 
-type DatabaseUsersApiGetDatabaseUserQueryParams struct {
+type DatabaseUsersApiGetDatabaseUserParams struct {
 		GroupId string
 		DatabaseName string
 		Username string
@@ -500,7 +500,7 @@ type DatabaseUsersApiListDatabaseUsersRequest struct {
 	pageNum *int32
 }
 
-type DatabaseUsersApiListDatabaseUsersQueryParams struct {
+type DatabaseUsersApiListDatabaseUsersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -666,7 +666,7 @@ type DatabaseUsersApiUpdateDatabaseUserRequest struct {
 	databaseUser *DatabaseUser
 }
 
-type DatabaseUsersApiUpdateDatabaseUserQueryParams struct {
+type DatabaseUsersApiUpdateDatabaseUserParams struct {
 		GroupId string
 		DatabaseName string
 		Username string

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -112,6 +112,10 @@ type DatabaseUsersApiCreateDatabaseUserRequest struct {
 	groupId string
 	databaseUser *DatabaseUser
 }
+type DatabaseUsersApiCreateDatabaseUserQueryParams struct {
+		groupId string
+		databaseUser *DatabaseUser
+}
 
 // Creates one database user in the specified project.
 func (r DatabaseUsersApiCreateDatabaseUserRequest) DatabaseUser(databaseUser DatabaseUser) DatabaseUsersApiCreateDatabaseUserRequest {
@@ -242,6 +246,11 @@ type DatabaseUsersApiDeleteDatabaseUserRequest struct {
 	databaseName string
 	username string
 }
+type DatabaseUsersApiDeleteDatabaseUserQueryParams struct {
+		groupId string
+		databaseName string
+		username string
+}
 
 func (r DatabaseUsersApiDeleteDatabaseUserRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteDatabaseUserExecute(r)
@@ -355,6 +364,11 @@ type DatabaseUsersApiGetDatabaseUserRequest struct {
 	groupId string
 	databaseName string
 	username string
+}
+type DatabaseUsersApiGetDatabaseUserQueryParams struct {
+		groupId string
+		databaseName string
+		username string
 }
 
 func (r DatabaseUsersApiGetDatabaseUserRequest) Execute() (*DatabaseUser, *http.Response, error) {
@@ -481,6 +495,12 @@ type DatabaseUsersApiListDatabaseUsersRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type DatabaseUsersApiListDatabaseUsersQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -640,6 +660,12 @@ type DatabaseUsersApiUpdateDatabaseUserRequest struct {
 	databaseName string
 	username string
 	databaseUser *DatabaseUser
+}
+type DatabaseUsersApiUpdateDatabaseUserQueryParams struct {
+		groupId string
+		databaseName string
+		username string
+		databaseUser *DatabaseUser
 }
 
 // Updates one database user that belongs to the specified project.

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -29,13 +29,13 @@ type DatabaseUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DatabaseUsersApiCreateDatabaseUserRequest
+	@return CreateDatabaseUserApiRequest
 	*/
-	CreateDatabaseUser(ctx context.Context, groupId string) DatabaseUsersApiCreateDatabaseUserRequest
+	CreateDatabaseUser(ctx context.Context, groupId string) CreateDatabaseUserApiRequest
 
 	// CreateDatabaseUserExecute executes the request
 	//  @return DatabaseUser
-	CreateDatabaseUserExecute(r DatabaseUsersApiCreateDatabaseUserRequest) (*DatabaseUser, *http.Response, error)
+	CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
 
 	/*
 	DeleteDatabaseUser Remove One Database User from One Project
@@ -46,12 +46,12 @@ type DatabaseUsersApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param databaseName Human-readable label that identifies the database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, or LDAP, this value should be `$external`. If the user authenticates with SCRAM-SHA, this value should be `admin`.
 	@param username Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:  | Authentication Method | Parameter Needed | Parameter Value | username Format | |---|---|---|---| | AWS IAM | awsType | ROLE | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | AWS IAM | awsType | USER | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | x.509 | x509Type | CUSTOMER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | x.509 | x509Type | MANAGED | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | USER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | GROUP | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | SCRAM-SHA | awsType, x509Type, ldapAuthType | NONE | Alphanumeric string | 
-	@return DatabaseUsersApiDeleteDatabaseUserRequest
+	@return DeleteDatabaseUserApiRequest
 	*/
-	DeleteDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DatabaseUsersApiDeleteDatabaseUserRequest
+	DeleteDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DeleteDatabaseUserApiRequest
 
 	// DeleteDatabaseUserExecute executes the request
-	DeleteDatabaseUserExecute(r DatabaseUsersApiDeleteDatabaseUserRequest) (*http.Response, error)
+	DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (*http.Response, error)
 
 	/*
 	GetDatabaseUser Return One Database User from One Project
@@ -62,13 +62,13 @@ type DatabaseUsersApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param databaseName Human-readable label that identifies the database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, or LDAP, this value should be `$external`. If the user authenticates with SCRAM-SHA, this value should be `admin`.
 	@param username Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:  | Authentication Method | Parameter Needed | Parameter Value | username Format | |---|---|---|---| | AWS IAM | awsType | ROLE | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | AWS IAM | awsType | USER | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | x.509 | x509Type | CUSTOMER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | x.509 | x509Type | MANAGED | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | USER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | GROUP | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | SCRAM-SHA | awsType, x509Type, ldapAuthType | NONE | Alphanumeric string | 
-	@return DatabaseUsersApiGetDatabaseUserRequest
+	@return GetDatabaseUserApiRequest
 	*/
-	GetDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DatabaseUsersApiGetDatabaseUserRequest
+	GetDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) GetDatabaseUserApiRequest
 
 	// GetDatabaseUserExecute executes the request
 	//  @return DatabaseUser
-	GetDatabaseUserExecute(r DatabaseUsersApiGetDatabaseUserRequest) (*DatabaseUser, *http.Response, error)
+	GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
 
 	/*
 	ListDatabaseUsers Return All Database Users from One Project
@@ -77,13 +77,13 @@ type DatabaseUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return DatabaseUsersApiListDatabaseUsersRequest
+	@return ListDatabaseUsersApiRequest
 	*/
-	ListDatabaseUsers(ctx context.Context, groupId string) DatabaseUsersApiListDatabaseUsersRequest
+	ListDatabaseUsers(ctx context.Context, groupId string) ListDatabaseUsersApiRequest
 
 	// ListDatabaseUsersExecute executes the request
 	//  @return PaginatedApiAtlasDatabaseUser
-	ListDatabaseUsersExecute(r DatabaseUsersApiListDatabaseUsersRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error)
+	ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error)
 
 	/*
 	UpdateDatabaseUser Update One Database User in One Project
@@ -94,19 +94,19 @@ type DatabaseUsersApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param databaseName Human-readable label that identifies the database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, or LDAP, this value should be `$external`. If the user authenticates with SCRAM-SHA, this value should be `admin`.
 	@param username Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:  | Authentication Method | Parameter Needed | Parameter Value | username Format | |---|---|---|---| | AWS IAM | awsType | ROLE | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | AWS IAM | awsType | USER | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | x.509 | x509Type | CUSTOMER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | x.509 | x509Type | MANAGED | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | USER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | GROUP | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | SCRAM-SHA | awsType, x509Type, ldapAuthType | NONE | Alphanumeric string | 
-	@return DatabaseUsersApiUpdateDatabaseUserRequest
+	@return UpdateDatabaseUserApiRequest
 	*/
-	UpdateDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DatabaseUsersApiUpdateDatabaseUserRequest
+	UpdateDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) UpdateDatabaseUserApiRequest
 
 	// UpdateDatabaseUserExecute executes the request
 	//  @return DatabaseUser
-	UpdateDatabaseUserExecute(r DatabaseUsersApiUpdateDatabaseUserRequest) (*DatabaseUser, *http.Response, error)
+	UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
 }
 
 // DatabaseUsersApiService DatabaseUsersApi service
 type DatabaseUsersApiService service
 
-type DatabaseUsersApiCreateDatabaseUserRequest struct {
+type CreateDatabaseUserApiRequest struct {
 	ctx context.Context
 	ApiService DatabaseUsersApi
 	groupId string
@@ -119,12 +119,12 @@ type CreateDatabaseUserParams struct {
 }
 
 // Creates one database user in the specified project.
-func (r DatabaseUsersApiCreateDatabaseUserRequest) DatabaseUser(databaseUser DatabaseUser) DatabaseUsersApiCreateDatabaseUserRequest {
+func (r CreateDatabaseUserApiRequest) DatabaseUser(databaseUser DatabaseUser) CreateDatabaseUserApiRequest {
 	r.databaseUser = &databaseUser
 	return r
 }
 
-func (r DatabaseUsersApiCreateDatabaseUserRequest) Execute() (*DatabaseUser, *http.Response, error) {
+func (r CreateDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
 	return r.ApiService.CreateDatabaseUserExecute(r)
 }
 
@@ -135,10 +135,10 @@ Creates one database user in the specified project. This MongoDB Cloud supports 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DatabaseUsersApiCreateDatabaseUserRequest
+ @return CreateDatabaseUserApiRequest
 */
-func (a *DatabaseUsersApiService) CreateDatabaseUser(ctx context.Context, groupId string) DatabaseUsersApiCreateDatabaseUserRequest {
-	return DatabaseUsersApiCreateDatabaseUserRequest{
+func (a *DatabaseUsersApiService) CreateDatabaseUser(ctx context.Context, groupId string) CreateDatabaseUserApiRequest {
+	return CreateDatabaseUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -147,7 +147,7 @@ func (a *DatabaseUsersApiService) CreateDatabaseUser(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DatabaseUser
-func (a *DatabaseUsersApiService) CreateDatabaseUserExecute(r DatabaseUsersApiCreateDatabaseUserRequest) (*DatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -240,7 +240,7 @@ func (a *DatabaseUsersApiService) CreateDatabaseUserExecute(r DatabaseUsersApiCr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DatabaseUsersApiDeleteDatabaseUserRequest struct {
+type DeleteDatabaseUserApiRequest struct {
 	ctx context.Context
 	ApiService DatabaseUsersApi
 	groupId string
@@ -254,7 +254,7 @@ type DeleteDatabaseUserParams struct {
 		Username string
 }
 
-func (r DatabaseUsersApiDeleteDatabaseUserRequest) Execute() (*http.Response, error) {
+func (r DeleteDatabaseUserApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteDatabaseUserExecute(r)
 }
 
@@ -267,10 +267,10 @@ Removes one database user from the specified project. To use this resource, the 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param databaseName Human-readable label that identifies the database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, or LDAP, this value should be `$external`. If the user authenticates with SCRAM-SHA, this value should be `admin`.
  @param username Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:  | Authentication Method | Parameter Needed | Parameter Value | username Format | |---|---|---|---| | AWS IAM | awsType | ROLE | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | AWS IAM | awsType | USER | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | x.509 | x509Type | CUSTOMER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | x.509 | x509Type | MANAGED | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | USER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | GROUP | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | SCRAM-SHA | awsType, x509Type, ldapAuthType | NONE | Alphanumeric string | 
- @return DatabaseUsersApiDeleteDatabaseUserRequest
+ @return DeleteDatabaseUserApiRequest
 */
-func (a *DatabaseUsersApiService) DeleteDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DatabaseUsersApiDeleteDatabaseUserRequest {
-	return DatabaseUsersApiDeleteDatabaseUserRequest{
+func (a *DatabaseUsersApiService) DeleteDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DeleteDatabaseUserApiRequest {
+	return DeleteDatabaseUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -280,7 +280,7 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUser(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DatabaseUsersApiDeleteDatabaseUserRequest) (*http.Response, error) {
+func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -360,7 +360,7 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DatabaseUsersApiDe
 	return localVarHTTPResponse, nil
 }
 
-type DatabaseUsersApiGetDatabaseUserRequest struct {
+type GetDatabaseUserApiRequest struct {
 	ctx context.Context
 	ApiService DatabaseUsersApi
 	groupId string
@@ -374,7 +374,7 @@ type GetDatabaseUserParams struct {
 		Username string
 }
 
-func (r DatabaseUsersApiGetDatabaseUserRequest) Execute() (*DatabaseUser, *http.Response, error) {
+func (r GetDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
 	return r.ApiService.GetDatabaseUserExecute(r)
 }
 
@@ -387,10 +387,10 @@ Returns one database user that belong to the specified project. To use this reso
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param databaseName Human-readable label that identifies the database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, or LDAP, this value should be `$external`. If the user authenticates with SCRAM-SHA, this value should be `admin`.
  @param username Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:  | Authentication Method | Parameter Needed | Parameter Value | username Format | |---|---|---|---| | AWS IAM | awsType | ROLE | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | AWS IAM | awsType | USER | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | x.509 | x509Type | CUSTOMER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | x.509 | x509Type | MANAGED | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | USER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | GROUP | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | SCRAM-SHA | awsType, x509Type, ldapAuthType | NONE | Alphanumeric string | 
- @return DatabaseUsersApiGetDatabaseUserRequest
+ @return GetDatabaseUserApiRequest
 */
-func (a *DatabaseUsersApiService) GetDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DatabaseUsersApiGetDatabaseUserRequest {
-	return DatabaseUsersApiGetDatabaseUserRequest{
+func (a *DatabaseUsersApiService) GetDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) GetDatabaseUserApiRequest {
+	return GetDatabaseUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -401,7 +401,7 @@ func (a *DatabaseUsersApiService) GetDatabaseUser(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return DatabaseUser
-func (a *DatabaseUsersApiService) GetDatabaseUserExecute(r DatabaseUsersApiGetDatabaseUserRequest) (*DatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -491,7 +491,7 @@ func (a *DatabaseUsersApiService) GetDatabaseUserExecute(r DatabaseUsersApiGetDa
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DatabaseUsersApiListDatabaseUsersRequest struct {
+type ListDatabaseUsersApiRequest struct {
 	ctx context.Context
 	ApiService DatabaseUsersApi
 	groupId string
@@ -508,24 +508,24 @@ type ListDatabaseUsersParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r DatabaseUsersApiListDatabaseUsersRequest) IncludeCount(includeCount bool) DatabaseUsersApiListDatabaseUsersRequest {
+func (r ListDatabaseUsersApiRequest) IncludeCount(includeCount bool) ListDatabaseUsersApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r DatabaseUsersApiListDatabaseUsersRequest) ItemsPerPage(itemsPerPage int32) DatabaseUsersApiListDatabaseUsersRequest {
+func (r ListDatabaseUsersApiRequest) ItemsPerPage(itemsPerPage int32) ListDatabaseUsersApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r DatabaseUsersApiListDatabaseUsersRequest) PageNum(pageNum int32) DatabaseUsersApiListDatabaseUsersRequest {
+func (r ListDatabaseUsersApiRequest) PageNum(pageNum int32) ListDatabaseUsersApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r DatabaseUsersApiListDatabaseUsersRequest) Execute() (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
+func (r ListDatabaseUsersApiRequest) Execute() (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
 	return r.ApiService.ListDatabaseUsersExecute(r)
 }
 
@@ -536,10 +536,10 @@ Returns all database users that belong to the specified project. To use this res
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return DatabaseUsersApiListDatabaseUsersRequest
+ @return ListDatabaseUsersApiRequest
 */
-func (a *DatabaseUsersApiService) ListDatabaseUsers(ctx context.Context, groupId string) DatabaseUsersApiListDatabaseUsersRequest {
-	return DatabaseUsersApiListDatabaseUsersRequest{
+func (a *DatabaseUsersApiService) ListDatabaseUsers(ctx context.Context, groupId string) ListDatabaseUsersApiRequest {
+	return ListDatabaseUsersApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -548,7 +548,7 @@ func (a *DatabaseUsersApiService) ListDatabaseUsers(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return PaginatedApiAtlasDatabaseUser
-func (a *DatabaseUsersApiService) ListDatabaseUsersExecute(r DatabaseUsersApiListDatabaseUsersRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -657,7 +657,7 @@ func (a *DatabaseUsersApiService) ListDatabaseUsersExecute(r DatabaseUsersApiLis
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type DatabaseUsersApiUpdateDatabaseUserRequest struct {
+type UpdateDatabaseUserApiRequest struct {
 	ctx context.Context
 	ApiService DatabaseUsersApi
 	groupId string
@@ -674,12 +674,12 @@ type UpdateDatabaseUserParams struct {
 }
 
 // Updates one database user that belongs to the specified project.
-func (r DatabaseUsersApiUpdateDatabaseUserRequest) DatabaseUser(databaseUser DatabaseUser) DatabaseUsersApiUpdateDatabaseUserRequest {
+func (r UpdateDatabaseUserApiRequest) DatabaseUser(databaseUser DatabaseUser) UpdateDatabaseUserApiRequest {
 	r.databaseUser = &databaseUser
 	return r
 }
 
-func (r DatabaseUsersApiUpdateDatabaseUserRequest) Execute() (*DatabaseUser, *http.Response, error) {
+func (r UpdateDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
 	return r.ApiService.UpdateDatabaseUserExecute(r)
 }
 
@@ -692,10 +692,10 @@ Updates one database user that belongs to the specified project. To use this res
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param databaseName Human-readable label that identifies the database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, or LDAP, this value should be `$external`. If the user authenticates with SCRAM-SHA, this value should be `admin`.
  @param username Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:  | Authentication Method | Parameter Needed | Parameter Value | username Format | |---|---|---|---| | AWS IAM | awsType | ROLE | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | AWS IAM | awsType | USER | <abbr title=\"Amazon Resource Name\">ARN</abbr> | | x.509 | x509Type | CUSTOMER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | x.509 | x509Type | MANAGED | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | USER | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | LDAP | ldapAuthType | GROUP | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name | | SCRAM-SHA | awsType, x509Type, ldapAuthType | NONE | Alphanumeric string | 
- @return DatabaseUsersApiUpdateDatabaseUserRequest
+ @return UpdateDatabaseUserApiRequest
 */
-func (a *DatabaseUsersApiService) UpdateDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DatabaseUsersApiUpdateDatabaseUserRequest {
-	return DatabaseUsersApiUpdateDatabaseUserRequest{
+func (a *DatabaseUsersApiService) UpdateDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) UpdateDatabaseUserApiRequest {
+	return UpdateDatabaseUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -706,7 +706,7 @@ func (a *DatabaseUsersApiService) UpdateDatabaseUser(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DatabaseUser
-func (a *DatabaseUsersApiService) UpdateDatabaseUserExecute(r DatabaseUsersApiUpdateDatabaseUserRequest) (*DatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -31,13 +31,13 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest
+	@return GetEncryptionAtRestApiRequest
 	*/
-	GetEncryptionAtRest(ctx context.Context, groupId string) EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest
+	GetEncryptionAtRest(ctx context.Context, groupId string) GetEncryptionAtRestApiRequest
 
 	// GetEncryptionAtRestExecute executes the request
 	//  @return EncryptionAtRest
-	GetEncryptionAtRestExecute(r EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest) (*EncryptionAtRest, *http.Response, error)
+	GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 
 	/*
 	UpdateEncryptionAtRest Update Configuration for Encryption at Rest using Customer-Managed Keys for One Project
@@ -48,19 +48,19 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest
+	@return UpdateEncryptionAtRestApiRequest
 	*/
-	UpdateEncryptionAtRest(ctx context.Context, groupId string) EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest
+	UpdateEncryptionAtRest(ctx context.Context, groupId string) UpdateEncryptionAtRestApiRequest
 
 	// UpdateEncryptionAtRestExecute executes the request
 	//  @return EncryptionAtRest
-	UpdateEncryptionAtRestExecute(r EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest) (*EncryptionAtRest, *http.Response, error)
+	UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 }
 
 // EncryptionAtRestUsingCustomerKeyManagementApiService EncryptionAtRestUsingCustomerKeyManagementApi service
 type EncryptionAtRestUsingCustomerKeyManagementApiService service
 
-type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest struct {
+type GetEncryptionAtRestApiRequest struct {
 	ctx context.Context
 	ApiService EncryptionAtRestUsingCustomerKeyManagementApi
 	groupId string
@@ -70,7 +70,7 @@ type GetEncryptionAtRestParams struct {
 		GroupId string
 }
 
-func (r EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
+func (r GetEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
 	return r.ApiService.GetEncryptionAtRestExecute(r)
 }
 
@@ -83,10 +83,10 @@ Returns the configuration for encryption at rest using the keys you manage throu
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest
+ @return GetEncryptionAtRestApiRequest
 */
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRest(ctx context.Context, groupId string) EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest {
-	return EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest{
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRest(ctx context.Context, groupId string) GetEncryptionAtRestApiRequest {
+	return GetEncryptionAtRestApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -95,7 +95,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 
 // Execute executes the request
 //  @return EncryptionAtRest
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestExecute(r EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest) (*EncryptionAtRest, *http.Response, error) {
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -183,7 +183,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest struct {
+type UpdateEncryptionAtRestApiRequest struct {
 	ctx context.Context
 	ApiService EncryptionAtRestUsingCustomerKeyManagementApi
 	groupId string
@@ -196,12 +196,12 @@ type UpdateEncryptionAtRestParams struct {
 }
 
 // Required parameters depend on whether someone has enabled Encryption at Rest using Customer Key Management:  If you have enabled Encryption at Rest using Customer Key Management (CMK), Atlas requires all of the parameters for the desired encryption provider.  - To use AWS Key Management Service (KMS), MongoDB Cloud requires all the fields in the **awsKms** object. - To use Azure Key Vault, MongoDB Cloud requires all the fields in the **azureKeyVault** object. - To use Google Cloud Key Management Service (KMS), MongoDB Cloud requires all the fields in the **googleCloudKms** object.  If you enabled Encryption at Rest using Customer Key  Management, administrators can pass only the changed fields for the **awsKms**, **azureKeyVault**, or **googleCloudKms** object to update the configuration to this endpoint.
-func (r EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest) EncryptionAtRest(encryptionAtRest EncryptionAtRest) EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest {
+func (r UpdateEncryptionAtRestApiRequest) EncryptionAtRest(encryptionAtRest EncryptionAtRest) UpdateEncryptionAtRestApiRequest {
 	r.encryptionAtRest = &encryptionAtRest
 	return r
 }
 
-func (r EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
+func (r UpdateEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
 	return r.ApiService.UpdateEncryptionAtRestExecute(r)
 }
 
@@ -214,10 +214,10 @@ Updates the configuration for encryption at rest using the keys you manage throu
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest
+ @return UpdateEncryptionAtRestApiRequest
 */
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRest(ctx context.Context, groupId string) EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest {
-	return EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest{
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRest(ctx context.Context, groupId string) UpdateEncryptionAtRestApiRequest {
+	return UpdateEncryptionAtRestApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -226,7 +226,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionA
 
 // Execute executes the request
 //  @return EncryptionAtRest
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRestExecute(r EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest) (*EncryptionAtRest, *http.Response, error) {
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -66,7 +66,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest str
 	groupId string
 }
 
-type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestParams struct {
+type GetEncryptionAtRestParams struct {
 		GroupId string
 }
 
@@ -190,7 +190,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest 
 	encryptionAtRest *EncryptionAtRest
 }
 
-type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestParams struct {
+type UpdateEncryptionAtRestParams struct {
 		GroupId string
 		EncryptionAtRest *EncryptionAtRest
 }

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -66,7 +66,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest str
 	groupId string
 }
 
-type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestQueryParams struct {
+type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestParams struct {
 		GroupId string
 }
 
@@ -190,7 +190,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest 
 	encryptionAtRest *EncryptionAtRest
 }
 
-type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestQueryParams struct {
+type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestParams struct {
 		GroupId string
 		EncryptionAtRest *EncryptionAtRest
 }

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -65,6 +65,9 @@ type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest str
 	ApiService EncryptionAtRestUsingCustomerKeyManagementApi
 	groupId string
 }
+type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestQueryParams struct {
+		groupId string
+}
 
 func (r EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
 	return r.ApiService.GetEncryptionAtRestExecute(r)
@@ -184,6 +187,10 @@ type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest 
 	ApiService EncryptionAtRestUsingCustomerKeyManagementApi
 	groupId string
 	encryptionAtRest *EncryptionAtRest
+}
+type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestQueryParams struct {
+		groupId string
+		encryptionAtRest *EncryptionAtRest
 }
 
 // Required parameters depend on whether someone has enabled Encryption at Rest using Customer Key Management:  If you have enabled Encryption at Rest using Customer Key Management (CMK), Atlas requires all of the parameters for the desired encryption provider.  - To use AWS Key Management Service (KMS), MongoDB Cloud requires all the fields in the **awsKms** object. - To use Azure Key Vault, MongoDB Cloud requires all the fields in the **azureKeyVault** object. - To use Google Cloud Key Management Service (KMS), MongoDB Cloud requires all the fields in the **googleCloudKms** object.  If you enabled Encryption at Rest using Customer Key  Management, administrators can pass only the changed fields for the **awsKms**, **azureKeyVault**, or **googleCloudKms** object to update the configuration to this endpoint.

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -66,7 +66,7 @@ type GetEncryptionAtRestApiRequest struct {
 	groupId string
 }
 
-type GetEncryptionAtRestParams struct {
+type GetEncryptionAtRestApiParams struct {
 		GroupId string
 }
 
@@ -190,7 +190,7 @@ type UpdateEncryptionAtRestApiRequest struct {
 	encryptionAtRest *EncryptionAtRest
 }
 
-type UpdateEncryptionAtRestParams struct {
+type UpdateEncryptionAtRestApiParams struct {
 		GroupId string
 		EncryptionAtRest *EncryptionAtRest
 }

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -65,8 +65,9 @@ type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest str
 	ApiService EncryptionAtRestUsingCustomerKeyManagementApi
 	groupId string
 }
+
 type EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r EncryptionAtRestUsingCustomerKeyManagementApiGetEncryptionAtRestRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
@@ -188,9 +189,10 @@ type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestRequest 
 	groupId string
 	encryptionAtRest *EncryptionAtRest
 }
+
 type EncryptionAtRestUsingCustomerKeyManagementApiUpdateEncryptionAtRestQueryParams struct {
-		groupId string
-		encryptionAtRest *EncryptionAtRest
+		GroupId string
+		EncryptionAtRest *EncryptionAtRest
 }
 
 // Required parameters depend on whether someone has enabled Encryption at Rest using Customer Key Management:  If you have enabled Encryption at Rest using Customer Key Management (CMK), Atlas requires all of the parameters for the desired encryption provider.  - To use AWS Key Management Service (KMS), MongoDB Cloud requires all the fields in the **awsKms** object. - To use Azure Key Vault, MongoDB Cloud requires all the fields in the **azureKeyVault** object. - To use Google Cloud Key Management Service (KMS), MongoDB Cloud requires all the fields in the **googleCloudKms** object.  If you enabled Encryption at Rest using Customer Key  Management, administrators can pass only the changed fields for the **awsKms**, **azureKeyVault**, or **googleCloudKms** object to update the configuration to this endpoint.

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -106,7 +106,7 @@ type EventsApiGetOrganizationEventRequest struct {
 	includeRaw *bool
 }
 
-type EventsApiGetOrganizationEventQueryParams struct {
+type EventsApiGetOrganizationEventParams struct {
 		OrgId string
 		EventId string
 		IncludeRaw *bool
@@ -255,7 +255,7 @@ type EventsApiGetProjectEventRequest struct {
 	includeRaw *bool
 }
 
-type EventsApiGetProjectEventQueryParams struct {
+type EventsApiGetProjectEventParams struct {
 		GroupId string
 		EventId string
 		IncludeRaw *bool
@@ -409,7 +409,7 @@ type EventsApiListOrganizationEventsRequest struct {
 	minDate *time.Time
 }
 
-type EventsApiListOrganizationEventsQueryParams struct {
+type EventsApiListOrganizationEventsParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -626,7 +626,7 @@ type EventsApiListProjectEventsRequest struct {
 	minDate *time.Time
 }
 
-type EventsApiListProjectEventsQueryParams struct {
+type EventsApiListProjectEventsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -106,7 +106,7 @@ type GetOrganizationEventApiRequest struct {
 	includeRaw *bool
 }
 
-type GetOrganizationEventParams struct {
+type GetOrganizationEventApiParams struct {
 		OrgId string
 		EventId string
 		IncludeRaw *bool
@@ -255,7 +255,7 @@ type GetProjectEventApiRequest struct {
 	includeRaw *bool
 }
 
-type GetProjectEventParams struct {
+type GetProjectEventApiParams struct {
 		GroupId string
 		EventId string
 		IncludeRaw *bool
@@ -409,7 +409,7 @@ type ListOrganizationEventsApiRequest struct {
 	minDate *time.Time
 }
 
-type ListOrganizationEventsParams struct {
+type ListOrganizationEventsApiParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -626,7 +626,7 @@ type ListProjectEventsApiRequest struct {
 	minDate *time.Time
 }
 
-type ListProjectEventsParams struct {
+type ListProjectEventsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -105,6 +105,11 @@ type EventsApiGetOrganizationEventRequest struct {
 	eventId string
 	includeRaw *bool
 }
+type EventsApiGetOrganizationEventQueryParams struct {
+		orgId string
+		eventId string
+		includeRaw *bool
+}
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
 func (r EventsApiGetOrganizationEventRequest) IncludeRaw(includeRaw bool) EventsApiGetOrganizationEventRequest {
@@ -247,6 +252,11 @@ type EventsApiGetProjectEventRequest struct {
 	groupId string
 	eventId string
 	includeRaw *bool
+}
+type EventsApiGetProjectEventQueryParams struct {
+		groupId string
+		eventId string
+		includeRaw *bool
 }
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
@@ -395,6 +405,16 @@ type EventsApiListOrganizationEventsRequest struct {
 	includeRaw *bool
 	maxDate *time.Time
 	minDate *time.Time
+}
+type EventsApiListOrganizationEventsQueryParams struct {
+		orgId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		eventType *EventTypeForOrg
+		includeRaw *bool
+		maxDate *time.Time
+		minDate *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -601,6 +621,17 @@ type EventsApiListProjectEventsRequest struct {
 	includeRaw *bool
 	maxDate *time.Time
 	minDate *time.Time
+}
+type EventsApiListProjectEventsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		clusterNames *[]string
+		eventType *EventTypeForNdsGroup
+		includeRaw *bool
+		maxDate *time.Time
+		minDate *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -34,13 +34,13 @@ type EventsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param eventId Unique 24-hexadecimal digit string that identifies the event that you want to return. Use the [/events](#tag/Events/operation/listOrganizationEvents) endpoint to retrieve all events to which the authenticated user has access.
-	@return EventsApiGetOrganizationEventRequest
+	@return GetOrganizationEventApiRequest
 	*/
-	GetOrganizationEvent(ctx context.Context, orgId string, eventId string) EventsApiGetOrganizationEventRequest
+	GetOrganizationEvent(ctx context.Context, orgId string, eventId string) GetOrganizationEventApiRequest
 
 	// GetOrganizationEventExecute executes the request
 	//  @return EventViewForOrg
-	GetOrganizationEventExecute(r EventsApiGetOrganizationEventRequest) (*EventViewForOrg, *http.Response, error)
+	GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error)
 
 	/*
 	GetProjectEvent Return One Event from One Project
@@ -52,13 +52,13 @@ type EventsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param eventId Unique 24-hexadecimal digit string that identifies the event that you want to return. Use the [/events](#tag/Events/operation/listProjectEvents) endpoint to retrieve all events to which the authenticated user has access.
-	@return EventsApiGetProjectEventRequest
+	@return GetProjectEventApiRequest
 	*/
-	GetProjectEvent(ctx context.Context, groupId string, eventId string) EventsApiGetProjectEventRequest
+	GetProjectEvent(ctx context.Context, groupId string, eventId string) GetProjectEventApiRequest
 
 	// GetProjectEventExecute executes the request
 	//  @return EventViewForNdsGroup
-	GetProjectEventExecute(r EventsApiGetProjectEventRequest) (*EventViewForNdsGroup, *http.Response, error)
+	GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error)
 
 	/*
 	ListOrganizationEvents Return All Events from One Organization
@@ -69,13 +69,13 @@ type EventsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return EventsApiListOrganizationEventsRequest
+	@return ListOrganizationEventsApiRequest
 	*/
-	ListOrganizationEvents(ctx context.Context, orgId string) EventsApiListOrganizationEventsRequest
+	ListOrganizationEvents(ctx context.Context, orgId string) ListOrganizationEventsApiRequest
 
 	// ListOrganizationEventsExecute executes the request
 	//  @return OrgPaginatedEvent
-	ListOrganizationEventsExecute(r EventsApiListOrganizationEventsRequest) (*OrgPaginatedEvent, *http.Response, error)
+	ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error)
 
 	/*
 	ListProjectEvents Return All Events from One Project
@@ -86,19 +86,19 @@ type EventsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return EventsApiListProjectEventsRequest
+	@return ListProjectEventsApiRequest
 	*/
-	ListProjectEvents(ctx context.Context, groupId string) EventsApiListProjectEventsRequest
+	ListProjectEvents(ctx context.Context, groupId string) ListProjectEventsApiRequest
 
 	// ListProjectEventsExecute executes the request
 	//  @return GroupPaginatedEvent
-	ListProjectEventsExecute(r EventsApiListProjectEventsRequest) (*GroupPaginatedEvent, *http.Response, error)
+	ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error)
 }
 
 // EventsApiService EventsApi service
 type EventsApiService service
 
-type EventsApiGetOrganizationEventRequest struct {
+type GetOrganizationEventApiRequest struct {
 	ctx context.Context
 	ApiService EventsApi
 	orgId string
@@ -113,12 +113,12 @@ type GetOrganizationEventParams struct {
 }
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
-func (r EventsApiGetOrganizationEventRequest) IncludeRaw(includeRaw bool) EventsApiGetOrganizationEventRequest {
+func (r GetOrganizationEventApiRequest) IncludeRaw(includeRaw bool) GetOrganizationEventApiRequest {
 	r.includeRaw = &includeRaw
 	return r
 }
 
-func (r EventsApiGetOrganizationEventRequest) Execute() (*EventViewForOrg, *http.Response, error) {
+func (r GetOrganizationEventApiRequest) Execute() (*EventViewForOrg, *http.Response, error) {
 	return r.ApiService.GetOrganizationEventExecute(r)
 }
 
@@ -132,10 +132,10 @@ Returns one event for the specified organization. Events identify significant da
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param eventId Unique 24-hexadecimal digit string that identifies the event that you want to return. Use the [/events](#tag/Events/operation/listOrganizationEvents) endpoint to retrieve all events to which the authenticated user has access.
- @return EventsApiGetOrganizationEventRequest
+ @return GetOrganizationEventApiRequest
 */
-func (a *EventsApiService) GetOrganizationEvent(ctx context.Context, orgId string, eventId string) EventsApiGetOrganizationEventRequest {
-	return EventsApiGetOrganizationEventRequest{
+func (a *EventsApiService) GetOrganizationEvent(ctx context.Context, orgId string, eventId string) GetOrganizationEventApiRequest {
+	return GetOrganizationEventApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -145,7 +145,7 @@ func (a *EventsApiService) GetOrganizationEvent(ctx context.Context, orgId strin
 
 // Execute executes the request
 //  @return EventViewForOrg
-func (a *EventsApiService) GetOrganizationEventExecute(r EventsApiGetOrganizationEventRequest) (*EventViewForOrg, *http.Response, error) {
+func (a *EventsApiService) GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -247,7 +247,7 @@ func (a *EventsApiService) GetOrganizationEventExecute(r EventsApiGetOrganizatio
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type EventsApiGetProjectEventRequest struct {
+type GetProjectEventApiRequest struct {
 	ctx context.Context
 	ApiService EventsApi
 	groupId string
@@ -262,12 +262,12 @@ type GetProjectEventParams struct {
 }
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
-func (r EventsApiGetProjectEventRequest) IncludeRaw(includeRaw bool) EventsApiGetProjectEventRequest {
+func (r GetProjectEventApiRequest) IncludeRaw(includeRaw bool) GetProjectEventApiRequest {
 	r.includeRaw = &includeRaw
 	return r
 }
 
-func (r EventsApiGetProjectEventRequest) Execute() (*EventViewForNdsGroup, *http.Response, error) {
+func (r GetProjectEventApiRequest) Execute() (*EventViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.GetProjectEventExecute(r)
 }
 
@@ -281,10 +281,10 @@ Returns one event for the specified project. Events identify significant databas
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param eventId Unique 24-hexadecimal digit string that identifies the event that you want to return. Use the [/events](#tag/Events/operation/listProjectEvents) endpoint to retrieve all events to which the authenticated user has access.
- @return EventsApiGetProjectEventRequest
+ @return GetProjectEventApiRequest
 */
-func (a *EventsApiService) GetProjectEvent(ctx context.Context, groupId string, eventId string) EventsApiGetProjectEventRequest {
-	return EventsApiGetProjectEventRequest{
+func (a *EventsApiService) GetProjectEvent(ctx context.Context, groupId string, eventId string) GetProjectEventApiRequest {
+	return GetProjectEventApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -294,7 +294,7 @@ func (a *EventsApiService) GetProjectEvent(ctx context.Context, groupId string, 
 
 // Execute executes the request
 //  @return EventViewForNdsGroup
-func (a *EventsApiService) GetProjectEventExecute(r EventsApiGetProjectEventRequest) (*EventViewForNdsGroup, *http.Response, error) {
+func (a *EventsApiService) GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -396,7 +396,7 @@ func (a *EventsApiService) GetProjectEventExecute(r EventsApiGetProjectEventRequ
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type EventsApiListOrganizationEventsRequest struct {
+type ListOrganizationEventsApiRequest struct {
 	ctx context.Context
 	ApiService EventsApi
 	orgId string
@@ -421,48 +421,48 @@ type ListOrganizationEventsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r EventsApiListOrganizationEventsRequest) IncludeCount(includeCount bool) EventsApiListOrganizationEventsRequest {
+func (r ListOrganizationEventsApiRequest) IncludeCount(includeCount bool) ListOrganizationEventsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r EventsApiListOrganizationEventsRequest) ItemsPerPage(itemsPerPage int32) EventsApiListOrganizationEventsRequest {
+func (r ListOrganizationEventsApiRequest) ItemsPerPage(itemsPerPage int32) ListOrganizationEventsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r EventsApiListOrganizationEventsRequest) PageNum(pageNum int32) EventsApiListOrganizationEventsRequest {
+func (r ListOrganizationEventsApiRequest) PageNum(pageNum int32) ListOrganizationEventsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Category of incident recorded at this moment in time.  **IMPORTANT**: The complete list of event type values changes frequently.
-func (r EventsApiListOrganizationEventsRequest) EventType(eventType EventTypeForOrg) EventsApiListOrganizationEventsRequest {
+func (r ListOrganizationEventsApiRequest) EventType(eventType EventTypeForOrg) ListOrganizationEventsApiRequest {
 	r.eventType = &eventType
 	return r
 }
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
-func (r EventsApiListOrganizationEventsRequest) IncludeRaw(includeRaw bool) EventsApiListOrganizationEventsRequest {
+func (r ListOrganizationEventsApiRequest) IncludeRaw(includeRaw bool) ListOrganizationEventsApiRequest {
 	r.includeRaw = &includeRaw
 	return r
 }
 
 // Date and time from when MongoDB Cloud stops returning events. This parameter uses the &lt;a href&#x3D;\&quot;https://en.wikipedia.org/wiki/ISO_8601\&quot; target&#x3D;\&quot;_blank\&quot; rel&#x3D;\&quot;noopener noreferrer\&quot;&gt;ISO 8601&lt;/a&gt; timestamp format in UTC.
-func (r EventsApiListOrganizationEventsRequest) MaxDate(maxDate time.Time) EventsApiListOrganizationEventsRequest {
+func (r ListOrganizationEventsApiRequest) MaxDate(maxDate time.Time) ListOrganizationEventsApiRequest {
 	r.maxDate = &maxDate
 	return r
 }
 
 // Date and time from when MongoDB Cloud starts returning events. This parameter uses the &lt;a href&#x3D;\&quot;https://en.wikipedia.org/wiki/ISO_8601\&quot; target&#x3D;\&quot;_blank\&quot; rel&#x3D;\&quot;noopener noreferrer\&quot;&gt;ISO 8601&lt;/a&gt; timestamp format in UTC.
-func (r EventsApiListOrganizationEventsRequest) MinDate(minDate time.Time) EventsApiListOrganizationEventsRequest {
+func (r ListOrganizationEventsApiRequest) MinDate(minDate time.Time) ListOrganizationEventsApiRequest {
 	r.minDate = &minDate
 	return r
 }
 
-func (r EventsApiListOrganizationEventsRequest) Execute() (*OrgPaginatedEvent, *http.Response, error) {
+func (r ListOrganizationEventsApiRequest) Execute() (*OrgPaginatedEvent, *http.Response, error) {
 	return r.ApiService.ListOrganizationEventsExecute(r)
 }
 
@@ -475,10 +475,10 @@ Returns all events for the specified organization. Events identify significant d
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return EventsApiListOrganizationEventsRequest
+ @return ListOrganizationEventsApiRequest
 */
-func (a *EventsApiService) ListOrganizationEvents(ctx context.Context, orgId string) EventsApiListOrganizationEventsRequest {
-	return EventsApiListOrganizationEventsRequest{
+func (a *EventsApiService) ListOrganizationEvents(ctx context.Context, orgId string) ListOrganizationEventsApiRequest {
+	return ListOrganizationEventsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -487,7 +487,7 @@ func (a *EventsApiService) ListOrganizationEvents(ctx context.Context, orgId str
 
 // Execute executes the request
 //  @return OrgPaginatedEvent
-func (a *EventsApiService) ListOrganizationEventsExecute(r EventsApiListOrganizationEventsRequest) (*OrgPaginatedEvent, *http.Response, error) {
+func (a *EventsApiService) ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -612,7 +612,7 @@ func (a *EventsApiService) ListOrganizationEventsExecute(r EventsApiListOrganiza
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type EventsApiListProjectEventsRequest struct {
+type ListProjectEventsApiRequest struct {
 	ctx context.Context
 	ApiService EventsApi
 	groupId string
@@ -639,54 +639,54 @@ type ListProjectEventsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r EventsApiListProjectEventsRequest) IncludeCount(includeCount bool) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) IncludeCount(includeCount bool) ListProjectEventsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r EventsApiListProjectEventsRequest) ItemsPerPage(itemsPerPage int32) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) ItemsPerPage(itemsPerPage int32) ListProjectEventsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r EventsApiListProjectEventsRequest) PageNum(pageNum int32) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) PageNum(pageNum int32) ListProjectEventsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Human-readable label that identifies the cluster.
-func (r EventsApiListProjectEventsRequest) ClusterNames(clusterNames []string) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) ClusterNames(clusterNames []string) ListProjectEventsApiRequest {
 	r.clusterNames = &clusterNames
 	return r
 }
 
 // Category of incident recorded at this moment in time.  **IMPORTANT**: The complete list of event type values changes frequently.
-func (r EventsApiListProjectEventsRequest) EventType(eventType EventTypeForNdsGroup) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) EventType(eventType EventTypeForNdsGroup) ListProjectEventsApiRequest {
 	r.eventType = &eventType
 	return r
 }
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
-func (r EventsApiListProjectEventsRequest) IncludeRaw(includeRaw bool) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) IncludeRaw(includeRaw bool) ListProjectEventsApiRequest {
 	r.includeRaw = &includeRaw
 	return r
 }
 
 // Date and time from when MongoDB Cloud stops returning events. This parameter uses the &lt;a href&#x3D;\&quot;https://en.wikipedia.org/wiki/ISO_8601\&quot; target&#x3D;\&quot;_blank\&quot; rel&#x3D;\&quot;noopener noreferrer\&quot;&gt;ISO 8601&lt;/a&gt; timestamp format in UTC.
-func (r EventsApiListProjectEventsRequest) MaxDate(maxDate time.Time) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) MaxDate(maxDate time.Time) ListProjectEventsApiRequest {
 	r.maxDate = &maxDate
 	return r
 }
 
 // Date and time from when MongoDB Cloud starts returning events. This parameter uses the &lt;a href&#x3D;\&quot;https://en.wikipedia.org/wiki/ISO_8601\&quot; target&#x3D;\&quot;_blank\&quot; rel&#x3D;\&quot;noopener noreferrer\&quot;&gt;ISO 8601&lt;/a&gt; timestamp format in UTC.
-func (r EventsApiListProjectEventsRequest) MinDate(minDate time.Time) EventsApiListProjectEventsRequest {
+func (r ListProjectEventsApiRequest) MinDate(minDate time.Time) ListProjectEventsApiRequest {
 	r.minDate = &minDate
 	return r
 }
 
-func (r EventsApiListProjectEventsRequest) Execute() (*GroupPaginatedEvent, *http.Response, error) {
+func (r ListProjectEventsApiRequest) Execute() (*GroupPaginatedEvent, *http.Response, error) {
 	return r.ApiService.ListProjectEventsExecute(r)
 }
 
@@ -699,10 +699,10 @@ Returns one event for the specified project. Events identify significant databas
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return EventsApiListProjectEventsRequest
+ @return ListProjectEventsApiRequest
 */
-func (a *EventsApiService) ListProjectEvents(ctx context.Context, groupId string) EventsApiListProjectEventsRequest {
-	return EventsApiListProjectEventsRequest{
+func (a *EventsApiService) ListProjectEvents(ctx context.Context, groupId string) ListProjectEventsApiRequest {
+	return ListProjectEventsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -711,7 +711,7 @@ func (a *EventsApiService) ListProjectEvents(ctx context.Context, groupId string
 
 // Execute executes the request
 //  @return GroupPaginatedEvent
-func (a *EventsApiService) ListProjectEventsExecute(r EventsApiListProjectEventsRequest) (*GroupPaginatedEvent, *http.Response, error) {
+func (a *EventsApiService) ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -106,7 +106,7 @@ type EventsApiGetOrganizationEventRequest struct {
 	includeRaw *bool
 }
 
-type EventsApiGetOrganizationEventParams struct {
+type GetOrganizationEventParams struct {
 		OrgId string
 		EventId string
 		IncludeRaw *bool
@@ -255,7 +255,7 @@ type EventsApiGetProjectEventRequest struct {
 	includeRaw *bool
 }
 
-type EventsApiGetProjectEventParams struct {
+type GetProjectEventParams struct {
 		GroupId string
 		EventId string
 		IncludeRaw *bool
@@ -409,7 +409,7 @@ type EventsApiListOrganizationEventsRequest struct {
 	minDate *time.Time
 }
 
-type EventsApiListOrganizationEventsParams struct {
+type ListOrganizationEventsParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -626,7 +626,7 @@ type EventsApiListProjectEventsRequest struct {
 	minDate *time.Time
 }
 
-type EventsApiListProjectEventsParams struct {
+type ListProjectEventsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -105,10 +105,11 @@ type EventsApiGetOrganizationEventRequest struct {
 	eventId string
 	includeRaw *bool
 }
+
 type EventsApiGetOrganizationEventQueryParams struct {
-		orgId string
-		eventId string
-		includeRaw *bool
+		OrgId string
+		EventId string
+		IncludeRaw *bool
 }
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
@@ -253,10 +254,11 @@ type EventsApiGetProjectEventRequest struct {
 	eventId string
 	includeRaw *bool
 }
+
 type EventsApiGetProjectEventQueryParams struct {
-		groupId string
-		eventId string
-		includeRaw *bool
+		GroupId string
+		EventId string
+		IncludeRaw *bool
 }
 
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
@@ -406,15 +408,16 @@ type EventsApiListOrganizationEventsRequest struct {
 	maxDate *time.Time
 	minDate *time.Time
 }
+
 type EventsApiListOrganizationEventsQueryParams struct {
-		orgId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		eventType *EventTypeForOrg
-		includeRaw *bool
-		maxDate *time.Time
-		minDate *time.Time
+		OrgId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		EventType *EventTypeForOrg
+		IncludeRaw *bool
+		MaxDate *time.Time
+		MinDate *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -622,16 +625,17 @@ type EventsApiListProjectEventsRequest struct {
 	maxDate *time.Time
 	minDate *time.Time
 }
+
 type EventsApiListProjectEventsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		clusterNames *[]string
-		eventType *EventTypeForNdsGroup
-		includeRaw *bool
-		maxDate *time.Time
-		minDate *time.Time
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		ClusterNames *[]string
+		EventType *EventTypeForNdsGroup
+		IncludeRaw *bool
+		MaxDate *time.Time
+		MinDate *time.Time
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -275,10 +275,11 @@ type FederatedAuthenticationApiCreateRoleMappingRequest struct {
 	orgId string
 	roleMapping *RoleMapping
 }
+
 type FederatedAuthenticationApiCreateRoleMappingQueryParams struct {
-		federationSettingsId string
-		orgId string
-		roleMapping *RoleMapping
+		FederationSettingsId string
+		OrgId string
+		RoleMapping *RoleMapping
 }
 
 // The role mapping that you want to create.
@@ -417,8 +418,9 @@ type FederatedAuthenticationApiDeleteFederationAppRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 }
+
 type FederatedAuthenticationApiDeleteFederationAppQueryParams struct {
-		federationSettingsId string
+		FederationSettingsId string
 }
 
 func (r FederatedAuthenticationApiDeleteFederationAppRequest) Execute() (*http.Response, error) {
@@ -528,10 +530,11 @@ type FederatedAuthenticationApiDeleteRoleMappingRequest struct {
 	id string
 	orgId string
 }
+
 type FederatedAuthenticationApiDeleteRoleMappingQueryParams struct {
-		federationSettingsId string
-		id string
-		orgId string
+		FederationSettingsId string
+		Id string
+		OrgId string
 }
 
 func (r FederatedAuthenticationApiDeleteRoleMappingRequest) Execute() (*http.Response, error) {
@@ -658,9 +661,10 @@ type FederatedAuthenticationApiGetConnectedOrgConfigRequest struct {
 	federationSettingsId string
 	orgId string
 }
+
 type FederatedAuthenticationApiGetConnectedOrgConfigQueryParams struct {
-		federationSettingsId string
-		orgId string
+		FederationSettingsId string
+		OrgId string
 }
 
 func (r FederatedAuthenticationApiGetConnectedOrgConfigRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
@@ -788,8 +792,9 @@ type FederatedAuthenticationApiGetFederationSettingsRequest struct {
 	ApiService FederatedAuthenticationApi
 	orgId string
 }
+
 type FederatedAuthenticationApiGetFederationSettingsQueryParams struct {
-		orgId string
+		OrgId string
 }
 
 func (r FederatedAuthenticationApiGetFederationSettingsRequest) Execute() (*OrgFederationSettings, *http.Response, error) {
@@ -909,9 +914,10 @@ type FederatedAuthenticationApiGetIdentityProviderRequest struct {
 	federationSettingsId string
 	identityProviderId string
 }
+
 type FederatedAuthenticationApiGetIdentityProviderQueryParams struct {
-		federationSettingsId string
-		identityProviderId string
+		FederationSettingsId string
+		IdentityProviderId string
 }
 
 func (r FederatedAuthenticationApiGetIdentityProviderRequest) Execute() (*IdentityProvider, *http.Response, error) {
@@ -1040,9 +1046,10 @@ type FederatedAuthenticationApiGetIdentityProviderMetadataRequest struct {
 	federationSettingsId string
 	identityProviderId string
 }
+
 type FederatedAuthenticationApiGetIdentityProviderMetadataQueryParams struct {
-		federationSettingsId string
-		identityProviderId string
+		FederationSettingsId string
+		IdentityProviderId string
 }
 
 func (r FederatedAuthenticationApiGetIdentityProviderMetadataRequest) Execute() (string, *http.Response, error) {
@@ -1172,10 +1179,11 @@ type FederatedAuthenticationApiGetRoleMappingRequest struct {
 	id string
 	orgId string
 }
+
 type FederatedAuthenticationApiGetRoleMappingQueryParams struct {
-		federationSettingsId string
-		id string
-		orgId string
+		FederationSettingsId string
+		Id string
+		OrgId string
 }
 
 func (r FederatedAuthenticationApiGetRoleMappingRequest) Execute() (*RoleMapping, *http.Response, error) {
@@ -1312,8 +1320,9 @@ type FederatedAuthenticationApiListConnectedOrgConfigsRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 }
+
 type FederatedAuthenticationApiListConnectedOrgConfigsQueryParams struct {
-		federationSettingsId string
+		FederationSettingsId string
 }
 
 func (r FederatedAuthenticationApiListConnectedOrgConfigsRequest) Execute() ([]ConnectedOrgConfig, *http.Response, error) {
@@ -1432,8 +1441,9 @@ type FederatedAuthenticationApiListIdentityProvidersRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 }
+
 type FederatedAuthenticationApiListIdentityProvidersQueryParams struct {
-		federationSettingsId string
+		FederationSettingsId string
 }
 
 func (r FederatedAuthenticationApiListIdentityProvidersRequest) Execute() ([]IdentityProvider, *http.Response, error) {
@@ -1553,9 +1563,10 @@ type FederatedAuthenticationApiListRoleMappingsRequest struct {
 	federationSettingsId string
 	orgId string
 }
+
 type FederatedAuthenticationApiListRoleMappingsQueryParams struct {
-		federationSettingsId string
-		orgId string
+		FederationSettingsId string
+		OrgId string
 }
 
 func (r FederatedAuthenticationApiListRoleMappingsRequest) Execute() ([]RoleMapping, *http.Response, error) {
@@ -1684,9 +1695,10 @@ type FederatedAuthenticationApiRemoveConnectedOrgConfigRequest struct {
 	federationSettingsId string
 	orgId string
 }
+
 type FederatedAuthenticationApiRemoveConnectedOrgConfigQueryParams struct {
-		federationSettingsId string
-		orgId string
+		FederationSettingsId string
+		OrgId string
 }
 
 func (r FederatedAuthenticationApiRemoveConnectedOrgConfigRequest) Execute() (*http.Response, error) {
@@ -1805,10 +1817,11 @@ type FederatedAuthenticationApiUpdateConnectedOrgConfigRequest struct {
 	orgId string
 	connectedOrgConfig *ConnectedOrgConfig
 }
+
 type FederatedAuthenticationApiUpdateConnectedOrgConfigQueryParams struct {
-		federationSettingsId string
-		orgId string
-		connectedOrgConfig *ConnectedOrgConfig
+		FederationSettingsId string
+		OrgId string
+		ConnectedOrgConfig *ConnectedOrgConfig
 }
 
 // The connected organization configuration that you want to update.
@@ -1955,10 +1968,11 @@ type FederatedAuthenticationApiUpdateIdentityProviderRequest struct {
 	identityProviderId string
 	identityProviderUpdate *IdentityProviderUpdate
 }
+
 type FederatedAuthenticationApiUpdateIdentityProviderQueryParams struct {
-		federationSettingsId string
-		identityProviderId string
-		identityProviderUpdate *IdentityProviderUpdate
+		FederationSettingsId string
+		IdentityProviderId string
+		IdentityProviderUpdate *IdentityProviderUpdate
 }
 
 // The identity provider that you want to update.
@@ -2100,11 +2114,12 @@ type FederatedAuthenticationApiUpdateRoleMappingRequest struct {
 	orgId string
 	roleMapping *RoleMapping
 }
+
 type FederatedAuthenticationApiUpdateRoleMappingQueryParams struct {
-		federationSettingsId string
-		id string
-		orgId string
-		roleMapping *RoleMapping
+		FederationSettingsId string
+		Id string
+		OrgId string
+		RoleMapping *RoleMapping
 }
 
 // The role mapping that you want to update.

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -275,6 +275,11 @@ type FederatedAuthenticationApiCreateRoleMappingRequest struct {
 	orgId string
 	roleMapping *RoleMapping
 }
+type FederatedAuthenticationApiCreateRoleMappingQueryParams struct {
+		federationSettingsId string
+		orgId string
+		roleMapping *RoleMapping
+}
 
 // The role mapping that you want to create.
 func (r FederatedAuthenticationApiCreateRoleMappingRequest) RoleMapping(roleMapping RoleMapping) FederatedAuthenticationApiCreateRoleMappingRequest {
@@ -412,6 +417,9 @@ type FederatedAuthenticationApiDeleteFederationAppRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 }
+type FederatedAuthenticationApiDeleteFederationAppQueryParams struct {
+		federationSettingsId string
+}
 
 func (r FederatedAuthenticationApiDeleteFederationAppRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteFederationAppExecute(r)
@@ -519,6 +527,11 @@ type FederatedAuthenticationApiDeleteRoleMappingRequest struct {
 	federationSettingsId string
 	id string
 	orgId string
+}
+type FederatedAuthenticationApiDeleteRoleMappingQueryParams struct {
+		federationSettingsId string
+		id string
+		orgId string
 }
 
 func (r FederatedAuthenticationApiDeleteRoleMappingRequest) Execute() (*http.Response, error) {
@@ -644,6 +657,10 @@ type FederatedAuthenticationApiGetConnectedOrgConfigRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 	orgId string
+}
+type FederatedAuthenticationApiGetConnectedOrgConfigQueryParams struct {
+		federationSettingsId string
+		orgId string
 }
 
 func (r FederatedAuthenticationApiGetConnectedOrgConfigRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
@@ -771,6 +788,9 @@ type FederatedAuthenticationApiGetFederationSettingsRequest struct {
 	ApiService FederatedAuthenticationApi
 	orgId string
 }
+type FederatedAuthenticationApiGetFederationSettingsQueryParams struct {
+		orgId string
+}
 
 func (r FederatedAuthenticationApiGetFederationSettingsRequest) Execute() (*OrgFederationSettings, *http.Response, error) {
 	return r.ApiService.GetFederationSettingsExecute(r)
@@ -888,6 +908,10 @@ type FederatedAuthenticationApiGetIdentityProviderRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 	identityProviderId string
+}
+type FederatedAuthenticationApiGetIdentityProviderQueryParams struct {
+		federationSettingsId string
+		identityProviderId string
 }
 
 func (r FederatedAuthenticationApiGetIdentityProviderRequest) Execute() (*IdentityProvider, *http.Response, error) {
@@ -1016,6 +1040,10 @@ type FederatedAuthenticationApiGetIdentityProviderMetadataRequest struct {
 	federationSettingsId string
 	identityProviderId string
 }
+type FederatedAuthenticationApiGetIdentityProviderMetadataQueryParams struct {
+		federationSettingsId string
+		identityProviderId string
+}
 
 func (r FederatedAuthenticationApiGetIdentityProviderMetadataRequest) Execute() (string, *http.Response, error) {
 	return r.ApiService.GetIdentityProviderMetadataExecute(r)
@@ -1143,6 +1171,11 @@ type FederatedAuthenticationApiGetRoleMappingRequest struct {
 	federationSettingsId string
 	id string
 	orgId string
+}
+type FederatedAuthenticationApiGetRoleMappingQueryParams struct {
+		federationSettingsId string
+		id string
+		orgId string
 }
 
 func (r FederatedAuthenticationApiGetRoleMappingRequest) Execute() (*RoleMapping, *http.Response, error) {
@@ -1279,6 +1312,9 @@ type FederatedAuthenticationApiListConnectedOrgConfigsRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 }
+type FederatedAuthenticationApiListConnectedOrgConfigsQueryParams struct {
+		federationSettingsId string
+}
 
 func (r FederatedAuthenticationApiListConnectedOrgConfigsRequest) Execute() ([]ConnectedOrgConfig, *http.Response, error) {
 	return r.ApiService.ListConnectedOrgConfigsExecute(r)
@@ -1395,6 +1431,9 @@ type FederatedAuthenticationApiListIdentityProvidersRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
+}
+type FederatedAuthenticationApiListIdentityProvidersQueryParams struct {
+		federationSettingsId string
 }
 
 func (r FederatedAuthenticationApiListIdentityProvidersRequest) Execute() ([]IdentityProvider, *http.Response, error) {
@@ -1513,6 +1552,10 @@ type FederatedAuthenticationApiListRoleMappingsRequest struct {
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
 	orgId string
+}
+type FederatedAuthenticationApiListRoleMappingsQueryParams struct {
+		federationSettingsId string
+		orgId string
 }
 
 func (r FederatedAuthenticationApiListRoleMappingsRequest) Execute() ([]RoleMapping, *http.Response, error) {
@@ -1641,6 +1684,10 @@ type FederatedAuthenticationApiRemoveConnectedOrgConfigRequest struct {
 	federationSettingsId string
 	orgId string
 }
+type FederatedAuthenticationApiRemoveConnectedOrgConfigQueryParams struct {
+		federationSettingsId string
+		orgId string
+}
 
 func (r FederatedAuthenticationApiRemoveConnectedOrgConfigRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveConnectedOrgConfigExecute(r)
@@ -1757,6 +1804,11 @@ type FederatedAuthenticationApiUpdateConnectedOrgConfigRequest struct {
 	federationSettingsId string
 	orgId string
 	connectedOrgConfig *ConnectedOrgConfig
+}
+type FederatedAuthenticationApiUpdateConnectedOrgConfigQueryParams struct {
+		federationSettingsId string
+		orgId string
+		connectedOrgConfig *ConnectedOrgConfig
 }
 
 // The connected organization configuration that you want to update.
@@ -1903,6 +1955,11 @@ type FederatedAuthenticationApiUpdateIdentityProviderRequest struct {
 	identityProviderId string
 	identityProviderUpdate *IdentityProviderUpdate
 }
+type FederatedAuthenticationApiUpdateIdentityProviderQueryParams struct {
+		federationSettingsId string
+		identityProviderId string
+		identityProviderUpdate *IdentityProviderUpdate
+}
 
 // The identity provider that you want to update.
 func (r FederatedAuthenticationApiUpdateIdentityProviderRequest) IdentityProviderUpdate(identityProviderUpdate IdentityProviderUpdate) FederatedAuthenticationApiUpdateIdentityProviderRequest {
@@ -2042,6 +2099,12 @@ type FederatedAuthenticationApiUpdateRoleMappingRequest struct {
 	id string
 	orgId string
 	roleMapping *RoleMapping
+}
+type FederatedAuthenticationApiUpdateRoleMappingQueryParams struct {
+		federationSettingsId string
+		id string
+		orgId string
+		roleMapping *RoleMapping
 }
 
 // The role mapping that you want to update.

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -30,13 +30,13 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return FederatedAuthenticationApiCreateRoleMappingRequest
+	@return CreateRoleMappingApiRequest
 	*/
-	CreateRoleMapping(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiCreateRoleMappingRequest
+	CreateRoleMapping(ctx context.Context, federationSettingsId string, orgId string) CreateRoleMappingApiRequest
 
 	// CreateRoleMappingExecute executes the request
 	//  @return RoleMapping
-	CreateRoleMappingExecute(r FederatedAuthenticationApiCreateRoleMappingRequest) (*RoleMapping, *http.Response, error)
+	CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
 
 	/*
 	DeleteFederationApp Delete the federation settings instance.
@@ -45,12 +45,12 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
-	@return FederatedAuthenticationApiDeleteFederationAppRequest
+	@return DeleteFederationAppApiRequest
 	*/
-	DeleteFederationApp(ctx context.Context, federationSettingsId string) FederatedAuthenticationApiDeleteFederationAppRequest
+	DeleteFederationApp(ctx context.Context, federationSettingsId string) DeleteFederationAppApiRequest
 
 	// DeleteFederationAppExecute executes the request
-	DeleteFederationAppExecute(r FederatedAuthenticationApiDeleteFederationAppRequest) (*http.Response, error)
+	DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error)
 
 	/*
 	DeleteRoleMapping Remove One Role Mapping from One Organization
@@ -61,12 +61,12 @@ type FederatedAuthenticationApi interface {
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param id Unique 24-hexadecimal digit string that identifies the role mapping that you want to remove.
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return FederatedAuthenticationApiDeleteRoleMappingRequest
+	@return DeleteRoleMappingApiRequest
 	*/
-	DeleteRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) FederatedAuthenticationApiDeleteRoleMappingRequest
+	DeleteRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) DeleteRoleMappingApiRequest
 
 	// DeleteRoleMappingExecute executes the request
-	DeleteRoleMappingExecute(r FederatedAuthenticationApiDeleteRoleMappingRequest) (*http.Response, error)
+	DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error)
 
 	/*
 	GetConnectedOrgConfig Return One Org Config Connected to One Federation
@@ -76,13 +76,13 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param orgId Unique 24-hexadecimal digit string that identifies the connected organization configuration to return.
-	@return FederatedAuthenticationApiGetConnectedOrgConfigRequest
+	@return GetConnectedOrgConfigApiRequest
 	*/
-	GetConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiGetConnectedOrgConfigRequest
+	GetConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) GetConnectedOrgConfigApiRequest
 
 	// GetConnectedOrgConfigExecute executes the request
 	//  @return ConnectedOrgConfig
-	GetConnectedOrgConfigExecute(r FederatedAuthenticationApiGetConnectedOrgConfigRequest) (*ConnectedOrgConfig, *http.Response, error)
+	GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
 	GetFederationSettings Return Federation Settings for One Organization
@@ -91,13 +91,13 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return FederatedAuthenticationApiGetFederationSettingsRequest
+	@return GetFederationSettingsApiRequest
 	*/
-	GetFederationSettings(ctx context.Context, orgId string) FederatedAuthenticationApiGetFederationSettingsRequest
+	GetFederationSettings(ctx context.Context, orgId string) GetFederationSettingsApiRequest
 
 	// GetFederationSettingsExecute executes the request
 	//  @return OrgFederationSettings
-	GetFederationSettingsExecute(r FederatedAuthenticationApiGetFederationSettingsRequest) (*OrgFederationSettings, *http.Response, error)
+	GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error)
 
 	/*
 	GetIdentityProvider Return one identity provider from the specified federation.
@@ -107,13 +107,13 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param identityProviderId Unique 20-hexadecimal digit string that identifies the identity provider.
-	@return FederatedAuthenticationApiGetIdentityProviderRequest
+	@return GetIdentityProviderApiRequest
 	*/
-	GetIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) FederatedAuthenticationApiGetIdentityProviderRequest
+	GetIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) GetIdentityProviderApiRequest
 
 	// GetIdentityProviderExecute executes the request
 	//  @return IdentityProvider
-	GetIdentityProviderExecute(r FederatedAuthenticationApiGetIdentityProviderRequest) (*IdentityProvider, *http.Response, error)
+	GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error)
 
 	/*
 	GetIdentityProviderMetadata Return the metadata of one identity provider in the specified federation.
@@ -123,13 +123,13 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param identityProviderId Unique 20-hexadecimal digit string that identifies the identity provider.
-	@return FederatedAuthenticationApiGetIdentityProviderMetadataRequest
+	@return GetIdentityProviderMetadataApiRequest
 	*/
-	GetIdentityProviderMetadata(ctx context.Context, federationSettingsId string, identityProviderId string) FederatedAuthenticationApiGetIdentityProviderMetadataRequest
+	GetIdentityProviderMetadata(ctx context.Context, federationSettingsId string, identityProviderId string) GetIdentityProviderMetadataApiRequest
 
 	// GetIdentityProviderMetadataExecute executes the request
 	//  @return string
-	GetIdentityProviderMetadataExecute(r FederatedAuthenticationApiGetIdentityProviderMetadataRequest) (string, *http.Response, error)
+	GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error)
 
 	/*
 	GetRoleMapping Return One Role Mapping from One Organization
@@ -140,13 +140,13 @@ type FederatedAuthenticationApi interface {
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param id Unique 24-hexadecimal digit string that identifies the role mapping that you want to return.
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return FederatedAuthenticationApiGetRoleMappingRequest
+	@return GetRoleMappingApiRequest
 	*/
-	GetRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) FederatedAuthenticationApiGetRoleMappingRequest
+	GetRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) GetRoleMappingApiRequest
 
 	// GetRoleMappingExecute executes the request
 	//  @return RoleMapping
-	GetRoleMappingExecute(r FederatedAuthenticationApiGetRoleMappingRequest) (*RoleMapping, *http.Response, error)
+	GetRoleMappingExecute(r GetRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
 
 	/*
 	ListConnectedOrgConfigs Return All Connected Org Configs from the Federation
@@ -155,13 +155,13 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
-	@return FederatedAuthenticationApiListConnectedOrgConfigsRequest
+	@return ListConnectedOrgConfigsApiRequest
 	*/
-	ListConnectedOrgConfigs(ctx context.Context, federationSettingsId string) FederatedAuthenticationApiListConnectedOrgConfigsRequest
+	ListConnectedOrgConfigs(ctx context.Context, federationSettingsId string) ListConnectedOrgConfigsApiRequest
 
 	// ListConnectedOrgConfigsExecute executes the request
 	//  @return []ConnectedOrgConfig
-	ListConnectedOrgConfigsExecute(r FederatedAuthenticationApiListConnectedOrgConfigsRequest) ([]ConnectedOrgConfig, *http.Response, error)
+	ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error)
 
 	/*
 	ListIdentityProviders Return all identity providers from the specified federation.
@@ -170,13 +170,13 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
-	@return FederatedAuthenticationApiListIdentityProvidersRequest
+	@return ListIdentityProvidersApiRequest
 	*/
-	ListIdentityProviders(ctx context.Context, federationSettingsId string) FederatedAuthenticationApiListIdentityProvidersRequest
+	ListIdentityProviders(ctx context.Context, federationSettingsId string) ListIdentityProvidersApiRequest
 
 	// ListIdentityProvidersExecute executes the request
 	//  @return []IdentityProvider
-	ListIdentityProvidersExecute(r FederatedAuthenticationApiListIdentityProvidersRequest) ([]IdentityProvider, *http.Response, error)
+	ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) ([]IdentityProvider, *http.Response, error)
 
 	/*
 	ListRoleMappings Return All Role Mappings from One Organization
@@ -186,13 +186,13 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return FederatedAuthenticationApiListRoleMappingsRequest
+	@return ListRoleMappingsApiRequest
 	*/
-	ListRoleMappings(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiListRoleMappingsRequest
+	ListRoleMappings(ctx context.Context, federationSettingsId string, orgId string) ListRoleMappingsApiRequest
 
 	// ListRoleMappingsExecute executes the request
 	//  @return []RoleMapping
-	ListRoleMappingsExecute(r FederatedAuthenticationApiListRoleMappingsRequest) ([]RoleMapping, *http.Response, error)
+	ListRoleMappingsExecute(r ListRoleMappingsApiRequest) ([]RoleMapping, *http.Response, error)
 
 	/*
 	RemoveConnectedOrgConfig Remove One Org Config Connected to One Federation
@@ -202,12 +202,12 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param orgId Unique 24-hexadecimal digit string that identifies the connected organization configuration to remove.
-	@return FederatedAuthenticationApiRemoveConnectedOrgConfigRequest
+	@return RemoveConnectedOrgConfigApiRequest
 	*/
-	RemoveConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiRemoveConnectedOrgConfigRequest
+	RemoveConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) RemoveConnectedOrgConfigApiRequest
 
 	// RemoveConnectedOrgConfigExecute executes the request
-	RemoveConnectedOrgConfigExecute(r FederatedAuthenticationApiRemoveConnectedOrgConfigRequest) (*http.Response, error)
+	RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (*http.Response, error)
 
 	/*
 	UpdateConnectedOrgConfig Update One Org Config Connected to One Federation
@@ -223,13 +223,13 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param orgId Unique 24-hexadecimal digit string that identifies the connected organization configuration to update.
-	@return FederatedAuthenticationApiUpdateConnectedOrgConfigRequest
+	@return UpdateConnectedOrgConfigApiRequest
 	*/
-	UpdateConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiUpdateConnectedOrgConfigRequest
+	UpdateConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) UpdateConnectedOrgConfigApiRequest
 
 	// UpdateConnectedOrgConfigExecute executes the request
 	//  @return ConnectedOrgConfig
-	UpdateConnectedOrgConfigExecute(r FederatedAuthenticationApiUpdateConnectedOrgConfigRequest) (*ConnectedOrgConfig, *http.Response, error)
+	UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
 	UpdateIdentityProvider Update the identity provider.
@@ -239,13 +239,13 @@ type FederatedAuthenticationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param identityProviderId Unique 20-hexadecimal digit string that identifies the identity provider.
-	@return FederatedAuthenticationApiUpdateIdentityProviderRequest
+	@return UpdateIdentityProviderApiRequest
 	*/
-	UpdateIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) FederatedAuthenticationApiUpdateIdentityProviderRequest
+	UpdateIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) UpdateIdentityProviderApiRequest
 
 	// UpdateIdentityProviderExecute executes the request
 	//  @return IdentityProvider
-	UpdateIdentityProviderExecute(r FederatedAuthenticationApiUpdateIdentityProviderRequest) (*IdentityProvider, *http.Response, error)
+	UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error)
 
 	/*
 	UpdateRoleMapping Update One Role Mapping in One Organization
@@ -256,19 +256,19 @@ type FederatedAuthenticationApi interface {
 	@param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
 	@param id Unique 24-hexadecimal digit string that identifies the role mapping that you want to update.
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return FederatedAuthenticationApiUpdateRoleMappingRequest
+	@return UpdateRoleMappingApiRequest
 	*/
-	UpdateRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) FederatedAuthenticationApiUpdateRoleMappingRequest
+	UpdateRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) UpdateRoleMappingApiRequest
 
 	// UpdateRoleMappingExecute executes the request
 	//  @return RoleMapping
-	UpdateRoleMappingExecute(r FederatedAuthenticationApiUpdateRoleMappingRequest) (*RoleMapping, *http.Response, error)
+	UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
 }
 
 // FederatedAuthenticationApiService FederatedAuthenticationApi service
 type FederatedAuthenticationApiService service
 
-type FederatedAuthenticationApiCreateRoleMappingRequest struct {
+type CreateRoleMappingApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -283,12 +283,12 @@ type CreateRoleMappingParams struct {
 }
 
 // The role mapping that you want to create.
-func (r FederatedAuthenticationApiCreateRoleMappingRequest) RoleMapping(roleMapping RoleMapping) FederatedAuthenticationApiCreateRoleMappingRequest {
+func (r CreateRoleMappingApiRequest) RoleMapping(roleMapping RoleMapping) CreateRoleMappingApiRequest {
 	r.roleMapping = &roleMapping
 	return r
 }
 
-func (r FederatedAuthenticationApiCreateRoleMappingRequest) Execute() (*RoleMapping, *http.Response, error) {
+func (r CreateRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
 	return r.ApiService.CreateRoleMappingExecute(r)
 }
 
@@ -300,10 +300,10 @@ Adds one role mapping to the specified organization in the specified federation.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return FederatedAuthenticationApiCreateRoleMappingRequest
+ @return CreateRoleMappingApiRequest
 */
-func (a *FederatedAuthenticationApiService) CreateRoleMapping(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiCreateRoleMappingRequest {
-	return FederatedAuthenticationApiCreateRoleMappingRequest{
+func (a *FederatedAuthenticationApiService) CreateRoleMapping(ctx context.Context, federationSettingsId string, orgId string) CreateRoleMappingApiRequest {
+	return CreateRoleMappingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -313,7 +313,7 @@ func (a *FederatedAuthenticationApiService) CreateRoleMapping(ctx context.Contex
 
 // Execute executes the request
 //  @return RoleMapping
-func (a *FederatedAuthenticationApiService) CreateRoleMappingExecute(r FederatedAuthenticationApiCreateRoleMappingRequest) (*RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -413,7 +413,7 @@ func (a *FederatedAuthenticationApiService) CreateRoleMappingExecute(r Federated
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiDeleteFederationAppRequest struct {
+type DeleteFederationAppApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -423,7 +423,7 @@ type DeleteFederationAppParams struct {
 		FederationSettingsId string
 }
 
-func (r FederatedAuthenticationApiDeleteFederationAppRequest) Execute() (*http.Response, error) {
+func (r DeleteFederationAppApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteFederationAppExecute(r)
 }
 
@@ -434,10 +434,10 @@ Deletes the federation settings instance and all associated data, including iden
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
- @return FederatedAuthenticationApiDeleteFederationAppRequest
+ @return DeleteFederationAppApiRequest
 */
-func (a *FederatedAuthenticationApiService) DeleteFederationApp(ctx context.Context, federationSettingsId string) FederatedAuthenticationApiDeleteFederationAppRequest {
-	return FederatedAuthenticationApiDeleteFederationAppRequest{
+func (a *FederatedAuthenticationApiService) DeleteFederationApp(ctx context.Context, federationSettingsId string) DeleteFederationAppApiRequest {
+	return DeleteFederationAppApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -445,7 +445,7 @@ func (a *FederatedAuthenticationApiService) DeleteFederationApp(ctx context.Cont
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) DeleteFederationAppExecute(r FederatedAuthenticationApiDeleteFederationAppRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -523,7 +523,7 @@ func (a *FederatedAuthenticationApiService) DeleteFederationAppExecute(r Federat
 	return localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiDeleteRoleMappingRequest struct {
+type DeleteRoleMappingApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -537,7 +537,7 @@ type DeleteRoleMappingParams struct {
 		OrgId string
 }
 
-func (r FederatedAuthenticationApiDeleteRoleMappingRequest) Execute() (*http.Response, error) {
+func (r DeleteRoleMappingApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteRoleMappingExecute(r)
 }
 
@@ -550,10 +550,10 @@ Removes one role mapping in the specified organization from the specified federa
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param id Unique 24-hexadecimal digit string that identifies the role mapping that you want to remove.
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return FederatedAuthenticationApiDeleteRoleMappingRequest
+ @return DeleteRoleMappingApiRequest
 */
-func (a *FederatedAuthenticationApiService) DeleteRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) FederatedAuthenticationApiDeleteRoleMappingRequest {
-	return FederatedAuthenticationApiDeleteRoleMappingRequest{
+func (a *FederatedAuthenticationApiService) DeleteRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) DeleteRoleMappingApiRequest {
+	return DeleteRoleMappingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -563,7 +563,7 @@ func (a *FederatedAuthenticationApiService) DeleteRoleMapping(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) DeleteRoleMappingExecute(r FederatedAuthenticationApiDeleteRoleMappingRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -655,7 +655,7 @@ func (a *FederatedAuthenticationApiService) DeleteRoleMappingExecute(r Federated
 	return localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiGetConnectedOrgConfigRequest struct {
+type GetConnectedOrgConfigApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -667,7 +667,7 @@ type GetConnectedOrgConfigParams struct {
 		OrgId string
 }
 
-func (r FederatedAuthenticationApiGetConnectedOrgConfigRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
+func (r GetConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
 	return r.ApiService.GetConnectedOrgConfigExecute(r)
 }
 
@@ -679,10 +679,10 @@ Returns the specified connected org config from the specified federation. To use
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param orgId Unique 24-hexadecimal digit string that identifies the connected organization configuration to return.
- @return FederatedAuthenticationApiGetConnectedOrgConfigRequest
+ @return GetConnectedOrgConfigApiRequest
 */
-func (a *FederatedAuthenticationApiService) GetConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiGetConnectedOrgConfigRequest {
-	return FederatedAuthenticationApiGetConnectedOrgConfigRequest{
+func (a *FederatedAuthenticationApiService) GetConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) GetConnectedOrgConfigApiRequest {
+	return GetConnectedOrgConfigApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -692,7 +692,7 @@ func (a *FederatedAuthenticationApiService) GetConnectedOrgConfig(ctx context.Co
 
 // Execute executes the request
 //  @return ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigExecute(r FederatedAuthenticationApiGetConnectedOrgConfigRequest) (*ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -787,7 +787,7 @@ func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigExecute(r Feder
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiGetFederationSettingsRequest struct {
+type GetFederationSettingsApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	orgId string
@@ -797,7 +797,7 @@ type GetFederationSettingsParams struct {
 		OrgId string
 }
 
-func (r FederatedAuthenticationApiGetFederationSettingsRequest) Execute() (*OrgFederationSettings, *http.Response, error) {
+func (r GetFederationSettingsApiRequest) Execute() (*OrgFederationSettings, *http.Response, error) {
 	return r.ApiService.GetFederationSettingsExecute(r)
 }
 
@@ -808,10 +808,10 @@ Returns information about the federation settings for the specified organization
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return FederatedAuthenticationApiGetFederationSettingsRequest
+ @return GetFederationSettingsApiRequest
 */
-func (a *FederatedAuthenticationApiService) GetFederationSettings(ctx context.Context, orgId string) FederatedAuthenticationApiGetFederationSettingsRequest {
-	return FederatedAuthenticationApiGetFederationSettingsRequest{
+func (a *FederatedAuthenticationApiService) GetFederationSettings(ctx context.Context, orgId string) GetFederationSettingsApiRequest {
+	return GetFederationSettingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -820,7 +820,7 @@ func (a *FederatedAuthenticationApiService) GetFederationSettings(ctx context.Co
 
 // Execute executes the request
 //  @return OrgFederationSettings
-func (a *FederatedAuthenticationApiService) GetFederationSettingsExecute(r FederatedAuthenticationApiGetFederationSettingsRequest) (*OrgFederationSettings, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -908,7 +908,7 @@ func (a *FederatedAuthenticationApiService) GetFederationSettingsExecute(r Feder
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiGetIdentityProviderRequest struct {
+type GetIdentityProviderApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -920,7 +920,7 @@ type GetIdentityProviderParams struct {
 		IdentityProviderId string
 }
 
-func (r FederatedAuthenticationApiGetIdentityProviderRequest) Execute() (*IdentityProvider, *http.Response, error) {
+func (r GetIdentityProviderApiRequest) Execute() (*IdentityProvider, *http.Response, error) {
 	return r.ApiService.GetIdentityProviderExecute(r)
 }
 
@@ -932,10 +932,10 @@ Returns one identity provider from the specified federation. To use this resourc
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param identityProviderId Unique 20-hexadecimal digit string that identifies the identity provider.
- @return FederatedAuthenticationApiGetIdentityProviderRequest
+ @return GetIdentityProviderApiRequest
 */
-func (a *FederatedAuthenticationApiService) GetIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) FederatedAuthenticationApiGetIdentityProviderRequest {
-	return FederatedAuthenticationApiGetIdentityProviderRequest{
+func (a *FederatedAuthenticationApiService) GetIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) GetIdentityProviderApiRequest {
+	return GetIdentityProviderApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -945,7 +945,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProvider(ctx context.Cont
 
 // Execute executes the request
 //  @return IdentityProvider
-func (a *FederatedAuthenticationApiService) GetIdentityProviderExecute(r FederatedAuthenticationApiGetIdentityProviderRequest) (*IdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1040,7 +1040,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderExecute(r Federat
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiGetIdentityProviderMetadataRequest struct {
+type GetIdentityProviderMetadataApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1052,7 +1052,7 @@ type GetIdentityProviderMetadataParams struct {
 		IdentityProviderId string
 }
 
-func (r FederatedAuthenticationApiGetIdentityProviderMetadataRequest) Execute() (string, *http.Response, error) {
+func (r GetIdentityProviderMetadataApiRequest) Execute() (string, *http.Response, error) {
 	return r.ApiService.GetIdentityProviderMetadataExecute(r)
 }
 
@@ -1064,10 +1064,10 @@ Returns the metadata of one identity provider in the specified federation. To us
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param identityProviderId Unique 20-hexadecimal digit string that identifies the identity provider.
- @return FederatedAuthenticationApiGetIdentityProviderMetadataRequest
+ @return GetIdentityProviderMetadataApiRequest
 */
-func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadata(ctx context.Context, federationSettingsId string, identityProviderId string) FederatedAuthenticationApiGetIdentityProviderMetadataRequest {
-	return FederatedAuthenticationApiGetIdentityProviderMetadataRequest{
+func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadata(ctx context.Context, federationSettingsId string, identityProviderId string) GetIdentityProviderMetadataApiRequest {
+	return GetIdentityProviderMetadataApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -1077,7 +1077,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadata(ctx cont
 
 // Execute executes the request
 //  @return string
-func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataExecute(r FederatedAuthenticationApiGetIdentityProviderMetadataRequest) (string, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1172,7 +1172,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataExecute(r
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiGetRoleMappingRequest struct {
+type GetRoleMappingApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1186,7 +1186,7 @@ type GetRoleMappingParams struct {
 		OrgId string
 }
 
-func (r FederatedAuthenticationApiGetRoleMappingRequest) Execute() (*RoleMapping, *http.Response, error) {
+func (r GetRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
 	return r.ApiService.GetRoleMappingExecute(r)
 }
 
@@ -1199,10 +1199,10 @@ Returns one role mapping from the specified organization in the specified federa
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param id Unique 24-hexadecimal digit string that identifies the role mapping that you want to return.
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return FederatedAuthenticationApiGetRoleMappingRequest
+ @return GetRoleMappingApiRequest
 */
-func (a *FederatedAuthenticationApiService) GetRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) FederatedAuthenticationApiGetRoleMappingRequest {
-	return FederatedAuthenticationApiGetRoleMappingRequest{
+func (a *FederatedAuthenticationApiService) GetRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) GetRoleMappingApiRequest {
+	return GetRoleMappingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -1213,7 +1213,7 @@ func (a *FederatedAuthenticationApiService) GetRoleMapping(ctx context.Context, 
 
 // Execute executes the request
 //  @return RoleMapping
-func (a *FederatedAuthenticationApiService) GetRoleMappingExecute(r FederatedAuthenticationApiGetRoleMappingRequest) (*RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) GetRoleMappingExecute(r GetRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1315,7 +1315,7 @@ func (a *FederatedAuthenticationApiService) GetRoleMappingExecute(r FederatedAut
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiListConnectedOrgConfigsRequest struct {
+type ListConnectedOrgConfigsApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1325,7 +1325,7 @@ type ListConnectedOrgConfigsParams struct {
 		FederationSettingsId string
 }
 
-func (r FederatedAuthenticationApiListConnectedOrgConfigsRequest) Execute() ([]ConnectedOrgConfig, *http.Response, error) {
+func (r ListConnectedOrgConfigsApiRequest) Execute() ([]ConnectedOrgConfig, *http.Response, error) {
 	return r.ApiService.ListConnectedOrgConfigsExecute(r)
 }
 
@@ -1336,10 +1336,10 @@ Returns all connected org configs in the specified federation. To use this resou
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
- @return FederatedAuthenticationApiListConnectedOrgConfigsRequest
+ @return ListConnectedOrgConfigsApiRequest
 */
-func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigs(ctx context.Context, federationSettingsId string) FederatedAuthenticationApiListConnectedOrgConfigsRequest {
-	return FederatedAuthenticationApiListConnectedOrgConfigsRequest{
+func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigs(ctx context.Context, federationSettingsId string) ListConnectedOrgConfigsApiRequest {
+	return ListConnectedOrgConfigsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -1348,7 +1348,7 @@ func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigs(ctx context.
 
 // Execute executes the request
 //  @return []ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsExecute(r FederatedAuthenticationApiListConnectedOrgConfigsRequest) ([]ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1436,7 +1436,7 @@ func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsExecute(r Fed
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiListIdentityProvidersRequest struct {
+type ListIdentityProvidersApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1446,7 +1446,7 @@ type ListIdentityProvidersParams struct {
 		FederationSettingsId string
 }
 
-func (r FederatedAuthenticationApiListIdentityProvidersRequest) Execute() ([]IdentityProvider, *http.Response, error) {
+func (r ListIdentityProvidersApiRequest) Execute() ([]IdentityProvider, *http.Response, error) {
 	return r.ApiService.ListIdentityProvidersExecute(r)
 }
 
@@ -1457,10 +1457,10 @@ Returns all identity providers in the specified federation. To use this resource
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
- @return FederatedAuthenticationApiListIdentityProvidersRequest
+ @return ListIdentityProvidersApiRequest
 */
-func (a *FederatedAuthenticationApiService) ListIdentityProviders(ctx context.Context, federationSettingsId string) FederatedAuthenticationApiListIdentityProvidersRequest {
-	return FederatedAuthenticationApiListIdentityProvidersRequest{
+func (a *FederatedAuthenticationApiService) ListIdentityProviders(ctx context.Context, federationSettingsId string) ListIdentityProvidersApiRequest {
+	return ListIdentityProvidersApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -1469,7 +1469,7 @@ func (a *FederatedAuthenticationApiService) ListIdentityProviders(ctx context.Co
 
 // Execute executes the request
 //  @return []IdentityProvider
-func (a *FederatedAuthenticationApiService) ListIdentityProvidersExecute(r FederatedAuthenticationApiListIdentityProvidersRequest) ([]IdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) ([]IdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1557,7 +1557,7 @@ func (a *FederatedAuthenticationApiService) ListIdentityProvidersExecute(r Feder
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiListRoleMappingsRequest struct {
+type ListRoleMappingsApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1569,7 +1569,7 @@ type ListRoleMappingsParams struct {
 		OrgId string
 }
 
-func (r FederatedAuthenticationApiListRoleMappingsRequest) Execute() ([]RoleMapping, *http.Response, error) {
+func (r ListRoleMappingsApiRequest) Execute() ([]RoleMapping, *http.Response, error) {
 	return r.ApiService.ListRoleMappingsExecute(r)
 }
 
@@ -1581,10 +1581,10 @@ Returns all role mappings from the specified organization in the specified feder
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return FederatedAuthenticationApiListRoleMappingsRequest
+ @return ListRoleMappingsApiRequest
 */
-func (a *FederatedAuthenticationApiService) ListRoleMappings(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiListRoleMappingsRequest {
-	return FederatedAuthenticationApiListRoleMappingsRequest{
+func (a *FederatedAuthenticationApiService) ListRoleMappings(ctx context.Context, federationSettingsId string, orgId string) ListRoleMappingsApiRequest {
+	return ListRoleMappingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -1594,7 +1594,7 @@ func (a *FederatedAuthenticationApiService) ListRoleMappings(ctx context.Context
 
 // Execute executes the request
 //  @return []RoleMapping
-func (a *FederatedAuthenticationApiService) ListRoleMappingsExecute(r FederatedAuthenticationApiListRoleMappingsRequest) ([]RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) ListRoleMappingsExecute(r ListRoleMappingsApiRequest) ([]RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1689,7 +1689,7 @@ func (a *FederatedAuthenticationApiService) ListRoleMappingsExecute(r FederatedA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiRemoveConnectedOrgConfigRequest struct {
+type RemoveConnectedOrgConfigApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1701,7 +1701,7 @@ type RemoveConnectedOrgConfigParams struct {
 		OrgId string
 }
 
-func (r FederatedAuthenticationApiRemoveConnectedOrgConfigRequest) Execute() (*http.Response, error) {
+func (r RemoveConnectedOrgConfigApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveConnectedOrgConfigExecute(r)
 }
 
@@ -1713,10 +1713,10 @@ Removes one connected organization configuration from the specified federation. 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param orgId Unique 24-hexadecimal digit string that identifies the connected organization configuration to remove.
- @return FederatedAuthenticationApiRemoveConnectedOrgConfigRequest
+ @return RemoveConnectedOrgConfigApiRequest
 */
-func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiRemoveConnectedOrgConfigRequest {
-	return FederatedAuthenticationApiRemoveConnectedOrgConfigRequest{
+func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) RemoveConnectedOrgConfigApiRequest {
+	return RemoveConnectedOrgConfigApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -1725,7 +1725,7 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfig(ctx context
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r FederatedAuthenticationApiRemoveConnectedOrgConfigRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1810,7 +1810,7 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r Fe
 	return localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiUpdateConnectedOrgConfigRequest struct {
+type UpdateConnectedOrgConfigApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1825,12 +1825,12 @@ type UpdateConnectedOrgConfigParams struct {
 }
 
 // The connected organization configuration that you want to update.
-func (r FederatedAuthenticationApiUpdateConnectedOrgConfigRequest) ConnectedOrgConfig(connectedOrgConfig ConnectedOrgConfig) FederatedAuthenticationApiUpdateConnectedOrgConfigRequest {
+func (r UpdateConnectedOrgConfigApiRequest) ConnectedOrgConfig(connectedOrgConfig ConnectedOrgConfig) UpdateConnectedOrgConfigApiRequest {
 	r.connectedOrgConfig = &connectedOrgConfig
 	return r
 }
 
-func (r FederatedAuthenticationApiUpdateConnectedOrgConfigRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
+func (r UpdateConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
 	return r.ApiService.UpdateConnectedOrgConfigExecute(r)
 }
 
@@ -1848,10 +1848,10 @@ Updates one connected organization configuration from the specified federation. 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param orgId Unique 24-hexadecimal digit string that identifies the connected organization configuration to update.
- @return FederatedAuthenticationApiUpdateConnectedOrgConfigRequest
+ @return UpdateConnectedOrgConfigApiRequest
 */
-func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) FederatedAuthenticationApiUpdateConnectedOrgConfigRequest {
-	return FederatedAuthenticationApiUpdateConnectedOrgConfigRequest{
+func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) UpdateConnectedOrgConfigApiRequest {
+	return UpdateConnectedOrgConfigApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -1861,7 +1861,7 @@ func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfig(ctx context
 
 // Execute executes the request
 //  @return ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigExecute(r FederatedAuthenticationApiUpdateConnectedOrgConfigRequest) (*ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1961,7 +1961,7 @@ func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigExecute(r Fe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiUpdateIdentityProviderRequest struct {
+type UpdateIdentityProviderApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -1976,12 +1976,12 @@ type UpdateIdentityProviderParams struct {
 }
 
 // The identity provider that you want to update.
-func (r FederatedAuthenticationApiUpdateIdentityProviderRequest) IdentityProviderUpdate(identityProviderUpdate IdentityProviderUpdate) FederatedAuthenticationApiUpdateIdentityProviderRequest {
+func (r UpdateIdentityProviderApiRequest) IdentityProviderUpdate(identityProviderUpdate IdentityProviderUpdate) UpdateIdentityProviderApiRequest {
 	r.identityProviderUpdate = &identityProviderUpdate
 	return r
 }
 
-func (r FederatedAuthenticationApiUpdateIdentityProviderRequest) Execute() (*IdentityProvider, *http.Response, error) {
+func (r UpdateIdentityProviderApiRequest) Execute() (*IdentityProvider, *http.Response, error) {
 	return r.ApiService.UpdateIdentityProviderExecute(r)
 }
 
@@ -1993,10 +1993,10 @@ Updates one identity provider in the specified federation. To use this resource,
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param identityProviderId Unique 20-hexadecimal digit string that identifies the identity provider.
- @return FederatedAuthenticationApiUpdateIdentityProviderRequest
+ @return UpdateIdentityProviderApiRequest
 */
-func (a *FederatedAuthenticationApiService) UpdateIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) FederatedAuthenticationApiUpdateIdentityProviderRequest {
-	return FederatedAuthenticationApiUpdateIdentityProviderRequest{
+func (a *FederatedAuthenticationApiService) UpdateIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) UpdateIdentityProviderApiRequest {
+	return UpdateIdentityProviderApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -2006,7 +2006,7 @@ func (a *FederatedAuthenticationApiService) UpdateIdentityProvider(ctx context.C
 
 // Execute executes the request
 //  @return IdentityProvider
-func (a *FederatedAuthenticationApiService) UpdateIdentityProviderExecute(r FederatedAuthenticationApiUpdateIdentityProviderRequest) (*IdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2106,7 +2106,7 @@ func (a *FederatedAuthenticationApiService) UpdateIdentityProviderExecute(r Fede
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type FederatedAuthenticationApiUpdateRoleMappingRequest struct {
+type UpdateRoleMappingApiRequest struct {
 	ctx context.Context
 	ApiService FederatedAuthenticationApi
 	federationSettingsId string
@@ -2123,12 +2123,12 @@ type UpdateRoleMappingParams struct {
 }
 
 // The role mapping that you want to update.
-func (r FederatedAuthenticationApiUpdateRoleMappingRequest) RoleMapping(roleMapping RoleMapping) FederatedAuthenticationApiUpdateRoleMappingRequest {
+func (r UpdateRoleMappingApiRequest) RoleMapping(roleMapping RoleMapping) UpdateRoleMappingApiRequest {
 	r.roleMapping = &roleMapping
 	return r
 }
 
-func (r FederatedAuthenticationApiUpdateRoleMappingRequest) Execute() (*RoleMapping, *http.Response, error) {
+func (r UpdateRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
 	return r.ApiService.UpdateRoleMappingExecute(r)
 }
 
@@ -2141,10 +2141,10 @@ Updates one role mapping in the specified organization in the specified federati
  @param federationSettingsId Unique 24-hexadecimal digit string that identifies your federation.
  @param id Unique 24-hexadecimal digit string that identifies the role mapping that you want to update.
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return FederatedAuthenticationApiUpdateRoleMappingRequest
+ @return UpdateRoleMappingApiRequest
 */
-func (a *FederatedAuthenticationApiService) UpdateRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) FederatedAuthenticationApiUpdateRoleMappingRequest {
-	return FederatedAuthenticationApiUpdateRoleMappingRequest{
+func (a *FederatedAuthenticationApiService) UpdateRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) UpdateRoleMappingApiRequest {
+	return UpdateRoleMappingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		federationSettingsId: federationSettingsId,
@@ -2155,7 +2155,7 @@ func (a *FederatedAuthenticationApiService) UpdateRoleMapping(ctx context.Contex
 
 // Execute executes the request
 //  @return RoleMapping
-func (a *FederatedAuthenticationApiService) UpdateRoleMappingExecute(r FederatedAuthenticationApiUpdateRoleMappingRequest) (*RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -276,7 +276,7 @@ type FederatedAuthenticationApiCreateRoleMappingRequest struct {
 	roleMapping *RoleMapping
 }
 
-type FederatedAuthenticationApiCreateRoleMappingQueryParams struct {
+type FederatedAuthenticationApiCreateRoleMappingParams struct {
 		FederationSettingsId string
 		OrgId string
 		RoleMapping *RoleMapping
@@ -419,7 +419,7 @@ type FederatedAuthenticationApiDeleteFederationAppRequest struct {
 	federationSettingsId string
 }
 
-type FederatedAuthenticationApiDeleteFederationAppQueryParams struct {
+type FederatedAuthenticationApiDeleteFederationAppParams struct {
 		FederationSettingsId string
 }
 
@@ -531,7 +531,7 @@ type FederatedAuthenticationApiDeleteRoleMappingRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiDeleteRoleMappingQueryParams struct {
+type FederatedAuthenticationApiDeleteRoleMappingParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string
@@ -662,7 +662,7 @@ type FederatedAuthenticationApiGetConnectedOrgConfigRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiGetConnectedOrgConfigQueryParams struct {
+type FederatedAuthenticationApiGetConnectedOrgConfigParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -793,7 +793,7 @@ type FederatedAuthenticationApiGetFederationSettingsRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiGetFederationSettingsQueryParams struct {
+type FederatedAuthenticationApiGetFederationSettingsParams struct {
 		OrgId string
 }
 
@@ -915,7 +915,7 @@ type FederatedAuthenticationApiGetIdentityProviderRequest struct {
 	identityProviderId string
 }
 
-type FederatedAuthenticationApiGetIdentityProviderQueryParams struct {
+type FederatedAuthenticationApiGetIdentityProviderParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 }
@@ -1047,7 +1047,7 @@ type FederatedAuthenticationApiGetIdentityProviderMetadataRequest struct {
 	identityProviderId string
 }
 
-type FederatedAuthenticationApiGetIdentityProviderMetadataQueryParams struct {
+type FederatedAuthenticationApiGetIdentityProviderMetadataParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 }
@@ -1180,7 +1180,7 @@ type FederatedAuthenticationApiGetRoleMappingRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiGetRoleMappingQueryParams struct {
+type FederatedAuthenticationApiGetRoleMappingParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string
@@ -1321,7 +1321,7 @@ type FederatedAuthenticationApiListConnectedOrgConfigsRequest struct {
 	federationSettingsId string
 }
 
-type FederatedAuthenticationApiListConnectedOrgConfigsQueryParams struct {
+type FederatedAuthenticationApiListConnectedOrgConfigsParams struct {
 		FederationSettingsId string
 }
 
@@ -1442,7 +1442,7 @@ type FederatedAuthenticationApiListIdentityProvidersRequest struct {
 	federationSettingsId string
 }
 
-type FederatedAuthenticationApiListIdentityProvidersQueryParams struct {
+type FederatedAuthenticationApiListIdentityProvidersParams struct {
 		FederationSettingsId string
 }
 
@@ -1564,7 +1564,7 @@ type FederatedAuthenticationApiListRoleMappingsRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiListRoleMappingsQueryParams struct {
+type FederatedAuthenticationApiListRoleMappingsParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -1696,7 +1696,7 @@ type FederatedAuthenticationApiRemoveConnectedOrgConfigRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiRemoveConnectedOrgConfigQueryParams struct {
+type FederatedAuthenticationApiRemoveConnectedOrgConfigParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -1818,7 +1818,7 @@ type FederatedAuthenticationApiUpdateConnectedOrgConfigRequest struct {
 	connectedOrgConfig *ConnectedOrgConfig
 }
 
-type FederatedAuthenticationApiUpdateConnectedOrgConfigQueryParams struct {
+type FederatedAuthenticationApiUpdateConnectedOrgConfigParams struct {
 		FederationSettingsId string
 		OrgId string
 		ConnectedOrgConfig *ConnectedOrgConfig
@@ -1969,7 +1969,7 @@ type FederatedAuthenticationApiUpdateIdentityProviderRequest struct {
 	identityProviderUpdate *IdentityProviderUpdate
 }
 
-type FederatedAuthenticationApiUpdateIdentityProviderQueryParams struct {
+type FederatedAuthenticationApiUpdateIdentityProviderParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 		IdentityProviderUpdate *IdentityProviderUpdate
@@ -2115,7 +2115,7 @@ type FederatedAuthenticationApiUpdateRoleMappingRequest struct {
 	roleMapping *RoleMapping
 }
 
-type FederatedAuthenticationApiUpdateRoleMappingQueryParams struct {
+type FederatedAuthenticationApiUpdateRoleMappingParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -276,7 +276,7 @@ type CreateRoleMappingApiRequest struct {
 	roleMapping *RoleMapping
 }
 
-type CreateRoleMappingParams struct {
+type CreateRoleMappingApiParams struct {
 		FederationSettingsId string
 		OrgId string
 		RoleMapping *RoleMapping
@@ -419,7 +419,7 @@ type DeleteFederationAppApiRequest struct {
 	federationSettingsId string
 }
 
-type DeleteFederationAppParams struct {
+type DeleteFederationAppApiParams struct {
 		FederationSettingsId string
 }
 
@@ -531,7 +531,7 @@ type DeleteRoleMappingApiRequest struct {
 	orgId string
 }
 
-type DeleteRoleMappingParams struct {
+type DeleteRoleMappingApiParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string
@@ -662,7 +662,7 @@ type GetConnectedOrgConfigApiRequest struct {
 	orgId string
 }
 
-type GetConnectedOrgConfigParams struct {
+type GetConnectedOrgConfigApiParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -793,7 +793,7 @@ type GetFederationSettingsApiRequest struct {
 	orgId string
 }
 
-type GetFederationSettingsParams struct {
+type GetFederationSettingsApiParams struct {
 		OrgId string
 }
 
@@ -915,7 +915,7 @@ type GetIdentityProviderApiRequest struct {
 	identityProviderId string
 }
 
-type GetIdentityProviderParams struct {
+type GetIdentityProviderApiParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 }
@@ -1047,7 +1047,7 @@ type GetIdentityProviderMetadataApiRequest struct {
 	identityProviderId string
 }
 
-type GetIdentityProviderMetadataParams struct {
+type GetIdentityProviderMetadataApiParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 }
@@ -1180,7 +1180,7 @@ type GetRoleMappingApiRequest struct {
 	orgId string
 }
 
-type GetRoleMappingParams struct {
+type GetRoleMappingApiParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string
@@ -1321,7 +1321,7 @@ type ListConnectedOrgConfigsApiRequest struct {
 	federationSettingsId string
 }
 
-type ListConnectedOrgConfigsParams struct {
+type ListConnectedOrgConfigsApiParams struct {
 		FederationSettingsId string
 }
 
@@ -1442,7 +1442,7 @@ type ListIdentityProvidersApiRequest struct {
 	federationSettingsId string
 }
 
-type ListIdentityProvidersParams struct {
+type ListIdentityProvidersApiParams struct {
 		FederationSettingsId string
 }
 
@@ -1564,7 +1564,7 @@ type ListRoleMappingsApiRequest struct {
 	orgId string
 }
 
-type ListRoleMappingsParams struct {
+type ListRoleMappingsApiParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -1696,7 +1696,7 @@ type RemoveConnectedOrgConfigApiRequest struct {
 	orgId string
 }
 
-type RemoveConnectedOrgConfigParams struct {
+type RemoveConnectedOrgConfigApiParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -1818,7 +1818,7 @@ type UpdateConnectedOrgConfigApiRequest struct {
 	connectedOrgConfig *ConnectedOrgConfig
 }
 
-type UpdateConnectedOrgConfigParams struct {
+type UpdateConnectedOrgConfigApiParams struct {
 		FederationSettingsId string
 		OrgId string
 		ConnectedOrgConfig *ConnectedOrgConfig
@@ -1969,7 +1969,7 @@ type UpdateIdentityProviderApiRequest struct {
 	identityProviderUpdate *IdentityProviderUpdate
 }
 
-type UpdateIdentityProviderParams struct {
+type UpdateIdentityProviderApiParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 		IdentityProviderUpdate *IdentityProviderUpdate
@@ -2115,7 +2115,7 @@ type UpdateRoleMappingApiRequest struct {
 	roleMapping *RoleMapping
 }
 
-type UpdateRoleMappingParams struct {
+type UpdateRoleMappingApiParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -276,7 +276,7 @@ type FederatedAuthenticationApiCreateRoleMappingRequest struct {
 	roleMapping *RoleMapping
 }
 
-type FederatedAuthenticationApiCreateRoleMappingParams struct {
+type CreateRoleMappingParams struct {
 		FederationSettingsId string
 		OrgId string
 		RoleMapping *RoleMapping
@@ -419,7 +419,7 @@ type FederatedAuthenticationApiDeleteFederationAppRequest struct {
 	federationSettingsId string
 }
 
-type FederatedAuthenticationApiDeleteFederationAppParams struct {
+type DeleteFederationAppParams struct {
 		FederationSettingsId string
 }
 
@@ -531,7 +531,7 @@ type FederatedAuthenticationApiDeleteRoleMappingRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiDeleteRoleMappingParams struct {
+type DeleteRoleMappingParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string
@@ -662,7 +662,7 @@ type FederatedAuthenticationApiGetConnectedOrgConfigRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiGetConnectedOrgConfigParams struct {
+type GetConnectedOrgConfigParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -793,7 +793,7 @@ type FederatedAuthenticationApiGetFederationSettingsRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiGetFederationSettingsParams struct {
+type GetFederationSettingsParams struct {
 		OrgId string
 }
 
@@ -915,7 +915,7 @@ type FederatedAuthenticationApiGetIdentityProviderRequest struct {
 	identityProviderId string
 }
 
-type FederatedAuthenticationApiGetIdentityProviderParams struct {
+type GetIdentityProviderParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 }
@@ -1047,7 +1047,7 @@ type FederatedAuthenticationApiGetIdentityProviderMetadataRequest struct {
 	identityProviderId string
 }
 
-type FederatedAuthenticationApiGetIdentityProviderMetadataParams struct {
+type GetIdentityProviderMetadataParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 }
@@ -1180,7 +1180,7 @@ type FederatedAuthenticationApiGetRoleMappingRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiGetRoleMappingParams struct {
+type GetRoleMappingParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string
@@ -1321,7 +1321,7 @@ type FederatedAuthenticationApiListConnectedOrgConfigsRequest struct {
 	federationSettingsId string
 }
 
-type FederatedAuthenticationApiListConnectedOrgConfigsParams struct {
+type ListConnectedOrgConfigsParams struct {
 		FederationSettingsId string
 }
 
@@ -1442,7 +1442,7 @@ type FederatedAuthenticationApiListIdentityProvidersRequest struct {
 	federationSettingsId string
 }
 
-type FederatedAuthenticationApiListIdentityProvidersParams struct {
+type ListIdentityProvidersParams struct {
 		FederationSettingsId string
 }
 
@@ -1564,7 +1564,7 @@ type FederatedAuthenticationApiListRoleMappingsRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiListRoleMappingsParams struct {
+type ListRoleMappingsParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -1696,7 +1696,7 @@ type FederatedAuthenticationApiRemoveConnectedOrgConfigRequest struct {
 	orgId string
 }
 
-type FederatedAuthenticationApiRemoveConnectedOrgConfigParams struct {
+type RemoveConnectedOrgConfigParams struct {
 		FederationSettingsId string
 		OrgId string
 }
@@ -1818,7 +1818,7 @@ type FederatedAuthenticationApiUpdateConnectedOrgConfigRequest struct {
 	connectedOrgConfig *ConnectedOrgConfig
 }
 
-type FederatedAuthenticationApiUpdateConnectedOrgConfigParams struct {
+type UpdateConnectedOrgConfigParams struct {
 		FederationSettingsId string
 		OrgId string
 		ConnectedOrgConfig *ConnectedOrgConfig
@@ -1969,7 +1969,7 @@ type FederatedAuthenticationApiUpdateIdentityProviderRequest struct {
 	identityProviderUpdate *IdentityProviderUpdate
 }
 
-type FederatedAuthenticationApiUpdateIdentityProviderParams struct {
+type UpdateIdentityProviderParams struct {
 		FederationSettingsId string
 		IdentityProviderId string
 		IdentityProviderUpdate *IdentityProviderUpdate
@@ -2115,7 +2115,7 @@ type FederatedAuthenticationApiUpdateRoleMappingRequest struct {
 	roleMapping *RoleMapping
 }
 
-type FederatedAuthenticationApiUpdateRoleMappingParams struct {
+type UpdateRoleMappingParams struct {
 		FederationSettingsId string
 		Id string
 		OrgId string

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -114,7 +114,7 @@ type GlobalClustersApiCreateCustomZoneMappingRequest struct {
 	geoSharding *GeoSharding
 }
 
-type GlobalClustersApiCreateCustomZoneMappingParams struct {
+type CreateCustomZoneMappingParams struct {
 		GroupId string
 		ClusterName string
 		GeoSharding *GeoSharding
@@ -259,7 +259,7 @@ type GlobalClustersApiCreateManagedNamespaceRequest struct {
 	managedNamespace *ManagedNamespace
 }
 
-type GlobalClustersApiCreateManagedNamespaceParams struct {
+type CreateManagedNamespaceParams struct {
 		GroupId string
 		ClusterName string
 		ManagedNamespace *ManagedNamespace
@@ -403,7 +403,7 @@ type GlobalClustersApiDeleteAllCustomZoneMappingsRequest struct {
 	clusterName string
 }
 
-type GlobalClustersApiDeleteAllCustomZoneMappingsParams struct {
+type DeleteAllCustomZoneMappingsParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -537,7 +537,7 @@ type GlobalClustersApiDeleteManagedNamespaceRequest struct {
 	collection *string
 }
 
-type GlobalClustersApiDeleteManagedNamespaceParams struct {
+type DeleteManagedNamespaceParams struct {
 		ClusterName string
 		GroupId string
 		Db *string
@@ -689,7 +689,7 @@ type GlobalClustersApiGetManagedNamespaceRequest struct {
 	clusterName string
 }
 
-type GlobalClustersApiGetManagedNamespaceParams struct {
+type GetManagedNamespaceParams struct {
 		GroupId string
 		ClusterName string
 }

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -114,7 +114,7 @@ type GlobalClustersApiCreateCustomZoneMappingRequest struct {
 	geoSharding *GeoSharding
 }
 
-type GlobalClustersApiCreateCustomZoneMappingQueryParams struct {
+type GlobalClustersApiCreateCustomZoneMappingParams struct {
 		GroupId string
 		ClusterName string
 		GeoSharding *GeoSharding
@@ -259,7 +259,7 @@ type GlobalClustersApiCreateManagedNamespaceRequest struct {
 	managedNamespace *ManagedNamespace
 }
 
-type GlobalClustersApiCreateManagedNamespaceQueryParams struct {
+type GlobalClustersApiCreateManagedNamespaceParams struct {
 		GroupId string
 		ClusterName string
 		ManagedNamespace *ManagedNamespace
@@ -403,7 +403,7 @@ type GlobalClustersApiDeleteAllCustomZoneMappingsRequest struct {
 	clusterName string
 }
 
-type GlobalClustersApiDeleteAllCustomZoneMappingsQueryParams struct {
+type GlobalClustersApiDeleteAllCustomZoneMappingsParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -537,7 +537,7 @@ type GlobalClustersApiDeleteManagedNamespaceRequest struct {
 	collection *string
 }
 
-type GlobalClustersApiDeleteManagedNamespaceQueryParams struct {
+type GlobalClustersApiDeleteManagedNamespaceParams struct {
 		ClusterName string
 		GroupId string
 		Db *string
@@ -689,7 +689,7 @@ type GlobalClustersApiGetManagedNamespaceRequest struct {
 	clusterName string
 }
 
-type GlobalClustersApiGetManagedNamespaceQueryParams struct {
+type GlobalClustersApiGetManagedNamespaceParams struct {
 		GroupId string
 		ClusterName string
 }

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -114,7 +114,7 @@ type CreateCustomZoneMappingApiRequest struct {
 	geoSharding *GeoSharding
 }
 
-type CreateCustomZoneMappingParams struct {
+type CreateCustomZoneMappingApiParams struct {
 		GroupId string
 		ClusterName string
 		GeoSharding *GeoSharding
@@ -259,7 +259,7 @@ type CreateManagedNamespaceApiRequest struct {
 	managedNamespace *ManagedNamespace
 }
 
-type CreateManagedNamespaceParams struct {
+type CreateManagedNamespaceApiParams struct {
 		GroupId string
 		ClusterName string
 		ManagedNamespace *ManagedNamespace
@@ -403,7 +403,7 @@ type DeleteAllCustomZoneMappingsApiRequest struct {
 	clusterName string
 }
 
-type DeleteAllCustomZoneMappingsParams struct {
+type DeleteAllCustomZoneMappingsApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -537,7 +537,7 @@ type DeleteManagedNamespaceApiRequest struct {
 	collection *string
 }
 
-type DeleteManagedNamespaceParams struct {
+type DeleteManagedNamespaceApiParams struct {
 		ClusterName string
 		GroupId string
 		Db *string
@@ -689,7 +689,7 @@ type GetManagedNamespaceApiRequest struct {
 	clusterName string
 }
 
-type GetManagedNamespaceParams struct {
+type GetManagedNamespaceApiParams struct {
 		GroupId string
 		ClusterName string
 }

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -113,6 +113,11 @@ type GlobalClustersApiCreateCustomZoneMappingRequest struct {
 	clusterName string
 	geoSharding *GeoSharding
 }
+type GlobalClustersApiCreateCustomZoneMappingQueryParams struct {
+		groupId string
+		clusterName string
+		geoSharding *GeoSharding
+}
 
 // Custom zone mapping to add to the specified global cluster.
 func (r GlobalClustersApiCreateCustomZoneMappingRequest) GeoSharding(geoSharding GeoSharding) GlobalClustersApiCreateCustomZoneMappingRequest {
@@ -252,6 +257,11 @@ type GlobalClustersApiCreateManagedNamespaceRequest struct {
 	clusterName string
 	managedNamespace *ManagedNamespace
 }
+type GlobalClustersApiCreateManagedNamespaceQueryParams struct {
+		groupId string
+		clusterName string
+		managedNamespace *ManagedNamespace
+}
 
 // Managed namespace to create within the specified global cluster.
 func (r GlobalClustersApiCreateManagedNamespaceRequest) ManagedNamespace(managedNamespace ManagedNamespace) GlobalClustersApiCreateManagedNamespaceRequest {
@@ -390,6 +400,10 @@ type GlobalClustersApiDeleteAllCustomZoneMappingsRequest struct {
 	groupId string
 	clusterName string
 }
+type GlobalClustersApiDeleteAllCustomZoneMappingsQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r GlobalClustersApiDeleteAllCustomZoneMappingsRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.DeleteAllCustomZoneMappingsExecute(r)
@@ -518,6 +532,12 @@ type GlobalClustersApiDeleteManagedNamespaceRequest struct {
 	groupId string
 	db *string
 	collection *string
+}
+type GlobalClustersApiDeleteManagedNamespaceQueryParams struct {
+		clusterName string
+		groupId string
+		db *string
+		collection *string
 }
 
 // Human-readable label that identifies the database that contains the collection.
@@ -663,6 +683,10 @@ type GlobalClustersApiGetManagedNamespaceRequest struct {
 	ApiService GlobalClustersApi
 	groupId string
 	clusterName string
+}
+type GlobalClustersApiGetManagedNamespaceQueryParams struct {
+		groupId string
+		clusterName string
 }
 
 func (r GlobalClustersApiGetManagedNamespaceRequest) Execute() (*GeoSharding, *http.Response, error) {

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -30,13 +30,13 @@ type GlobalClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies this advanced cluster.
-	@return GlobalClustersApiCreateCustomZoneMappingRequest
+	@return CreateCustomZoneMappingApiRequest
 	*/
-	CreateCustomZoneMapping(ctx context.Context, groupId string, clusterName string) GlobalClustersApiCreateCustomZoneMappingRequest
+	CreateCustomZoneMapping(ctx context.Context, groupId string, clusterName string) CreateCustomZoneMappingApiRequest
 
 	// CreateCustomZoneMappingExecute executes the request
 	//  @return GeoSharding
-	CreateCustomZoneMappingExecute(r GlobalClustersApiCreateCustomZoneMappingRequest) (*GeoSharding, *http.Response, error)
+	CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	CreateManagedNamespace Create One Managed Namespace in One Global Multi-Cloud Cluster
@@ -46,13 +46,13 @@ type GlobalClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies this advanced cluster.
-	@return GlobalClustersApiCreateManagedNamespaceRequest
+	@return CreateManagedNamespaceApiRequest
 	*/
-	CreateManagedNamespace(ctx context.Context, groupId string, clusterName string) GlobalClustersApiCreateManagedNamespaceRequest
+	CreateManagedNamespace(ctx context.Context, groupId string, clusterName string) CreateManagedNamespaceApiRequest
 
 	// CreateManagedNamespaceExecute executes the request
 	//  @return GeoSharding
-	CreateManagedNamespaceExecute(r GlobalClustersApiCreateManagedNamespaceRequest) (*GeoSharding, *http.Response, error)
+	CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	DeleteAllCustomZoneMappings Remove All Custom Zone Mappings from One Global Multi-Cloud Cluster
@@ -62,13 +62,13 @@ type GlobalClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies this advanced cluster.
-	@return GlobalClustersApiDeleteAllCustomZoneMappingsRequest
+	@return DeleteAllCustomZoneMappingsApiRequest
 	*/
-	DeleteAllCustomZoneMappings(ctx context.Context, groupId string, clusterName string) GlobalClustersApiDeleteAllCustomZoneMappingsRequest
+	DeleteAllCustomZoneMappings(ctx context.Context, groupId string, clusterName string) DeleteAllCustomZoneMappingsApiRequest
 
 	// DeleteAllCustomZoneMappingsExecute executes the request
 	//  @return GeoSharding
-	DeleteAllCustomZoneMappingsExecute(r GlobalClustersApiDeleteAllCustomZoneMappingsRequest) (*GeoSharding, *http.Response, error)
+	DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	DeleteManagedNamespace Remove One Managed Namespace from One Global Multi-Cloud Cluster
@@ -78,13 +78,13 @@ type GlobalClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param clusterName Human-readable label that identifies this advanced cluster.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return GlobalClustersApiDeleteManagedNamespaceRequest
+	@return DeleteManagedNamespaceApiRequest
 	*/
-	DeleteManagedNamespace(ctx context.Context, clusterName string, groupId string) GlobalClustersApiDeleteManagedNamespaceRequest
+	DeleteManagedNamespace(ctx context.Context, clusterName string, groupId string) DeleteManagedNamespaceApiRequest
 
 	// DeleteManagedNamespaceExecute executes the request
 	//  @return GeoSharding
-	DeleteManagedNamespaceExecute(r GlobalClustersApiDeleteManagedNamespaceRequest) (*GeoSharding, *http.Response, error)
+	DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	GetManagedNamespace Return One Managed Namespace in One Global Multi-Cloud Cluster
@@ -94,19 +94,19 @@ type GlobalClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies this advanced cluster.
-	@return GlobalClustersApiGetManagedNamespaceRequest
+	@return GetManagedNamespaceApiRequest
 	*/
-	GetManagedNamespace(ctx context.Context, groupId string, clusterName string) GlobalClustersApiGetManagedNamespaceRequest
+	GetManagedNamespace(ctx context.Context, groupId string, clusterName string) GetManagedNamespaceApiRequest
 
 	// GetManagedNamespaceExecute executes the request
 	//  @return GeoSharding
-	GetManagedNamespaceExecute(r GlobalClustersApiGetManagedNamespaceRequest) (*GeoSharding, *http.Response, error)
+	GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 }
 
 // GlobalClustersApiService GlobalClustersApi service
 type GlobalClustersApiService service
 
-type GlobalClustersApiCreateCustomZoneMappingRequest struct {
+type CreateCustomZoneMappingApiRequest struct {
 	ctx context.Context
 	ApiService GlobalClustersApi
 	groupId string
@@ -121,12 +121,12 @@ type CreateCustomZoneMappingParams struct {
 }
 
 // Custom zone mapping to add to the specified global cluster.
-func (r GlobalClustersApiCreateCustomZoneMappingRequest) GeoSharding(geoSharding GeoSharding) GlobalClustersApiCreateCustomZoneMappingRequest {
+func (r CreateCustomZoneMappingApiRequest) GeoSharding(geoSharding GeoSharding) CreateCustomZoneMappingApiRequest {
 	r.geoSharding = &geoSharding
 	return r
 }
 
-func (r GlobalClustersApiCreateCustomZoneMappingRequest) Execute() (*GeoSharding, *http.Response, error) {
+func (r CreateCustomZoneMappingApiRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.CreateCustomZoneMappingExecute(r)
 }
 
@@ -138,10 +138,10 @@ Creates one custom zone mapping for the specified global cluster. A custom zone 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies this advanced cluster.
- @return GlobalClustersApiCreateCustomZoneMappingRequest
+ @return CreateCustomZoneMappingApiRequest
 */
-func (a *GlobalClustersApiService) CreateCustomZoneMapping(ctx context.Context, groupId string, clusterName string) GlobalClustersApiCreateCustomZoneMappingRequest {
-	return GlobalClustersApiCreateCustomZoneMappingRequest{
+func (a *GlobalClustersApiService) CreateCustomZoneMapping(ctx context.Context, groupId string, clusterName string) CreateCustomZoneMappingApiRequest {
+	return CreateCustomZoneMappingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -151,7 +151,7 @@ func (a *GlobalClustersApiService) CreateCustomZoneMapping(ctx context.Context, 
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) CreateCustomZoneMappingExecute(r GlobalClustersApiCreateCustomZoneMappingRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -251,7 +251,7 @@ func (a *GlobalClustersApiService) CreateCustomZoneMappingExecute(r GlobalCluste
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type GlobalClustersApiCreateManagedNamespaceRequest struct {
+type CreateManagedNamespaceApiRequest struct {
 	ctx context.Context
 	ApiService GlobalClustersApi
 	groupId string
@@ -266,12 +266,12 @@ type CreateManagedNamespaceParams struct {
 }
 
 // Managed namespace to create within the specified global cluster.
-func (r GlobalClustersApiCreateManagedNamespaceRequest) ManagedNamespace(managedNamespace ManagedNamespace) GlobalClustersApiCreateManagedNamespaceRequest {
+func (r CreateManagedNamespaceApiRequest) ManagedNamespace(managedNamespace ManagedNamespace) CreateManagedNamespaceApiRequest {
 	r.managedNamespace = &managedNamespace
 	return r
 }
 
-func (r GlobalClustersApiCreateManagedNamespaceRequest) Execute() (*GeoSharding, *http.Response, error) {
+func (r CreateManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.CreateManagedNamespaceExecute(r)
 }
 
@@ -283,10 +283,10 @@ Creates one managed namespace within the specified global cluster. A managed nam
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies this advanced cluster.
- @return GlobalClustersApiCreateManagedNamespaceRequest
+ @return CreateManagedNamespaceApiRequest
 */
-func (a *GlobalClustersApiService) CreateManagedNamespace(ctx context.Context, groupId string, clusterName string) GlobalClustersApiCreateManagedNamespaceRequest {
-	return GlobalClustersApiCreateManagedNamespaceRequest{
+func (a *GlobalClustersApiService) CreateManagedNamespace(ctx context.Context, groupId string, clusterName string) CreateManagedNamespaceApiRequest {
+	return CreateManagedNamespaceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -296,7 +296,7 @@ func (a *GlobalClustersApiService) CreateManagedNamespace(ctx context.Context, g
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) CreateManagedNamespaceExecute(r GlobalClustersApiCreateManagedNamespaceRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -396,7 +396,7 @@ func (a *GlobalClustersApiService) CreateManagedNamespaceExecute(r GlobalCluster
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type GlobalClustersApiDeleteAllCustomZoneMappingsRequest struct {
+type DeleteAllCustomZoneMappingsApiRequest struct {
 	ctx context.Context
 	ApiService GlobalClustersApi
 	groupId string
@@ -408,7 +408,7 @@ type DeleteAllCustomZoneMappingsParams struct {
 		ClusterName string
 }
 
-func (r GlobalClustersApiDeleteAllCustomZoneMappingsRequest) Execute() (*GeoSharding, *http.Response, error) {
+func (r DeleteAllCustomZoneMappingsApiRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.DeleteAllCustomZoneMappingsExecute(r)
 }
 
@@ -420,10 +420,10 @@ Removes all custom zone mappings for the specified global cluster. A custom zone
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies this advanced cluster.
- @return GlobalClustersApiDeleteAllCustomZoneMappingsRequest
+ @return DeleteAllCustomZoneMappingsApiRequest
 */
-func (a *GlobalClustersApiService) DeleteAllCustomZoneMappings(ctx context.Context, groupId string, clusterName string) GlobalClustersApiDeleteAllCustomZoneMappingsRequest {
-	return GlobalClustersApiDeleteAllCustomZoneMappingsRequest{
+func (a *GlobalClustersApiService) DeleteAllCustomZoneMappings(ctx context.Context, groupId string, clusterName string) DeleteAllCustomZoneMappingsApiRequest {
+	return DeleteAllCustomZoneMappingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -433,7 +433,7 @@ func (a *GlobalClustersApiService) DeleteAllCustomZoneMappings(ctx context.Conte
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsExecute(r GlobalClustersApiDeleteAllCustomZoneMappingsRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -528,7 +528,7 @@ func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsExecute(r GlobalCl
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type GlobalClustersApiDeleteManagedNamespaceRequest struct {
+type DeleteManagedNamespaceApiRequest struct {
 	ctx context.Context
 	ApiService GlobalClustersApi
 	clusterName string
@@ -545,18 +545,18 @@ type DeleteManagedNamespaceParams struct {
 }
 
 // Human-readable label that identifies the database that contains the collection.
-func (r GlobalClustersApiDeleteManagedNamespaceRequest) Db(db string) GlobalClustersApiDeleteManagedNamespaceRequest {
+func (r DeleteManagedNamespaceApiRequest) Db(db string) DeleteManagedNamespaceApiRequest {
 	r.db = &db
 	return r
 }
 
 // Human-readable label that identifies the collection associated with the managed namespace.
-func (r GlobalClustersApiDeleteManagedNamespaceRequest) Collection(collection string) GlobalClustersApiDeleteManagedNamespaceRequest {
+func (r DeleteManagedNamespaceApiRequest) Collection(collection string) DeleteManagedNamespaceApiRequest {
 	r.collection = &collection
 	return r
 }
 
-func (r GlobalClustersApiDeleteManagedNamespaceRequest) Execute() (*GeoSharding, *http.Response, error) {
+func (r DeleteManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.DeleteManagedNamespaceExecute(r)
 }
 
@@ -568,10 +568,10 @@ Removes one managed namespace within the specified global cluster. A managed nam
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param clusterName Human-readable label that identifies this advanced cluster.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return GlobalClustersApiDeleteManagedNamespaceRequest
+ @return DeleteManagedNamespaceApiRequest
 */
-func (a *GlobalClustersApiService) DeleteManagedNamespace(ctx context.Context, clusterName string, groupId string) GlobalClustersApiDeleteManagedNamespaceRequest {
-	return GlobalClustersApiDeleteManagedNamespaceRequest{
+func (a *GlobalClustersApiService) DeleteManagedNamespace(ctx context.Context, clusterName string, groupId string) DeleteManagedNamespaceApiRequest {
+	return DeleteManagedNamespaceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		clusterName: clusterName,
@@ -581,7 +581,7 @@ func (a *GlobalClustersApiService) DeleteManagedNamespace(ctx context.Context, c
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) DeleteManagedNamespaceExecute(r GlobalClustersApiDeleteManagedNamespaceRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -682,7 +682,7 @@ func (a *GlobalClustersApiService) DeleteManagedNamespaceExecute(r GlobalCluster
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type GlobalClustersApiGetManagedNamespaceRequest struct {
+type GetManagedNamespaceApiRequest struct {
 	ctx context.Context
 	ApiService GlobalClustersApi
 	groupId string
@@ -694,7 +694,7 @@ type GetManagedNamespaceParams struct {
 		ClusterName string
 }
 
-func (r GlobalClustersApiGetManagedNamespaceRequest) Execute() (*GeoSharding, *http.Response, error) {
+func (r GetManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.GetManagedNamespaceExecute(r)
 }
 
@@ -706,10 +706,10 @@ Returns one managed namespace within the specified global cluster. A managed nam
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies this advanced cluster.
- @return GlobalClustersApiGetManagedNamespaceRequest
+ @return GetManagedNamespaceApiRequest
 */
-func (a *GlobalClustersApiService) GetManagedNamespace(ctx context.Context, groupId string, clusterName string) GlobalClustersApiGetManagedNamespaceRequest {
-	return GlobalClustersApiGetManagedNamespaceRequest{
+func (a *GlobalClustersApiService) GetManagedNamespace(ctx context.Context, groupId string, clusterName string) GetManagedNamespaceApiRequest {
+	return GetManagedNamespaceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -719,7 +719,7 @@ func (a *GlobalClustersApiService) GetManagedNamespace(ctx context.Context, grou
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) GetManagedNamespaceExecute(r GlobalClustersApiGetManagedNamespaceRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -113,10 +113,11 @@ type GlobalClustersApiCreateCustomZoneMappingRequest struct {
 	clusterName string
 	geoSharding *GeoSharding
 }
+
 type GlobalClustersApiCreateCustomZoneMappingQueryParams struct {
-		groupId string
-		clusterName string
-		geoSharding *GeoSharding
+		GroupId string
+		ClusterName string
+		GeoSharding *GeoSharding
 }
 
 // Custom zone mapping to add to the specified global cluster.
@@ -257,10 +258,11 @@ type GlobalClustersApiCreateManagedNamespaceRequest struct {
 	clusterName string
 	managedNamespace *ManagedNamespace
 }
+
 type GlobalClustersApiCreateManagedNamespaceQueryParams struct {
-		groupId string
-		clusterName string
-		managedNamespace *ManagedNamespace
+		GroupId string
+		ClusterName string
+		ManagedNamespace *ManagedNamespace
 }
 
 // Managed namespace to create within the specified global cluster.
@@ -400,9 +402,10 @@ type GlobalClustersApiDeleteAllCustomZoneMappingsRequest struct {
 	groupId string
 	clusterName string
 }
+
 type GlobalClustersApiDeleteAllCustomZoneMappingsQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r GlobalClustersApiDeleteAllCustomZoneMappingsRequest) Execute() (*GeoSharding, *http.Response, error) {
@@ -533,11 +536,12 @@ type GlobalClustersApiDeleteManagedNamespaceRequest struct {
 	db *string
 	collection *string
 }
+
 type GlobalClustersApiDeleteManagedNamespaceQueryParams struct {
-		clusterName string
-		groupId string
-		db *string
-		collection *string
+		ClusterName string
+		GroupId string
+		Db *string
+		Collection *string
 }
 
 // Human-readable label that identifies the database that contains the collection.
@@ -684,9 +688,10 @@ type GlobalClustersApiGetManagedNamespaceRequest struct {
 	groupId string
 	clusterName string
 }
+
 type GlobalClustersApiGetManagedNamespaceQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r GlobalClustersApiGetManagedNamespaceRequest) Execute() (*GeoSharding, *http.Response, error) {

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -30,12 +30,12 @@ type InvoicesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param invoiceId Unique 24-hexadecimal digit string that identifies the invoice submitted to the specified organization. Charges typically post the next day.
-	@return InvoicesApiDownloadInvoiceCSVRequest
+	@return DownloadInvoiceCSVApiRequest
 	*/
-	DownloadInvoiceCSV(ctx context.Context, orgId string, invoiceId string) InvoicesApiDownloadInvoiceCSVRequest
+	DownloadInvoiceCSV(ctx context.Context, orgId string, invoiceId string) DownloadInvoiceCSVApiRequest
 
 	// DownloadInvoiceCSVExecute executes the request
-	DownloadInvoiceCSVExecute(r InvoicesApiDownloadInvoiceCSVRequest) (*http.Response, error)
+	DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (*http.Response, error)
 
 	/*
 	GetInvoice Return One Organization Invoice
@@ -45,13 +45,13 @@ type InvoicesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param invoiceId Unique 24-hexadecimal digit string that identifies the invoice submitted to the specified organization. Charges typically post the next day.
-	@return InvoicesApiGetInvoiceRequest
+	@return GetInvoiceApiRequest
 	*/
-	GetInvoice(ctx context.Context, orgId string, invoiceId string) InvoicesApiGetInvoiceRequest
+	GetInvoice(ctx context.Context, orgId string, invoiceId string) GetInvoiceApiRequest
 
 	// GetInvoiceExecute executes the request
 	//  @return Invoice
-	GetInvoiceExecute(r InvoicesApiGetInvoiceRequest) (*Invoice, *http.Response, error)
+	GetInvoiceExecute(r GetInvoiceApiRequest) (*Invoice, *http.Response, error)
 
 	/*
 	ListInvoices Return All Invoices for One Organization
@@ -60,13 +60,13 @@ type InvoicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return InvoicesApiListInvoicesRequest
+	@return ListInvoicesApiRequest
 	*/
-	ListInvoices(ctx context.Context, orgId string) InvoicesApiListInvoicesRequest
+	ListInvoices(ctx context.Context, orgId string) ListInvoicesApiRequest
 
 	// ListInvoicesExecute executes the request
 	//  @return PaginatedApiInvoice
-	ListInvoicesExecute(r InvoicesApiListInvoicesRequest) (*PaginatedApiInvoice, *http.Response, error)
+	ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 
 	/*
 	ListPendingInvoices Return All Pending Invoices for One Organization
@@ -75,19 +75,19 @@ type InvoicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return InvoicesApiListPendingInvoicesRequest
+	@return ListPendingInvoicesApiRequest
 	*/
-	ListPendingInvoices(ctx context.Context, orgId string) InvoicesApiListPendingInvoicesRequest
+	ListPendingInvoices(ctx context.Context, orgId string) ListPendingInvoicesApiRequest
 
 	// ListPendingInvoicesExecute executes the request
 	//  @return PaginatedApiInvoice
-	ListPendingInvoicesExecute(r InvoicesApiListPendingInvoicesRequest) (*PaginatedApiInvoice, *http.Response, error)
+	ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 }
 
 // InvoicesApiService InvoicesApi service
 type InvoicesApiService service
 
-type InvoicesApiDownloadInvoiceCSVRequest struct {
+type DownloadInvoiceCSVApiRequest struct {
 	ctx context.Context
 	ApiService InvoicesApi
 	orgId string
@@ -99,7 +99,7 @@ type DownloadInvoiceCSVParams struct {
 		InvoiceId string
 }
 
-func (r InvoicesApiDownloadInvoiceCSVRequest) Execute() (*http.Response, error) {
+func (r DownloadInvoiceCSVApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DownloadInvoiceCSVExecute(r)
 }
 
@@ -111,10 +111,10 @@ Returns one invoice that MongoDB issued to the specified organization in CSV for
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param invoiceId Unique 24-hexadecimal digit string that identifies the invoice submitted to the specified organization. Charges typically post the next day.
- @return InvoicesApiDownloadInvoiceCSVRequest
+ @return DownloadInvoiceCSVApiRequest
 */
-func (a *InvoicesApiService) DownloadInvoiceCSV(ctx context.Context, orgId string, invoiceId string) InvoicesApiDownloadInvoiceCSVRequest {
-	return InvoicesApiDownloadInvoiceCSVRequest{
+func (a *InvoicesApiService) DownloadInvoiceCSV(ctx context.Context, orgId string, invoiceId string) DownloadInvoiceCSVApiRequest {
+	return DownloadInvoiceCSVApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -123,7 +123,7 @@ func (a *InvoicesApiService) DownloadInvoiceCSV(ctx context.Context, orgId strin
 }
 
 // Execute executes the request
-func (a *InvoicesApiService) DownloadInvoiceCSVExecute(r InvoicesApiDownloadInvoiceCSVRequest) (*http.Response, error) {
+func (a *InvoicesApiService) DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -202,7 +202,7 @@ func (a *InvoicesApiService) DownloadInvoiceCSVExecute(r InvoicesApiDownloadInvo
 	return localVarHTTPResponse, nil
 }
 
-type InvoicesApiGetInvoiceRequest struct {
+type GetInvoiceApiRequest struct {
 	ctx context.Context
 	ApiService InvoicesApi
 	orgId string
@@ -214,7 +214,7 @@ type GetInvoiceParams struct {
 		InvoiceId string
 }
 
-func (r InvoicesApiGetInvoiceRequest) Execute() (*Invoice, *http.Response, error) {
+func (r GetInvoiceApiRequest) Execute() (*Invoice, *http.Response, error) {
 	return r.ApiService.GetInvoiceExecute(r)
 }
 
@@ -226,10 +226,10 @@ Returns one invoice that MongoDB issued to the specified organization. A unique 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param invoiceId Unique 24-hexadecimal digit string that identifies the invoice submitted to the specified organization. Charges typically post the next day.
- @return InvoicesApiGetInvoiceRequest
+ @return GetInvoiceApiRequest
 */
-func (a *InvoicesApiService) GetInvoice(ctx context.Context, orgId string, invoiceId string) InvoicesApiGetInvoiceRequest {
-	return InvoicesApiGetInvoiceRequest{
+func (a *InvoicesApiService) GetInvoice(ctx context.Context, orgId string, invoiceId string) GetInvoiceApiRequest {
+	return GetInvoiceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -239,7 +239,7 @@ func (a *InvoicesApiService) GetInvoice(ctx context.Context, orgId string, invoi
 
 // Execute executes the request
 //  @return Invoice
-func (a *InvoicesApiService) GetInvoiceExecute(r InvoicesApiGetInvoiceRequest) (*Invoice, *http.Response, error) {
+func (a *InvoicesApiService) GetInvoiceExecute(r GetInvoiceApiRequest) (*Invoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -334,7 +334,7 @@ func (a *InvoicesApiService) GetInvoiceExecute(r InvoicesApiGetInvoiceRequest) (
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type InvoicesApiListInvoicesRequest struct {
+type ListInvoicesApiRequest struct {
 	ctx context.Context
 	ApiService InvoicesApi
 	orgId string
@@ -351,24 +351,24 @@ type ListInvoicesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r InvoicesApiListInvoicesRequest) IncludeCount(includeCount bool) InvoicesApiListInvoicesRequest {
+func (r ListInvoicesApiRequest) IncludeCount(includeCount bool) ListInvoicesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r InvoicesApiListInvoicesRequest) ItemsPerPage(itemsPerPage int32) InvoicesApiListInvoicesRequest {
+func (r ListInvoicesApiRequest) ItemsPerPage(itemsPerPage int32) ListInvoicesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r InvoicesApiListInvoicesRequest) PageNum(pageNum int32) InvoicesApiListInvoicesRequest {
+func (r ListInvoicesApiRequest) PageNum(pageNum int32) ListInvoicesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r InvoicesApiListInvoicesRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
+func (r ListInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
 	return r.ApiService.ListInvoicesExecute(r)
 }
 
@@ -379,10 +379,10 @@ Returns all invoices that MongoDB issued to the specified organization. This lis
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return InvoicesApiListInvoicesRequest
+ @return ListInvoicesApiRequest
 */
-func (a *InvoicesApiService) ListInvoices(ctx context.Context, orgId string) InvoicesApiListInvoicesRequest {
-	return InvoicesApiListInvoicesRequest{
+func (a *InvoicesApiService) ListInvoices(ctx context.Context, orgId string) ListInvoicesApiRequest {
+	return ListInvoicesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -391,7 +391,7 @@ func (a *InvoicesApiService) ListInvoices(ctx context.Context, orgId string) Inv
 
 // Execute executes the request
 //  @return PaginatedApiInvoice
-func (a *InvoicesApiService) ListInvoicesExecute(r InvoicesApiListInvoicesRequest) (*PaginatedApiInvoice, *http.Response, error) {
+func (a *InvoicesApiService) ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -500,7 +500,7 @@ func (a *InvoicesApiService) ListInvoicesExecute(r InvoicesApiListInvoicesReques
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type InvoicesApiListPendingInvoicesRequest struct {
+type ListPendingInvoicesApiRequest struct {
 	ctx context.Context
 	ApiService InvoicesApi
 	orgId string
@@ -510,7 +510,7 @@ type ListPendingInvoicesParams struct {
 		OrgId string
 }
 
-func (r InvoicesApiListPendingInvoicesRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
+func (r ListPendingInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
 	return r.ApiService.ListPendingInvoicesExecute(r)
 }
 
@@ -521,10 +521,10 @@ Returns all invoices accruing charges for the current billing cycle for the spec
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return InvoicesApiListPendingInvoicesRequest
+ @return ListPendingInvoicesApiRequest
 */
-func (a *InvoicesApiService) ListPendingInvoices(ctx context.Context, orgId string) InvoicesApiListPendingInvoicesRequest {
-	return InvoicesApiListPendingInvoicesRequest{
+func (a *InvoicesApiService) ListPendingInvoices(ctx context.Context, orgId string) ListPendingInvoicesApiRequest {
+	return ListPendingInvoicesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -533,7 +533,7 @@ func (a *InvoicesApiService) ListPendingInvoices(ctx context.Context, orgId stri
 
 // Execute executes the request
 //  @return PaginatedApiInvoice
-func (a *InvoicesApiService) ListPendingInvoicesExecute(r InvoicesApiListPendingInvoicesRequest) (*PaginatedApiInvoice, *http.Response, error) {
+func (a *InvoicesApiService) ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -94,7 +94,7 @@ type InvoicesApiDownloadInvoiceCSVRequest struct {
 	invoiceId string
 }
 
-type InvoicesApiDownloadInvoiceCSVParams struct {
+type DownloadInvoiceCSVParams struct {
 		OrgId string
 		InvoiceId string
 }
@@ -209,7 +209,7 @@ type InvoicesApiGetInvoiceRequest struct {
 	invoiceId string
 }
 
-type InvoicesApiGetInvoiceParams struct {
+type GetInvoiceParams struct {
 		OrgId string
 		InvoiceId string
 }
@@ -343,7 +343,7 @@ type InvoicesApiListInvoicesRequest struct {
 	pageNum *int32
 }
 
-type InvoicesApiListInvoicesParams struct {
+type ListInvoicesParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -506,7 +506,7 @@ type InvoicesApiListPendingInvoicesRequest struct {
 	orgId string
 }
 
-type InvoicesApiListPendingInvoicesParams struct {
+type ListPendingInvoicesParams struct {
 		OrgId string
 }
 

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -94,7 +94,7 @@ type DownloadInvoiceCSVApiRequest struct {
 	invoiceId string
 }
 
-type DownloadInvoiceCSVParams struct {
+type DownloadInvoiceCSVApiParams struct {
 		OrgId string
 		InvoiceId string
 }
@@ -209,7 +209,7 @@ type GetInvoiceApiRequest struct {
 	invoiceId string
 }
 
-type GetInvoiceParams struct {
+type GetInvoiceApiParams struct {
 		OrgId string
 		InvoiceId string
 }
@@ -343,7 +343,7 @@ type ListInvoicesApiRequest struct {
 	pageNum *int32
 }
 
-type ListInvoicesParams struct {
+type ListInvoicesApiParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -506,7 +506,7 @@ type ListPendingInvoicesApiRequest struct {
 	orgId string
 }
 
-type ListPendingInvoicesParams struct {
+type ListPendingInvoicesApiParams struct {
 		OrgId string
 }
 

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -93,9 +93,10 @@ type InvoicesApiDownloadInvoiceCSVRequest struct {
 	orgId string
 	invoiceId string
 }
+
 type InvoicesApiDownloadInvoiceCSVQueryParams struct {
-		orgId string
-		invoiceId string
+		OrgId string
+		InvoiceId string
 }
 
 func (r InvoicesApiDownloadInvoiceCSVRequest) Execute() (*http.Response, error) {
@@ -207,9 +208,10 @@ type InvoicesApiGetInvoiceRequest struct {
 	orgId string
 	invoiceId string
 }
+
 type InvoicesApiGetInvoiceQueryParams struct {
-		orgId string
-		invoiceId string
+		OrgId string
+		InvoiceId string
 }
 
 func (r InvoicesApiGetInvoiceRequest) Execute() (*Invoice, *http.Response, error) {
@@ -340,11 +342,12 @@ type InvoicesApiListInvoicesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type InvoicesApiListInvoicesQueryParams struct {
-		orgId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		OrgId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -502,8 +505,9 @@ type InvoicesApiListPendingInvoicesRequest struct {
 	ApiService InvoicesApi
 	orgId string
 }
+
 type InvoicesApiListPendingInvoicesQueryParams struct {
-		orgId string
+		OrgId string
 }
 
 func (r InvoicesApiListPendingInvoicesRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -94,7 +94,7 @@ type InvoicesApiDownloadInvoiceCSVRequest struct {
 	invoiceId string
 }
 
-type InvoicesApiDownloadInvoiceCSVQueryParams struct {
+type InvoicesApiDownloadInvoiceCSVParams struct {
 		OrgId string
 		InvoiceId string
 }
@@ -209,7 +209,7 @@ type InvoicesApiGetInvoiceRequest struct {
 	invoiceId string
 }
 
-type InvoicesApiGetInvoiceQueryParams struct {
+type InvoicesApiGetInvoiceParams struct {
 		OrgId string
 		InvoiceId string
 }
@@ -343,7 +343,7 @@ type InvoicesApiListInvoicesRequest struct {
 	pageNum *int32
 }
 
-type InvoicesApiListInvoicesQueryParams struct {
+type InvoicesApiListInvoicesParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -506,7 +506,7 @@ type InvoicesApiListPendingInvoicesRequest struct {
 	orgId string
 }
 
-type InvoicesApiListPendingInvoicesQueryParams struct {
+type InvoicesApiListPendingInvoicesParams struct {
 		OrgId string
 }
 

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -93,6 +93,10 @@ type InvoicesApiDownloadInvoiceCSVRequest struct {
 	orgId string
 	invoiceId string
 }
+type InvoicesApiDownloadInvoiceCSVQueryParams struct {
+		orgId string
+		invoiceId string
+}
 
 func (r InvoicesApiDownloadInvoiceCSVRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DownloadInvoiceCSVExecute(r)
@@ -202,6 +206,10 @@ type InvoicesApiGetInvoiceRequest struct {
 	ApiService InvoicesApi
 	orgId string
 	invoiceId string
+}
+type InvoicesApiGetInvoiceQueryParams struct {
+		orgId string
+		invoiceId string
 }
 
 func (r InvoicesApiGetInvoiceRequest) Execute() (*Invoice, *http.Response, error) {
@@ -331,6 +339,12 @@ type InvoicesApiListInvoicesRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type InvoicesApiListInvoicesQueryParams struct {
+		orgId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -487,6 +501,9 @@ type InvoicesApiListPendingInvoicesRequest struct {
 	ctx context.Context
 	ApiService InvoicesApi
 	orgId string
+}
+type InvoicesApiListPendingInvoicesQueryParams struct {
+		orgId string
 }
 
 func (r InvoicesApiListPendingInvoicesRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -29,12 +29,12 @@ type LDAPConfigurationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return LDAPConfigurationApiDeleteLDAPConfigurationRequest
+	@return DeleteLDAPConfigurationApiRequest
 	*/
-	DeleteLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiDeleteLDAPConfigurationRequest
+	DeleteLDAPConfiguration(ctx context.Context, groupId string) DeleteLDAPConfigurationApiRequest
 
 	// DeleteLDAPConfigurationExecute executes the request
-	DeleteLDAPConfigurationExecute(r LDAPConfigurationApiDeleteLDAPConfigurationRequest) (*http.Response, error)
+	DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*http.Response, error)
 
 	/*
 	GetLDAPConfiguration Return the Current LDAP or X.509 Configuration
@@ -43,13 +43,13 @@ type LDAPConfigurationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return LDAPConfigurationApiGetLDAPConfigurationRequest
+	@return GetLDAPConfigurationApiRequest
 	*/
-	GetLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiGetLDAPConfigurationRequest
+	GetLDAPConfiguration(ctx context.Context, groupId string) GetLDAPConfigurationApiRequest
 
 	// GetLDAPConfigurationExecute executes the request
 	//  @return UserSecurity
-	GetLDAPConfigurationExecute(r LDAPConfigurationApiGetLDAPConfigurationRequest) (*UserSecurity, *http.Response, error)
+	GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 	GetLDAPConfigurationStatus Return the Status of One Verify LDAP Configuration Request
@@ -59,13 +59,13 @@ type LDAPConfigurationApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param requestId Unique string that identifies the request to verify an <abbr title=\"Lightweight Directory Access Protocol\">LDAP</abbr> configuration.
-	@return LDAPConfigurationApiGetLDAPConfigurationStatusRequest
+	@return GetLDAPConfigurationStatusApiRequest
 	*/
-	GetLDAPConfigurationStatus(ctx context.Context, groupId string, requestId string) LDAPConfigurationApiGetLDAPConfigurationStatusRequest
+	GetLDAPConfigurationStatus(ctx context.Context, groupId string, requestId string) GetLDAPConfigurationStatusApiRequest
 
 	// GetLDAPConfigurationStatusExecute executes the request
 	//  @return NDSLDAPVerifyConnectivityJobRequest
-	GetLDAPConfigurationStatusExecute(r LDAPConfigurationApiGetLDAPConfigurationStatusRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
+	GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
 
 	/*
 	SaveLDAPConfiguration Edit the LDAP or X.509 Configuration
@@ -76,13 +76,13 @@ Updating this configuration triggers a rolling restart of the database.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return LDAPConfigurationApiSaveLDAPConfigurationRequest
+	@return SaveLDAPConfigurationApiRequest
 	*/
-	SaveLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiSaveLDAPConfigurationRequest
+	SaveLDAPConfiguration(ctx context.Context, groupId string) SaveLDAPConfigurationApiRequest
 
 	// SaveLDAPConfigurationExecute executes the request
 	//  @return UserSecurity
-	SaveLDAPConfigurationExecute(r LDAPConfigurationApiSaveLDAPConfigurationRequest) (*UserSecurity, *http.Response, error)
+	SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 	VerifyLDAPConfiguration Verify the LDAP Configuration in One Project
@@ -91,19 +91,19 @@ Updating this configuration triggers a rolling restart of the database.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return LDAPConfigurationApiVerifyLDAPConfigurationRequest
+	@return VerifyLDAPConfigurationApiRequest
 	*/
-	VerifyLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiVerifyLDAPConfigurationRequest
+	VerifyLDAPConfiguration(ctx context.Context, groupId string) VerifyLDAPConfigurationApiRequest
 
 	// VerifyLDAPConfigurationExecute executes the request
 	//  @return NDSLDAPVerifyConnectivityJobRequest
-	VerifyLDAPConfigurationExecute(r LDAPConfigurationApiVerifyLDAPConfigurationRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
+	VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
 }
 
 // LDAPConfigurationApiService LDAPConfigurationApi service
 type LDAPConfigurationApiService service
 
-type LDAPConfigurationApiDeleteLDAPConfigurationRequest struct {
+type DeleteLDAPConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService LDAPConfigurationApi
 	groupId string
@@ -113,7 +113,7 @@ type DeleteLDAPConfigurationParams struct {
 		GroupId string
 }
 
-func (r LDAPConfigurationApiDeleteLDAPConfigurationRequest) Execute() (*http.Response, error) {
+func (r DeleteLDAPConfigurationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLDAPConfigurationExecute(r)
 }
 
@@ -124,10 +124,10 @@ Removes the current LDAP Distinguished Name mapping captured in the ``userToDNMa
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return LDAPConfigurationApiDeleteLDAPConfigurationRequest
+ @return DeleteLDAPConfigurationApiRequest
 */
-func (a *LDAPConfigurationApiService) DeleteLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiDeleteLDAPConfigurationRequest {
-	return LDAPConfigurationApiDeleteLDAPConfigurationRequest{
+func (a *LDAPConfigurationApiService) DeleteLDAPConfiguration(ctx context.Context, groupId string) DeleteLDAPConfigurationApiRequest {
+	return DeleteLDAPConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -135,7 +135,7 @@ func (a *LDAPConfigurationApiService) DeleteLDAPConfiguration(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationExecute(r LDAPConfigurationApiDeleteLDAPConfigurationRequest) (*http.Response, error) {
+func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -213,7 +213,7 @@ func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationExecute(r LDAPConfi
 	return localVarHTTPResponse, nil
 }
 
-type LDAPConfigurationApiGetLDAPConfigurationRequest struct {
+type GetLDAPConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService LDAPConfigurationApi
 	groupId string
@@ -223,7 +223,7 @@ type GetLDAPConfigurationParams struct {
 		GroupId string
 }
 
-func (r LDAPConfigurationApiGetLDAPConfigurationRequest) Execute() (*UserSecurity, *http.Response, error) {
+func (r GetLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
 	return r.ApiService.GetLDAPConfigurationExecute(r)
 }
 
@@ -234,10 +234,10 @@ Returns the current LDAP configuration for the specified project. To use this re
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return LDAPConfigurationApiGetLDAPConfigurationRequest
+ @return GetLDAPConfigurationApiRequest
 */
-func (a *LDAPConfigurationApiService) GetLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiGetLDAPConfigurationRequest {
-	return LDAPConfigurationApiGetLDAPConfigurationRequest{
+func (a *LDAPConfigurationApiService) GetLDAPConfiguration(ctx context.Context, groupId string) GetLDAPConfigurationApiRequest {
+	return GetLDAPConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -246,7 +246,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfiguration(ctx context.Context, 
 
 // Execute executes the request
 //  @return UserSecurity
-func (a *LDAPConfigurationApiService) GetLDAPConfigurationExecute(r LDAPConfigurationApiGetLDAPConfigurationRequest) (*UserSecurity, *http.Response, error) {
+func (a *LDAPConfigurationApiService) GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -334,7 +334,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationExecute(r LDAPConfigur
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LDAPConfigurationApiGetLDAPConfigurationStatusRequest struct {
+type GetLDAPConfigurationStatusApiRequest struct {
 	ctx context.Context
 	ApiService LDAPConfigurationApi
 	groupId string
@@ -346,7 +346,7 @@ type GetLDAPConfigurationStatusParams struct {
 		RequestId string
 }
 
-func (r LDAPConfigurationApiGetLDAPConfigurationStatusRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (r GetLDAPConfigurationStatusApiRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	return r.ApiService.GetLDAPConfigurationStatusExecute(r)
 }
 
@@ -358,10 +358,10 @@ Returns the status of one request to verify one LDAP configuration for the speci
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param requestId Unique string that identifies the request to verify an <abbr title=\"Lightweight Directory Access Protocol\">LDAP</abbr> configuration.
- @return LDAPConfigurationApiGetLDAPConfigurationStatusRequest
+ @return GetLDAPConfigurationStatusApiRequest
 */
-func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatus(ctx context.Context, groupId string, requestId string) LDAPConfigurationApiGetLDAPConfigurationStatusRequest {
-	return LDAPConfigurationApiGetLDAPConfigurationStatusRequest{
+func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatus(ctx context.Context, groupId string, requestId string) GetLDAPConfigurationStatusApiRequest {
+	return GetLDAPConfigurationStatusApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -371,7 +371,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatus(ctx context.Con
 
 // Execute executes the request
 //  @return NDSLDAPVerifyConnectivityJobRequest
-func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusExecute(r LDAPConfigurationApiGetLDAPConfigurationStatusRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -466,7 +466,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusExecute(r LDAPCo
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LDAPConfigurationApiSaveLDAPConfigurationRequest struct {
+type SaveLDAPConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService LDAPConfigurationApi
 	groupId string
@@ -479,12 +479,12 @@ type SaveLDAPConfigurationParams struct {
 }
 
 // Updates the LDAP configuration for the specified project.
-func (r LDAPConfigurationApiSaveLDAPConfigurationRequest) UserSecurity(userSecurity UserSecurity) LDAPConfigurationApiSaveLDAPConfigurationRequest {
+func (r SaveLDAPConfigurationApiRequest) UserSecurity(userSecurity UserSecurity) SaveLDAPConfigurationApiRequest {
 	r.userSecurity = &userSecurity
 	return r
 }
 
-func (r LDAPConfigurationApiSaveLDAPConfigurationRequest) Execute() (*UserSecurity, *http.Response, error) {
+func (r SaveLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
 	return r.ApiService.SaveLDAPConfigurationExecute(r)
 }
 
@@ -497,10 +497,10 @@ Updating this configuration triggers a rolling restart of the database.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return LDAPConfigurationApiSaveLDAPConfigurationRequest
+ @return SaveLDAPConfigurationApiRequest
 */
-func (a *LDAPConfigurationApiService) SaveLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiSaveLDAPConfigurationRequest {
-	return LDAPConfigurationApiSaveLDAPConfigurationRequest{
+func (a *LDAPConfigurationApiService) SaveLDAPConfiguration(ctx context.Context, groupId string) SaveLDAPConfigurationApiRequest {
+	return SaveLDAPConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -509,7 +509,7 @@ func (a *LDAPConfigurationApiService) SaveLDAPConfiguration(ctx context.Context,
 
 // Execute executes the request
 //  @return UserSecurity
-func (a *LDAPConfigurationApiService) SaveLDAPConfigurationExecute(r LDAPConfigurationApiSaveLDAPConfigurationRequest) (*UserSecurity, *http.Response, error) {
+func (a *LDAPConfigurationApiService) SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -602,7 +602,7 @@ func (a *LDAPConfigurationApiService) SaveLDAPConfigurationExecute(r LDAPConfigu
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LDAPConfigurationApiVerifyLDAPConfigurationRequest struct {
+type VerifyLDAPConfigurationApiRequest struct {
 	ctx context.Context
 	ApiService LDAPConfigurationApi
 	groupId string
@@ -615,12 +615,12 @@ type VerifyLDAPConfigurationParams struct {
 }
 
 // The LDAP configuration for the specified project that you want to verify.
-func (r LDAPConfigurationApiVerifyLDAPConfigurationRequest) NDSLDAPVerifyConnectivityJobRequestParams(nDSLDAPVerifyConnectivityJobRequestParams NDSLDAPVerifyConnectivityJobRequestParams) LDAPConfigurationApiVerifyLDAPConfigurationRequest {
+func (r VerifyLDAPConfigurationApiRequest) NDSLDAPVerifyConnectivityJobRequestParams(nDSLDAPVerifyConnectivityJobRequestParams NDSLDAPVerifyConnectivityJobRequestParams) VerifyLDAPConfigurationApiRequest {
 	r.nDSLDAPVerifyConnectivityJobRequestParams = &nDSLDAPVerifyConnectivityJobRequestParams
 	return r
 }
 
-func (r LDAPConfigurationApiVerifyLDAPConfigurationRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (r VerifyLDAPConfigurationApiRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	return r.ApiService.VerifyLDAPConfigurationExecute(r)
 }
 
@@ -631,10 +631,10 @@ Verifies the LDAP configuration for the specified project. To use this resource,
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return LDAPConfigurationApiVerifyLDAPConfigurationRequest
+ @return VerifyLDAPConfigurationApiRequest
 */
-func (a *LDAPConfigurationApiService) VerifyLDAPConfiguration(ctx context.Context, groupId string) LDAPConfigurationApiVerifyLDAPConfigurationRequest {
-	return LDAPConfigurationApiVerifyLDAPConfigurationRequest{
+func (a *LDAPConfigurationApiService) VerifyLDAPConfiguration(ctx context.Context, groupId string) VerifyLDAPConfigurationApiRequest {
+	return VerifyLDAPConfigurationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -643,7 +643,7 @@ func (a *LDAPConfigurationApiService) VerifyLDAPConfiguration(ctx context.Contex
 
 // Execute executes the request
 //  @return NDSLDAPVerifyConnectivityJobRequest
-func (a *LDAPConfigurationApiService) VerifyLDAPConfigurationExecute(r LDAPConfigurationApiVerifyLDAPConfigurationRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (a *LDAPConfigurationApiService) VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -108,8 +108,9 @@ type LDAPConfigurationApiDeleteLDAPConfigurationRequest struct {
 	ApiService LDAPConfigurationApi
 	groupId string
 }
+
 type LDAPConfigurationApiDeleteLDAPConfigurationQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r LDAPConfigurationApiDeleteLDAPConfigurationRequest) Execute() (*http.Response, error) {
@@ -217,8 +218,9 @@ type LDAPConfigurationApiGetLDAPConfigurationRequest struct {
 	ApiService LDAPConfigurationApi
 	groupId string
 }
+
 type LDAPConfigurationApiGetLDAPConfigurationQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r LDAPConfigurationApiGetLDAPConfigurationRequest) Execute() (*UserSecurity, *http.Response, error) {
@@ -338,9 +340,10 @@ type LDAPConfigurationApiGetLDAPConfigurationStatusRequest struct {
 	groupId string
 	requestId string
 }
+
 type LDAPConfigurationApiGetLDAPConfigurationStatusQueryParams struct {
-		groupId string
-		requestId string
+		GroupId string
+		RequestId string
 }
 
 func (r LDAPConfigurationApiGetLDAPConfigurationStatusRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
@@ -469,9 +472,10 @@ type LDAPConfigurationApiSaveLDAPConfigurationRequest struct {
 	groupId string
 	userSecurity *UserSecurity
 }
+
 type LDAPConfigurationApiSaveLDAPConfigurationQueryParams struct {
-		groupId string
-		userSecurity *UserSecurity
+		GroupId string
+		UserSecurity *UserSecurity
 }
 
 // Updates the LDAP configuration for the specified project.
@@ -604,9 +608,10 @@ type LDAPConfigurationApiVerifyLDAPConfigurationRequest struct {
 	groupId string
 	nDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }
+
 type LDAPConfigurationApiVerifyLDAPConfigurationQueryParams struct {
-		groupId string
-		nDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
+		GroupId string
+		NDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }
 
 // The LDAP configuration for the specified project that you want to verify.

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -108,6 +108,9 @@ type LDAPConfigurationApiDeleteLDAPConfigurationRequest struct {
 	ApiService LDAPConfigurationApi
 	groupId string
 }
+type LDAPConfigurationApiDeleteLDAPConfigurationQueryParams struct {
+		groupId string
+}
 
 func (r LDAPConfigurationApiDeleteLDAPConfigurationRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLDAPConfigurationExecute(r)
@@ -213,6 +216,9 @@ type LDAPConfigurationApiGetLDAPConfigurationRequest struct {
 	ctx context.Context
 	ApiService LDAPConfigurationApi
 	groupId string
+}
+type LDAPConfigurationApiGetLDAPConfigurationQueryParams struct {
+		groupId string
 }
 
 func (r LDAPConfigurationApiGetLDAPConfigurationRequest) Execute() (*UserSecurity, *http.Response, error) {
@@ -331,6 +337,10 @@ type LDAPConfigurationApiGetLDAPConfigurationStatusRequest struct {
 	ApiService LDAPConfigurationApi
 	groupId string
 	requestId string
+}
+type LDAPConfigurationApiGetLDAPConfigurationStatusQueryParams struct {
+		groupId string
+		requestId string
 }
 
 func (r LDAPConfigurationApiGetLDAPConfigurationStatusRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
@@ -458,6 +468,10 @@ type LDAPConfigurationApiSaveLDAPConfigurationRequest struct {
 	ApiService LDAPConfigurationApi
 	groupId string
 	userSecurity *UserSecurity
+}
+type LDAPConfigurationApiSaveLDAPConfigurationQueryParams struct {
+		groupId string
+		userSecurity *UserSecurity
 }
 
 // Updates the LDAP configuration for the specified project.
@@ -589,6 +603,10 @@ type LDAPConfigurationApiVerifyLDAPConfigurationRequest struct {
 	ApiService LDAPConfigurationApi
 	groupId string
 	nDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
+}
+type LDAPConfigurationApiVerifyLDAPConfigurationQueryParams struct {
+		groupId string
+		nDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }
 
 // The LDAP configuration for the specified project that you want to verify.

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -109,7 +109,7 @@ type DeleteLDAPConfigurationApiRequest struct {
 	groupId string
 }
 
-type DeleteLDAPConfigurationParams struct {
+type DeleteLDAPConfigurationApiParams struct {
 		GroupId string
 }
 
@@ -219,7 +219,7 @@ type GetLDAPConfigurationApiRequest struct {
 	groupId string
 }
 
-type GetLDAPConfigurationParams struct {
+type GetLDAPConfigurationApiParams struct {
 		GroupId string
 }
 
@@ -341,7 +341,7 @@ type GetLDAPConfigurationStatusApiRequest struct {
 	requestId string
 }
 
-type GetLDAPConfigurationStatusParams struct {
+type GetLDAPConfigurationStatusApiParams struct {
 		GroupId string
 		RequestId string
 }
@@ -473,7 +473,7 @@ type SaveLDAPConfigurationApiRequest struct {
 	userSecurity *UserSecurity
 }
 
-type SaveLDAPConfigurationParams struct {
+type SaveLDAPConfigurationApiParams struct {
 		GroupId string
 		UserSecurity *UserSecurity
 }
@@ -609,7 +609,7 @@ type VerifyLDAPConfigurationApiRequest struct {
 	nDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }
 
-type VerifyLDAPConfigurationParams struct {
+type VerifyLDAPConfigurationApiParams struct {
 		GroupId string
 		NDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -109,7 +109,7 @@ type LDAPConfigurationApiDeleteLDAPConfigurationRequest struct {
 	groupId string
 }
 
-type LDAPConfigurationApiDeleteLDAPConfigurationParams struct {
+type DeleteLDAPConfigurationParams struct {
 		GroupId string
 }
 
@@ -219,7 +219,7 @@ type LDAPConfigurationApiGetLDAPConfigurationRequest struct {
 	groupId string
 }
 
-type LDAPConfigurationApiGetLDAPConfigurationParams struct {
+type GetLDAPConfigurationParams struct {
 		GroupId string
 }
 
@@ -341,7 +341,7 @@ type LDAPConfigurationApiGetLDAPConfigurationStatusRequest struct {
 	requestId string
 }
 
-type LDAPConfigurationApiGetLDAPConfigurationStatusParams struct {
+type GetLDAPConfigurationStatusParams struct {
 		GroupId string
 		RequestId string
 }
@@ -473,7 +473,7 @@ type LDAPConfigurationApiSaveLDAPConfigurationRequest struct {
 	userSecurity *UserSecurity
 }
 
-type LDAPConfigurationApiSaveLDAPConfigurationParams struct {
+type SaveLDAPConfigurationParams struct {
 		GroupId string
 		UserSecurity *UserSecurity
 }
@@ -609,7 +609,7 @@ type LDAPConfigurationApiVerifyLDAPConfigurationRequest struct {
 	nDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }
 
-type LDAPConfigurationApiVerifyLDAPConfigurationParams struct {
+type VerifyLDAPConfigurationParams struct {
 		GroupId string
 		NDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -109,7 +109,7 @@ type LDAPConfigurationApiDeleteLDAPConfigurationRequest struct {
 	groupId string
 }
 
-type LDAPConfigurationApiDeleteLDAPConfigurationQueryParams struct {
+type LDAPConfigurationApiDeleteLDAPConfigurationParams struct {
 		GroupId string
 }
 
@@ -219,7 +219,7 @@ type LDAPConfigurationApiGetLDAPConfigurationRequest struct {
 	groupId string
 }
 
-type LDAPConfigurationApiGetLDAPConfigurationQueryParams struct {
+type LDAPConfigurationApiGetLDAPConfigurationParams struct {
 		GroupId string
 }
 
@@ -341,7 +341,7 @@ type LDAPConfigurationApiGetLDAPConfigurationStatusRequest struct {
 	requestId string
 }
 
-type LDAPConfigurationApiGetLDAPConfigurationStatusQueryParams struct {
+type LDAPConfigurationApiGetLDAPConfigurationStatusParams struct {
 		GroupId string
 		RequestId string
 }
@@ -473,7 +473,7 @@ type LDAPConfigurationApiSaveLDAPConfigurationRequest struct {
 	userSecurity *UserSecurity
 }
 
-type LDAPConfigurationApiSaveLDAPConfigurationQueryParams struct {
+type LDAPConfigurationApiSaveLDAPConfigurationParams struct {
 		GroupId string
 		UserSecurity *UserSecurity
 }
@@ -609,7 +609,7 @@ type LDAPConfigurationApiVerifyLDAPConfigurationRequest struct {
 	nDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }
 
-type LDAPConfigurationApiVerifyLDAPConfigurationQueryParams struct {
+type LDAPConfigurationApiVerifyLDAPConfigurationParams struct {
 		GroupId string
 		NDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -235,6 +235,11 @@ type LegacyBackupApiDeleteLegacySnapshotRequest struct {
 	clusterName string
 	snapshotId string
 }
+type LegacyBackupApiDeleteLegacySnapshotQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
+}
 
 func (r LegacyBackupApiDeleteLegacySnapshotRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLegacySnapshotExecute(r)
@@ -363,6 +368,11 @@ type LegacyBackupApiGetLegacyBackupCheckpointRequest struct {
 	groupId string
 	checkpointId string
 	clusterName string
+}
+type LegacyBackupApiGetLegacyBackupCheckpointQueryParams struct {
+		groupId string
+		checkpointId string
+		clusterName string
 }
 
 func (r LegacyBackupApiGetLegacyBackupCheckpointRequest) Execute() (*Checkpoint, *http.Response, error) {
@@ -503,6 +513,11 @@ type LegacyBackupApiGetLegacyBackupRestoreJobRequest struct {
 	groupId string
 	clusterName string
 	jobId string
+}
+type LegacyBackupApiGetLegacyBackupRestoreJobQueryParams struct {
+		groupId string
+		clusterName string
+		jobId string
 }
 
 func (r LegacyBackupApiGetLegacyBackupRestoreJobRequest) Execute() (*RestoreJob, *http.Response, error) {
@@ -646,6 +661,11 @@ type LegacyBackupApiGetLegacySnapshotRequest struct {
 	clusterName string
 	snapshotId string
 }
+type LegacyBackupApiGetLegacySnapshotQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
+}
 
 func (r LegacyBackupApiGetLegacySnapshotRequest) Execute() (*Snapshot, *http.Response, error) {
 	return r.ApiService.GetLegacySnapshotExecute(r)
@@ -785,6 +805,10 @@ type LegacyBackupApiGetLegacySnapshotScheduleRequest struct {
 	groupId string
 	clusterName string
 }
+type LegacyBackupApiGetLegacySnapshotScheduleQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r LegacyBackupApiGetLegacySnapshotScheduleRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
 	return r.ApiService.GetLegacySnapshotScheduleExecute(r)
@@ -919,6 +943,13 @@ type LegacyBackupApiListLegacyBackupCheckpointsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type LegacyBackupApiListLegacyBackupCheckpointsQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1092,6 +1123,14 @@ type LegacyBackupApiListLegacyBackupRestoreJobsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 	batchId *string
+}
+type LegacyBackupApiListLegacyBackupRestoreJobsQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		batchId *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1277,6 +1316,14 @@ type LegacyBackupApiListLegacySnapshotsRequest struct {
 	pageNum *int32
 	completed *string
 }
+type LegacyBackupApiListLegacySnapshotsQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		completed *string
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r LegacyBackupApiListLegacySnapshotsRequest) IncludeCount(includeCount bool) LegacyBackupApiListLegacySnapshotsRequest {
@@ -1461,6 +1508,12 @@ type LegacyBackupApiUpdateLegacySnapshotRetentionRequest struct {
 	snapshotId string
 	snapshot *Snapshot
 }
+type LegacyBackupApiUpdateLegacySnapshotRetentionQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
+		snapshot *Snapshot
+}
 
 // Changes One Legacy Backup Snapshot Expiration.
 func (r LegacyBackupApiUpdateLegacySnapshotRetentionRequest) Snapshot(snapshot Snapshot) LegacyBackupApiUpdateLegacySnapshotRetentionRequest {
@@ -1611,6 +1664,11 @@ type LegacyBackupApiUpdateLegacySnapshotScheduleRequest struct {
 	groupId string
 	clusterName string
 	snapshotSchedule *SnapshotSchedule
+}
+type LegacyBackupApiUpdateLegacySnapshotScheduleQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotSchedule *SnapshotSchedule
 }
 
 // Update the snapshot schedule for one cluster in the specified project.

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -235,10 +235,11 @@ type LegacyBackupApiDeleteLegacySnapshotRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type LegacyBackupApiDeleteLegacySnapshotQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r LegacyBackupApiDeleteLegacySnapshotRequest) Execute() (*http.Response, error) {
@@ -369,10 +370,11 @@ type LegacyBackupApiGetLegacyBackupCheckpointRequest struct {
 	checkpointId string
 	clusterName string
 }
+
 type LegacyBackupApiGetLegacyBackupCheckpointQueryParams struct {
-		groupId string
-		checkpointId string
-		clusterName string
+		GroupId string
+		CheckpointId string
+		ClusterName string
 }
 
 func (r LegacyBackupApiGetLegacyBackupCheckpointRequest) Execute() (*Checkpoint, *http.Response, error) {
@@ -514,10 +516,11 @@ type LegacyBackupApiGetLegacyBackupRestoreJobRequest struct {
 	clusterName string
 	jobId string
 }
+
 type LegacyBackupApiGetLegacyBackupRestoreJobQueryParams struct {
-		groupId string
-		clusterName string
-		jobId string
+		GroupId string
+		ClusterName string
+		JobId string
 }
 
 func (r LegacyBackupApiGetLegacyBackupRestoreJobRequest) Execute() (*RestoreJob, *http.Response, error) {
@@ -661,10 +664,11 @@ type LegacyBackupApiGetLegacySnapshotRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type LegacyBackupApiGetLegacySnapshotQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r LegacyBackupApiGetLegacySnapshotRequest) Execute() (*Snapshot, *http.Response, error) {
@@ -805,9 +809,10 @@ type LegacyBackupApiGetLegacySnapshotScheduleRequest struct {
 	groupId string
 	clusterName string
 }
+
 type LegacyBackupApiGetLegacySnapshotScheduleQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r LegacyBackupApiGetLegacySnapshotScheduleRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
@@ -944,12 +949,13 @@ type LegacyBackupApiListLegacyBackupCheckpointsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type LegacyBackupApiListLegacyBackupCheckpointsQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1124,13 +1130,14 @@ type LegacyBackupApiListLegacyBackupRestoreJobsRequest struct {
 	pageNum *int32
 	batchId *string
 }
+
 type LegacyBackupApiListLegacyBackupRestoreJobsQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		batchId *string
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		BatchId *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1316,13 +1323,14 @@ type LegacyBackupApiListLegacySnapshotsRequest struct {
 	pageNum *int32
 	completed *string
 }
+
 type LegacyBackupApiListLegacySnapshotsQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		completed *string
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		Completed *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1508,11 +1516,12 @@ type LegacyBackupApiUpdateLegacySnapshotRetentionRequest struct {
 	snapshotId string
 	snapshot *Snapshot
 }
+
 type LegacyBackupApiUpdateLegacySnapshotRetentionQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
-		snapshot *Snapshot
+		GroupId string
+		ClusterName string
+		SnapshotId string
+		Snapshot *Snapshot
 }
 
 // Changes One Legacy Backup Snapshot Expiration.
@@ -1665,10 +1674,11 @@ type LegacyBackupApiUpdateLegacySnapshotScheduleRequest struct {
 	clusterName string
 	snapshotSchedule *SnapshotSchedule
 }
+
 type LegacyBackupApiUpdateLegacySnapshotScheduleQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotSchedule *SnapshotSchedule
+		GroupId string
+		ClusterName string
+		SnapshotSchedule *SnapshotSchedule
 }
 
 // Update the snapshot schedule for one cluster in the specified project.

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -236,7 +236,7 @@ type LegacyBackupApiDeleteLegacySnapshotRequest struct {
 	snapshotId string
 }
 
-type LegacyBackupApiDeleteLegacySnapshotParams struct {
+type DeleteLegacySnapshotParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -371,7 +371,7 @@ type LegacyBackupApiGetLegacyBackupCheckpointRequest struct {
 	clusterName string
 }
 
-type LegacyBackupApiGetLegacyBackupCheckpointParams struct {
+type GetLegacyBackupCheckpointParams struct {
 		GroupId string
 		CheckpointId string
 		ClusterName string
@@ -517,7 +517,7 @@ type LegacyBackupApiGetLegacyBackupRestoreJobRequest struct {
 	jobId string
 }
 
-type LegacyBackupApiGetLegacyBackupRestoreJobParams struct {
+type GetLegacyBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		JobId string
@@ -665,7 +665,7 @@ type LegacyBackupApiGetLegacySnapshotRequest struct {
 	snapshotId string
 }
 
-type LegacyBackupApiGetLegacySnapshotParams struct {
+type GetLegacySnapshotParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -810,7 +810,7 @@ type LegacyBackupApiGetLegacySnapshotScheduleRequest struct {
 	clusterName string
 }
 
-type LegacyBackupApiGetLegacySnapshotScheduleParams struct {
+type GetLegacySnapshotScheduleParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -950,7 +950,7 @@ type LegacyBackupApiListLegacyBackupCheckpointsRequest struct {
 	pageNum *int32
 }
 
-type LegacyBackupApiListLegacyBackupCheckpointsParams struct {
+type ListLegacyBackupCheckpointsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1131,7 +1131,7 @@ type LegacyBackupApiListLegacyBackupRestoreJobsRequest struct {
 	batchId *string
 }
 
-type LegacyBackupApiListLegacyBackupRestoreJobsParams struct {
+type ListLegacyBackupRestoreJobsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1324,7 +1324,7 @@ type LegacyBackupApiListLegacySnapshotsRequest struct {
 	completed *string
 }
 
-type LegacyBackupApiListLegacySnapshotsParams struct {
+type ListLegacySnapshotsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1517,7 +1517,7 @@ type LegacyBackupApiUpdateLegacySnapshotRetentionRequest struct {
 	snapshot *Snapshot
 }
 
-type LegacyBackupApiUpdateLegacySnapshotRetentionParams struct {
+type UpdateLegacySnapshotRetentionParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1675,7 +1675,7 @@ type LegacyBackupApiUpdateLegacySnapshotScheduleRequest struct {
 	snapshotSchedule *SnapshotSchedule
 }
 
-type LegacyBackupApiUpdateLegacySnapshotScheduleParams struct {
+type UpdateLegacySnapshotScheduleParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotSchedule *SnapshotSchedule

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -236,7 +236,7 @@ type LegacyBackupApiDeleteLegacySnapshotRequest struct {
 	snapshotId string
 }
 
-type LegacyBackupApiDeleteLegacySnapshotQueryParams struct {
+type LegacyBackupApiDeleteLegacySnapshotParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -371,7 +371,7 @@ type LegacyBackupApiGetLegacyBackupCheckpointRequest struct {
 	clusterName string
 }
 
-type LegacyBackupApiGetLegacyBackupCheckpointQueryParams struct {
+type LegacyBackupApiGetLegacyBackupCheckpointParams struct {
 		GroupId string
 		CheckpointId string
 		ClusterName string
@@ -517,7 +517,7 @@ type LegacyBackupApiGetLegacyBackupRestoreJobRequest struct {
 	jobId string
 }
 
-type LegacyBackupApiGetLegacyBackupRestoreJobQueryParams struct {
+type LegacyBackupApiGetLegacyBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		JobId string
@@ -665,7 +665,7 @@ type LegacyBackupApiGetLegacySnapshotRequest struct {
 	snapshotId string
 }
 
-type LegacyBackupApiGetLegacySnapshotQueryParams struct {
+type LegacyBackupApiGetLegacySnapshotParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -810,7 +810,7 @@ type LegacyBackupApiGetLegacySnapshotScheduleRequest struct {
 	clusterName string
 }
 
-type LegacyBackupApiGetLegacySnapshotScheduleQueryParams struct {
+type LegacyBackupApiGetLegacySnapshotScheduleParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -950,7 +950,7 @@ type LegacyBackupApiListLegacyBackupCheckpointsRequest struct {
 	pageNum *int32
 }
 
-type LegacyBackupApiListLegacyBackupCheckpointsQueryParams struct {
+type LegacyBackupApiListLegacyBackupCheckpointsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1131,7 +1131,7 @@ type LegacyBackupApiListLegacyBackupRestoreJobsRequest struct {
 	batchId *string
 }
 
-type LegacyBackupApiListLegacyBackupRestoreJobsQueryParams struct {
+type LegacyBackupApiListLegacyBackupRestoreJobsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1324,7 +1324,7 @@ type LegacyBackupApiListLegacySnapshotsRequest struct {
 	completed *string
 }
 
-type LegacyBackupApiListLegacySnapshotsQueryParams struct {
+type LegacyBackupApiListLegacySnapshotsParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1517,7 +1517,7 @@ type LegacyBackupApiUpdateLegacySnapshotRetentionRequest struct {
 	snapshot *Snapshot
 }
 
-type LegacyBackupApiUpdateLegacySnapshotRetentionQueryParams struct {
+type LegacyBackupApiUpdateLegacySnapshotRetentionParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1675,7 +1675,7 @@ type LegacyBackupApiUpdateLegacySnapshotScheduleRequest struct {
 	snapshotSchedule *SnapshotSchedule
 }
 
-type LegacyBackupApiUpdateLegacySnapshotScheduleQueryParams struct {
+type LegacyBackupApiUpdateLegacySnapshotScheduleParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotSchedule *SnapshotSchedule

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -31,15 +31,15 @@ type LegacyBackupApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return LegacyBackupApiDeleteLegacySnapshotRequest
+	@return DeleteLegacySnapshotApiRequest
 
 	Deprecated
 	*/
-	DeleteLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) LegacyBackupApiDeleteLegacySnapshotRequest
+	DeleteLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteLegacySnapshotApiRequest
 
 	// DeleteLegacySnapshotExecute executes the request
 	// Deprecated
-	DeleteLegacySnapshotExecute(r LegacyBackupApiDeleteLegacySnapshotRequest) (*http.Response, error)
+	DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (*http.Response, error)
 
 	/*
 	GetLegacyBackupCheckpoint Return One Legacy Backup Checkpoint
@@ -50,16 +50,16 @@ type LegacyBackupApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param checkpointId Unique 24-hexadecimal digit string that identifies the checkpoint.
 	@param clusterName Human-readable label that identifies the cluster that contains the checkpoints that you want to return.
-	@return LegacyBackupApiGetLegacyBackupCheckpointRequest
+	@return GetLegacyBackupCheckpointApiRequest
 
 	Deprecated
 	*/
-	GetLegacyBackupCheckpoint(ctx context.Context, groupId string, checkpointId string, clusterName string) LegacyBackupApiGetLegacyBackupCheckpointRequest
+	GetLegacyBackupCheckpoint(ctx context.Context, groupId string, checkpointId string, clusterName string) GetLegacyBackupCheckpointApiRequest
 
 	// GetLegacyBackupCheckpointExecute executes the request
 	//  @return Checkpoint
 	// Deprecated
-	GetLegacyBackupCheckpointExecute(r LegacyBackupApiGetLegacyBackupCheckpointRequest) (*Checkpoint, *http.Response, error)
+	GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*Checkpoint, *http.Response, error)
 
 	/*
 	GetLegacyBackupRestoreJob Return One Legacy Backup Restore Job
@@ -72,16 +72,16 @@ type LegacyBackupApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
 	@param jobId Unique 24-hexadecimal digit string that identifies the restore job.
-	@return LegacyBackupApiGetLegacyBackupRestoreJobRequest
+	@return GetLegacyBackupRestoreJobApiRequest
 
 	Deprecated
 	*/
-	GetLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string, jobId string) LegacyBackupApiGetLegacyBackupRestoreJobRequest
+	GetLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string, jobId string) GetLegacyBackupRestoreJobApiRequest
 
 	// GetLegacyBackupRestoreJobExecute executes the request
 	//  @return RestoreJob
 	// Deprecated
-	GetLegacyBackupRestoreJobExecute(r LegacyBackupApiGetLegacyBackupRestoreJobRequest) (*RestoreJob, *http.Response, error)
+	GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*RestoreJob, *http.Response, error)
 
 	/*
 	GetLegacySnapshot Return One Legacy Backup Snapshot
@@ -92,16 +92,16 @@ type LegacyBackupApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return LegacyBackupApiGetLegacySnapshotRequest
+	@return GetLegacySnapshotApiRequest
 
 	Deprecated
 	*/
-	GetLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) LegacyBackupApiGetLegacySnapshotRequest
+	GetLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) GetLegacySnapshotApiRequest
 
 	// GetLegacySnapshotExecute executes the request
 	//  @return Snapshot
 	// Deprecated
-	GetLegacySnapshotExecute(r LegacyBackupApiGetLegacySnapshotRequest) (*Snapshot, *http.Response, error)
+	GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*Snapshot, *http.Response, error)
 
 	/*
 	GetLegacySnapshotSchedule Return One Snapshot Schedule
@@ -113,16 +113,16 @@ type LegacyBackupApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
-	@return LegacyBackupApiGetLegacySnapshotScheduleRequest
+	@return GetLegacySnapshotScheduleApiRequest
 
 	Deprecated
 	*/
-	GetLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) LegacyBackupApiGetLegacySnapshotScheduleRequest
+	GetLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) GetLegacySnapshotScheduleApiRequest
 
 	// GetLegacySnapshotScheduleExecute executes the request
 	//  @return SnapshotSchedule
 	// Deprecated
-	GetLegacySnapshotScheduleExecute(r LegacyBackupApiGetLegacySnapshotScheduleRequest) (*SnapshotSchedule, *http.Response, error)
+	GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error)
 
 	/*
 	ListLegacyBackupCheckpoints Return All Legacy Backup Checkpoints
@@ -132,16 +132,16 @@ type LegacyBackupApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster that contains the checkpoints that you want to return.
-	@return LegacyBackupApiListLegacyBackupCheckpointsRequest
+	@return ListLegacyBackupCheckpointsApiRequest
 
 	Deprecated
 	*/
-	ListLegacyBackupCheckpoints(ctx context.Context, groupId string, clusterName string) LegacyBackupApiListLegacyBackupCheckpointsRequest
+	ListLegacyBackupCheckpoints(ctx context.Context, groupId string, clusterName string) ListLegacyBackupCheckpointsApiRequest
 
 	// ListLegacyBackupCheckpointsExecute executes the request
 	//  @return PaginatedApiAtlasCheckpoint
 	// Deprecated
-	ListLegacyBackupCheckpointsExecute(r LegacyBackupApiListLegacyBackupCheckpointsRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error)
+	ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error)
 
 	/*
 	ListLegacyBackupRestoreJobs Return All Legacy Backup Restore Jobs
@@ -153,16 +153,16 @@ type LegacyBackupApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
-	@return LegacyBackupApiListLegacyBackupRestoreJobsRequest
+	@return ListLegacyBackupRestoreJobsApiRequest
 
 	Deprecated
 	*/
-	ListLegacyBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) LegacyBackupApiListLegacyBackupRestoreJobsRequest
+	ListLegacyBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListLegacyBackupRestoreJobsApiRequest
 
 	// ListLegacyBackupRestoreJobsExecute executes the request
 	//  @return PaginatedRestoreJob
 	// Deprecated
-	ListLegacyBackupRestoreJobsExecute(r LegacyBackupApiListLegacyBackupRestoreJobsRequest) (*PaginatedRestoreJob, *http.Response, error)
+	ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 
 	/*
 	ListLegacySnapshots Return All Legacy Backup Snapshots
@@ -172,16 +172,16 @@ type LegacyBackupApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return LegacyBackupApiListLegacySnapshotsRequest
+	@return ListLegacySnapshotsApiRequest
 
 	Deprecated
 	*/
-	ListLegacySnapshots(ctx context.Context, groupId string, clusterName string) LegacyBackupApiListLegacySnapshotsRequest
+	ListLegacySnapshots(ctx context.Context, groupId string, clusterName string) ListLegacySnapshotsApiRequest
 
 	// ListLegacySnapshotsExecute executes the request
 	//  @return PaginatedSnapshot
 	// Deprecated
-	ListLegacySnapshotsExecute(r LegacyBackupApiListLegacySnapshotsRequest) (*PaginatedSnapshot, *http.Response, error)
+	ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error)
 
 	/*
 	UpdateLegacySnapshotRetention Change One Legacy Backup Snapshot Expiration
@@ -192,16 +192,16 @@ type LegacyBackupApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return LegacyBackupApiUpdateLegacySnapshotRetentionRequest
+	@return UpdateLegacySnapshotRetentionApiRequest
 
 	Deprecated
 	*/
-	UpdateLegacySnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) LegacyBackupApiUpdateLegacySnapshotRetentionRequest
+	UpdateLegacySnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) UpdateLegacySnapshotRetentionApiRequest
 
 	// UpdateLegacySnapshotRetentionExecute executes the request
 	//  @return Snapshot
 	// Deprecated
-	UpdateLegacySnapshotRetentionExecute(r LegacyBackupApiUpdateLegacySnapshotRetentionRequest) (*Snapshot, *http.Response, error)
+	UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*Snapshot, *http.Response, error)
 
 	/*
 	UpdateLegacySnapshotSchedule Update Snapshot Schedule for One Cluster
@@ -213,22 +213,22 @@ type LegacyBackupApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
-	@return LegacyBackupApiUpdateLegacySnapshotScheduleRequest
+	@return UpdateLegacySnapshotScheduleApiRequest
 
 	Deprecated
 	*/
-	UpdateLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) LegacyBackupApiUpdateLegacySnapshotScheduleRequest
+	UpdateLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) UpdateLegacySnapshotScheduleApiRequest
 
 	// UpdateLegacySnapshotScheduleExecute executes the request
 	//  @return SnapshotSchedule
 	// Deprecated
-	UpdateLegacySnapshotScheduleExecute(r LegacyBackupApiUpdateLegacySnapshotScheduleRequest) (*SnapshotSchedule, *http.Response, error)
+	UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error)
 }
 
 // LegacyBackupApiService LegacyBackupApi service
 type LegacyBackupApiService service
 
-type LegacyBackupApiDeleteLegacySnapshotRequest struct {
+type DeleteLegacySnapshotApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -242,7 +242,7 @@ type DeleteLegacySnapshotParams struct {
 		SnapshotId string
 }
 
-func (r LegacyBackupApiDeleteLegacySnapshotRequest) Execute() (*http.Response, error) {
+func (r DeleteLegacySnapshotApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLegacySnapshotExecute(r)
 }
 
@@ -255,12 +255,12 @@ Removes one legacy backup snapshot for one cluster in the specified project. To 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return LegacyBackupApiDeleteLegacySnapshotRequest
+ @return DeleteLegacySnapshotApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) DeleteLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) LegacyBackupApiDeleteLegacySnapshotRequest {
-	return LegacyBackupApiDeleteLegacySnapshotRequest{
+func (a *LegacyBackupApiService) DeleteLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteLegacySnapshotApiRequest {
+	return DeleteLegacySnapshotApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -271,7 +271,7 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshot(ctx context.Context, group
 
 // Execute executes the request
 // Deprecated
-func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r LegacyBackupApiDeleteLegacySnapshotRequest) (*http.Response, error) {
+func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -363,7 +363,7 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r LegacyBackupApiDe
 	return localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiGetLegacyBackupCheckpointRequest struct {
+type GetLegacyBackupCheckpointApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -377,7 +377,7 @@ type GetLegacyBackupCheckpointParams struct {
 		ClusterName string
 }
 
-func (r LegacyBackupApiGetLegacyBackupCheckpointRequest) Execute() (*Checkpoint, *http.Response, error) {
+func (r GetLegacyBackupCheckpointApiRequest) Execute() (*Checkpoint, *http.Response, error) {
 	return r.ApiService.GetLegacyBackupCheckpointExecute(r)
 }
 
@@ -390,12 +390,12 @@ Returns one legacy backup checkpoint for one cluster in the specified project. T
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param checkpointId Unique 24-hexadecimal digit string that identifies the checkpoint.
  @param clusterName Human-readable label that identifies the cluster that contains the checkpoints that you want to return.
- @return LegacyBackupApiGetLegacyBackupCheckpointRequest
+ @return GetLegacyBackupCheckpointApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) GetLegacyBackupCheckpoint(ctx context.Context, groupId string, checkpointId string, clusterName string) LegacyBackupApiGetLegacyBackupCheckpointRequest {
-	return LegacyBackupApiGetLegacyBackupCheckpointRequest{
+func (a *LegacyBackupApiService) GetLegacyBackupCheckpoint(ctx context.Context, groupId string, checkpointId string, clusterName string) GetLegacyBackupCheckpointApiRequest {
+	return GetLegacyBackupCheckpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -407,7 +407,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupCheckpoint(ctx context.Context, 
 // Execute executes the request
 //  @return Checkpoint
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacyBackupCheckpointExecute(r LegacyBackupApiGetLegacyBackupCheckpointRequest) (*Checkpoint, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*Checkpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -509,7 +509,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupCheckpointExecute(r LegacyBackup
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiGetLegacyBackupRestoreJobRequest struct {
+type GetLegacyBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -523,7 +523,7 @@ type GetLegacyBackupRestoreJobParams struct {
 		JobId string
 }
 
-func (r LegacyBackupApiGetLegacyBackupRestoreJobRequest) Execute() (*RestoreJob, *http.Response, error) {
+func (r GetLegacyBackupRestoreJobApiRequest) Execute() (*RestoreJob, *http.Response, error) {
 	return r.ApiService.GetLegacyBackupRestoreJobExecute(r)
 }
 
@@ -538,12 +538,12 @@ Returns one legacy backup restore job for one cluster in the specified project. 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
  @param jobId Unique 24-hexadecimal digit string that identifies the restore job.
- @return LegacyBackupApiGetLegacyBackupRestoreJobRequest
+ @return GetLegacyBackupRestoreJobApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) GetLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string, jobId string) LegacyBackupApiGetLegacyBackupRestoreJobRequest {
-	return LegacyBackupApiGetLegacyBackupRestoreJobRequest{
+func (a *LegacyBackupApiService) GetLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string, jobId string) GetLegacyBackupRestoreJobApiRequest {
+	return GetLegacyBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -555,7 +555,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupRestoreJob(ctx context.Context, 
 // Execute executes the request
 //  @return RestoreJob
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobExecute(r LegacyBackupApiGetLegacyBackupRestoreJobRequest) (*RestoreJob, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*RestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -657,7 +657,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobExecute(r LegacyBackup
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiGetLegacySnapshotRequest struct {
+type GetLegacySnapshotApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -671,7 +671,7 @@ type GetLegacySnapshotParams struct {
 		SnapshotId string
 }
 
-func (r LegacyBackupApiGetLegacySnapshotRequest) Execute() (*Snapshot, *http.Response, error) {
+func (r GetLegacySnapshotApiRequest) Execute() (*Snapshot, *http.Response, error) {
 	return r.ApiService.GetLegacySnapshotExecute(r)
 }
 
@@ -684,12 +684,12 @@ Returns one legacy backup snapshot for one cluster in the specified project. To 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return LegacyBackupApiGetLegacySnapshotRequest
+ @return GetLegacySnapshotApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) GetLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) LegacyBackupApiGetLegacySnapshotRequest {
-	return LegacyBackupApiGetLegacySnapshotRequest{
+func (a *LegacyBackupApiService) GetLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) GetLegacySnapshotApiRequest {
+	return GetLegacySnapshotApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -701,7 +701,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshot(ctx context.Context, groupId 
 // Execute executes the request
 //  @return Snapshot
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacySnapshotExecute(r LegacyBackupApiGetLegacySnapshotRequest) (*Snapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*Snapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -803,7 +803,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotExecute(r LegacyBackupApiGetLe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiGetLegacySnapshotScheduleRequest struct {
+type GetLegacySnapshotScheduleApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -815,7 +815,7 @@ type GetLegacySnapshotScheduleParams struct {
 		ClusterName string
 }
 
-func (r LegacyBackupApiGetLegacySnapshotScheduleRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
+func (r GetLegacySnapshotScheduleApiRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
 	return r.ApiService.GetLegacySnapshotScheduleExecute(r)
 }
 
@@ -829,12 +829,12 @@ Returns the snapshot schedule for one cluster in the specified project. To use t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
- @return LegacyBackupApiGetLegacySnapshotScheduleRequest
+ @return GetLegacySnapshotScheduleApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) GetLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) LegacyBackupApiGetLegacySnapshotScheduleRequest {
-	return LegacyBackupApiGetLegacySnapshotScheduleRequest{
+func (a *LegacyBackupApiService) GetLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) GetLegacySnapshotScheduleApiRequest {
+	return GetLegacySnapshotScheduleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -845,7 +845,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotSchedule(ctx context.Context, 
 // Execute executes the request
 //  @return SnapshotSchedule
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacySnapshotScheduleExecute(r LegacyBackupApiGetLegacySnapshotScheduleRequest) (*SnapshotSchedule, *http.Response, error) {
+func (a *LegacyBackupApiService) GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -940,7 +940,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotScheduleExecute(r LegacyBackup
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiListLegacyBackupCheckpointsRequest struct {
+type ListLegacyBackupCheckpointsApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -959,24 +959,24 @@ type ListLegacyBackupCheckpointsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r LegacyBackupApiListLegacyBackupCheckpointsRequest) IncludeCount(includeCount bool) LegacyBackupApiListLegacyBackupCheckpointsRequest {
+func (r ListLegacyBackupCheckpointsApiRequest) IncludeCount(includeCount bool) ListLegacyBackupCheckpointsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r LegacyBackupApiListLegacyBackupCheckpointsRequest) ItemsPerPage(itemsPerPage int32) LegacyBackupApiListLegacyBackupCheckpointsRequest {
+func (r ListLegacyBackupCheckpointsApiRequest) ItemsPerPage(itemsPerPage int32) ListLegacyBackupCheckpointsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r LegacyBackupApiListLegacyBackupCheckpointsRequest) PageNum(pageNum int32) LegacyBackupApiListLegacyBackupCheckpointsRequest {
+func (r ListLegacyBackupCheckpointsApiRequest) PageNum(pageNum int32) ListLegacyBackupCheckpointsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r LegacyBackupApiListLegacyBackupCheckpointsRequest) Execute() (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
+func (r ListLegacyBackupCheckpointsApiRequest) Execute() (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
 	return r.ApiService.ListLegacyBackupCheckpointsExecute(r)
 }
 
@@ -988,12 +988,12 @@ Returns all legacy backup checkpoints for one cluster in the specified project. 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster that contains the checkpoints that you want to return.
- @return LegacyBackupApiListLegacyBackupCheckpointsRequest
+ @return ListLegacyBackupCheckpointsApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) ListLegacyBackupCheckpoints(ctx context.Context, groupId string, clusterName string) LegacyBackupApiListLegacyBackupCheckpointsRequest {
-	return LegacyBackupApiListLegacyBackupCheckpointsRequest{
+func (a *LegacyBackupApiService) ListLegacyBackupCheckpoints(ctx context.Context, groupId string, clusterName string) ListLegacyBackupCheckpointsApiRequest {
+	return ListLegacyBackupCheckpointsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1004,7 +1004,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupCheckpoints(ctx context.Context
 // Execute executes the request
 //  @return PaginatedApiAtlasCheckpoint
 // Deprecated
-func (a *LegacyBackupApiService) ListLegacyBackupCheckpointsExecute(r LegacyBackupApiListLegacyBackupCheckpointsRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
+func (a *LegacyBackupApiService) ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1120,7 +1120,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupCheckpointsExecute(r LegacyBack
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiListLegacyBackupRestoreJobsRequest struct {
+type ListLegacyBackupRestoreJobsApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -1141,30 +1141,30 @@ type ListLegacyBackupRestoreJobsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r LegacyBackupApiListLegacyBackupRestoreJobsRequest) IncludeCount(includeCount bool) LegacyBackupApiListLegacyBackupRestoreJobsRequest {
+func (r ListLegacyBackupRestoreJobsApiRequest) IncludeCount(includeCount bool) ListLegacyBackupRestoreJobsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r LegacyBackupApiListLegacyBackupRestoreJobsRequest) ItemsPerPage(itemsPerPage int32) LegacyBackupApiListLegacyBackupRestoreJobsRequest {
+func (r ListLegacyBackupRestoreJobsApiRequest) ItemsPerPage(itemsPerPage int32) ListLegacyBackupRestoreJobsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r LegacyBackupApiListLegacyBackupRestoreJobsRequest) PageNum(pageNum int32) LegacyBackupApiListLegacyBackupRestoreJobsRequest {
+func (r ListLegacyBackupRestoreJobsApiRequest) PageNum(pageNum int32) ListLegacyBackupRestoreJobsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Unique 24-hexadecimal digit string that identifies the batch of restore jobs to return. Timestamp in ISO 8601 date and time format in UTC when creating a restore job for a sharded cluster, Application creates a separate job for each shard, plus another for the config host. Each of these jobs comprise one batch. A restore job for a replica set can&#39;t be part of a batch.
-func (r LegacyBackupApiListLegacyBackupRestoreJobsRequest) BatchId(batchId string) LegacyBackupApiListLegacyBackupRestoreJobsRequest {
+func (r ListLegacyBackupRestoreJobsApiRequest) BatchId(batchId string) ListLegacyBackupRestoreJobsApiRequest {
 	r.batchId = &batchId
 	return r
 }
 
-func (r LegacyBackupApiListLegacyBackupRestoreJobsRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
+func (r ListLegacyBackupRestoreJobsApiRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
 	return r.ApiService.ListLegacyBackupRestoreJobsExecute(r)
 }
 
@@ -1178,12 +1178,12 @@ Returns all legacy backup restore jobs for one cluster in the specified project.
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
- @return LegacyBackupApiListLegacyBackupRestoreJobsRequest
+ @return ListLegacyBackupRestoreJobsApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) LegacyBackupApiListLegacyBackupRestoreJobsRequest {
-	return LegacyBackupApiListLegacyBackupRestoreJobsRequest{
+func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListLegacyBackupRestoreJobsApiRequest {
+	return ListLegacyBackupRestoreJobsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1194,7 +1194,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobs(ctx context.Context
 // Execute executes the request
 //  @return PaginatedRestoreJob
 // Deprecated
-func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobsExecute(r LegacyBackupApiListLegacyBackupRestoreJobsRequest) (*PaginatedRestoreJob, *http.Response, error) {
+func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1313,7 +1313,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobsExecute(r LegacyBack
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiListLegacySnapshotsRequest struct {
+type ListLegacySnapshotsApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -1334,30 +1334,30 @@ type ListLegacySnapshotsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r LegacyBackupApiListLegacySnapshotsRequest) IncludeCount(includeCount bool) LegacyBackupApiListLegacySnapshotsRequest {
+func (r ListLegacySnapshotsApiRequest) IncludeCount(includeCount bool) ListLegacySnapshotsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r LegacyBackupApiListLegacySnapshotsRequest) ItemsPerPage(itemsPerPage int32) LegacyBackupApiListLegacySnapshotsRequest {
+func (r ListLegacySnapshotsApiRequest) ItemsPerPage(itemsPerPage int32) ListLegacySnapshotsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r LegacyBackupApiListLegacySnapshotsRequest) PageNum(pageNum int32) LegacyBackupApiListLegacySnapshotsRequest {
+func (r ListLegacySnapshotsApiRequest) PageNum(pageNum int32) ListLegacySnapshotsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Human-readable label that specifies whether to return only completed, incomplete, or all snapshots. By default, MongoDB Cloud only returns completed snapshots.
-func (r LegacyBackupApiListLegacySnapshotsRequest) Completed(completed string) LegacyBackupApiListLegacySnapshotsRequest {
+func (r ListLegacySnapshotsApiRequest) Completed(completed string) ListLegacySnapshotsApiRequest {
 	r.completed = &completed
 	return r
 }
 
-func (r LegacyBackupApiListLegacySnapshotsRequest) Execute() (*PaginatedSnapshot, *http.Response, error) {
+func (r ListLegacySnapshotsApiRequest) Execute() (*PaginatedSnapshot, *http.Response, error) {
 	return r.ApiService.ListLegacySnapshotsExecute(r)
 }
 
@@ -1369,12 +1369,12 @@ Returns all legacy backup snapshots for one cluster in the specified project. To
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return LegacyBackupApiListLegacySnapshotsRequest
+ @return ListLegacySnapshotsApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) ListLegacySnapshots(ctx context.Context, groupId string, clusterName string) LegacyBackupApiListLegacySnapshotsRequest {
-	return LegacyBackupApiListLegacySnapshotsRequest{
+func (a *LegacyBackupApiService) ListLegacySnapshots(ctx context.Context, groupId string, clusterName string) ListLegacySnapshotsApiRequest {
+	return ListLegacySnapshotsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1385,7 +1385,7 @@ func (a *LegacyBackupApiService) ListLegacySnapshots(ctx context.Context, groupI
 // Execute executes the request
 //  @return PaginatedSnapshot
 // Deprecated
-func (a *LegacyBackupApiService) ListLegacySnapshotsExecute(r LegacyBackupApiListLegacySnapshotsRequest) (*PaginatedSnapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1508,7 +1508,7 @@ func (a *LegacyBackupApiService) ListLegacySnapshotsExecute(r LegacyBackupApiLis
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiUpdateLegacySnapshotRetentionRequest struct {
+type UpdateLegacySnapshotRetentionApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -1525,12 +1525,12 @@ type UpdateLegacySnapshotRetentionParams struct {
 }
 
 // Changes One Legacy Backup Snapshot Expiration.
-func (r LegacyBackupApiUpdateLegacySnapshotRetentionRequest) Snapshot(snapshot Snapshot) LegacyBackupApiUpdateLegacySnapshotRetentionRequest {
+func (r UpdateLegacySnapshotRetentionApiRequest) Snapshot(snapshot Snapshot) UpdateLegacySnapshotRetentionApiRequest {
 	r.snapshot = &snapshot
 	return r
 }
 
-func (r LegacyBackupApiUpdateLegacySnapshotRetentionRequest) Execute() (*Snapshot, *http.Response, error) {
+func (r UpdateLegacySnapshotRetentionApiRequest) Execute() (*Snapshot, *http.Response, error) {
 	return r.ApiService.UpdateLegacySnapshotRetentionExecute(r)
 }
 
@@ -1543,12 +1543,12 @@ Changes the expiration date for one legacy backup snapshot for one cluster in th
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return LegacyBackupApiUpdateLegacySnapshotRetentionRequest
+ @return UpdateLegacySnapshotRetentionApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) UpdateLegacySnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) LegacyBackupApiUpdateLegacySnapshotRetentionRequest {
-	return LegacyBackupApiUpdateLegacySnapshotRetentionRequest{
+func (a *LegacyBackupApiService) UpdateLegacySnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) UpdateLegacySnapshotRetentionApiRequest {
+	return UpdateLegacySnapshotRetentionApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1560,7 +1560,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotRetention(ctx context.Conte
 // Execute executes the request
 //  @return Snapshot
 // Deprecated
-func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionExecute(r LegacyBackupApiUpdateLegacySnapshotRetentionRequest) (*Snapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*Snapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1667,7 +1667,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionExecute(r LegacyBa
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type LegacyBackupApiUpdateLegacySnapshotScheduleRequest struct {
+type UpdateLegacySnapshotScheduleApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupApi
 	groupId string
@@ -1682,12 +1682,12 @@ type UpdateLegacySnapshotScheduleParams struct {
 }
 
 // Update the snapshot schedule for one cluster in the specified project.
-func (r LegacyBackupApiUpdateLegacySnapshotScheduleRequest) SnapshotSchedule(snapshotSchedule SnapshotSchedule) LegacyBackupApiUpdateLegacySnapshotScheduleRequest {
+func (r UpdateLegacySnapshotScheduleApiRequest) SnapshotSchedule(snapshotSchedule SnapshotSchedule) UpdateLegacySnapshotScheduleApiRequest {
 	r.snapshotSchedule = &snapshotSchedule
 	return r
 }
 
-func (r LegacyBackupApiUpdateLegacySnapshotScheduleRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
+func (r UpdateLegacySnapshotScheduleApiRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
 	return r.ApiService.UpdateLegacySnapshotScheduleExecute(r)
 }
 
@@ -1701,12 +1701,12 @@ Updates the snapshot schedule for one cluster in the specified project. To use t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
- @return LegacyBackupApiUpdateLegacySnapshotScheduleRequest
+ @return UpdateLegacySnapshotScheduleApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupApiService) UpdateLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) LegacyBackupApiUpdateLegacySnapshotScheduleRequest {
-	return LegacyBackupApiUpdateLegacySnapshotScheduleRequest{
+func (a *LegacyBackupApiService) UpdateLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) UpdateLegacySnapshotScheduleApiRequest {
+	return UpdateLegacySnapshotScheduleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1717,7 +1717,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotSchedule(ctx context.Contex
 // Execute executes the request
 //  @return SnapshotSchedule
 // Deprecated
-func (a *LegacyBackupApiService) UpdateLegacySnapshotScheduleExecute(r LegacyBackupApiUpdateLegacySnapshotScheduleRequest) (*SnapshotSchedule, *http.Response, error) {
+func (a *LegacyBackupApiService) UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -236,7 +236,7 @@ type DeleteLegacySnapshotApiRequest struct {
 	snapshotId string
 }
 
-type DeleteLegacySnapshotParams struct {
+type DeleteLegacySnapshotApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -371,7 +371,7 @@ type GetLegacyBackupCheckpointApiRequest struct {
 	clusterName string
 }
 
-type GetLegacyBackupCheckpointParams struct {
+type GetLegacyBackupCheckpointApiParams struct {
 		GroupId string
 		CheckpointId string
 		ClusterName string
@@ -517,7 +517,7 @@ type GetLegacyBackupRestoreJobApiRequest struct {
 	jobId string
 }
 
-type GetLegacyBackupRestoreJobParams struct {
+type GetLegacyBackupRestoreJobApiParams struct {
 		GroupId string
 		ClusterName string
 		JobId string
@@ -665,7 +665,7 @@ type GetLegacySnapshotApiRequest struct {
 	snapshotId string
 }
 
-type GetLegacySnapshotParams struct {
+type GetLegacySnapshotApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -810,7 +810,7 @@ type GetLegacySnapshotScheduleApiRequest struct {
 	clusterName string
 }
 
-type GetLegacySnapshotScheduleParams struct {
+type GetLegacySnapshotScheduleApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -950,7 +950,7 @@ type ListLegacyBackupCheckpointsApiRequest struct {
 	pageNum *int32
 }
 
-type ListLegacyBackupCheckpointsParams struct {
+type ListLegacyBackupCheckpointsApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1131,7 +1131,7 @@ type ListLegacyBackupRestoreJobsApiRequest struct {
 	batchId *string
 }
 
-type ListLegacyBackupRestoreJobsParams struct {
+type ListLegacyBackupRestoreJobsApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1324,7 +1324,7 @@ type ListLegacySnapshotsApiRequest struct {
 	completed *string
 }
 
-type ListLegacySnapshotsParams struct {
+type ListLegacySnapshotsApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -1517,7 +1517,7 @@ type UpdateLegacySnapshotRetentionApiRequest struct {
 	snapshot *Snapshot
 }
 
-type UpdateLegacySnapshotRetentionParams struct {
+type UpdateLegacySnapshotRetentionApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -1675,7 +1675,7 @@ type UpdateLegacySnapshotScheduleApiRequest struct {
 	snapshotSchedule *SnapshotSchedule
 }
 
-type UpdateLegacySnapshotScheduleParams struct {
+type UpdateLegacySnapshotScheduleApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotSchedule *SnapshotSchedule

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -53,7 +53,7 @@ type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest struct {
 	restoreJob *RestoreJob
 }
 
-type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobQueryParams struct {
+type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJob *RestoreJob

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -53,7 +53,7 @@ type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest struct {
 	restoreJob *RestoreJob
 }
 
-type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobParams struct {
+type CreateLegacyBackupRestoreJobParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJob *RestoreJob

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -30,22 +30,22 @@ type LegacyBackupRestoreJobsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
-	@return LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest
+	@return CreateLegacyBackupRestoreJobApiRequest
 
 	Deprecated
 	*/
-	CreateLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string) LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest
+	CreateLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateLegacyBackupRestoreJobApiRequest
 
 	// CreateLegacyBackupRestoreJobExecute executes the request
 	//  @return PaginatedRestoreJob
 	// Deprecated
-	CreateLegacyBackupRestoreJobExecute(r LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest) (*PaginatedRestoreJob, *http.Response, error)
+	CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 }
 
 // LegacyBackupRestoreJobsApiService LegacyBackupRestoreJobsApi service
 type LegacyBackupRestoreJobsApiService service
 
-type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest struct {
+type CreateLegacyBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService LegacyBackupRestoreJobsApi
 	groupId string
@@ -60,12 +60,12 @@ type CreateLegacyBackupRestoreJobParams struct {
 }
 
 // Legacy backup to restore to one cluster in the specified project.
-func (r LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest) RestoreJob(restoreJob RestoreJob) LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest {
+func (r CreateLegacyBackupRestoreJobApiRequest) RestoreJob(restoreJob RestoreJob) CreateLegacyBackupRestoreJobApiRequest {
 	r.restoreJob = &restoreJob
 	return r
 }
 
-func (r LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
+func (r CreateLegacyBackupRestoreJobApiRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
 	return r.ApiService.CreateLegacyBackupRestoreJobExecute(r)
 }
 
@@ -77,12 +77,12 @@ Restores one legacy backup for one cluster in the specified project. To use this
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
- @return LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest
+ @return CreateLegacyBackupRestoreJobApiRequest
 
 Deprecated
 */
-func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string) LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest {
-	return LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest{
+func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateLegacyBackupRestoreJobApiRequest {
+	return CreateLegacyBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -93,7 +93,7 @@ func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJob(ctx con
 // Execute executes the request
 //  @return PaginatedRestoreJob
 // Deprecated
-func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJobExecute(r LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest) (*PaginatedRestoreJob, *http.Response, error) {
+func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -52,10 +52,11 @@ type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest struct {
 	clusterName string
 	restoreJob *RestoreJob
 }
+
 type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobQueryParams struct {
-		groupId string
-		clusterName string
-		restoreJob *RestoreJob
+		GroupId string
+		ClusterName string
+		RestoreJob *RestoreJob
 }
 
 // Legacy backup to restore to one cluster in the specified project.

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -53,7 +53,7 @@ type CreateLegacyBackupRestoreJobApiRequest struct {
 	restoreJob *RestoreJob
 }
 
-type CreateLegacyBackupRestoreJobParams struct {
+type CreateLegacyBackupRestoreJobApiParams struct {
 		GroupId string
 		ClusterName string
 		RestoreJob *RestoreJob

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -52,6 +52,11 @@ type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest struct {
 	clusterName string
 	restoreJob *RestoreJob
 }
+type LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobQueryParams struct {
+		groupId string
+		clusterName string
+		restoreJob *RestoreJob
+}
 
 // Legacy backup to restore to one cluster in the specified project.
 func (r LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest) RestoreJob(restoreJob RestoreJob) LegacyBackupRestoreJobsApiCreateLegacyBackupRestoreJobRequest {

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -29,12 +29,12 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MaintenanceWindowsApiDeferMaintenanceWindowRequest
+	@return DeferMaintenanceWindowApiRequest
 	*/
-	DeferMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiDeferMaintenanceWindowRequest
+	DeferMaintenanceWindow(ctx context.Context, groupId string) DeferMaintenanceWindowApiRequest
 
 	// DeferMaintenanceWindowExecute executes the request
-	DeferMaintenanceWindowExecute(r MaintenanceWindowsApiDeferMaintenanceWindowRequest) (*http.Response, error)
+	DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
 	GetMaintenanceWindow Return One Maintenance Window for One Project
@@ -43,13 +43,13 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MaintenanceWindowsApiGetMaintenanceWindowRequest
+	@return GetMaintenanceWindowApiRequest
 	*/
-	GetMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiGetMaintenanceWindowRequest
+	GetMaintenanceWindow(ctx context.Context, groupId string) GetMaintenanceWindowApiRequest
 
 	// GetMaintenanceWindowExecute executes the request
 	//  @return GroupMaintenanceWindow
-	GetMaintenanceWindowExecute(r MaintenanceWindowsApiGetMaintenanceWindowRequest) (*GroupMaintenanceWindow, *http.Response, error)
+	GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error)
 
 	/*
 	ResetMaintenanceWindow Reset One Maintenance Window for One Project
@@ -58,12 +58,12 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MaintenanceWindowsApiResetMaintenanceWindowRequest
+	@return ResetMaintenanceWindowApiRequest
 	*/
-	ResetMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiResetMaintenanceWindowRequest
+	ResetMaintenanceWindow(ctx context.Context, groupId string) ResetMaintenanceWindowApiRequest
 
 	// ResetMaintenanceWindowExecute executes the request
-	ResetMaintenanceWindowExecute(r MaintenanceWindowsApiResetMaintenanceWindowRequest) (*http.Response, error)
+	ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
 	ToggleMaintenanceAutoDefer Toggle Automatic Deferral of Maintenance for One Project
@@ -72,12 +72,12 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest
+	@return ToggleMaintenanceAutoDeferApiRequest
 	*/
-	ToggleMaintenanceAutoDefer(ctx context.Context, groupId string) MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest
+	ToggleMaintenanceAutoDefer(ctx context.Context, groupId string) ToggleMaintenanceAutoDeferApiRequest
 
 	// ToggleMaintenanceAutoDeferExecute executes the request
-	ToggleMaintenanceAutoDeferExecute(r MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest) (*http.Response, error)
+	ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error)
 
 	/*
 	UpdateMaintenanceWindow Update Maintenance Window for One Project
@@ -86,18 +86,18 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MaintenanceWindowsApiUpdateMaintenanceWindowRequest
+	@return UpdateMaintenanceWindowApiRequest
 	*/
-	UpdateMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiUpdateMaintenanceWindowRequest
+	UpdateMaintenanceWindow(ctx context.Context, groupId string) UpdateMaintenanceWindowApiRequest
 
 	// UpdateMaintenanceWindowExecute executes the request
-	UpdateMaintenanceWindowExecute(r MaintenanceWindowsApiUpdateMaintenanceWindowRequest) (*http.Response, error)
+	UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (*http.Response, error)
 }
 
 // MaintenanceWindowsApiService MaintenanceWindowsApi service
 type MaintenanceWindowsApiService service
 
-type MaintenanceWindowsApiDeferMaintenanceWindowRequest struct {
+type DeferMaintenanceWindowApiRequest struct {
 	ctx context.Context
 	ApiService MaintenanceWindowsApi
 	groupId string
@@ -107,7 +107,7 @@ type DeferMaintenanceWindowParams struct {
 		GroupId string
 }
 
-func (r MaintenanceWindowsApiDeferMaintenanceWindowRequest) Execute() (*http.Response, error) {
+func (r DeferMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeferMaintenanceWindowExecute(r)
 }
 
@@ -118,10 +118,10 @@ Defers the maintenance window for the specified project. Urgent maintenance acti
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MaintenanceWindowsApiDeferMaintenanceWindowRequest
+ @return DeferMaintenanceWindowApiRequest
 */
-func (a *MaintenanceWindowsApiService) DeferMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiDeferMaintenanceWindowRequest {
-	return MaintenanceWindowsApiDeferMaintenanceWindowRequest{
+func (a *MaintenanceWindowsApiService) DeferMaintenanceWindow(ctx context.Context, groupId string) DeferMaintenanceWindowApiRequest {
+	return DeferMaintenanceWindowApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -129,7 +129,7 @@ func (a *MaintenanceWindowsApiService) DeferMaintenanceWindow(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowExecute(r MaintenanceWindowsApiDeferMaintenanceWindowRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -207,7 +207,7 @@ func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowExecute(r Maintenan
 	return localVarHTTPResponse, nil
 }
 
-type MaintenanceWindowsApiGetMaintenanceWindowRequest struct {
+type GetMaintenanceWindowApiRequest struct {
 	ctx context.Context
 	ApiService MaintenanceWindowsApi
 	groupId string
@@ -217,7 +217,7 @@ type GetMaintenanceWindowParams struct {
 		GroupId string
 }
 
-func (r MaintenanceWindowsApiGetMaintenanceWindowRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
+func (r GetMaintenanceWindowApiRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
 	return r.ApiService.GetMaintenanceWindowExecute(r)
 }
 
@@ -228,10 +228,10 @@ Returns the maintenance window for the specified project. MongoDB Cloud starts t
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MaintenanceWindowsApiGetMaintenanceWindowRequest
+ @return GetMaintenanceWindowApiRequest
 */
-func (a *MaintenanceWindowsApiService) GetMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiGetMaintenanceWindowRequest {
-	return MaintenanceWindowsApiGetMaintenanceWindowRequest{
+func (a *MaintenanceWindowsApiService) GetMaintenanceWindow(ctx context.Context, groupId string) GetMaintenanceWindowApiRequest {
+	return GetMaintenanceWindowApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -240,7 +240,7 @@ func (a *MaintenanceWindowsApiService) GetMaintenanceWindow(ctx context.Context,
 
 // Execute executes the request
 //  @return GroupMaintenanceWindow
-func (a *MaintenanceWindowsApiService) GetMaintenanceWindowExecute(r MaintenanceWindowsApiGetMaintenanceWindowRequest) (*GroupMaintenanceWindow, *http.Response, error) {
+func (a *MaintenanceWindowsApiService) GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -328,7 +328,7 @@ func (a *MaintenanceWindowsApiService) GetMaintenanceWindowExecute(r Maintenance
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MaintenanceWindowsApiResetMaintenanceWindowRequest struct {
+type ResetMaintenanceWindowApiRequest struct {
 	ctx context.Context
 	ApiService MaintenanceWindowsApi
 	groupId string
@@ -338,7 +338,7 @@ type ResetMaintenanceWindowParams struct {
 		GroupId string
 }
 
-func (r MaintenanceWindowsApiResetMaintenanceWindowRequest) Execute() (*http.Response, error) {
+func (r ResetMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.ResetMaintenanceWindowExecute(r)
 }
 
@@ -349,10 +349,10 @@ Resets the maintenance window for the specified project. To use this resource, t
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MaintenanceWindowsApiResetMaintenanceWindowRequest
+ @return ResetMaintenanceWindowApiRequest
 */
-func (a *MaintenanceWindowsApiService) ResetMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiResetMaintenanceWindowRequest {
-	return MaintenanceWindowsApiResetMaintenanceWindowRequest{
+func (a *MaintenanceWindowsApiService) ResetMaintenanceWindow(ctx context.Context, groupId string) ResetMaintenanceWindowApiRequest {
+	return ResetMaintenanceWindowApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -360,7 +360,7 @@ func (a *MaintenanceWindowsApiService) ResetMaintenanceWindow(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowExecute(r MaintenanceWindowsApiResetMaintenanceWindowRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -438,7 +438,7 @@ func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowExecute(r Maintenan
 	return localVarHTTPResponse, nil
 }
 
-type MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest struct {
+type ToggleMaintenanceAutoDeferApiRequest struct {
 	ctx context.Context
 	ApiService MaintenanceWindowsApi
 	groupId string
@@ -448,7 +448,7 @@ type ToggleMaintenanceAutoDeferParams struct {
 		GroupId string
 }
 
-func (r MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest) Execute() (*http.Response, error) {
+func (r ToggleMaintenanceAutoDeferApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.ToggleMaintenanceAutoDeferExecute(r)
 }
 
@@ -459,10 +459,10 @@ Toggles automatic deferral of the maintenance window for the specified project. 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest
+ @return ToggleMaintenanceAutoDeferApiRequest
 */
-func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDefer(ctx context.Context, groupId string) MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest {
-	return MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest{
+func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDefer(ctx context.Context, groupId string) ToggleMaintenanceAutoDeferApiRequest {
+	return ToggleMaintenanceAutoDeferApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -470,7 +470,7 @@ func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDefer(ctx context.Co
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferExecute(r MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -548,7 +548,7 @@ func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferExecute(r Maint
 	return localVarHTTPResponse, nil
 }
 
-type MaintenanceWindowsApiUpdateMaintenanceWindowRequest struct {
+type UpdateMaintenanceWindowApiRequest struct {
 	ctx context.Context
 	ApiService MaintenanceWindowsApi
 	groupId string
@@ -561,12 +561,12 @@ type UpdateMaintenanceWindowParams struct {
 }
 
 // Updates the maintenance window for the specified project.
-func (r MaintenanceWindowsApiUpdateMaintenanceWindowRequest) GroupMaintenanceWindow(groupMaintenanceWindow GroupMaintenanceWindow) MaintenanceWindowsApiUpdateMaintenanceWindowRequest {
+func (r UpdateMaintenanceWindowApiRequest) GroupMaintenanceWindow(groupMaintenanceWindow GroupMaintenanceWindow) UpdateMaintenanceWindowApiRequest {
 	r.groupMaintenanceWindow = &groupMaintenanceWindow
 	return r
 }
 
-func (r MaintenanceWindowsApiUpdateMaintenanceWindowRequest) Execute() (*http.Response, error) {
+func (r UpdateMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.UpdateMaintenanceWindowExecute(r)
 }
 
@@ -577,10 +577,10 @@ Updates the maintenance window for the specified project. Urgent maintenance act
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MaintenanceWindowsApiUpdateMaintenanceWindowRequest
+ @return UpdateMaintenanceWindowApiRequest
 */
-func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindow(ctx context.Context, groupId string) MaintenanceWindowsApiUpdateMaintenanceWindowRequest {
-	return MaintenanceWindowsApiUpdateMaintenanceWindowRequest{
+func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindow(ctx context.Context, groupId string) UpdateMaintenanceWindowApiRequest {
+	return UpdateMaintenanceWindowApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -588,7 +588,7 @@ func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindow(ctx context.Conte
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowExecute(r MaintenanceWindowsApiUpdateMaintenanceWindowRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -103,7 +103,7 @@ type DeferMaintenanceWindowApiRequest struct {
 	groupId string
 }
 
-type DeferMaintenanceWindowParams struct {
+type DeferMaintenanceWindowApiParams struct {
 		GroupId string
 }
 
@@ -213,7 +213,7 @@ type GetMaintenanceWindowApiRequest struct {
 	groupId string
 }
 
-type GetMaintenanceWindowParams struct {
+type GetMaintenanceWindowApiParams struct {
 		GroupId string
 }
 
@@ -334,7 +334,7 @@ type ResetMaintenanceWindowApiRequest struct {
 	groupId string
 }
 
-type ResetMaintenanceWindowParams struct {
+type ResetMaintenanceWindowApiParams struct {
 		GroupId string
 }
 
@@ -444,7 +444,7 @@ type ToggleMaintenanceAutoDeferApiRequest struct {
 	groupId string
 }
 
-type ToggleMaintenanceAutoDeferParams struct {
+type ToggleMaintenanceAutoDeferApiParams struct {
 		GroupId string
 }
 
@@ -555,7 +555,7 @@ type UpdateMaintenanceWindowApiRequest struct {
 	groupMaintenanceWindow *GroupMaintenanceWindow
 }
 
-type UpdateMaintenanceWindowParams struct {
+type UpdateMaintenanceWindowApiParams struct {
 		GroupId string
 		GroupMaintenanceWindow *GroupMaintenanceWindow
 }

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -103,7 +103,7 @@ type MaintenanceWindowsApiDeferMaintenanceWindowRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiDeferMaintenanceWindowQueryParams struct {
+type MaintenanceWindowsApiDeferMaintenanceWindowParams struct {
 		GroupId string
 }
 
@@ -213,7 +213,7 @@ type MaintenanceWindowsApiGetMaintenanceWindowRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiGetMaintenanceWindowQueryParams struct {
+type MaintenanceWindowsApiGetMaintenanceWindowParams struct {
 		GroupId string
 }
 
@@ -334,7 +334,7 @@ type MaintenanceWindowsApiResetMaintenanceWindowRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiResetMaintenanceWindowQueryParams struct {
+type MaintenanceWindowsApiResetMaintenanceWindowParams struct {
 		GroupId string
 }
 
@@ -444,7 +444,7 @@ type MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiToggleMaintenanceAutoDeferQueryParams struct {
+type MaintenanceWindowsApiToggleMaintenanceAutoDeferParams struct {
 		GroupId string
 }
 
@@ -555,7 +555,7 @@ type MaintenanceWindowsApiUpdateMaintenanceWindowRequest struct {
 	groupMaintenanceWindow *GroupMaintenanceWindow
 }
 
-type MaintenanceWindowsApiUpdateMaintenanceWindowQueryParams struct {
+type MaintenanceWindowsApiUpdateMaintenanceWindowParams struct {
 		GroupId string
 		GroupMaintenanceWindow *GroupMaintenanceWindow
 }

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -102,6 +102,9 @@ type MaintenanceWindowsApiDeferMaintenanceWindowRequest struct {
 	ApiService MaintenanceWindowsApi
 	groupId string
 }
+type MaintenanceWindowsApiDeferMaintenanceWindowQueryParams struct {
+		groupId string
+}
 
 func (r MaintenanceWindowsApiDeferMaintenanceWindowRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeferMaintenanceWindowExecute(r)
@@ -207,6 +210,9 @@ type MaintenanceWindowsApiGetMaintenanceWindowRequest struct {
 	ctx context.Context
 	ApiService MaintenanceWindowsApi
 	groupId string
+}
+type MaintenanceWindowsApiGetMaintenanceWindowQueryParams struct {
+		groupId string
 }
 
 func (r MaintenanceWindowsApiGetMaintenanceWindowRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
@@ -325,6 +331,9 @@ type MaintenanceWindowsApiResetMaintenanceWindowRequest struct {
 	ApiService MaintenanceWindowsApi
 	groupId string
 }
+type MaintenanceWindowsApiResetMaintenanceWindowQueryParams struct {
+		groupId string
+}
 
 func (r MaintenanceWindowsApiResetMaintenanceWindowRequest) Execute() (*http.Response, error) {
 	return r.ApiService.ResetMaintenanceWindowExecute(r)
@@ -430,6 +439,9 @@ type MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest struct {
 	ctx context.Context
 	ApiService MaintenanceWindowsApi
 	groupId string
+}
+type MaintenanceWindowsApiToggleMaintenanceAutoDeferQueryParams struct {
+		groupId string
 }
 
 func (r MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest) Execute() (*http.Response, error) {
@@ -537,6 +549,10 @@ type MaintenanceWindowsApiUpdateMaintenanceWindowRequest struct {
 	ApiService MaintenanceWindowsApi
 	groupId string
 	groupMaintenanceWindow *GroupMaintenanceWindow
+}
+type MaintenanceWindowsApiUpdateMaintenanceWindowQueryParams struct {
+		groupId string
+		groupMaintenanceWindow *GroupMaintenanceWindow
 }
 
 // Updates the maintenance window for the specified project.

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -103,7 +103,7 @@ type MaintenanceWindowsApiDeferMaintenanceWindowRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiDeferMaintenanceWindowParams struct {
+type DeferMaintenanceWindowParams struct {
 		GroupId string
 }
 
@@ -213,7 +213,7 @@ type MaintenanceWindowsApiGetMaintenanceWindowRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiGetMaintenanceWindowParams struct {
+type GetMaintenanceWindowParams struct {
 		GroupId string
 }
 
@@ -334,7 +334,7 @@ type MaintenanceWindowsApiResetMaintenanceWindowRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiResetMaintenanceWindowParams struct {
+type ResetMaintenanceWindowParams struct {
 		GroupId string
 }
 
@@ -444,7 +444,7 @@ type MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest struct {
 	groupId string
 }
 
-type MaintenanceWindowsApiToggleMaintenanceAutoDeferParams struct {
+type ToggleMaintenanceAutoDeferParams struct {
 		GroupId string
 }
 
@@ -555,7 +555,7 @@ type MaintenanceWindowsApiUpdateMaintenanceWindowRequest struct {
 	groupMaintenanceWindow *GroupMaintenanceWindow
 }
 
-type MaintenanceWindowsApiUpdateMaintenanceWindowParams struct {
+type UpdateMaintenanceWindowParams struct {
 		GroupId string
 		GroupMaintenanceWindow *GroupMaintenanceWindow
 }

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -102,8 +102,9 @@ type MaintenanceWindowsApiDeferMaintenanceWindowRequest struct {
 	ApiService MaintenanceWindowsApi
 	groupId string
 }
+
 type MaintenanceWindowsApiDeferMaintenanceWindowQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r MaintenanceWindowsApiDeferMaintenanceWindowRequest) Execute() (*http.Response, error) {
@@ -211,8 +212,9 @@ type MaintenanceWindowsApiGetMaintenanceWindowRequest struct {
 	ApiService MaintenanceWindowsApi
 	groupId string
 }
+
 type MaintenanceWindowsApiGetMaintenanceWindowQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r MaintenanceWindowsApiGetMaintenanceWindowRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
@@ -331,8 +333,9 @@ type MaintenanceWindowsApiResetMaintenanceWindowRequest struct {
 	ApiService MaintenanceWindowsApi
 	groupId string
 }
+
 type MaintenanceWindowsApiResetMaintenanceWindowQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r MaintenanceWindowsApiResetMaintenanceWindowRequest) Execute() (*http.Response, error) {
@@ -440,8 +443,9 @@ type MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest struct {
 	ApiService MaintenanceWindowsApi
 	groupId string
 }
+
 type MaintenanceWindowsApiToggleMaintenanceAutoDeferQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r MaintenanceWindowsApiToggleMaintenanceAutoDeferRequest) Execute() (*http.Response, error) {
@@ -550,9 +554,10 @@ type MaintenanceWindowsApiUpdateMaintenanceWindowRequest struct {
 	groupId string
 	groupMaintenanceWindow *GroupMaintenanceWindow
 }
+
 type MaintenanceWindowsApiUpdateMaintenanceWindowQueryParams struct {
-		groupId string
-		groupMaintenanceWindow *GroupMaintenanceWindow
+		GroupId string
+		GroupMaintenanceWindow *GroupMaintenanceWindow
 }
 
 // Updates the maintenance window for the specified project.

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -80,7 +80,7 @@ type MongoDBCloudUsersApiCreateUserRequest struct {
 	appUser *AppUser
 }
 
-type MongoDBCloudUsersApiCreateUserQueryParams struct {
+type MongoDBCloudUsersApiCreateUserParams struct {
 		AppUser *AppUser
 }
 
@@ -207,7 +207,7 @@ type MongoDBCloudUsersApiGetUserRequest struct {
 	userId string
 }
 
-type MongoDBCloudUsersApiGetUserQueryParams struct {
+type MongoDBCloudUsersApiGetUserParams struct {
 		UserId string
 }
 
@@ -328,7 +328,7 @@ type MongoDBCloudUsersApiGetUserByUsernameRequest struct {
 	userName string
 }
 
-type MongoDBCloudUsersApiGetUserByUsernameQueryParams struct {
+type MongoDBCloudUsersApiGetUserByUsernameParams struct {
 		UserName string
 }
 

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -80,7 +80,7 @@ type MongoDBCloudUsersApiCreateUserRequest struct {
 	appUser *AppUser
 }
 
-type MongoDBCloudUsersApiCreateUserParams struct {
+type CreateUserParams struct {
 		AppUser *AppUser
 }
 
@@ -207,7 +207,7 @@ type MongoDBCloudUsersApiGetUserRequest struct {
 	userId string
 }
 
-type MongoDBCloudUsersApiGetUserParams struct {
+type GetUserParams struct {
 		UserId string
 }
 
@@ -328,7 +328,7 @@ type MongoDBCloudUsersApiGetUserByUsernameRequest struct {
 	userName string
 }
 
-type MongoDBCloudUsersApiGetUserByUsernameParams struct {
+type GetUserByUsernameParams struct {
 		UserName string
 }
 

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -79,8 +79,9 @@ type MongoDBCloudUsersApiCreateUserRequest struct {
 	ApiService MongoDBCloudUsersApi
 	appUser *AppUser
 }
+
 type MongoDBCloudUsersApiCreateUserQueryParams struct {
-		appUser *AppUser
+		AppUser *AppUser
 }
 
 // MongoDB Cloud user account to create.
@@ -205,8 +206,9 @@ type MongoDBCloudUsersApiGetUserRequest struct {
 	ApiService MongoDBCloudUsersApi
 	userId string
 }
+
 type MongoDBCloudUsersApiGetUserQueryParams struct {
-		userId string
+		UserId string
 }
 
 func (r MongoDBCloudUsersApiGetUserRequest) Execute() (*AppUser, *http.Response, error) {
@@ -325,8 +327,9 @@ type MongoDBCloudUsersApiGetUserByUsernameRequest struct {
 	ApiService MongoDBCloudUsersApi
 	userName string
 }
+
 type MongoDBCloudUsersApiGetUserByUsernameQueryParams struct {
-		userName string
+		UserName string
 }
 
 func (r MongoDBCloudUsersApiGetUserByUsernameRequest) Execute() (*AppUser, *http.Response, error) {

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -79,6 +79,9 @@ type MongoDBCloudUsersApiCreateUserRequest struct {
 	ApiService MongoDBCloudUsersApi
 	appUser *AppUser
 }
+type MongoDBCloudUsersApiCreateUserQueryParams struct {
+		appUser *AppUser
+}
 
 // MongoDB Cloud user account to create.
 func (r MongoDBCloudUsersApiCreateUserRequest) AppUser(appUser AppUser) MongoDBCloudUsersApiCreateUserRequest {
@@ -202,6 +205,9 @@ type MongoDBCloudUsersApiGetUserRequest struct {
 	ApiService MongoDBCloudUsersApi
 	userId string
 }
+type MongoDBCloudUsersApiGetUserQueryParams struct {
+		userId string
+}
 
 func (r MongoDBCloudUsersApiGetUserRequest) Execute() (*AppUser, *http.Response, error) {
 	return r.ApiService.GetUserExecute(r)
@@ -318,6 +324,9 @@ type MongoDBCloudUsersApiGetUserByUsernameRequest struct {
 	ctx context.Context
 	ApiService MongoDBCloudUsersApi
 	userName string
+}
+type MongoDBCloudUsersApiGetUserByUsernameQueryParams struct {
+		userName string
 }
 
 func (r MongoDBCloudUsersApiGetUserByUsernameRequest) Execute() (*AppUser, *http.Response, error) {

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -32,13 +32,13 @@ type MongoDBCloudUsersApi interface {
  To use this resource, the requesting API Key can have any role. This resource doesn't require the API Key to have an Access List.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return MongoDBCloudUsersApiCreateUserRequest
+	@return CreateUserApiRequest
 	*/
-	CreateUser(ctx context.Context) MongoDBCloudUsersApiCreateUserRequest
+	CreateUser(ctx context.Context) CreateUserApiRequest
 
 	// CreateUserExecute executes the request
 	//  @return AppUser
-	CreateUserExecute(r MongoDBCloudUsersApiCreateUserRequest) (*AppUser, *http.Response, error)
+	CreateUserExecute(r CreateUserApiRequest) (*AppUser, *http.Response, error)
 
 	/*
 	GetUser Return One MongoDB Cloud User using Its ID
@@ -47,13 +47,13 @@ type MongoDBCloudUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param userId Unique 24-hexadecimal digit string that identifies this user.
-	@return MongoDBCloudUsersApiGetUserRequest
+	@return GetUserApiRequest
 	*/
-	GetUser(ctx context.Context, userId string) MongoDBCloudUsersApiGetUserRequest
+	GetUser(ctx context.Context, userId string) GetUserApiRequest
 
 	// GetUserExecute executes the request
 	//  @return AppUser
-	GetUserExecute(r MongoDBCloudUsersApiGetUserRequest) (*AppUser, *http.Response, error)
+	GetUserExecute(r GetUserApiRequest) (*AppUser, *http.Response, error)
 
 	/*
 	GetUserByUsername Return One MongoDB Cloud User using Their Username
@@ -62,19 +62,19 @@ type MongoDBCloudUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param userName Email address that belongs to the MongoDB Cloud user account. You cannot modify this address after creating the user.
-	@return MongoDBCloudUsersApiGetUserByUsernameRequest
+	@return GetUserByUsernameApiRequest
 	*/
-	GetUserByUsername(ctx context.Context, userName string) MongoDBCloudUsersApiGetUserByUsernameRequest
+	GetUserByUsername(ctx context.Context, userName string) GetUserByUsernameApiRequest
 
 	// GetUserByUsernameExecute executes the request
 	//  @return AppUser
-	GetUserByUsernameExecute(r MongoDBCloudUsersApiGetUserByUsernameRequest) (*AppUser, *http.Response, error)
+	GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*AppUser, *http.Response, error)
 }
 
 // MongoDBCloudUsersApiService MongoDBCloudUsersApi service
 type MongoDBCloudUsersApiService service
 
-type MongoDBCloudUsersApiCreateUserRequest struct {
+type CreateUserApiRequest struct {
 	ctx context.Context
 	ApiService MongoDBCloudUsersApi
 	appUser *AppUser
@@ -85,12 +85,12 @@ type CreateUserParams struct {
 }
 
 // MongoDB Cloud user account to create.
-func (r MongoDBCloudUsersApiCreateUserRequest) AppUser(appUser AppUser) MongoDBCloudUsersApiCreateUserRequest {
+func (r CreateUserApiRequest) AppUser(appUser AppUser) CreateUserApiRequest {
 	r.appUser = &appUser
 	return r
 }
 
-func (r MongoDBCloudUsersApiCreateUserRequest) Execute() (*AppUser, *http.Response, error) {
+func (r CreateUserApiRequest) Execute() (*AppUser, *http.Response, error) {
 	return r.ApiService.CreateUserExecute(r)
 }
 
@@ -104,10 +104,10 @@ Creates one MongoDB Cloud user account. A MongoDB Cloud user account grants acce
  To use this resource, the requesting API Key can have any role. This resource doesn't require the API Key to have an Access List.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return MongoDBCloudUsersApiCreateUserRequest
+ @return CreateUserApiRequest
 */
-func (a *MongoDBCloudUsersApiService) CreateUser(ctx context.Context) MongoDBCloudUsersApiCreateUserRequest {
-	return MongoDBCloudUsersApiCreateUserRequest{
+func (a *MongoDBCloudUsersApiService) CreateUser(ctx context.Context) CreateUserApiRequest {
+	return CreateUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -115,7 +115,7 @@ func (a *MongoDBCloudUsersApiService) CreateUser(ctx context.Context) MongoDBClo
 
 // Execute executes the request
 //  @return AppUser
-func (a *MongoDBCloudUsersApiService) CreateUserExecute(r MongoDBCloudUsersApiCreateUserRequest) (*AppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) CreateUserExecute(r CreateUserApiRequest) (*AppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -201,7 +201,7 @@ func (a *MongoDBCloudUsersApiService) CreateUserExecute(r MongoDBCloudUsersApiCr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MongoDBCloudUsersApiGetUserRequest struct {
+type GetUserApiRequest struct {
 	ctx context.Context
 	ApiService MongoDBCloudUsersApi
 	userId string
@@ -211,7 +211,7 @@ type GetUserParams struct {
 		UserId string
 }
 
-func (r MongoDBCloudUsersApiGetUserRequest) Execute() (*AppUser, *http.Response, error) {
+func (r GetUserApiRequest) Execute() (*AppUser, *http.Response, error) {
 	return r.ApiService.GetUserExecute(r)
 }
 
@@ -222,10 +222,10 @@ Returns the details for one MongoDB Cloud user account with the specified unique
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param userId Unique 24-hexadecimal digit string that identifies this user.
- @return MongoDBCloudUsersApiGetUserRequest
+ @return GetUserApiRequest
 */
-func (a *MongoDBCloudUsersApiService) GetUser(ctx context.Context, userId string) MongoDBCloudUsersApiGetUserRequest {
-	return MongoDBCloudUsersApiGetUserRequest{
+func (a *MongoDBCloudUsersApiService) GetUser(ctx context.Context, userId string) GetUserApiRequest {
+	return GetUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		userId: userId,
@@ -234,7 +234,7 @@ func (a *MongoDBCloudUsersApiService) GetUser(ctx context.Context, userId string
 
 // Execute executes the request
 //  @return AppUser
-func (a *MongoDBCloudUsersApiService) GetUserExecute(r MongoDBCloudUsersApiGetUserRequest) (*AppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) GetUserExecute(r GetUserApiRequest) (*AppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -322,7 +322,7 @@ func (a *MongoDBCloudUsersApiService) GetUserExecute(r MongoDBCloudUsersApiGetUs
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MongoDBCloudUsersApiGetUserByUsernameRequest struct {
+type GetUserByUsernameApiRequest struct {
 	ctx context.Context
 	ApiService MongoDBCloudUsersApi
 	userName string
@@ -332,7 +332,7 @@ type GetUserByUsernameParams struct {
 		UserName string
 }
 
-func (r MongoDBCloudUsersApiGetUserByUsernameRequest) Execute() (*AppUser, *http.Response, error) {
+func (r GetUserByUsernameApiRequest) Execute() (*AppUser, *http.Response, error) {
 	return r.ApiService.GetUserByUsernameExecute(r)
 }
 
@@ -343,10 +343,10 @@ Returns the details for one MongoDB Cloud user account with the specified userna
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param userName Email address that belongs to the MongoDB Cloud user account. You cannot modify this address after creating the user.
- @return MongoDBCloudUsersApiGetUserByUsernameRequest
+ @return GetUserByUsernameApiRequest
 */
-func (a *MongoDBCloudUsersApiService) GetUserByUsername(ctx context.Context, userName string) MongoDBCloudUsersApiGetUserByUsernameRequest {
-	return MongoDBCloudUsersApiGetUserByUsernameRequest{
+func (a *MongoDBCloudUsersApiService) GetUserByUsername(ctx context.Context, userName string) GetUserByUsernameApiRequest {
+	return GetUserByUsernameApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		userName: userName,
@@ -355,7 +355,7 @@ func (a *MongoDBCloudUsersApiService) GetUserByUsername(ctx context.Context, use
 
 // Execute executes the request
 //  @return AppUser
-func (a *MongoDBCloudUsersApiService) GetUserByUsernameExecute(r MongoDBCloudUsersApiGetUserByUsernameRequest) (*AppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*AppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -80,7 +80,7 @@ type CreateUserApiRequest struct {
 	appUser *AppUser
 }
 
-type CreateUserParams struct {
+type CreateUserApiParams struct {
 		AppUser *AppUser
 }
 
@@ -207,7 +207,7 @@ type GetUserApiRequest struct {
 	userId string
 }
 
-type GetUserParams struct {
+type GetUserApiParams struct {
 		UserId string
 }
 
@@ -328,7 +328,7 @@ type GetUserByUsernameApiRequest struct {
 	userName string
 }
 
-type GetUserByUsernameParams struct {
+type GetUserByUsernameApiParams struct {
 		UserName string
 }
 

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -286,6 +286,10 @@ type MonitoringAndLogsApiGetAtlasProcessRequest struct {
 	groupId string
 	processId string
 }
+type MonitoringAndLogsApiGetAtlasProcessQueryParams struct {
+		groupId string
+		processId string
+}
 
 func (r MonitoringAndLogsApiGetAtlasProcessRequest) Execute() (*HostViewAtlas, *http.Response, error) {
 	return r.ApiService.GetAtlasProcessExecute(r)
@@ -407,6 +411,11 @@ type MonitoringAndLogsApiGetDatabaseRequest struct {
 	groupId string
 	databaseName string
 	processId string
+}
+type MonitoringAndLogsApiGetDatabaseQueryParams struct {
+		groupId string
+		databaseName string
+		processId string
 }
 
 func (r MonitoringAndLogsApiGetDatabaseRequest) Execute() (*Database, *http.Response, error) {
@@ -533,6 +542,12 @@ type MonitoringAndLogsApiGetDatabaseMeasurementsRequest struct {
 	databaseName string
 	processId string
 	m *[]string
+}
+type MonitoringAndLogsApiGetDatabaseMeasurementsQueryParams struct {
+		groupId string
+		databaseName string
+		processId string
+		m *[]string
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
@@ -676,6 +691,12 @@ type MonitoringAndLogsApiGetDiskMeasurementsRequest struct {
 	partitionName string
 	processId string
 	m *[]string
+}
+type MonitoringAndLogsApiGetDiskMeasurementsQueryParams struct {
+		groupId string
+		partitionName string
+		processId string
+		m *[]string
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
@@ -827,6 +848,13 @@ type MonitoringAndLogsApiGetHostLogsRequest struct {
 	endDate *int64
 	startDate *int64
 }
+type MonitoringAndLogsApiGetHostLogsQueryParams struct {
+		groupId string
+		hostName string
+		logName string
+		endDate *int64
+		startDate *int64
+}
 
 // Date and time when the period specifies the inclusive ending point for the range of log messages to retrieve. This parameter expresses its value in the number of seconds that have elapsed since the UNIX epoch.
 func (r MonitoringAndLogsApiGetHostLogsRequest) EndDate(endDate int64) MonitoringAndLogsApiGetHostLogsRequest {
@@ -970,6 +998,12 @@ type MonitoringAndLogsApiGetHostMeasurementsRequest struct {
 	processId string
 	m *[]string
 	period *time.Time
+}
+type MonitoringAndLogsApiGetHostMeasurementsQueryParams struct {
+		groupId string
+		processId string
+		m *[]string
+		period *time.Time
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
@@ -1131,6 +1165,18 @@ type MonitoringAndLogsApiGetIndexMetricsRequest struct {
 	period *string
 	start *time.Time
 	end *time.Time
+}
+type MonitoringAndLogsApiGetIndexMetricsQueryParams struct {
+		processId string
+		indexName string
+		databaseName string
+		collectionName string
+		groupId string
+		granularity *string
+		metrics *[]string
+		period *string
+		start *time.Time
+		end *time.Time
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
@@ -1327,6 +1373,15 @@ type MonitoringAndLogsApiGetMeasurementsRequest struct {
 	start *time.Time
 	end *time.Time
 }
+type MonitoringAndLogsApiGetMeasurementsQueryParams struct {
+		processId string
+		groupId string
+		granularity *string
+		metrics *[]string
+		period *string
+		start *time.Time
+		end *time.Time
+}
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
 func (r MonitoringAndLogsApiGetMeasurementsRequest) Granularity(granularity string) MonitoringAndLogsApiGetMeasurementsRequest {
@@ -1510,6 +1565,12 @@ type MonitoringAndLogsApiListAtlasProcessesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type MonitoringAndLogsApiListAtlasProcessesQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r MonitoringAndLogsApiListAtlasProcessesRequest) IncludeCount(includeCount bool) MonitoringAndLogsApiListAtlasProcessesRequest {
@@ -1669,6 +1730,13 @@ type MonitoringAndLogsApiListDatabasesRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type MonitoringAndLogsApiListDatabasesQueryParams struct {
+		groupId string
+		processId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1831,6 +1899,11 @@ type MonitoringAndLogsApiListDiskMeasurementsRequest struct {
 	groupId string
 	processId string
 }
+type MonitoringAndLogsApiListDiskMeasurementsQueryParams struct {
+		partitionName string
+		groupId string
+		processId string
+}
 
 func (r MonitoringAndLogsApiListDiskMeasurementsRequest) Execute() (*DiskPartition, *http.Response, error) {
 	return r.ApiService.ListDiskMeasurementsExecute(r)
@@ -1963,6 +2036,13 @@ type MonitoringAndLogsApiListDiskPartitionsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type MonitoringAndLogsApiListDiskPartitionsQueryParams struct {
+		groupId string
+		processId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -2130,6 +2210,17 @@ type MonitoringAndLogsApiListIndexMetricsRequest struct {
 	period *string
 	start *time.Time
 	end *time.Time
+}
+type MonitoringAndLogsApiListIndexMetricsQueryParams struct {
+		processId string
+		databaseName string
+		collectionName string
+		groupId string
+		granularity *string
+		metrics *[]string
+		period *string
+		start *time.Time
+		end *time.Time
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
@@ -2317,6 +2408,10 @@ type MonitoringAndLogsApiListMetricTypesRequest struct {
 	ApiService MonitoringAndLogsApi
 	processId string
 	groupId string
+}
+type MonitoringAndLogsApiListMetricTypesQueryParams struct {
+		processId string
+		groupId string
 }
 
 func (r MonitoringAndLogsApiListMetricTypesRequest) Execute() (*FTSMetrics, *http.Response, error) {

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -286,9 +286,10 @@ type MonitoringAndLogsApiGetAtlasProcessRequest struct {
 	groupId string
 	processId string
 }
+
 type MonitoringAndLogsApiGetAtlasProcessQueryParams struct {
-		groupId string
-		processId string
+		GroupId string
+		ProcessId string
 }
 
 func (r MonitoringAndLogsApiGetAtlasProcessRequest) Execute() (*HostViewAtlas, *http.Response, error) {
@@ -412,10 +413,11 @@ type MonitoringAndLogsApiGetDatabaseRequest struct {
 	databaseName string
 	processId string
 }
+
 type MonitoringAndLogsApiGetDatabaseQueryParams struct {
-		groupId string
-		databaseName string
-		processId string
+		GroupId string
+		DatabaseName string
+		ProcessId string
 }
 
 func (r MonitoringAndLogsApiGetDatabaseRequest) Execute() (*Database, *http.Response, error) {
@@ -543,11 +545,12 @@ type MonitoringAndLogsApiGetDatabaseMeasurementsRequest struct {
 	processId string
 	m *[]string
 }
+
 type MonitoringAndLogsApiGetDatabaseMeasurementsQueryParams struct {
-		groupId string
-		databaseName string
-		processId string
-		m *[]string
+		GroupId string
+		DatabaseName string
+		ProcessId string
+		M *[]string
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
@@ -692,11 +695,12 @@ type MonitoringAndLogsApiGetDiskMeasurementsRequest struct {
 	processId string
 	m *[]string
 }
+
 type MonitoringAndLogsApiGetDiskMeasurementsQueryParams struct {
-		groupId string
-		partitionName string
-		processId string
-		m *[]string
+		GroupId string
+		PartitionName string
+		ProcessId string
+		M *[]string
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
@@ -848,12 +852,13 @@ type MonitoringAndLogsApiGetHostLogsRequest struct {
 	endDate *int64
 	startDate *int64
 }
+
 type MonitoringAndLogsApiGetHostLogsQueryParams struct {
-		groupId string
-		hostName string
-		logName string
-		endDate *int64
-		startDate *int64
+		GroupId string
+		HostName string
+		LogName string
+		EndDate *int64
+		StartDate *int64
 }
 
 // Date and time when the period specifies the inclusive ending point for the range of log messages to retrieve. This parameter expresses its value in the number of seconds that have elapsed since the UNIX epoch.
@@ -999,11 +1004,12 @@ type MonitoringAndLogsApiGetHostMeasurementsRequest struct {
 	m *[]string
 	period *time.Time
 }
+
 type MonitoringAndLogsApiGetHostMeasurementsQueryParams struct {
-		groupId string
-		processId string
-		m *[]string
-		period *time.Time
+		GroupId string
+		ProcessId string
+		M *[]string
+		Period *time.Time
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
@@ -1166,17 +1172,18 @@ type MonitoringAndLogsApiGetIndexMetricsRequest struct {
 	start *time.Time
 	end *time.Time
 }
+
 type MonitoringAndLogsApiGetIndexMetricsQueryParams struct {
-		processId string
-		indexName string
-		databaseName string
-		collectionName string
-		groupId string
-		granularity *string
-		metrics *[]string
-		period *string
-		start *time.Time
-		end *time.Time
+		ProcessId string
+		IndexName string
+		DatabaseName string
+		CollectionName string
+		GroupId string
+		Granularity *string
+		Metrics *[]string
+		Period *string
+		Start *time.Time
+		End *time.Time
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
@@ -1373,14 +1380,15 @@ type MonitoringAndLogsApiGetMeasurementsRequest struct {
 	start *time.Time
 	end *time.Time
 }
+
 type MonitoringAndLogsApiGetMeasurementsQueryParams struct {
-		processId string
-		groupId string
-		granularity *string
-		metrics *[]string
-		period *string
-		start *time.Time
-		end *time.Time
+		ProcessId string
+		GroupId string
+		Granularity *string
+		Metrics *[]string
+		Period *string
+		Start *time.Time
+		End *time.Time
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
@@ -1565,11 +1573,12 @@ type MonitoringAndLogsApiListAtlasProcessesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type MonitoringAndLogsApiListAtlasProcessesQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1731,12 +1740,13 @@ type MonitoringAndLogsApiListDatabasesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type MonitoringAndLogsApiListDatabasesQueryParams struct {
-		groupId string
-		processId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ProcessId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1899,10 +1909,11 @@ type MonitoringAndLogsApiListDiskMeasurementsRequest struct {
 	groupId string
 	processId string
 }
+
 type MonitoringAndLogsApiListDiskMeasurementsQueryParams struct {
-		partitionName string
-		groupId string
-		processId string
+		PartitionName string
+		GroupId string
+		ProcessId string
 }
 
 func (r MonitoringAndLogsApiListDiskMeasurementsRequest) Execute() (*DiskPartition, *http.Response, error) {
@@ -2037,12 +2048,13 @@ type MonitoringAndLogsApiListDiskPartitionsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type MonitoringAndLogsApiListDiskPartitionsQueryParams struct {
-		groupId string
-		processId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ProcessId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -2211,16 +2223,17 @@ type MonitoringAndLogsApiListIndexMetricsRequest struct {
 	start *time.Time
 	end *time.Time
 }
+
 type MonitoringAndLogsApiListIndexMetricsQueryParams struct {
-		processId string
-		databaseName string
-		collectionName string
-		groupId string
-		granularity *string
-		metrics *[]string
-		period *string
-		start *time.Time
-		end *time.Time
+		ProcessId string
+		DatabaseName string
+		CollectionName string
+		GroupId string
+		Granularity *string
+		Metrics *[]string
+		Period *string
+		Start *time.Time
+		End *time.Time
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
@@ -2409,9 +2422,10 @@ type MonitoringAndLogsApiListMetricTypesRequest struct {
 	processId string
 	groupId string
 }
+
 type MonitoringAndLogsApiListMetricTypesQueryParams struct {
-		processId string
-		groupId string
+		ProcessId string
+		GroupId string
 }
 
 func (r MonitoringAndLogsApiListMetricTypesRequest) Execute() (*FTSMetrics, *http.Response, error) {

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -287,7 +287,7 @@ type GetAtlasProcessApiRequest struct {
 	processId string
 }
 
-type GetAtlasProcessParams struct {
+type GetAtlasProcessApiParams struct {
 		GroupId string
 		ProcessId string
 }
@@ -414,7 +414,7 @@ type GetDatabaseApiRequest struct {
 	processId string
 }
 
-type GetDatabaseParams struct {
+type GetDatabaseApiParams struct {
 		GroupId string
 		DatabaseName string
 		ProcessId string
@@ -546,7 +546,7 @@ type GetDatabaseMeasurementsApiRequest struct {
 	m *[]string
 }
 
-type GetDatabaseMeasurementsParams struct {
+type GetDatabaseMeasurementsApiParams struct {
 		GroupId string
 		DatabaseName string
 		ProcessId string
@@ -696,7 +696,7 @@ type GetDiskMeasurementsApiRequest struct {
 	m *[]string
 }
 
-type GetDiskMeasurementsParams struct {
+type GetDiskMeasurementsApiParams struct {
 		GroupId string
 		PartitionName string
 		ProcessId string
@@ -853,7 +853,7 @@ type GetHostLogsApiRequest struct {
 	startDate *int64
 }
 
-type GetHostLogsParams struct {
+type GetHostLogsApiParams struct {
 		GroupId string
 		HostName string
 		LogName string
@@ -1005,7 +1005,7 @@ type GetHostMeasurementsApiRequest struct {
 	period *time.Time
 }
 
-type GetHostMeasurementsParams struct {
+type GetHostMeasurementsApiParams struct {
 		GroupId string
 		ProcessId string
 		M *[]string
@@ -1173,7 +1173,7 @@ type GetIndexMetricsApiRequest struct {
 	end *time.Time
 }
 
-type GetIndexMetricsParams struct {
+type GetIndexMetricsApiParams struct {
 		ProcessId string
 		IndexName string
 		DatabaseName string
@@ -1381,7 +1381,7 @@ type GetMeasurementsApiRequest struct {
 	end *time.Time
 }
 
-type GetMeasurementsParams struct {
+type GetMeasurementsApiParams struct {
 		ProcessId string
 		GroupId string
 		Granularity *string
@@ -1574,7 +1574,7 @@ type ListAtlasProcessesApiRequest struct {
 	pageNum *int32
 }
 
-type ListAtlasProcessesParams struct {
+type ListAtlasProcessesApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1741,7 +1741,7 @@ type ListDatabasesApiRequest struct {
 	pageNum *int32
 }
 
-type ListDatabasesParams struct {
+type ListDatabasesApiParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool
@@ -1910,7 +1910,7 @@ type ListDiskMeasurementsApiRequest struct {
 	processId string
 }
 
-type ListDiskMeasurementsParams struct {
+type ListDiskMeasurementsApiParams struct {
 		PartitionName string
 		GroupId string
 		ProcessId string
@@ -2049,7 +2049,7 @@ type ListDiskPartitionsApiRequest struct {
 	pageNum *int32
 }
 
-type ListDiskPartitionsParams struct {
+type ListDiskPartitionsApiParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool
@@ -2224,7 +2224,7 @@ type ListIndexMetricsApiRequest struct {
 	end *time.Time
 }
 
-type ListIndexMetricsParams struct {
+type ListIndexMetricsApiParams struct {
 		ProcessId string
 		DatabaseName string
 		CollectionName string
@@ -2423,7 +2423,7 @@ type ListMetricTypesApiRequest struct {
 	groupId string
 }
 
-type ListMetricTypesParams struct {
+type ListMetricTypesApiParams struct {
 		ProcessId string
 		GroupId string
 }

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -33,13 +33,13 @@ type MonitoringAndLogsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiGetAtlasProcessRequest
+	@return GetAtlasProcessApiRequest
 	*/
-	GetAtlasProcess(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiGetAtlasProcessRequest
+	GetAtlasProcess(ctx context.Context, groupId string, processId string) GetAtlasProcessApiRequest
 
 	// GetAtlasProcessExecute executes the request
 	//  @return HostViewAtlas
-	GetAtlasProcessExecute(r MonitoringAndLogsApiGetAtlasProcessRequest) (*HostViewAtlas, *http.Response, error)
+	GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*HostViewAtlas, *http.Response, error)
 
 	/*
 	GetDatabase Return One Database for a MongoDB Process
@@ -50,13 +50,13 @@ type MonitoringAndLogsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param databaseName Human-readable label that identifies the database that the specified MongoDB process serves.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiGetDatabaseRequest
+	@return GetDatabaseApiRequest
 	*/
-	GetDatabase(ctx context.Context, groupId string, databaseName string, processId string) MonitoringAndLogsApiGetDatabaseRequest
+	GetDatabase(ctx context.Context, groupId string, databaseName string, processId string) GetDatabaseApiRequest
 
 	// GetDatabaseExecute executes the request
 	//  @return Database
-	GetDatabaseExecute(r MonitoringAndLogsApiGetDatabaseRequest) (*Database, *http.Response, error)
+	GetDatabaseExecute(r GetDatabaseApiRequest) (*Database, *http.Response, error)
 
 	/*
 	GetDatabaseMeasurements Return Measurements of One Database for One MongoDB Process
@@ -67,13 +67,13 @@ type MonitoringAndLogsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param databaseName Human-readable label that identifies the database that the specified MongoDB process serves.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiGetDatabaseMeasurementsRequest
+	@return GetDatabaseMeasurementsApiRequest
 	*/
-	GetDatabaseMeasurements(ctx context.Context, groupId string, databaseName string, processId string) MonitoringAndLogsApiGetDatabaseMeasurementsRequest
+	GetDatabaseMeasurements(ctx context.Context, groupId string, databaseName string, processId string) GetDatabaseMeasurementsApiRequest
 
 	// GetDatabaseMeasurementsExecute executes the request
 	//  @return MeasurementsGeneralViewAtlas
-	GetDatabaseMeasurementsExecute(r MonitoringAndLogsApiGetDatabaseMeasurementsRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
+	GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 	GetDiskMeasurements Return Measurements of One Disk for One MongoDB Process
@@ -90,13 +90,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param partitionName Human-readable label of the disk or partition to which the measurements apply.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiGetDiskMeasurementsRequest
+	@return GetDiskMeasurementsApiRequest
 	*/
-	GetDiskMeasurements(ctx context.Context, groupId string, partitionName string, processId string) MonitoringAndLogsApiGetDiskMeasurementsRequest
+	GetDiskMeasurements(ctx context.Context, groupId string, partitionName string, processId string) GetDiskMeasurementsApiRequest
 
 	// GetDiskMeasurementsExecute executes the request
 	//  @return MeasurementsGeneralViewAtlas
-	GetDiskMeasurementsExecute(r MonitoringAndLogsApiGetDiskMeasurementsRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
+	GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 	GetHostLogs Download Logs for One Multi-Cloud Cluster Host in One Project
@@ -107,13 +107,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param hostName Fully qualified domain name or IP address of the MongoDB host that stores the log files that you want to download.
 	@param logName Human-readable label of the log file that you want to return. You can return audit logs only if you enable Database Auditing for the specified project.
-	@return MonitoringAndLogsApiGetHostLogsRequest
+	@return GetHostLogsApiRequest
 	*/
-	GetHostLogs(ctx context.Context, groupId string, hostName string, logName string) MonitoringAndLogsApiGetHostLogsRequest
+	GetHostLogs(ctx context.Context, groupId string, hostName string, logName string) GetHostLogsApiRequest
 
 	// GetHostLogsExecute executes the request
 	//  @return *os.File
-	GetHostLogsExecute(r MonitoringAndLogsApiGetHostLogsRequest) (*os.File, *http.Response, error)
+	GetHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error)
 
 	/*
 	GetHostMeasurements Return Measurements for One MongoDB Process
@@ -129,13 +129,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiGetHostMeasurementsRequest
+	@return GetHostMeasurementsApiRequest
 	*/
-	GetHostMeasurements(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiGetHostMeasurementsRequest
+	GetHostMeasurements(ctx context.Context, groupId string, processId string) GetHostMeasurementsApiRequest
 
 	// GetHostMeasurementsExecute executes the request
 	//  @return MeasurementsGeneralViewAtlas
-	GetHostMeasurementsExecute(r MonitoringAndLogsApiGetHostMeasurementsRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
+	GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 	GetIndexMetrics Return Atlas Search Metrics for One Index in One Specified Namespace
@@ -148,13 +148,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param databaseName Human-readable label that identifies the database.
 	@param collectionName Human-readable label that identifies the collection.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MonitoringAndLogsApiGetIndexMetricsRequest
+	@return GetIndexMetricsApiRequest
 	*/
-	GetIndexMetrics(ctx context.Context, processId string, indexName string, databaseName string, collectionName string, groupId string) MonitoringAndLogsApiGetIndexMetricsRequest
+	GetIndexMetrics(ctx context.Context, processId string, indexName string, databaseName string, collectionName string, groupId string) GetIndexMetricsApiRequest
 
 	// GetIndexMetricsExecute executes the request
 	//  @return MeasurementsIndexes
-	GetIndexMetricsExecute(r MonitoringAndLogsApiGetIndexMetricsRequest) (*MeasurementsIndexes, *http.Response, error)
+	GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
 	GetMeasurements Return Atlas Search Hardware and Status Metrics
@@ -164,13 +164,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param processId Combination of hostname and IANA port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (mongod or mongos). The port must be the IANA port on which the MongoDB process listens for requests.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MonitoringAndLogsApiGetMeasurementsRequest
+	@return GetMeasurementsApiRequest
 	*/
-	GetMeasurements(ctx context.Context, processId string, groupId string) MonitoringAndLogsApiGetMeasurementsRequest
+	GetMeasurements(ctx context.Context, processId string, groupId string) GetMeasurementsApiRequest
 
 	// GetMeasurementsExecute executes the request
 	//  @return MeasurementsNonIndex
-	GetMeasurementsExecute(r MonitoringAndLogsApiGetMeasurementsRequest) (*MeasurementsNonIndex, *http.Response, error)
+	GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error)
 
 	/*
 	ListAtlasProcesses Return All MongoDB Processes in One Project
@@ -179,13 +179,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MonitoringAndLogsApiListAtlasProcessesRequest
+	@return ListAtlasProcessesApiRequest
 	*/
-	ListAtlasProcesses(ctx context.Context, groupId string) MonitoringAndLogsApiListAtlasProcessesRequest
+	ListAtlasProcesses(ctx context.Context, groupId string) ListAtlasProcessesApiRequest
 
 	// ListAtlasProcessesExecute executes the request
 	//  @return PaginatedHostViewAtlas
-	ListAtlasProcessesExecute(r MonitoringAndLogsApiListAtlasProcessesRequest) (*PaginatedHostViewAtlas, *http.Response, error)
+	ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error)
 
 	/*
 	ListDatabases Return Available Databases for One MongoDB Process
@@ -195,13 +195,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiListDatabasesRequest
+	@return ListDatabasesApiRequest
 	*/
-	ListDatabases(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiListDatabasesRequest
+	ListDatabases(ctx context.Context, groupId string, processId string) ListDatabasesApiRequest
 
 	// ListDatabasesExecute executes the request
 	//  @return PaginatedDatabase
-	ListDatabasesExecute(r MonitoringAndLogsApiListDatabasesRequest) (*PaginatedDatabase, *http.Response, error)
+	ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error)
 
 	/*
 	ListDiskMeasurements Return Measurements of One Disk
@@ -218,13 +218,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param partitionName Human-readable label of the disk or partition to which the measurements apply.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiListDiskMeasurementsRequest
+	@return ListDiskMeasurementsApiRequest
 	*/
-	ListDiskMeasurements(ctx context.Context, partitionName string, groupId string, processId string) MonitoringAndLogsApiListDiskMeasurementsRequest
+	ListDiskMeasurements(ctx context.Context, partitionName string, groupId string, processId string) ListDiskMeasurementsApiRequest
 
 	// ListDiskMeasurementsExecute executes the request
 	//  @return DiskPartition
-	ListDiskMeasurementsExecute(r MonitoringAndLogsApiListDiskMeasurementsRequest) (*DiskPartition, *http.Response, error)
+	ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*DiskPartition, *http.Response, error)
 
 	/*
 	ListDiskPartitions Return Available Disks for One MongoDB Process
@@ -234,13 +234,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return MonitoringAndLogsApiListDiskPartitionsRequest
+	@return ListDiskPartitionsApiRequest
 	*/
-	ListDiskPartitions(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiListDiskPartitionsRequest
+	ListDiskPartitions(ctx context.Context, groupId string, processId string) ListDiskPartitionsApiRequest
 
 	// ListDiskPartitionsExecute executes the request
 	//  @return PaginatedDiskPartition
-	ListDiskPartitionsExecute(r MonitoringAndLogsApiListDiskPartitionsRequest) (*PaginatedDiskPartition, *http.Response, error)
+	ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error)
 
 	/*
 	ListIndexMetrics Return All Atlas Search Index Metrics for One Namespace
@@ -252,13 +252,13 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param databaseName Human-readable label that identifies the database.
 	@param collectionName Human-readable label that identifies the collection.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MonitoringAndLogsApiListIndexMetricsRequest
+	@return ListIndexMetricsApiRequest
 	*/
-	ListIndexMetrics(ctx context.Context, processId string, databaseName string, collectionName string, groupId string) MonitoringAndLogsApiListIndexMetricsRequest
+	ListIndexMetrics(ctx context.Context, processId string, databaseName string, collectionName string, groupId string) ListIndexMetricsApiRequest
 
 	// ListIndexMetricsExecute executes the request
 	//  @return MeasurementsIndexes
-	ListIndexMetricsExecute(r MonitoringAndLogsApiListIndexMetricsRequest) (*MeasurementsIndexes, *http.Response, error)
+	ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
 	ListMetricTypes Return All Atlas Search Metric Types for One Process
@@ -268,19 +268,19 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param processId Combination of hostname and IANA port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (mongod or mongos). The port must be the IANA port on which the MongoDB process listens for requests.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MonitoringAndLogsApiListMetricTypesRequest
+	@return ListMetricTypesApiRequest
 	*/
-	ListMetricTypes(ctx context.Context, processId string, groupId string) MonitoringAndLogsApiListMetricTypesRequest
+	ListMetricTypes(ctx context.Context, processId string, groupId string) ListMetricTypesApiRequest
 
 	// ListMetricTypesExecute executes the request
 	//  @return FTSMetrics
-	ListMetricTypesExecute(r MonitoringAndLogsApiListMetricTypesRequest) (*FTSMetrics, *http.Response, error)
+	ListMetricTypesExecute(r ListMetricTypesApiRequest) (*FTSMetrics, *http.Response, error)
 }
 
 // MonitoringAndLogsApiService MonitoringAndLogsApi service
 type MonitoringAndLogsApiService service
 
-type MonitoringAndLogsApiGetAtlasProcessRequest struct {
+type GetAtlasProcessApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -292,7 +292,7 @@ type GetAtlasProcessParams struct {
 		ProcessId string
 }
 
-func (r MonitoringAndLogsApiGetAtlasProcessRequest) Execute() (*HostViewAtlas, *http.Response, error) {
+func (r GetAtlasProcessApiRequest) Execute() (*HostViewAtlas, *http.Response, error) {
 	return r.ApiService.GetAtlasProcessExecute(r)
 }
 
@@ -304,10 +304,10 @@ Returns the processes for the specified host for the specified project. To use t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiGetAtlasProcessRequest
+ @return GetAtlasProcessApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetAtlasProcess(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiGetAtlasProcessRequest {
-	return MonitoringAndLogsApiGetAtlasProcessRequest{
+func (a *MonitoringAndLogsApiService) GetAtlasProcess(ctx context.Context, groupId string, processId string) GetAtlasProcessApiRequest {
+	return GetAtlasProcessApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -317,7 +317,7 @@ func (a *MonitoringAndLogsApiService) GetAtlasProcess(ctx context.Context, group
 
 // Execute executes the request
 //  @return HostViewAtlas
-func (a *MonitoringAndLogsApiService) GetAtlasProcessExecute(r MonitoringAndLogsApiGetAtlasProcessRequest) (*HostViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*HostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -406,7 +406,7 @@ func (a *MonitoringAndLogsApiService) GetAtlasProcessExecute(r MonitoringAndLogs
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiGetDatabaseRequest struct {
+type GetDatabaseApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -420,7 +420,7 @@ type GetDatabaseParams struct {
 		ProcessId string
 }
 
-func (r MonitoringAndLogsApiGetDatabaseRequest) Execute() (*Database, *http.Response, error) {
+func (r GetDatabaseApiRequest) Execute() (*Database, *http.Response, error) {
 	return r.ApiService.GetDatabaseExecute(r)
 }
 
@@ -433,10 +433,10 @@ Returns one database running on the specified host for the specified project. To
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param databaseName Human-readable label that identifies the database that the specified MongoDB process serves.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiGetDatabaseRequest
+ @return GetDatabaseApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetDatabase(ctx context.Context, groupId string, databaseName string, processId string) MonitoringAndLogsApiGetDatabaseRequest {
-	return MonitoringAndLogsApiGetDatabaseRequest{
+func (a *MonitoringAndLogsApiService) GetDatabase(ctx context.Context, groupId string, databaseName string, processId string) GetDatabaseApiRequest {
+	return GetDatabaseApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -447,7 +447,7 @@ func (a *MonitoringAndLogsApiService) GetDatabase(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return Database
-func (a *MonitoringAndLogsApiService) GetDatabaseExecute(r MonitoringAndLogsApiGetDatabaseRequest) (*Database, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetDatabaseExecute(r GetDatabaseApiRequest) (*Database, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -537,7 +537,7 @@ func (a *MonitoringAndLogsApiService) GetDatabaseExecute(r MonitoringAndLogsApiG
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiGetDatabaseMeasurementsRequest struct {
+type GetDatabaseMeasurementsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -554,12 +554,12 @@ type GetDatabaseMeasurementsParams struct {
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
-func (r MonitoringAndLogsApiGetDatabaseMeasurementsRequest) M(m []string) MonitoringAndLogsApiGetDatabaseMeasurementsRequest {
+func (r GetDatabaseMeasurementsApiRequest) M(m []string) GetDatabaseMeasurementsApiRequest {
 	r.m = &m
 	return r
 }
 
-func (r MonitoringAndLogsApiGetDatabaseMeasurementsRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (r GetDatabaseMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	return r.ApiService.GetDatabaseMeasurementsExecute(r)
 }
 
@@ -572,10 +572,10 @@ Returns the measurements of one database for the specified host for the specifie
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param databaseName Human-readable label that identifies the database that the specified MongoDB process serves.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiGetDatabaseMeasurementsRequest
+ @return GetDatabaseMeasurementsApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetDatabaseMeasurements(ctx context.Context, groupId string, databaseName string, processId string) MonitoringAndLogsApiGetDatabaseMeasurementsRequest {
-	return MonitoringAndLogsApiGetDatabaseMeasurementsRequest{
+func (a *MonitoringAndLogsApiService) GetDatabaseMeasurements(ctx context.Context, groupId string, databaseName string, processId string) GetDatabaseMeasurementsApiRequest {
+	return GetDatabaseMeasurementsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -586,7 +586,7 @@ func (a *MonitoringAndLogsApiService) GetDatabaseMeasurements(ctx context.Contex
 
 // Execute executes the request
 //  @return MeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) GetDatabaseMeasurementsExecute(r MonitoringAndLogsApiGetDatabaseMeasurementsRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -687,7 +687,7 @@ func (a *MonitoringAndLogsApiService) GetDatabaseMeasurementsExecute(r Monitorin
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiGetDiskMeasurementsRequest struct {
+type GetDiskMeasurementsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -704,12 +704,12 @@ type GetDiskMeasurementsParams struct {
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
-func (r MonitoringAndLogsApiGetDiskMeasurementsRequest) M(m []string) MonitoringAndLogsApiGetDiskMeasurementsRequest {
+func (r GetDiskMeasurementsApiRequest) M(m []string) GetDiskMeasurementsApiRequest {
 	r.m = &m
 	return r
 }
 
-func (r MonitoringAndLogsApiGetDiskMeasurementsRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (r GetDiskMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	return r.ApiService.GetDiskMeasurementsExecute(r)
 }
 
@@ -728,10 +728,10 @@ To use this resource, the requesting API Key must have the Project Read Only rol
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param partitionName Human-readable label of the disk or partition to which the measurements apply.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiGetDiskMeasurementsRequest
+ @return GetDiskMeasurementsApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetDiskMeasurements(ctx context.Context, groupId string, partitionName string, processId string) MonitoringAndLogsApiGetDiskMeasurementsRequest {
-	return MonitoringAndLogsApiGetDiskMeasurementsRequest{
+func (a *MonitoringAndLogsApiService) GetDiskMeasurements(ctx context.Context, groupId string, partitionName string, processId string) GetDiskMeasurementsApiRequest {
+	return GetDiskMeasurementsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -742,7 +742,7 @@ func (a *MonitoringAndLogsApiService) GetDiskMeasurements(ctx context.Context, g
 
 // Execute executes the request
 //  @return MeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) GetDiskMeasurementsExecute(r MonitoringAndLogsApiGetDiskMeasurementsRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -843,7 +843,7 @@ func (a *MonitoringAndLogsApiService) GetDiskMeasurementsExecute(r MonitoringAnd
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiGetHostLogsRequest struct {
+type GetHostLogsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -862,18 +862,18 @@ type GetHostLogsParams struct {
 }
 
 // Date and time when the period specifies the inclusive ending point for the range of log messages to retrieve. This parameter expresses its value in the number of seconds that have elapsed since the UNIX epoch.
-func (r MonitoringAndLogsApiGetHostLogsRequest) EndDate(endDate int64) MonitoringAndLogsApiGetHostLogsRequest {
+func (r GetHostLogsApiRequest) EndDate(endDate int64) GetHostLogsApiRequest {
 	r.endDate = &endDate
 	return r
 }
 
 // Date and time when the period specifies the inclusive starting point for the range of log messages to retrieve. This parameter expresses its value in the number of seconds that have elapsed since the UNIX epoch.
-func (r MonitoringAndLogsApiGetHostLogsRequest) StartDate(startDate int64) MonitoringAndLogsApiGetHostLogsRequest {
+func (r GetHostLogsApiRequest) StartDate(startDate int64) GetHostLogsApiRequest {
 	r.startDate = &startDate
 	return r
 }
 
-func (r MonitoringAndLogsApiGetHostLogsRequest) Execute() (*os.File, *http.Response, error) {
+func (r GetHostLogsApiRequest) Execute() (*os.File, *http.Response, error) {
 	return r.ApiService.GetHostLogsExecute(r)
 }
 
@@ -886,10 +886,10 @@ Returns a compressed (.gz) log file that contains a range of log messages for th
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param hostName Fully qualified domain name or IP address of the MongoDB host that stores the log files that you want to download.
  @param logName Human-readable label of the log file that you want to return. You can return audit logs only if you enable Database Auditing for the specified project.
- @return MonitoringAndLogsApiGetHostLogsRequest
+ @return GetHostLogsApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetHostLogs(ctx context.Context, groupId string, hostName string, logName string) MonitoringAndLogsApiGetHostLogsRequest {
-	return MonitoringAndLogsApiGetHostLogsRequest{
+func (a *MonitoringAndLogsApiService) GetHostLogs(ctx context.Context, groupId string, hostName string, logName string) GetHostLogsApiRequest {
+	return GetHostLogsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -900,7 +900,7 @@ func (a *MonitoringAndLogsApiService) GetHostLogs(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return *os.File
-func (a *MonitoringAndLogsApiService) GetHostLogsExecute(r MonitoringAndLogsApiGetHostLogsRequest) (*os.File, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -996,7 +996,7 @@ func (a *MonitoringAndLogsApiService) GetHostLogsExecute(r MonitoringAndLogsApiG
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiGetHostMeasurementsRequest struct {
+type GetHostMeasurementsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -1013,18 +1013,18 @@ type GetHostMeasurementsParams struct {
 }
 
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
-func (r MonitoringAndLogsApiGetHostMeasurementsRequest) M(m []string) MonitoringAndLogsApiGetHostMeasurementsRequest {
+func (r GetHostMeasurementsApiRequest) M(m []string) GetHostMeasurementsApiRequest {
 	r.m = &m
 	return r
 }
 
 // Date and time that indicates how far in the past to query. You can&#39;t set this value with **start** and **end** in the same request. This parameter expresses its value in the ISO 8601 duration format in UTC
-func (r MonitoringAndLogsApiGetHostMeasurementsRequest) Period(period time.Time) MonitoringAndLogsApiGetHostMeasurementsRequest {
+func (r GetHostMeasurementsApiRequest) Period(period time.Time) GetHostMeasurementsApiRequest {
 	r.period = &period
 	return r
 }
 
-func (r MonitoringAndLogsApiGetHostMeasurementsRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (r GetHostMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	return r.ApiService.GetHostMeasurementsExecute(r)
 }
 
@@ -1042,10 +1042,10 @@ To use this resource, the requesting API Key must have the Project Read Only rol
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiGetHostMeasurementsRequest
+ @return GetHostMeasurementsApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetHostMeasurements(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiGetHostMeasurementsRequest {
-	return MonitoringAndLogsApiGetHostMeasurementsRequest{
+func (a *MonitoringAndLogsApiService) GetHostMeasurements(ctx context.Context, groupId string, processId string) GetHostMeasurementsApiRequest {
+	return GetHostMeasurementsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1055,7 +1055,7 @@ func (a *MonitoringAndLogsApiService) GetHostMeasurements(ctx context.Context, g
 
 // Execute executes the request
 //  @return MeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) GetHostMeasurementsExecute(r MonitoringAndLogsApiGetHostMeasurementsRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1158,7 +1158,7 @@ func (a *MonitoringAndLogsApiService) GetHostMeasurementsExecute(r MonitoringAnd
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiGetIndexMetricsRequest struct {
+type GetIndexMetricsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	processId string
@@ -1187,36 +1187,36 @@ type GetIndexMetricsParams struct {
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
-func (r MonitoringAndLogsApiGetIndexMetricsRequest) Granularity(granularity string) MonitoringAndLogsApiGetIndexMetricsRequest {
+func (r GetIndexMetricsApiRequest) Granularity(granularity string) GetIndexMetricsApiRequest {
 	r.granularity = &granularity
 	return r
 }
 
 // List that contains the measurements that MongoDB Atlas reports for the associated data series.
-func (r MonitoringAndLogsApiGetIndexMetricsRequest) Metrics(metrics []string) MonitoringAndLogsApiGetIndexMetricsRequest {
+func (r GetIndexMetricsApiRequest) Metrics(metrics []string) GetIndexMetricsApiRequest {
 	r.metrics = &metrics
 	return r
 }
 
 // Duration over which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC. Include this parameter when you do not set **start** and **end**.
-func (r MonitoringAndLogsApiGetIndexMetricsRequest) Period(period string) MonitoringAndLogsApiGetIndexMetricsRequest {
+func (r GetIndexMetricsApiRequest) Period(period string) GetIndexMetricsApiRequest {
 	r.period = &period
 	return r
 }
 
 // Date and time when MongoDB Cloud begins reporting the metrics. This parameter expresses its value in the ISO 8601 timestamp format in UTC. Include this parameter when you do not set **period**.
-func (r MonitoringAndLogsApiGetIndexMetricsRequest) Start(start time.Time) MonitoringAndLogsApiGetIndexMetricsRequest {
+func (r GetIndexMetricsApiRequest) Start(start time.Time) GetIndexMetricsApiRequest {
 	r.start = &start
 	return r
 }
 
 // Date and time when MongoDB Cloud stops reporting the metrics. This parameter expresses its value in the ISO 8601 timestamp format in UTC. Include this parameter when you do not set **period**.
-func (r MonitoringAndLogsApiGetIndexMetricsRequest) End(end time.Time) MonitoringAndLogsApiGetIndexMetricsRequest {
+func (r GetIndexMetricsApiRequest) End(end time.Time) GetIndexMetricsApiRequest {
 	r.end = &end
 	return r
 }
 
-func (r MonitoringAndLogsApiGetIndexMetricsRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
+func (r GetIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
 	return r.ApiService.GetIndexMetricsExecute(r)
 }
 
@@ -1231,10 +1231,10 @@ Returns the Atlas Search metrics data series within the provided time range for 
  @param databaseName Human-readable label that identifies the database.
  @param collectionName Human-readable label that identifies the collection.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MonitoringAndLogsApiGetIndexMetricsRequest
+ @return GetIndexMetricsApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetIndexMetrics(ctx context.Context, processId string, indexName string, databaseName string, collectionName string, groupId string) MonitoringAndLogsApiGetIndexMetricsRequest {
-	return MonitoringAndLogsApiGetIndexMetricsRequest{
+func (a *MonitoringAndLogsApiService) GetIndexMetrics(ctx context.Context, processId string, indexName string, databaseName string, collectionName string, groupId string) GetIndexMetricsApiRequest {
+	return GetIndexMetricsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		processId: processId,
@@ -1247,7 +1247,7 @@ func (a *MonitoringAndLogsApiService) GetIndexMetrics(ctx context.Context, proce
 
 // Execute executes the request
 //  @return MeasurementsIndexes
-func (a *MonitoringAndLogsApiService) GetIndexMetricsExecute(r MonitoringAndLogsApiGetIndexMetricsRequest) (*MeasurementsIndexes, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1369,7 +1369,7 @@ func (a *MonitoringAndLogsApiService) GetIndexMetricsExecute(r MonitoringAndLogs
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiGetMeasurementsRequest struct {
+type GetMeasurementsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	processId string
@@ -1392,36 +1392,36 @@ type GetMeasurementsParams struct {
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
-func (r MonitoringAndLogsApiGetMeasurementsRequest) Granularity(granularity string) MonitoringAndLogsApiGetMeasurementsRequest {
+func (r GetMeasurementsApiRequest) Granularity(granularity string) GetMeasurementsApiRequest {
 	r.granularity = &granularity
 	return r
 }
 
 // List that contains the metrics that you want MongoDB Atlas to report for the associated data series. If you don&#39;t set this parameter, this resource returns all hardware and status metrics for the associated data series.
-func (r MonitoringAndLogsApiGetMeasurementsRequest) Metrics(metrics []string) MonitoringAndLogsApiGetMeasurementsRequest {
+func (r GetMeasurementsApiRequest) Metrics(metrics []string) GetMeasurementsApiRequest {
 	r.metrics = &metrics
 	return r
 }
 
 // Duration over which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC. Include this parameter when you do not set **start** and **end**.
-func (r MonitoringAndLogsApiGetMeasurementsRequest) Period(period string) MonitoringAndLogsApiGetMeasurementsRequest {
+func (r GetMeasurementsApiRequest) Period(period string) GetMeasurementsApiRequest {
 	r.period = &period
 	return r
 }
 
 // Date and time when MongoDB Cloud begins reporting the metrics. This parameter expresses its value in the ISO 8601 timestamp format in UTC. Include this parameter when you do not set **period**.
-func (r MonitoringAndLogsApiGetMeasurementsRequest) Start(start time.Time) MonitoringAndLogsApiGetMeasurementsRequest {
+func (r GetMeasurementsApiRequest) Start(start time.Time) GetMeasurementsApiRequest {
 	r.start = &start
 	return r
 }
 
 // Date and time when MongoDB Cloud stops reporting the metrics. This parameter expresses its value in the ISO 8601 timestamp format in UTC. Include this parameter when you do not set **period**.
-func (r MonitoringAndLogsApiGetMeasurementsRequest) End(end time.Time) MonitoringAndLogsApiGetMeasurementsRequest {
+func (r GetMeasurementsApiRequest) End(end time.Time) GetMeasurementsApiRequest {
 	r.end = &end
 	return r
 }
 
-func (r MonitoringAndLogsApiGetMeasurementsRequest) Execute() (*MeasurementsNonIndex, *http.Response, error) {
+func (r GetMeasurementsApiRequest) Execute() (*MeasurementsNonIndex, *http.Response, error) {
 	return r.ApiService.GetMeasurementsExecute(r)
 }
 
@@ -1433,10 +1433,10 @@ Returns the Atlas Search hardware and status data series within the provided tim
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param processId Combination of hostname and IANA port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (mongod or mongos). The port must be the IANA port on which the MongoDB process listens for requests.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MonitoringAndLogsApiGetMeasurementsRequest
+ @return GetMeasurementsApiRequest
 */
-func (a *MonitoringAndLogsApiService) GetMeasurements(ctx context.Context, processId string, groupId string) MonitoringAndLogsApiGetMeasurementsRequest {
-	return MonitoringAndLogsApiGetMeasurementsRequest{
+func (a *MonitoringAndLogsApiService) GetMeasurements(ctx context.Context, processId string, groupId string) GetMeasurementsApiRequest {
+	return GetMeasurementsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		processId: processId,
@@ -1446,7 +1446,7 @@ func (a *MonitoringAndLogsApiService) GetMeasurements(ctx context.Context, proce
 
 // Execute executes the request
 //  @return MeasurementsNonIndex
-func (a *MonitoringAndLogsApiService) GetMeasurementsExecute(r MonitoringAndLogsApiGetMeasurementsRequest) (*MeasurementsNonIndex, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1565,7 +1565,7 @@ func (a *MonitoringAndLogsApiService) GetMeasurementsExecute(r MonitoringAndLogs
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiListAtlasProcessesRequest struct {
+type ListAtlasProcessesApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -1582,24 +1582,24 @@ type ListAtlasProcessesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r MonitoringAndLogsApiListAtlasProcessesRequest) IncludeCount(includeCount bool) MonitoringAndLogsApiListAtlasProcessesRequest {
+func (r ListAtlasProcessesApiRequest) IncludeCount(includeCount bool) ListAtlasProcessesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r MonitoringAndLogsApiListAtlasProcessesRequest) ItemsPerPage(itemsPerPage int32) MonitoringAndLogsApiListAtlasProcessesRequest {
+func (r ListAtlasProcessesApiRequest) ItemsPerPage(itemsPerPage int32) ListAtlasProcessesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r MonitoringAndLogsApiListAtlasProcessesRequest) PageNum(pageNum int32) MonitoringAndLogsApiListAtlasProcessesRequest {
+func (r ListAtlasProcessesApiRequest) PageNum(pageNum int32) ListAtlasProcessesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r MonitoringAndLogsApiListAtlasProcessesRequest) Execute() (*PaginatedHostViewAtlas, *http.Response, error) {
+func (r ListAtlasProcessesApiRequest) Execute() (*PaginatedHostViewAtlas, *http.Response, error) {
 	return r.ApiService.ListAtlasProcessesExecute(r)
 }
 
@@ -1610,10 +1610,10 @@ Returns details of all processes for the specified project. A MongoDB process ca
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MonitoringAndLogsApiListAtlasProcessesRequest
+ @return ListAtlasProcessesApiRequest
 */
-func (a *MonitoringAndLogsApiService) ListAtlasProcesses(ctx context.Context, groupId string) MonitoringAndLogsApiListAtlasProcessesRequest {
-	return MonitoringAndLogsApiListAtlasProcessesRequest{
+func (a *MonitoringAndLogsApiService) ListAtlasProcesses(ctx context.Context, groupId string) ListAtlasProcessesApiRequest {
+	return ListAtlasProcessesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1622,7 +1622,7 @@ func (a *MonitoringAndLogsApiService) ListAtlasProcesses(ctx context.Context, gr
 
 // Execute executes the request
 //  @return PaginatedHostViewAtlas
-func (a *MonitoringAndLogsApiService) ListAtlasProcessesExecute(r MonitoringAndLogsApiListAtlasProcessesRequest) (*PaginatedHostViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1731,7 +1731,7 @@ func (a *MonitoringAndLogsApiService) ListAtlasProcessesExecute(r MonitoringAndL
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiListDatabasesRequest struct {
+type ListDatabasesApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -1750,24 +1750,24 @@ type ListDatabasesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r MonitoringAndLogsApiListDatabasesRequest) IncludeCount(includeCount bool) MonitoringAndLogsApiListDatabasesRequest {
+func (r ListDatabasesApiRequest) IncludeCount(includeCount bool) ListDatabasesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r MonitoringAndLogsApiListDatabasesRequest) ItemsPerPage(itemsPerPage int32) MonitoringAndLogsApiListDatabasesRequest {
+func (r ListDatabasesApiRequest) ItemsPerPage(itemsPerPage int32) ListDatabasesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r MonitoringAndLogsApiListDatabasesRequest) PageNum(pageNum int32) MonitoringAndLogsApiListDatabasesRequest {
+func (r ListDatabasesApiRequest) PageNum(pageNum int32) ListDatabasesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r MonitoringAndLogsApiListDatabasesRequest) Execute() (*PaginatedDatabase, *http.Response, error) {
+func (r ListDatabasesApiRequest) Execute() (*PaginatedDatabase, *http.Response, error) {
 	return r.ApiService.ListDatabasesExecute(r)
 }
 
@@ -1779,10 +1779,10 @@ Returns the list of databases running on the specified host for the specified pr
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiListDatabasesRequest
+ @return ListDatabasesApiRequest
 */
-func (a *MonitoringAndLogsApiService) ListDatabases(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiListDatabasesRequest {
-	return MonitoringAndLogsApiListDatabasesRequest{
+func (a *MonitoringAndLogsApiService) ListDatabases(ctx context.Context, groupId string, processId string) ListDatabasesApiRequest {
+	return ListDatabasesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1792,7 +1792,7 @@ func (a *MonitoringAndLogsApiService) ListDatabases(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return PaginatedDatabase
-func (a *MonitoringAndLogsApiService) ListDatabasesExecute(r MonitoringAndLogsApiListDatabasesRequest) (*PaginatedDatabase, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1902,7 +1902,7 @@ func (a *MonitoringAndLogsApiService) ListDatabasesExecute(r MonitoringAndLogsAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiListDiskMeasurementsRequest struct {
+type ListDiskMeasurementsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	partitionName string
@@ -1916,7 +1916,7 @@ type ListDiskMeasurementsParams struct {
 		ProcessId string
 }
 
-func (r MonitoringAndLogsApiListDiskMeasurementsRequest) Execute() (*DiskPartition, *http.Response, error) {
+func (r ListDiskMeasurementsApiRequest) Execute() (*DiskPartition, *http.Response, error) {
 	return r.ApiService.ListDiskMeasurementsExecute(r)
 }
 
@@ -1935,10 +1935,10 @@ To use this resource, the requesting API Key must have the Project Read Only rol
  @param partitionName Human-readable label of the disk or partition to which the measurements apply.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiListDiskMeasurementsRequest
+ @return ListDiskMeasurementsApiRequest
 */
-func (a *MonitoringAndLogsApiService) ListDiskMeasurements(ctx context.Context, partitionName string, groupId string, processId string) MonitoringAndLogsApiListDiskMeasurementsRequest {
-	return MonitoringAndLogsApiListDiskMeasurementsRequest{
+func (a *MonitoringAndLogsApiService) ListDiskMeasurements(ctx context.Context, partitionName string, groupId string, processId string) ListDiskMeasurementsApiRequest {
+	return ListDiskMeasurementsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		partitionName: partitionName,
@@ -1949,7 +1949,7 @@ func (a *MonitoringAndLogsApiService) ListDiskMeasurements(ctx context.Context, 
 
 // Execute executes the request
 //  @return DiskPartition
-func (a *MonitoringAndLogsApiService) ListDiskMeasurementsExecute(r MonitoringAndLogsApiListDiskMeasurementsRequest) (*DiskPartition, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*DiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2039,7 +2039,7 @@ func (a *MonitoringAndLogsApiService) ListDiskMeasurementsExecute(r MonitoringAn
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiListDiskPartitionsRequest struct {
+type ListDiskPartitionsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	groupId string
@@ -2058,24 +2058,24 @@ type ListDiskPartitionsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r MonitoringAndLogsApiListDiskPartitionsRequest) IncludeCount(includeCount bool) MonitoringAndLogsApiListDiskPartitionsRequest {
+func (r ListDiskPartitionsApiRequest) IncludeCount(includeCount bool) ListDiskPartitionsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r MonitoringAndLogsApiListDiskPartitionsRequest) ItemsPerPage(itemsPerPage int32) MonitoringAndLogsApiListDiskPartitionsRequest {
+func (r ListDiskPartitionsApiRequest) ItemsPerPage(itemsPerPage int32) ListDiskPartitionsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r MonitoringAndLogsApiListDiskPartitionsRequest) PageNum(pageNum int32) MonitoringAndLogsApiListDiskPartitionsRequest {
+func (r ListDiskPartitionsApiRequest) PageNum(pageNum int32) ListDiskPartitionsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r MonitoringAndLogsApiListDiskPartitionsRequest) Execute() (*PaginatedDiskPartition, *http.Response, error) {
+func (r ListDiskPartitionsApiRequest) Execute() (*PaginatedDiskPartition, *http.Response, error) {
 	return r.ApiService.ListDiskPartitionsExecute(r)
 }
 
@@ -2087,10 +2087,10 @@ Returns the list of disks or partitions for the specified host for the specified
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of hostname and Internet Assigned Numbers Authority (IANA) port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return MonitoringAndLogsApiListDiskPartitionsRequest
+ @return ListDiskPartitionsApiRequest
 */
-func (a *MonitoringAndLogsApiService) ListDiskPartitions(ctx context.Context, groupId string, processId string) MonitoringAndLogsApiListDiskPartitionsRequest {
-	return MonitoringAndLogsApiListDiskPartitionsRequest{
+func (a *MonitoringAndLogsApiService) ListDiskPartitions(ctx context.Context, groupId string, processId string) ListDiskPartitionsApiRequest {
+	return ListDiskPartitionsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2100,7 +2100,7 @@ func (a *MonitoringAndLogsApiService) ListDiskPartitions(ctx context.Context, gr
 
 // Execute executes the request
 //  @return PaginatedDiskPartition
-func (a *MonitoringAndLogsApiService) ListDiskPartitionsExecute(r MonitoringAndLogsApiListDiskPartitionsRequest) (*PaginatedDiskPartition, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2210,7 +2210,7 @@ func (a *MonitoringAndLogsApiService) ListDiskPartitionsExecute(r MonitoringAndL
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiListIndexMetricsRequest struct {
+type ListIndexMetricsApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	processId string
@@ -2237,36 +2237,36 @@ type ListIndexMetricsParams struct {
 }
 
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
-func (r MonitoringAndLogsApiListIndexMetricsRequest) Granularity(granularity string) MonitoringAndLogsApiListIndexMetricsRequest {
+func (r ListIndexMetricsApiRequest) Granularity(granularity string) ListIndexMetricsApiRequest {
 	r.granularity = &granularity
 	return r
 }
 
 // List that contains the measurements that MongoDB Atlas reports for the associated data series.
-func (r MonitoringAndLogsApiListIndexMetricsRequest) Metrics(metrics []string) MonitoringAndLogsApiListIndexMetricsRequest {
+func (r ListIndexMetricsApiRequest) Metrics(metrics []string) ListIndexMetricsApiRequest {
 	r.metrics = &metrics
 	return r
 }
 
 // Duration over which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC. Include this parameter when you do not set **start** and **end**.
-func (r MonitoringAndLogsApiListIndexMetricsRequest) Period(period string) MonitoringAndLogsApiListIndexMetricsRequest {
+func (r ListIndexMetricsApiRequest) Period(period string) ListIndexMetricsApiRequest {
 	r.period = &period
 	return r
 }
 
 // Date and time when MongoDB Cloud begins reporting the metrics. This parameter expresses its value in the ISO 8601 timestamp format in UTC. Include this parameter when you do not set **period**.
-func (r MonitoringAndLogsApiListIndexMetricsRequest) Start(start time.Time) MonitoringAndLogsApiListIndexMetricsRequest {
+func (r ListIndexMetricsApiRequest) Start(start time.Time) ListIndexMetricsApiRequest {
 	r.start = &start
 	return r
 }
 
 // Date and time when MongoDB Cloud stops reporting the metrics. This parameter expresses its value in the ISO 8601 timestamp format in UTC. Include this parameter when you do not set **period**.
-func (r MonitoringAndLogsApiListIndexMetricsRequest) End(end time.Time) MonitoringAndLogsApiListIndexMetricsRequest {
+func (r ListIndexMetricsApiRequest) End(end time.Time) ListIndexMetricsApiRequest {
 	r.end = &end
 	return r
 }
 
-func (r MonitoringAndLogsApiListIndexMetricsRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
+func (r ListIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
 	return r.ApiService.ListIndexMetricsExecute(r)
 }
 
@@ -2280,10 +2280,10 @@ Returns the Atlas Search index metrics within the specified time range for one n
  @param databaseName Human-readable label that identifies the database.
  @param collectionName Human-readable label that identifies the collection.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MonitoringAndLogsApiListIndexMetricsRequest
+ @return ListIndexMetricsApiRequest
 */
-func (a *MonitoringAndLogsApiService) ListIndexMetrics(ctx context.Context, processId string, databaseName string, collectionName string, groupId string) MonitoringAndLogsApiListIndexMetricsRequest {
-	return MonitoringAndLogsApiListIndexMetricsRequest{
+func (a *MonitoringAndLogsApiService) ListIndexMetrics(ctx context.Context, processId string, databaseName string, collectionName string, groupId string) ListIndexMetricsApiRequest {
+	return ListIndexMetricsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		processId: processId,
@@ -2295,7 +2295,7 @@ func (a *MonitoringAndLogsApiService) ListIndexMetrics(ctx context.Context, proc
 
 // Execute executes the request
 //  @return MeasurementsIndexes
-func (a *MonitoringAndLogsApiService) ListIndexMetricsExecute(r MonitoringAndLogsApiListIndexMetricsRequest) (*MeasurementsIndexes, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2416,7 +2416,7 @@ func (a *MonitoringAndLogsApiService) ListIndexMetricsExecute(r MonitoringAndLog
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MonitoringAndLogsApiListMetricTypesRequest struct {
+type ListMetricTypesApiRequest struct {
 	ctx context.Context
 	ApiService MonitoringAndLogsApi
 	processId string
@@ -2428,7 +2428,7 @@ type ListMetricTypesParams struct {
 		GroupId string
 }
 
-func (r MonitoringAndLogsApiListMetricTypesRequest) Execute() (*FTSMetrics, *http.Response, error) {
+func (r ListMetricTypesApiRequest) Execute() (*FTSMetrics, *http.Response, error) {
 	return r.ApiService.ListMetricTypesExecute(r)
 }
 
@@ -2440,10 +2440,10 @@ Return all Atlas Search metric types available for one process in the specified 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param processId Combination of hostname and IANA port that serves the MongoDB process. The host must be the hostname, fully qualified domain name (FQDN), or Internet Protocol address (IPv4 or IPv6) of the host that runs the MongoDB process (mongod or mongos). The port must be the IANA port on which the MongoDB process listens for requests.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MonitoringAndLogsApiListMetricTypesRequest
+ @return ListMetricTypesApiRequest
 */
-func (a *MonitoringAndLogsApiService) ListMetricTypes(ctx context.Context, processId string, groupId string) MonitoringAndLogsApiListMetricTypesRequest {
-	return MonitoringAndLogsApiListMetricTypesRequest{
+func (a *MonitoringAndLogsApiService) ListMetricTypes(ctx context.Context, processId string, groupId string) ListMetricTypesApiRequest {
+	return ListMetricTypesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		processId: processId,
@@ -2453,7 +2453,7 @@ func (a *MonitoringAndLogsApiService) ListMetricTypes(ctx context.Context, proce
 
 // Execute executes the request
 //  @return FTSMetrics
-func (a *MonitoringAndLogsApiService) ListMetricTypesExecute(r MonitoringAndLogsApiListMetricTypesRequest) (*FTSMetrics, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) ListMetricTypesExecute(r ListMetricTypesApiRequest) (*FTSMetrics, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -287,7 +287,7 @@ type MonitoringAndLogsApiGetAtlasProcessRequest struct {
 	processId string
 }
 
-type MonitoringAndLogsApiGetAtlasProcessQueryParams struct {
+type MonitoringAndLogsApiGetAtlasProcessParams struct {
 		GroupId string
 		ProcessId string
 }
@@ -414,7 +414,7 @@ type MonitoringAndLogsApiGetDatabaseRequest struct {
 	processId string
 }
 
-type MonitoringAndLogsApiGetDatabaseQueryParams struct {
+type MonitoringAndLogsApiGetDatabaseParams struct {
 		GroupId string
 		DatabaseName string
 		ProcessId string
@@ -546,7 +546,7 @@ type MonitoringAndLogsApiGetDatabaseMeasurementsRequest struct {
 	m *[]string
 }
 
-type MonitoringAndLogsApiGetDatabaseMeasurementsQueryParams struct {
+type MonitoringAndLogsApiGetDatabaseMeasurementsParams struct {
 		GroupId string
 		DatabaseName string
 		ProcessId string
@@ -696,7 +696,7 @@ type MonitoringAndLogsApiGetDiskMeasurementsRequest struct {
 	m *[]string
 }
 
-type MonitoringAndLogsApiGetDiskMeasurementsQueryParams struct {
+type MonitoringAndLogsApiGetDiskMeasurementsParams struct {
 		GroupId string
 		PartitionName string
 		ProcessId string
@@ -853,7 +853,7 @@ type MonitoringAndLogsApiGetHostLogsRequest struct {
 	startDate *int64
 }
 
-type MonitoringAndLogsApiGetHostLogsQueryParams struct {
+type MonitoringAndLogsApiGetHostLogsParams struct {
 		GroupId string
 		HostName string
 		LogName string
@@ -1005,7 +1005,7 @@ type MonitoringAndLogsApiGetHostMeasurementsRequest struct {
 	period *time.Time
 }
 
-type MonitoringAndLogsApiGetHostMeasurementsQueryParams struct {
+type MonitoringAndLogsApiGetHostMeasurementsParams struct {
 		GroupId string
 		ProcessId string
 		M *[]string
@@ -1173,7 +1173,7 @@ type MonitoringAndLogsApiGetIndexMetricsRequest struct {
 	end *time.Time
 }
 
-type MonitoringAndLogsApiGetIndexMetricsQueryParams struct {
+type MonitoringAndLogsApiGetIndexMetricsParams struct {
 		ProcessId string
 		IndexName string
 		DatabaseName string
@@ -1381,7 +1381,7 @@ type MonitoringAndLogsApiGetMeasurementsRequest struct {
 	end *time.Time
 }
 
-type MonitoringAndLogsApiGetMeasurementsQueryParams struct {
+type MonitoringAndLogsApiGetMeasurementsParams struct {
 		ProcessId string
 		GroupId string
 		Granularity *string
@@ -1574,7 +1574,7 @@ type MonitoringAndLogsApiListAtlasProcessesRequest struct {
 	pageNum *int32
 }
 
-type MonitoringAndLogsApiListAtlasProcessesQueryParams struct {
+type MonitoringAndLogsApiListAtlasProcessesParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1741,7 +1741,7 @@ type MonitoringAndLogsApiListDatabasesRequest struct {
 	pageNum *int32
 }
 
-type MonitoringAndLogsApiListDatabasesQueryParams struct {
+type MonitoringAndLogsApiListDatabasesParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool
@@ -1910,7 +1910,7 @@ type MonitoringAndLogsApiListDiskMeasurementsRequest struct {
 	processId string
 }
 
-type MonitoringAndLogsApiListDiskMeasurementsQueryParams struct {
+type MonitoringAndLogsApiListDiskMeasurementsParams struct {
 		PartitionName string
 		GroupId string
 		ProcessId string
@@ -2049,7 +2049,7 @@ type MonitoringAndLogsApiListDiskPartitionsRequest struct {
 	pageNum *int32
 }
 
-type MonitoringAndLogsApiListDiskPartitionsQueryParams struct {
+type MonitoringAndLogsApiListDiskPartitionsParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool
@@ -2224,7 +2224,7 @@ type MonitoringAndLogsApiListIndexMetricsRequest struct {
 	end *time.Time
 }
 
-type MonitoringAndLogsApiListIndexMetricsQueryParams struct {
+type MonitoringAndLogsApiListIndexMetricsParams struct {
 		ProcessId string
 		DatabaseName string
 		CollectionName string
@@ -2423,7 +2423,7 @@ type MonitoringAndLogsApiListMetricTypesRequest struct {
 	groupId string
 }
 
-type MonitoringAndLogsApiListMetricTypesQueryParams struct {
+type MonitoringAndLogsApiListMetricTypesParams struct {
 		ProcessId string
 		GroupId string
 }

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -287,7 +287,7 @@ type MonitoringAndLogsApiGetAtlasProcessRequest struct {
 	processId string
 }
 
-type MonitoringAndLogsApiGetAtlasProcessParams struct {
+type GetAtlasProcessParams struct {
 		GroupId string
 		ProcessId string
 }
@@ -414,7 +414,7 @@ type MonitoringAndLogsApiGetDatabaseRequest struct {
 	processId string
 }
 
-type MonitoringAndLogsApiGetDatabaseParams struct {
+type GetDatabaseParams struct {
 		GroupId string
 		DatabaseName string
 		ProcessId string
@@ -546,7 +546,7 @@ type MonitoringAndLogsApiGetDatabaseMeasurementsRequest struct {
 	m *[]string
 }
 
-type MonitoringAndLogsApiGetDatabaseMeasurementsParams struct {
+type GetDatabaseMeasurementsParams struct {
 		GroupId string
 		DatabaseName string
 		ProcessId string
@@ -696,7 +696,7 @@ type MonitoringAndLogsApiGetDiskMeasurementsRequest struct {
 	m *[]string
 }
 
-type MonitoringAndLogsApiGetDiskMeasurementsParams struct {
+type GetDiskMeasurementsParams struct {
 		GroupId string
 		PartitionName string
 		ProcessId string
@@ -853,7 +853,7 @@ type MonitoringAndLogsApiGetHostLogsRequest struct {
 	startDate *int64
 }
 
-type MonitoringAndLogsApiGetHostLogsParams struct {
+type GetHostLogsParams struct {
 		GroupId string
 		HostName string
 		LogName string
@@ -1005,7 +1005,7 @@ type MonitoringAndLogsApiGetHostMeasurementsRequest struct {
 	period *time.Time
 }
 
-type MonitoringAndLogsApiGetHostMeasurementsParams struct {
+type GetHostMeasurementsParams struct {
 		GroupId string
 		ProcessId string
 		M *[]string
@@ -1173,7 +1173,7 @@ type MonitoringAndLogsApiGetIndexMetricsRequest struct {
 	end *time.Time
 }
 
-type MonitoringAndLogsApiGetIndexMetricsParams struct {
+type GetIndexMetricsParams struct {
 		ProcessId string
 		IndexName string
 		DatabaseName string
@@ -1381,7 +1381,7 @@ type MonitoringAndLogsApiGetMeasurementsRequest struct {
 	end *time.Time
 }
 
-type MonitoringAndLogsApiGetMeasurementsParams struct {
+type GetMeasurementsParams struct {
 		ProcessId string
 		GroupId string
 		Granularity *string
@@ -1574,7 +1574,7 @@ type MonitoringAndLogsApiListAtlasProcessesRequest struct {
 	pageNum *int32
 }
 
-type MonitoringAndLogsApiListAtlasProcessesParams struct {
+type ListAtlasProcessesParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1741,7 +1741,7 @@ type MonitoringAndLogsApiListDatabasesRequest struct {
 	pageNum *int32
 }
 
-type MonitoringAndLogsApiListDatabasesParams struct {
+type ListDatabasesParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool
@@ -1910,7 +1910,7 @@ type MonitoringAndLogsApiListDiskMeasurementsRequest struct {
 	processId string
 }
 
-type MonitoringAndLogsApiListDiskMeasurementsParams struct {
+type ListDiskMeasurementsParams struct {
 		PartitionName string
 		GroupId string
 		ProcessId string
@@ -2049,7 +2049,7 @@ type MonitoringAndLogsApiListDiskPartitionsRequest struct {
 	pageNum *int32
 }
 
-type MonitoringAndLogsApiListDiskPartitionsParams struct {
+type ListDiskPartitionsParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool
@@ -2224,7 +2224,7 @@ type MonitoringAndLogsApiListIndexMetricsRequest struct {
 	end *time.Time
 }
 
-type MonitoringAndLogsApiListIndexMetricsParams struct {
+type ListIndexMetricsParams struct {
 		ProcessId string
 		DatabaseName string
 		CollectionName string
@@ -2423,7 +2423,7 @@ type MonitoringAndLogsApiListMetricTypesRequest struct {
 	groupId string
 }
 
-type MonitoringAndLogsApiListMetricTypesParams struct {
+type ListMetricTypesParams struct {
 		ProcessId string
 		GroupId string
 }

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -124,9 +124,10 @@ type MultiCloudClustersApiCreateClusterRequest struct {
 	groupId string
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
+
 type MultiCloudClustersApiCreateClusterQueryParams struct {
-		groupId string
-		clusterDescriptionV15 *ClusterDescriptionV15
+		GroupId string
+		ClusterDescriptionV15 *ClusterDescriptionV15
 }
 
 // Cluster to create in the specific project.
@@ -258,10 +259,11 @@ type MultiCloudClustersApiDeleteClusterRequest struct {
 	clusterName string
 	retainBackups *bool
 }
+
 type MultiCloudClustersApiDeleteClusterQueryParams struct {
-		groupId string
-		clusterName string
-		retainBackups *bool
+		GroupId string
+		ClusterName string
+		RetainBackups *bool
 }
 
 // Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.
@@ -388,9 +390,10 @@ type MultiCloudClustersApiGetClusterRequest struct {
 	groupId string
 	clusterName string
 }
+
 type MultiCloudClustersApiGetClusterQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r MultiCloudClustersApiGetClusterRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
@@ -521,11 +524,12 @@ type MultiCloudClustersApiListClustersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type MultiCloudClustersApiListClustersQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -684,9 +688,10 @@ type MultiCloudClustersApiTestFailoverRequest struct {
 	groupId string
 	clusterName string
 }
+
 type MultiCloudClustersApiTestFailoverQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r MultiCloudClustersApiTestFailoverRequest) Execute() (*http.Response, error) {
@@ -805,10 +810,11 @@ type MultiCloudClustersApiUpdateClusterRequest struct {
 	clusterName string
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
+
 type MultiCloudClustersApiUpdateClusterQueryParams struct {
-		groupId string
-		clusterName string
-		clusterDescriptionV15 *ClusterDescriptionV15
+		GroupId string
+		ClusterName string
+		ClusterDescriptionV15 *ClusterDescriptionV15
 }
 
 // Cluster to update in the specified project.

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -29,13 +29,13 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MultiCloudClustersApiCreateClusterRequest
+	@return CreateClusterApiRequest
 	*/
-	CreateCluster(ctx context.Context, groupId string) MultiCloudClustersApiCreateClusterRequest
+	CreateCluster(ctx context.Context, groupId string) CreateClusterApiRequest
 
 	// CreateClusterExecute executes the request
 	//  @return ClusterDescriptionV15
-	CreateClusterExecute(r MultiCloudClustersApiCreateClusterRequest) (*ClusterDescriptionV15, *http.Response, error)
+	CreateClusterExecute(r CreateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
 
 	/*
 	DeleteCluster Remove One Multi-Cloud Cluster from One Project
@@ -45,12 +45,12 @@ type MultiCloudClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return MultiCloudClustersApiDeleteClusterRequest
+	@return DeleteClusterApiRequest
 	*/
-	DeleteCluster(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiDeleteClusterRequest
+	DeleteCluster(ctx context.Context, groupId string, clusterName string) DeleteClusterApiRequest
 
 	// DeleteClusterExecute executes the request
-	DeleteClusterExecute(r MultiCloudClustersApiDeleteClusterRequest) (*http.Response, error)
+	DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error)
 
 	/*
 	GetCluster Return One Multi-Cloud Cluster from One Project
@@ -60,13 +60,13 @@ type MultiCloudClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies this advanced cluster.
-	@return MultiCloudClustersApiGetClusterRequest
+	@return GetClusterApiRequest
 	*/
-	GetCluster(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiGetClusterRequest
+	GetCluster(ctx context.Context, groupId string, clusterName string) GetClusterApiRequest
 
 	// GetClusterExecute executes the request
 	//  @return ClusterDescriptionV15
-	GetClusterExecute(r MultiCloudClustersApiGetClusterRequest) (*ClusterDescriptionV15, *http.Response, error)
+	GetClusterExecute(r GetClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
 
 	/*
 	ListClusters Return All Multi-Cloud Clusters from One Project
@@ -75,13 +75,13 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return MultiCloudClustersApiListClustersRequest
+	@return ListClustersApiRequest
 	*/
-	ListClusters(ctx context.Context, groupId string) MultiCloudClustersApiListClustersRequest
+	ListClusters(ctx context.Context, groupId string) ListClustersApiRequest
 
 	// ListClustersExecute executes the request
 	//  @return PaginatedClusterDescriptionV15
-	ListClustersExecute(r MultiCloudClustersApiListClustersRequest) (*PaginatedClusterDescriptionV15, *http.Response, error)
+	ListClustersExecute(r ListClustersApiRequest) (*PaginatedClusterDescriptionV15, *http.Response, error)
 
 	/*
 	TestFailover Test Failover for One Multi-Cloud Cluster
@@ -91,12 +91,12 @@ type MultiCloudClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return MultiCloudClustersApiTestFailoverRequest
+	@return TestFailoverApiRequest
 	*/
-	TestFailover(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiTestFailoverRequest
+	TestFailover(ctx context.Context, groupId string, clusterName string) TestFailoverApiRequest
 
 	// TestFailoverExecute executes the request
-	TestFailoverExecute(r MultiCloudClustersApiTestFailoverRequest) (*http.Response, error)
+	TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error)
 
 	/*
 	UpdateCluster Modify One Multi-Cloud Cluster from One Project
@@ -106,19 +106,19 @@ type MultiCloudClustersApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the advanced cluster to modify.
-	@return MultiCloudClustersApiUpdateClusterRequest
+	@return UpdateClusterApiRequest
 	*/
-	UpdateCluster(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiUpdateClusterRequest
+	UpdateCluster(ctx context.Context, groupId string, clusterName string) UpdateClusterApiRequest
 
 	// UpdateClusterExecute executes the request
 	//  @return ClusterDescriptionV15
-	UpdateClusterExecute(r MultiCloudClustersApiUpdateClusterRequest) (*ClusterDescriptionV15, *http.Response, error)
+	UpdateClusterExecute(r UpdateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
 }
 
 // MultiCloudClustersApiService MultiCloudClustersApi service
 type MultiCloudClustersApiService service
 
-type MultiCloudClustersApiCreateClusterRequest struct {
+type CreateClusterApiRequest struct {
 	ctx context.Context
 	ApiService MultiCloudClustersApi
 	groupId string
@@ -131,12 +131,12 @@ type CreateClusterParams struct {
 }
 
 // Cluster to create in the specific project.
-func (r MultiCloudClustersApiCreateClusterRequest) ClusterDescriptionV15(clusterDescriptionV15 ClusterDescriptionV15) MultiCloudClustersApiCreateClusterRequest {
+func (r CreateClusterApiRequest) ClusterDescriptionV15(clusterDescriptionV15 ClusterDescriptionV15) CreateClusterApiRequest {
 	r.clusterDescriptionV15 = &clusterDescriptionV15
 	return r
 }
 
-func (r MultiCloudClustersApiCreateClusterRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
+func (r CreateClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
 	return r.ApiService.CreateClusterExecute(r)
 }
 
@@ -147,10 +147,10 @@ Creates one cluster in the specified project. Clusters contain a group of hosts 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MultiCloudClustersApiCreateClusterRequest
+ @return CreateClusterApiRequest
 */
-func (a *MultiCloudClustersApiService) CreateCluster(ctx context.Context, groupId string) MultiCloudClustersApiCreateClusterRequest {
-	return MultiCloudClustersApiCreateClusterRequest{
+func (a *MultiCloudClustersApiService) CreateCluster(ctx context.Context, groupId string) CreateClusterApiRequest {
+	return CreateClusterApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -159,7 +159,7 @@ func (a *MultiCloudClustersApiService) CreateCluster(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return ClusterDescriptionV15
-func (a *MultiCloudClustersApiService) CreateClusterExecute(r MultiCloudClustersApiCreateClusterRequest) (*ClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) CreateClusterExecute(r CreateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -252,7 +252,7 @@ func (a *MultiCloudClustersApiService) CreateClusterExecute(r MultiCloudClusters
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MultiCloudClustersApiDeleteClusterRequest struct {
+type DeleteClusterApiRequest struct {
 	ctx context.Context
 	ApiService MultiCloudClustersApi
 	groupId string
@@ -267,12 +267,12 @@ type DeleteClusterParams struct {
 }
 
 // Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.
-func (r MultiCloudClustersApiDeleteClusterRequest) RetainBackups(retainBackups bool) MultiCloudClustersApiDeleteClusterRequest {
+func (r DeleteClusterApiRequest) RetainBackups(retainBackups bool) DeleteClusterApiRequest {
 	r.retainBackups = &retainBackups
 	return r
 }
 
-func (r MultiCloudClustersApiDeleteClusterRequest) Execute() (*http.Response, error) {
+func (r DeleteClusterApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteClusterExecute(r)
 }
 
@@ -284,10 +284,10 @@ Removes one cluster with advanced features from the specified project. The clust
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return MultiCloudClustersApiDeleteClusterRequest
+ @return DeleteClusterApiRequest
 */
-func (a *MultiCloudClustersApiService) DeleteCluster(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiDeleteClusterRequest {
-	return MultiCloudClustersApiDeleteClusterRequest{
+func (a *MultiCloudClustersApiService) DeleteCluster(ctx context.Context, groupId string, clusterName string) DeleteClusterApiRequest {
+	return DeleteClusterApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -296,7 +296,7 @@ func (a *MultiCloudClustersApiService) DeleteCluster(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *MultiCloudClustersApiService) DeleteClusterExecute(r MultiCloudClustersApiDeleteClusterRequest) (*http.Response, error) {
+func (a *MultiCloudClustersApiService) DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -384,7 +384,7 @@ func (a *MultiCloudClustersApiService) DeleteClusterExecute(r MultiCloudClusters
 	return localVarHTTPResponse, nil
 }
 
-type MultiCloudClustersApiGetClusterRequest struct {
+type GetClusterApiRequest struct {
 	ctx context.Context
 	ApiService MultiCloudClustersApi
 	groupId string
@@ -396,7 +396,7 @@ type GetClusterParams struct {
 		ClusterName string
 }
 
-func (r MultiCloudClustersApiGetClusterRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
+func (r GetClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
 	return r.ApiService.GetClusterExecute(r)
 }
 
@@ -408,10 +408,10 @@ Returns the details for one cluster in the specified project. Clusters contain a
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies this advanced cluster.
- @return MultiCloudClustersApiGetClusterRequest
+ @return GetClusterApiRequest
 */
-func (a *MultiCloudClustersApiService) GetCluster(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiGetClusterRequest {
-	return MultiCloudClustersApiGetClusterRequest{
+func (a *MultiCloudClustersApiService) GetCluster(ctx context.Context, groupId string, clusterName string) GetClusterApiRequest {
+	return GetClusterApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -421,7 +421,7 @@ func (a *MultiCloudClustersApiService) GetCluster(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return ClusterDescriptionV15
-func (a *MultiCloudClustersApiService) GetClusterExecute(r MultiCloudClustersApiGetClusterRequest) (*ClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) GetClusterExecute(r GetClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -516,7 +516,7 @@ func (a *MultiCloudClustersApiService) GetClusterExecute(r MultiCloudClustersApi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MultiCloudClustersApiListClustersRequest struct {
+type ListClustersApiRequest struct {
 	ctx context.Context
 	ApiService MultiCloudClustersApi
 	groupId string
@@ -533,24 +533,24 @@ type ListClustersParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r MultiCloudClustersApiListClustersRequest) IncludeCount(includeCount bool) MultiCloudClustersApiListClustersRequest {
+func (r ListClustersApiRequest) IncludeCount(includeCount bool) ListClustersApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r MultiCloudClustersApiListClustersRequest) ItemsPerPage(itemsPerPage int32) MultiCloudClustersApiListClustersRequest {
+func (r ListClustersApiRequest) ItemsPerPage(itemsPerPage int32) ListClustersApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r MultiCloudClustersApiListClustersRequest) PageNum(pageNum int32) MultiCloudClustersApiListClustersRequest {
+func (r ListClustersApiRequest) PageNum(pageNum int32) ListClustersApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r MultiCloudClustersApiListClustersRequest) Execute() (*PaginatedClusterDescriptionV15, *http.Response, error) {
+func (r ListClustersApiRequest) Execute() (*PaginatedClusterDescriptionV15, *http.Response, error) {
 	return r.ApiService.ListClustersExecute(r)
 }
 
@@ -561,10 +561,10 @@ Returns the details for all clusters in the specific project to which you have a
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return MultiCloudClustersApiListClustersRequest
+ @return ListClustersApiRequest
 */
-func (a *MultiCloudClustersApiService) ListClusters(ctx context.Context, groupId string) MultiCloudClustersApiListClustersRequest {
-	return MultiCloudClustersApiListClustersRequest{
+func (a *MultiCloudClustersApiService) ListClusters(ctx context.Context, groupId string) ListClustersApiRequest {
+	return ListClustersApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -573,7 +573,7 @@ func (a *MultiCloudClustersApiService) ListClusters(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return PaginatedClusterDescriptionV15
-func (a *MultiCloudClustersApiService) ListClustersExecute(r MultiCloudClustersApiListClustersRequest) (*PaginatedClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) ListClustersExecute(r ListClustersApiRequest) (*PaginatedClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -682,7 +682,7 @@ func (a *MultiCloudClustersApiService) ListClustersExecute(r MultiCloudClustersA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type MultiCloudClustersApiTestFailoverRequest struct {
+type TestFailoverApiRequest struct {
 	ctx context.Context
 	ApiService MultiCloudClustersApi
 	groupId string
@@ -694,7 +694,7 @@ type TestFailoverParams struct {
 		ClusterName string
 }
 
-func (r MultiCloudClustersApiTestFailoverRequest) Execute() (*http.Response, error) {
+func (r TestFailoverApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.TestFailoverExecute(r)
 }
 
@@ -706,10 +706,10 @@ Starts a failover test for the specified cluster in the specified project. Clust
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return MultiCloudClustersApiTestFailoverRequest
+ @return TestFailoverApiRequest
 */
-func (a *MultiCloudClustersApiService) TestFailover(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiTestFailoverRequest {
-	return MultiCloudClustersApiTestFailoverRequest{
+func (a *MultiCloudClustersApiService) TestFailover(ctx context.Context, groupId string, clusterName string) TestFailoverApiRequest {
+	return TestFailoverApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -718,7 +718,7 @@ func (a *MultiCloudClustersApiService) TestFailover(ctx context.Context, groupId
 }
 
 // Execute executes the request
-func (a *MultiCloudClustersApiService) TestFailoverExecute(r MultiCloudClustersApiTestFailoverRequest) (*http.Response, error) {
+func (a *MultiCloudClustersApiService) TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -803,7 +803,7 @@ func (a *MultiCloudClustersApiService) TestFailoverExecute(r MultiCloudClustersA
 	return localVarHTTPResponse, nil
 }
 
-type MultiCloudClustersApiUpdateClusterRequest struct {
+type UpdateClusterApiRequest struct {
 	ctx context.Context
 	ApiService MultiCloudClustersApi
 	groupId string
@@ -818,12 +818,12 @@ type UpdateClusterParams struct {
 }
 
 // Cluster to update in the specified project.
-func (r MultiCloudClustersApiUpdateClusterRequest) ClusterDescriptionV15(clusterDescriptionV15 ClusterDescriptionV15) MultiCloudClustersApiUpdateClusterRequest {
+func (r UpdateClusterApiRequest) ClusterDescriptionV15(clusterDescriptionV15 ClusterDescriptionV15) UpdateClusterApiRequest {
 	r.clusterDescriptionV15 = &clusterDescriptionV15
 	return r
 }
 
-func (r MultiCloudClustersApiUpdateClusterRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
+func (r UpdateClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
 	return r.ApiService.UpdateClusterExecute(r)
 }
 
@@ -835,10 +835,10 @@ Updates the details for one cluster in the specified project. Clusters contain a
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the advanced cluster to modify.
- @return MultiCloudClustersApiUpdateClusterRequest
+ @return UpdateClusterApiRequest
 */
-func (a *MultiCloudClustersApiService) UpdateCluster(ctx context.Context, groupId string, clusterName string) MultiCloudClustersApiUpdateClusterRequest {
-	return MultiCloudClustersApiUpdateClusterRequest{
+func (a *MultiCloudClustersApiService) UpdateCluster(ctx context.Context, groupId string, clusterName string) UpdateClusterApiRequest {
+	return UpdateClusterApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -848,7 +848,7 @@ func (a *MultiCloudClustersApiService) UpdateCluster(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return ClusterDescriptionV15
-func (a *MultiCloudClustersApiService) UpdateClusterExecute(r MultiCloudClustersApiUpdateClusterRequest) (*ClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) UpdateClusterExecute(r UpdateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -125,7 +125,7 @@ type CreateClusterApiRequest struct {
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
 
-type CreateClusterParams struct {
+type CreateClusterApiParams struct {
 		GroupId string
 		ClusterDescriptionV15 *ClusterDescriptionV15
 }
@@ -260,7 +260,7 @@ type DeleteClusterApiRequest struct {
 	retainBackups *bool
 }
 
-type DeleteClusterParams struct {
+type DeleteClusterApiParams struct {
 		GroupId string
 		ClusterName string
 		RetainBackups *bool
@@ -391,7 +391,7 @@ type GetClusterApiRequest struct {
 	clusterName string
 }
 
-type GetClusterParams struct {
+type GetClusterApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -525,7 +525,7 @@ type ListClustersApiRequest struct {
 	pageNum *int32
 }
 
-type ListClustersParams struct {
+type ListClustersApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -689,7 +689,7 @@ type TestFailoverApiRequest struct {
 	clusterName string
 }
 
-type TestFailoverParams struct {
+type TestFailoverApiParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -811,7 +811,7 @@ type UpdateClusterApiRequest struct {
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
 
-type UpdateClusterParams struct {
+type UpdateClusterApiParams struct {
 		GroupId string
 		ClusterName string
 		ClusterDescriptionV15 *ClusterDescriptionV15

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -125,7 +125,7 @@ type MultiCloudClustersApiCreateClusterRequest struct {
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
 
-type MultiCloudClustersApiCreateClusterQueryParams struct {
+type MultiCloudClustersApiCreateClusterParams struct {
 		GroupId string
 		ClusterDescriptionV15 *ClusterDescriptionV15
 }
@@ -260,7 +260,7 @@ type MultiCloudClustersApiDeleteClusterRequest struct {
 	retainBackups *bool
 }
 
-type MultiCloudClustersApiDeleteClusterQueryParams struct {
+type MultiCloudClustersApiDeleteClusterParams struct {
 		GroupId string
 		ClusterName string
 		RetainBackups *bool
@@ -391,7 +391,7 @@ type MultiCloudClustersApiGetClusterRequest struct {
 	clusterName string
 }
 
-type MultiCloudClustersApiGetClusterQueryParams struct {
+type MultiCloudClustersApiGetClusterParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -525,7 +525,7 @@ type MultiCloudClustersApiListClustersRequest struct {
 	pageNum *int32
 }
 
-type MultiCloudClustersApiListClustersQueryParams struct {
+type MultiCloudClustersApiListClustersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -689,7 +689,7 @@ type MultiCloudClustersApiTestFailoverRequest struct {
 	clusterName string
 }
 
-type MultiCloudClustersApiTestFailoverQueryParams struct {
+type MultiCloudClustersApiTestFailoverParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -811,7 +811,7 @@ type MultiCloudClustersApiUpdateClusterRequest struct {
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
 
-type MultiCloudClustersApiUpdateClusterQueryParams struct {
+type MultiCloudClustersApiUpdateClusterParams struct {
 		GroupId string
 		ClusterName string
 		ClusterDescriptionV15 *ClusterDescriptionV15

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -124,6 +124,10 @@ type MultiCloudClustersApiCreateClusterRequest struct {
 	groupId string
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
+type MultiCloudClustersApiCreateClusterQueryParams struct {
+		groupId string
+		clusterDescriptionV15 *ClusterDescriptionV15
+}
 
 // Cluster to create in the specific project.
 func (r MultiCloudClustersApiCreateClusterRequest) ClusterDescriptionV15(clusterDescriptionV15 ClusterDescriptionV15) MultiCloudClustersApiCreateClusterRequest {
@@ -254,6 +258,11 @@ type MultiCloudClustersApiDeleteClusterRequest struct {
 	clusterName string
 	retainBackups *bool
 }
+type MultiCloudClustersApiDeleteClusterQueryParams struct {
+		groupId string
+		clusterName string
+		retainBackups *bool
+}
 
 // Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.
 func (r MultiCloudClustersApiDeleteClusterRequest) RetainBackups(retainBackups bool) MultiCloudClustersApiDeleteClusterRequest {
@@ -378,6 +387,10 @@ type MultiCloudClustersApiGetClusterRequest struct {
 	ApiService MultiCloudClustersApi
 	groupId string
 	clusterName string
+}
+type MultiCloudClustersApiGetClusterQueryParams struct {
+		groupId string
+		clusterName string
 }
 
 func (r MultiCloudClustersApiGetClusterRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
@@ -507,6 +520,12 @@ type MultiCloudClustersApiListClustersRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type MultiCloudClustersApiListClustersQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -665,6 +684,10 @@ type MultiCloudClustersApiTestFailoverRequest struct {
 	groupId string
 	clusterName string
 }
+type MultiCloudClustersApiTestFailoverQueryParams struct {
+		groupId string
+		clusterName string
+}
 
 func (r MultiCloudClustersApiTestFailoverRequest) Execute() (*http.Response, error) {
 	return r.ApiService.TestFailoverExecute(r)
@@ -781,6 +804,11 @@ type MultiCloudClustersApiUpdateClusterRequest struct {
 	groupId string
 	clusterName string
 	clusterDescriptionV15 *ClusterDescriptionV15
+}
+type MultiCloudClustersApiUpdateClusterQueryParams struct {
+		groupId string
+		clusterName string
+		clusterDescriptionV15 *ClusterDescriptionV15
 }
 
 // Cluster to update in the specified project.

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -125,7 +125,7 @@ type MultiCloudClustersApiCreateClusterRequest struct {
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
 
-type MultiCloudClustersApiCreateClusterParams struct {
+type CreateClusterParams struct {
 		GroupId string
 		ClusterDescriptionV15 *ClusterDescriptionV15
 }
@@ -260,7 +260,7 @@ type MultiCloudClustersApiDeleteClusterRequest struct {
 	retainBackups *bool
 }
 
-type MultiCloudClustersApiDeleteClusterParams struct {
+type DeleteClusterParams struct {
 		GroupId string
 		ClusterName string
 		RetainBackups *bool
@@ -391,7 +391,7 @@ type MultiCloudClustersApiGetClusterRequest struct {
 	clusterName string
 }
 
-type MultiCloudClustersApiGetClusterParams struct {
+type GetClusterParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -525,7 +525,7 @@ type MultiCloudClustersApiListClustersRequest struct {
 	pageNum *int32
 }
 
-type MultiCloudClustersApiListClustersParams struct {
+type ListClustersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -689,7 +689,7 @@ type MultiCloudClustersApiTestFailoverRequest struct {
 	clusterName string
 }
 
-type MultiCloudClustersApiTestFailoverParams struct {
+type TestFailoverParams struct {
 		GroupId string
 		ClusterName string
 }
@@ -811,7 +811,7 @@ type MultiCloudClustersApiUpdateClusterRequest struct {
 	clusterDescriptionV15 *ClusterDescriptionV15
 }
 
-type MultiCloudClustersApiUpdateClusterParams struct {
+type UpdateClusterParams struct {
 		GroupId string
 		ClusterName string
 		ClusterDescriptionV15 *ClusterDescriptionV15

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -237,9 +237,10 @@ type NetworkPeeringApiCreatePeeringConnectionRequest struct {
 	groupId string
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
+
 type NetworkPeeringApiCreatePeeringConnectionQueryParams struct {
-		groupId string
-		containerPeerViewRequest *ContainerPeerViewRequest
+		GroupId string
+		ContainerPeerViewRequest *ContainerPeerViewRequest
 }
 
 // Create one network peering connection.
@@ -370,9 +371,10 @@ type NetworkPeeringApiCreatePeeringContainerRequest struct {
 	groupId string
 	cloudProviderContainer *CloudProviderContainer
 }
+
 type NetworkPeeringApiCreatePeeringContainerQueryParams struct {
-		groupId string
-		cloudProviderContainer *CloudProviderContainer
+		GroupId string
+		CloudProviderContainer *CloudProviderContainer
 }
 
 // Creates one new network peering container in the specified project.
@@ -503,9 +505,10 @@ type NetworkPeeringApiDeletePeeringConnectionRequest struct {
 	groupId string
 	peerId string
 }
+
 type NetworkPeeringApiDeletePeeringConnectionQueryParams struct {
-		groupId string
-		peerId string
+		GroupId string
+		PeerId string
 }
 
 func (r NetworkPeeringApiDeletePeeringConnectionRequest) Execute() (*http.Response, error) {
@@ -623,9 +626,10 @@ type NetworkPeeringApiDeletePeeringContainerRequest struct {
 	groupId string
 	containerId string
 }
+
 type NetworkPeeringApiDeletePeeringContainerQueryParams struct {
-		groupId string
-		containerId string
+		GroupId string
+		ContainerId string
 }
 
 func (r NetworkPeeringApiDeletePeeringContainerRequest) Execute() (*http.Response, error) {
@@ -743,9 +747,10 @@ type NetworkPeeringApiDisablePeeringRequest struct {
 	groupId string
 	privateIPMode *PrivateIPMode
 }
+
 type NetworkPeeringApiDisablePeeringQueryParams struct {
-		groupId string
-		privateIPMode *PrivateIPMode
+		GroupId string
+		PrivateIPMode *PrivateIPMode
 }
 
 // Disables Connect via Peering Only mode for the specified project.
@@ -879,9 +884,10 @@ type NetworkPeeringApiGetPeeringConnectionRequest struct {
 	groupId string
 	peerId string
 }
+
 type NetworkPeeringApiGetPeeringConnectionQueryParams struct {
-		groupId string
-		peerId string
+		GroupId string
+		PeerId string
 }
 
 func (r NetworkPeeringApiGetPeeringConnectionRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
@@ -1010,9 +1016,10 @@ type NetworkPeeringApiGetPeeringContainerRequest struct {
 	groupId string
 	containerId string
 }
+
 type NetworkPeeringApiGetPeeringContainerQueryParams struct {
-		groupId string
-		containerId string
+		GroupId string
+		ContainerId string
 }
 
 func (r NetworkPeeringApiGetPeeringContainerRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
@@ -1144,12 +1151,13 @@ type NetworkPeeringApiListPeeringConnectionsRequest struct {
 	pageNum *int32
 	providerName *string
 }
+
 type NetworkPeeringApiListPeeringConnectionsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		providerName *string
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		ProviderName *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1324,12 +1332,13 @@ type NetworkPeeringApiListPeeringContainerByCloudProviderRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type NetworkPeeringApiListPeeringContainerByCloudProviderQueryParams struct {
-		groupId string
-		providerName *string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ProviderName *string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Cloud service provider that serves the desired network peering containers.
@@ -1500,11 +1509,12 @@ type NetworkPeeringApiListPeeringContainersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type NetworkPeeringApiListPeeringContainersQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1664,10 +1674,11 @@ type NetworkPeeringApiUpdatePeeringConnectionRequest struct {
 	peerId string
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
+
 type NetworkPeeringApiUpdatePeeringConnectionQueryParams struct {
-		groupId string
-		peerId string
-		containerPeerViewRequest *ContainerPeerViewRequest
+		GroupId string
+		PeerId string
+		ContainerPeerViewRequest *ContainerPeerViewRequest
 }
 
 // Modify one network peering connection.
@@ -1808,10 +1819,11 @@ type NetworkPeeringApiUpdatePeeringContainerRequest struct {
 	containerId string
 	cloudProviderContainer *CloudProviderContainer
 }
+
 type NetworkPeeringApiUpdatePeeringContainerQueryParams struct {
-		groupId string
-		containerId string
-		cloudProviderContainer *CloudProviderContainer
+		GroupId string
+		ContainerId string
+		CloudProviderContainer *CloudProviderContainer
 }
 
 // Updates the network details and labels of one specified network peering container in the specified project.
@@ -1950,8 +1962,9 @@ type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest struct
 	ApiService NetworkPeeringApi
 	groupId string
 }
+
 type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest) Execute() (*PrivateIPMode, *http.Response, error) {

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -238,7 +238,7 @@ type NetworkPeeringApiCreatePeeringConnectionRequest struct {
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
 
-type NetworkPeeringApiCreatePeeringConnectionParams struct {
+type CreatePeeringConnectionParams struct {
 		GroupId string
 		ContainerPeerViewRequest *ContainerPeerViewRequest
 }
@@ -372,7 +372,7 @@ type NetworkPeeringApiCreatePeeringContainerRequest struct {
 	cloudProviderContainer *CloudProviderContainer
 }
 
-type NetworkPeeringApiCreatePeeringContainerParams struct {
+type CreatePeeringContainerParams struct {
 		GroupId string
 		CloudProviderContainer *CloudProviderContainer
 }
@@ -506,7 +506,7 @@ type NetworkPeeringApiDeletePeeringConnectionRequest struct {
 	peerId string
 }
 
-type NetworkPeeringApiDeletePeeringConnectionParams struct {
+type DeletePeeringConnectionParams struct {
 		GroupId string
 		PeerId string
 }
@@ -627,7 +627,7 @@ type NetworkPeeringApiDeletePeeringContainerRequest struct {
 	containerId string
 }
 
-type NetworkPeeringApiDeletePeeringContainerParams struct {
+type DeletePeeringContainerParams struct {
 		GroupId string
 		ContainerId string
 }
@@ -748,7 +748,7 @@ type NetworkPeeringApiDisablePeeringRequest struct {
 	privateIPMode *PrivateIPMode
 }
 
-type NetworkPeeringApiDisablePeeringParams struct {
+type DisablePeeringParams struct {
 		GroupId string
 		PrivateIPMode *PrivateIPMode
 }
@@ -885,7 +885,7 @@ type NetworkPeeringApiGetPeeringConnectionRequest struct {
 	peerId string
 }
 
-type NetworkPeeringApiGetPeeringConnectionParams struct {
+type GetPeeringConnectionParams struct {
 		GroupId string
 		PeerId string
 }
@@ -1017,7 +1017,7 @@ type NetworkPeeringApiGetPeeringContainerRequest struct {
 	containerId string
 }
 
-type NetworkPeeringApiGetPeeringContainerParams struct {
+type GetPeeringContainerParams struct {
 		GroupId string
 		ContainerId string
 }
@@ -1152,7 +1152,7 @@ type NetworkPeeringApiListPeeringConnectionsRequest struct {
 	providerName *string
 }
 
-type NetworkPeeringApiListPeeringConnectionsParams struct {
+type ListPeeringConnectionsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1333,7 +1333,7 @@ type NetworkPeeringApiListPeeringContainerByCloudProviderRequest struct {
 	pageNum *int32
 }
 
-type NetworkPeeringApiListPeeringContainerByCloudProviderParams struct {
+type ListPeeringContainerByCloudProviderParams struct {
 		GroupId string
 		ProviderName *string
 		IncludeCount *bool
@@ -1510,7 +1510,7 @@ type NetworkPeeringApiListPeeringContainersRequest struct {
 	pageNum *int32
 }
 
-type NetworkPeeringApiListPeeringContainersParams struct {
+type ListPeeringContainersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1675,7 +1675,7 @@ type NetworkPeeringApiUpdatePeeringConnectionRequest struct {
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
 
-type NetworkPeeringApiUpdatePeeringConnectionParams struct {
+type UpdatePeeringConnectionParams struct {
 		GroupId string
 		PeerId string
 		ContainerPeerViewRequest *ContainerPeerViewRequest
@@ -1820,7 +1820,7 @@ type NetworkPeeringApiUpdatePeeringContainerRequest struct {
 	cloudProviderContainer *CloudProviderContainer
 }
 
-type NetworkPeeringApiUpdatePeeringContainerParams struct {
+type UpdatePeeringContainerParams struct {
 		GroupId string
 		ContainerId string
 		CloudProviderContainer *CloudProviderContainer
@@ -1963,7 +1963,7 @@ type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest struct
 	groupId string
 }
 
-type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectParams struct {
+type VerifyConnectViaPeeringOnlyModeForOneProjectParams struct {
 		GroupId string
 }
 

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -237,6 +237,10 @@ type NetworkPeeringApiCreatePeeringConnectionRequest struct {
 	groupId string
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
+type NetworkPeeringApiCreatePeeringConnectionQueryParams struct {
+		groupId string
+		containerPeerViewRequest *ContainerPeerViewRequest
+}
 
 // Create one network peering connection.
 func (r NetworkPeeringApiCreatePeeringConnectionRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) NetworkPeeringApiCreatePeeringConnectionRequest {
@@ -365,6 +369,10 @@ type NetworkPeeringApiCreatePeeringContainerRequest struct {
 	ApiService NetworkPeeringApi
 	groupId string
 	cloudProviderContainer *CloudProviderContainer
+}
+type NetworkPeeringApiCreatePeeringContainerQueryParams struct {
+		groupId string
+		cloudProviderContainer *CloudProviderContainer
 }
 
 // Creates one new network peering container in the specified project.
@@ -495,6 +503,10 @@ type NetworkPeeringApiDeletePeeringConnectionRequest struct {
 	groupId string
 	peerId string
 }
+type NetworkPeeringApiDeletePeeringConnectionQueryParams struct {
+		groupId string
+		peerId string
+}
 
 func (r NetworkPeeringApiDeletePeeringConnectionRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePeeringConnectionExecute(r)
@@ -611,6 +623,10 @@ type NetworkPeeringApiDeletePeeringContainerRequest struct {
 	groupId string
 	containerId string
 }
+type NetworkPeeringApiDeletePeeringContainerQueryParams struct {
+		groupId string
+		containerId string
+}
 
 func (r NetworkPeeringApiDeletePeeringContainerRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePeeringContainerExecute(r)
@@ -726,6 +742,10 @@ type NetworkPeeringApiDisablePeeringRequest struct {
 	ApiService NetworkPeeringApi
 	groupId string
 	privateIPMode *PrivateIPMode
+}
+type NetworkPeeringApiDisablePeeringQueryParams struct {
+		groupId string
+		privateIPMode *PrivateIPMode
 }
 
 // Disables Connect via Peering Only mode for the specified project.
@@ -859,6 +879,10 @@ type NetworkPeeringApiGetPeeringConnectionRequest struct {
 	groupId string
 	peerId string
 }
+type NetworkPeeringApiGetPeeringConnectionQueryParams struct {
+		groupId string
+		peerId string
+}
 
 func (r NetworkPeeringApiGetPeeringConnectionRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
 	return r.ApiService.GetPeeringConnectionExecute(r)
@@ -985,6 +1009,10 @@ type NetworkPeeringApiGetPeeringContainerRequest struct {
 	ApiService NetworkPeeringApi
 	groupId string
 	containerId string
+}
+type NetworkPeeringApiGetPeeringContainerQueryParams struct {
+		groupId string
+		containerId string
 }
 
 func (r NetworkPeeringApiGetPeeringContainerRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
@@ -1115,6 +1143,13 @@ type NetworkPeeringApiListPeeringConnectionsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 	providerName *string
+}
+type NetworkPeeringApiListPeeringConnectionsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		providerName *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1289,6 +1324,13 @@ type NetworkPeeringApiListPeeringContainerByCloudProviderRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type NetworkPeeringApiListPeeringContainerByCloudProviderQueryParams struct {
+		groupId string
+		providerName *string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Cloud service provider that serves the desired network peering containers.
 func (r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) ProviderName(providerName string) NetworkPeeringApiListPeeringContainerByCloudProviderRequest {
@@ -1458,6 +1500,12 @@ type NetworkPeeringApiListPeeringContainersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type NetworkPeeringApiListPeeringContainersQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r NetworkPeeringApiListPeeringContainersRequest) IncludeCount(includeCount bool) NetworkPeeringApiListPeeringContainersRequest {
@@ -1616,6 +1664,11 @@ type NetworkPeeringApiUpdatePeeringConnectionRequest struct {
 	peerId string
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
+type NetworkPeeringApiUpdatePeeringConnectionQueryParams struct {
+		groupId string
+		peerId string
+		containerPeerViewRequest *ContainerPeerViewRequest
+}
 
 // Modify one network peering connection.
 func (r NetworkPeeringApiUpdatePeeringConnectionRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) NetworkPeeringApiUpdatePeeringConnectionRequest {
@@ -1755,6 +1808,11 @@ type NetworkPeeringApiUpdatePeeringContainerRequest struct {
 	containerId string
 	cloudProviderContainer *CloudProviderContainer
 }
+type NetworkPeeringApiUpdatePeeringContainerQueryParams struct {
+		groupId string
+		containerId string
+		cloudProviderContainer *CloudProviderContainer
+}
 
 // Updates the network details and labels of one specified network peering container in the specified project.
 func (r NetworkPeeringApiUpdatePeeringContainerRequest) CloudProviderContainer(cloudProviderContainer CloudProviderContainer) NetworkPeeringApiUpdatePeeringContainerRequest {
@@ -1891,6 +1949,9 @@ type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest struct
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
+}
+type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectQueryParams struct {
+		groupId string
 }
 
 func (r NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest) Execute() (*PrivateIPMode, *http.Response, error) {

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -238,7 +238,7 @@ type CreatePeeringConnectionApiRequest struct {
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
 
-type CreatePeeringConnectionParams struct {
+type CreatePeeringConnectionApiParams struct {
 		GroupId string
 		ContainerPeerViewRequest *ContainerPeerViewRequest
 }
@@ -372,7 +372,7 @@ type CreatePeeringContainerApiRequest struct {
 	cloudProviderContainer *CloudProviderContainer
 }
 
-type CreatePeeringContainerParams struct {
+type CreatePeeringContainerApiParams struct {
 		GroupId string
 		CloudProviderContainer *CloudProviderContainer
 }
@@ -506,7 +506,7 @@ type DeletePeeringConnectionApiRequest struct {
 	peerId string
 }
 
-type DeletePeeringConnectionParams struct {
+type DeletePeeringConnectionApiParams struct {
 		GroupId string
 		PeerId string
 }
@@ -627,7 +627,7 @@ type DeletePeeringContainerApiRequest struct {
 	containerId string
 }
 
-type DeletePeeringContainerParams struct {
+type DeletePeeringContainerApiParams struct {
 		GroupId string
 		ContainerId string
 }
@@ -748,7 +748,7 @@ type DisablePeeringApiRequest struct {
 	privateIPMode *PrivateIPMode
 }
 
-type DisablePeeringParams struct {
+type DisablePeeringApiParams struct {
 		GroupId string
 		PrivateIPMode *PrivateIPMode
 }
@@ -885,7 +885,7 @@ type GetPeeringConnectionApiRequest struct {
 	peerId string
 }
 
-type GetPeeringConnectionParams struct {
+type GetPeeringConnectionApiParams struct {
 		GroupId string
 		PeerId string
 }
@@ -1017,7 +1017,7 @@ type GetPeeringContainerApiRequest struct {
 	containerId string
 }
 
-type GetPeeringContainerParams struct {
+type GetPeeringContainerApiParams struct {
 		GroupId string
 		ContainerId string
 }
@@ -1152,7 +1152,7 @@ type ListPeeringConnectionsApiRequest struct {
 	providerName *string
 }
 
-type ListPeeringConnectionsParams struct {
+type ListPeeringConnectionsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1333,7 +1333,7 @@ type ListPeeringContainerByCloudProviderApiRequest struct {
 	pageNum *int32
 }
 
-type ListPeeringContainerByCloudProviderParams struct {
+type ListPeeringContainerByCloudProviderApiParams struct {
 		GroupId string
 		ProviderName *string
 		IncludeCount *bool
@@ -1510,7 +1510,7 @@ type ListPeeringContainersApiRequest struct {
 	pageNum *int32
 }
 
-type ListPeeringContainersParams struct {
+type ListPeeringContainersApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1675,7 +1675,7 @@ type UpdatePeeringConnectionApiRequest struct {
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
 
-type UpdatePeeringConnectionParams struct {
+type UpdatePeeringConnectionApiParams struct {
 		GroupId string
 		PeerId string
 		ContainerPeerViewRequest *ContainerPeerViewRequest
@@ -1820,7 +1820,7 @@ type UpdatePeeringContainerApiRequest struct {
 	cloudProviderContainer *CloudProviderContainer
 }
 
-type UpdatePeeringContainerParams struct {
+type UpdatePeeringContainerApiParams struct {
 		GroupId string
 		ContainerId string
 		CloudProviderContainer *CloudProviderContainer
@@ -1963,7 +1963,7 @@ type VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest struct {
 	groupId string
 }
 
-type VerifyConnectViaPeeringOnlyModeForOneProjectParams struct {
+type VerifyConnectViaPeeringOnlyModeForOneProjectApiParams struct {
 		GroupId string
 }
 

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -29,13 +29,13 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return NetworkPeeringApiCreatePeeringConnectionRequest
+	@return CreatePeeringConnectionApiRequest
 	*/
-	CreatePeeringConnection(ctx context.Context, groupId string) NetworkPeeringApiCreatePeeringConnectionRequest
+	CreatePeeringConnection(ctx context.Context, groupId string) CreatePeeringConnectionApiRequest
 
 	// CreatePeeringConnectionExecute executes the request
 	//  @return CreatePeeringConnection200Response
-	CreatePeeringConnectionExecute(r NetworkPeeringApiCreatePeeringConnectionRequest) (*CreatePeeringConnection200Response, *http.Response, error)
+	CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*CreatePeeringConnection200Response, *http.Response, error)
 
 	/*
 	CreatePeeringContainer Create One New Network Peering Container
@@ -44,13 +44,13 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return NetworkPeeringApiCreatePeeringContainerRequest
+	@return CreatePeeringContainerApiRequest
 	*/
-	CreatePeeringContainer(ctx context.Context, groupId string) NetworkPeeringApiCreatePeeringContainerRequest
+	CreatePeeringContainer(ctx context.Context, groupId string) CreatePeeringContainerApiRequest
 
 	// CreatePeeringContainerExecute executes the request
 	//  @return CloudProviderContainer
-	CreatePeeringContainerExecute(r NetworkPeeringApiCreatePeeringContainerRequest) (*CloudProviderContainer, *http.Response, error)
+	CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 	DeletePeeringConnection Remove One Existing Network Peering Connection
@@ -60,12 +60,12 @@ type NetworkPeeringApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param peerId Unique 24-hexadecimal digit string that identifies the network peering connection that you want to delete.
-	@return NetworkPeeringApiDeletePeeringConnectionRequest
+	@return DeletePeeringConnectionApiRequest
 	*/
-	DeletePeeringConnection(ctx context.Context, groupId string, peerId string) NetworkPeeringApiDeletePeeringConnectionRequest
+	DeletePeeringConnection(ctx context.Context, groupId string, peerId string) DeletePeeringConnectionApiRequest
 
 	// DeletePeeringConnectionExecute executes the request
-	DeletePeeringConnectionExecute(r NetworkPeeringApiDeletePeeringConnectionRequest) (*http.Response, error)
+	DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (*http.Response, error)
 
 	/*
 	DeletePeeringContainer Remove One Network Peering Container
@@ -75,12 +75,12 @@ type NetworkPeeringApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param containerId Unique 24-hexadecimal digit string that identifies the MongoDB Cloud network container that you want to remove.
-	@return NetworkPeeringApiDeletePeeringContainerRequest
+	@return DeletePeeringContainerApiRequest
 	*/
-	DeletePeeringContainer(ctx context.Context, groupId string, containerId string) NetworkPeeringApiDeletePeeringContainerRequest
+	DeletePeeringContainer(ctx context.Context, groupId string, containerId string) DeletePeeringContainerApiRequest
 
 	// DeletePeeringContainerExecute executes the request
-	DeletePeeringContainerExecute(r NetworkPeeringApiDeletePeeringContainerRequest) (*http.Response, error)
+	DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (*http.Response, error)
 
 	/*
 	DisablePeering Disable Connect via Peering Only Mode for One Project
@@ -89,16 +89,16 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return NetworkPeeringApiDisablePeeringRequest
+	@return DisablePeeringApiRequest
 
 	Deprecated
 	*/
-	DisablePeering(ctx context.Context, groupId string) NetworkPeeringApiDisablePeeringRequest
+	DisablePeering(ctx context.Context, groupId string) DisablePeeringApiRequest
 
 	// DisablePeeringExecute executes the request
 	//  @return PrivateIPMode
 	// Deprecated
-	DisablePeeringExecute(r NetworkPeeringApiDisablePeeringRequest) (*PrivateIPMode, *http.Response, error)
+	DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error)
 
 	/*
 	GetPeeringConnection Return One Network Peering Connection in One Project
@@ -108,13 +108,13 @@ type NetworkPeeringApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param peerId Unique 24-hexadecimal digit string that identifies the network peering connection that you want to retrieve.
-	@return NetworkPeeringApiGetPeeringConnectionRequest
+	@return GetPeeringConnectionApiRequest
 	*/
-	GetPeeringConnection(ctx context.Context, groupId string, peerId string) NetworkPeeringApiGetPeeringConnectionRequest
+	GetPeeringConnection(ctx context.Context, groupId string, peerId string) GetPeeringConnectionApiRequest
 
 	// GetPeeringConnectionExecute executes the request
 	//  @return GetPeeringConnection200Response
-	GetPeeringConnectionExecute(r NetworkPeeringApiGetPeeringConnectionRequest) (*GetPeeringConnection200Response, *http.Response, error)
+	GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error)
 
 	/*
 	GetPeeringContainer Return One Network Peering Container
@@ -124,13 +124,13 @@ type NetworkPeeringApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param containerId Unique 24-hexadecimal digit string that identifies the MongoDB Cloud network container that you want to remove.
-	@return NetworkPeeringApiGetPeeringContainerRequest
+	@return GetPeeringContainerApiRequest
 	*/
-	GetPeeringContainer(ctx context.Context, groupId string, containerId string) NetworkPeeringApiGetPeeringContainerRequest
+	GetPeeringContainer(ctx context.Context, groupId string, containerId string) GetPeeringContainerApiRequest
 
 	// GetPeeringContainerExecute executes the request
 	//  @return CloudProviderContainer
-	GetPeeringContainerExecute(r NetworkPeeringApiGetPeeringContainerRequest) (*CloudProviderContainer, *http.Response, error)
+	GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 	ListPeeringConnections Return All Network Peering Connections in One Project
@@ -139,13 +139,13 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return NetworkPeeringApiListPeeringConnectionsRequest
+	@return ListPeeringConnectionsApiRequest
 	*/
-	ListPeeringConnections(ctx context.Context, groupId string) NetworkPeeringApiListPeeringConnectionsRequest
+	ListPeeringConnections(ctx context.Context, groupId string) ListPeeringConnectionsApiRequest
 
 	// ListPeeringConnectionsExecute executes the request
 	//  @return ListPeeringConnections200Response
-	ListPeeringConnectionsExecute(r NetworkPeeringApiListPeeringConnectionsRequest) (*ListPeeringConnections200Response, *http.Response, error)
+	ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*ListPeeringConnections200Response, *http.Response, error)
 
 	/*
 	ListPeeringContainerByCloudProvider Return All Network Peering Containers in One Project for One Cloud Provider
@@ -154,13 +154,13 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return NetworkPeeringApiListPeeringContainerByCloudProviderRequest
+	@return ListPeeringContainerByCloudProviderApiRequest
 	*/
-	ListPeeringContainerByCloudProvider(ctx context.Context, groupId string) NetworkPeeringApiListPeeringContainerByCloudProviderRequest
+	ListPeeringContainerByCloudProvider(ctx context.Context, groupId string) ListPeeringContainerByCloudProviderApiRequest
 
 	// ListPeeringContainerByCloudProviderExecute executes the request
 	//  @return PaginatedCloudProviderContainer
-	ListPeeringContainerByCloudProviderExecute(r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
+	ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
 	ListPeeringContainers Return All Network Peering Containers in One Project
@@ -169,13 +169,13 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return NetworkPeeringApiListPeeringContainersRequest
+	@return ListPeeringContainersApiRequest
 	*/
-	ListPeeringContainers(ctx context.Context, groupId string) NetworkPeeringApiListPeeringContainersRequest
+	ListPeeringContainers(ctx context.Context, groupId string) ListPeeringContainersApiRequest
 
 	// ListPeeringContainersExecute executes the request
 	//  @return PaginatedCloudProviderContainer
-	ListPeeringContainersExecute(r NetworkPeeringApiListPeeringContainersRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
+	ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
 	UpdatePeeringConnection Update One New Network Peering Connection
@@ -185,13 +185,13 @@ type NetworkPeeringApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param peerId Unique 24-hexadecimal digit string that identifies the network peering connection that you want to update.
-	@return NetworkPeeringApiUpdatePeeringConnectionRequest
+	@return UpdatePeeringConnectionApiRequest
 	*/
-	UpdatePeeringConnection(ctx context.Context, groupId string, peerId string) NetworkPeeringApiUpdatePeeringConnectionRequest
+	UpdatePeeringConnection(ctx context.Context, groupId string, peerId string) UpdatePeeringConnectionApiRequest
 
 	// UpdatePeeringConnectionExecute executes the request
 	//  @return GetPeeringConnection200Response
-	UpdatePeeringConnectionExecute(r NetworkPeeringApiUpdatePeeringConnectionRequest) (*GetPeeringConnection200Response, *http.Response, error)
+	UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error)
 
 	/*
 	UpdatePeeringContainer Update One Network Peering Container
@@ -201,13 +201,13 @@ type NetworkPeeringApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param containerId Unique 24-hexadecimal digit string that identifies the MongoDB Cloud network container that you want to remove.
-	@return NetworkPeeringApiUpdatePeeringContainerRequest
+	@return UpdatePeeringContainerApiRequest
 	*/
-	UpdatePeeringContainer(ctx context.Context, groupId string, containerId string) NetworkPeeringApiUpdatePeeringContainerRequest
+	UpdatePeeringContainer(ctx context.Context, groupId string, containerId string) UpdatePeeringContainerApiRequest
 
 	// UpdatePeeringContainerExecute executes the request
 	//  @return CloudProviderContainer
-	UpdatePeeringContainerExecute(r NetworkPeeringApiUpdatePeeringContainerRequest) (*CloudProviderContainer, *http.Response, error)
+	UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 	VerifyConnectViaPeeringOnlyModeForOneProject Verify Connect via Peering Only Mode for One Project
@@ -216,22 +216,22 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest
+	@return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 
 	Deprecated
 	*/
-	VerifyConnectViaPeeringOnlyModeForOneProject(ctx context.Context, groupId string) NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest
+	VerifyConnectViaPeeringOnlyModeForOneProject(ctx context.Context, groupId string) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 
 	// VerifyConnectViaPeeringOnlyModeForOneProjectExecute executes the request
 	//  @return PrivateIPMode
 	// Deprecated
-	VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest) (*PrivateIPMode, *http.Response, error)
+	VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error)
 }
 
 // NetworkPeeringApiService NetworkPeeringApi service
 type NetworkPeeringApiService service
 
-type NetworkPeeringApiCreatePeeringConnectionRequest struct {
+type CreatePeeringConnectionApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -244,12 +244,12 @@ type CreatePeeringConnectionParams struct {
 }
 
 // Create one network peering connection.
-func (r NetworkPeeringApiCreatePeeringConnectionRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) NetworkPeeringApiCreatePeeringConnectionRequest {
+func (r CreatePeeringConnectionApiRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) CreatePeeringConnectionApiRequest {
 	r.containerPeerViewRequest = &containerPeerViewRequest
 	return r
 }
 
-func (r NetworkPeeringApiCreatePeeringConnectionRequest) Execute() (*CreatePeeringConnection200Response, *http.Response, error) {
+func (r CreatePeeringConnectionApiRequest) Execute() (*CreatePeeringConnection200Response, *http.Response, error) {
 	return r.ApiService.CreatePeeringConnectionExecute(r)
 }
 
@@ -260,10 +260,10 @@ Creates one new network peering connection in the specified project. Network pee
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return NetworkPeeringApiCreatePeeringConnectionRequest
+ @return CreatePeeringConnectionApiRequest
 */
-func (a *NetworkPeeringApiService) CreatePeeringConnection(ctx context.Context, groupId string) NetworkPeeringApiCreatePeeringConnectionRequest {
-	return NetworkPeeringApiCreatePeeringConnectionRequest{
+func (a *NetworkPeeringApiService) CreatePeeringConnection(ctx context.Context, groupId string) CreatePeeringConnectionApiRequest {
+	return CreatePeeringConnectionApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -272,7 +272,7 @@ func (a *NetworkPeeringApiService) CreatePeeringConnection(ctx context.Context, 
 
 // Execute executes the request
 //  @return CreatePeeringConnection200Response
-func (a *NetworkPeeringApiService) CreatePeeringConnectionExecute(r NetworkPeeringApiCreatePeeringConnectionRequest) (*CreatePeeringConnection200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*CreatePeeringConnection200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -365,7 +365,7 @@ func (a *NetworkPeeringApiService) CreatePeeringConnectionExecute(r NetworkPeeri
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiCreatePeeringContainerRequest struct {
+type CreatePeeringContainerApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -378,12 +378,12 @@ type CreatePeeringContainerParams struct {
 }
 
 // Creates one new network peering container in the specified project.
-func (r NetworkPeeringApiCreatePeeringContainerRequest) CloudProviderContainer(cloudProviderContainer CloudProviderContainer) NetworkPeeringApiCreatePeeringContainerRequest {
+func (r CreatePeeringContainerApiRequest) CloudProviderContainer(cloudProviderContainer CloudProviderContainer) CreatePeeringContainerApiRequest {
 	r.cloudProviderContainer = &cloudProviderContainer
 	return r
 }
 
-func (r NetworkPeeringApiCreatePeeringContainerRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
+func (r CreatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
 	return r.ApiService.CreatePeeringContainerExecute(r)
 }
 
@@ -394,10 +394,10 @@ Creates one new network peering container in the specified project. MongoDB Clou
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return NetworkPeeringApiCreatePeeringContainerRequest
+ @return CreatePeeringContainerApiRequest
 */
-func (a *NetworkPeeringApiService) CreatePeeringContainer(ctx context.Context, groupId string) NetworkPeeringApiCreatePeeringContainerRequest {
-	return NetworkPeeringApiCreatePeeringContainerRequest{
+func (a *NetworkPeeringApiService) CreatePeeringContainer(ctx context.Context, groupId string) CreatePeeringContainerApiRequest {
+	return CreatePeeringContainerApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -406,7 +406,7 @@ func (a *NetworkPeeringApiService) CreatePeeringContainer(ctx context.Context, g
 
 // Execute executes the request
 //  @return CloudProviderContainer
-func (a *NetworkPeeringApiService) CreatePeeringContainerExecute(r NetworkPeeringApiCreatePeeringContainerRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -499,7 +499,7 @@ func (a *NetworkPeeringApiService) CreatePeeringContainerExecute(r NetworkPeerin
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiDeletePeeringConnectionRequest struct {
+type DeletePeeringConnectionApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -511,7 +511,7 @@ type DeletePeeringConnectionParams struct {
 		PeerId string
 }
 
-func (r NetworkPeeringApiDeletePeeringConnectionRequest) Execute() (*http.Response, error) {
+func (r DeletePeeringConnectionApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePeeringConnectionExecute(r)
 }
 
@@ -523,10 +523,10 @@ Removes one network peering connection in the specified project. If you Removes 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param peerId Unique 24-hexadecimal digit string that identifies the network peering connection that you want to delete.
- @return NetworkPeeringApiDeletePeeringConnectionRequest
+ @return DeletePeeringConnectionApiRequest
 */
-func (a *NetworkPeeringApiService) DeletePeeringConnection(ctx context.Context, groupId string, peerId string) NetworkPeeringApiDeletePeeringConnectionRequest {
-	return NetworkPeeringApiDeletePeeringConnectionRequest{
+func (a *NetworkPeeringApiService) DeletePeeringConnection(ctx context.Context, groupId string, peerId string) DeletePeeringConnectionApiRequest {
+	return DeletePeeringConnectionApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -535,7 +535,7 @@ func (a *NetworkPeeringApiService) DeletePeeringConnection(ctx context.Context, 
 }
 
 // Execute executes the request
-func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r NetworkPeeringApiDeletePeeringConnectionRequest) (*http.Response, error) {
+func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -620,7 +620,7 @@ func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r NetworkPeeri
 	return localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiDeletePeeringContainerRequest struct {
+type DeletePeeringContainerApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -632,7 +632,7 @@ type DeletePeeringContainerParams struct {
 		ContainerId string
 }
 
-func (r NetworkPeeringApiDeletePeeringContainerRequest) Execute() (*http.Response, error) {
+func (r DeletePeeringContainerApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePeeringContainerExecute(r)
 }
 
@@ -644,10 +644,10 @@ Removes one network peering container in the specified project. To use this reso
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param containerId Unique 24-hexadecimal digit string that identifies the MongoDB Cloud network container that you want to remove.
- @return NetworkPeeringApiDeletePeeringContainerRequest
+ @return DeletePeeringContainerApiRequest
 */
-func (a *NetworkPeeringApiService) DeletePeeringContainer(ctx context.Context, groupId string, containerId string) NetworkPeeringApiDeletePeeringContainerRequest {
-	return NetworkPeeringApiDeletePeeringContainerRequest{
+func (a *NetworkPeeringApiService) DeletePeeringContainer(ctx context.Context, groupId string, containerId string) DeletePeeringContainerApiRequest {
+	return DeletePeeringContainerApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -656,7 +656,7 @@ func (a *NetworkPeeringApiService) DeletePeeringContainer(ctx context.Context, g
 }
 
 // Execute executes the request
-func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r NetworkPeeringApiDeletePeeringContainerRequest) (*http.Response, error) {
+func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -741,7 +741,7 @@ func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r NetworkPeerin
 	return localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiDisablePeeringRequest struct {
+type DisablePeeringApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -754,12 +754,12 @@ type DisablePeeringParams struct {
 }
 
 // Disables Connect via Peering Only mode for the specified project.
-func (r NetworkPeeringApiDisablePeeringRequest) PrivateIPMode(privateIPMode PrivateIPMode) NetworkPeeringApiDisablePeeringRequest {
+func (r DisablePeeringApiRequest) PrivateIPMode(privateIPMode PrivateIPMode) DisablePeeringApiRequest {
 	r.privateIPMode = &privateIPMode
 	return r
 }
 
-func (r NetworkPeeringApiDisablePeeringRequest) Execute() (*PrivateIPMode, *http.Response, error) {
+func (r DisablePeeringApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
 	return r.ApiService.DisablePeeringExecute(r)
 }
 
@@ -770,12 +770,12 @@ Disables Connect via Peering Only mode for the specified project. To use this re
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return NetworkPeeringApiDisablePeeringRequest
+ @return DisablePeeringApiRequest
 
 Deprecated
 */
-func (a *NetworkPeeringApiService) DisablePeering(ctx context.Context, groupId string) NetworkPeeringApiDisablePeeringRequest {
-	return NetworkPeeringApiDisablePeeringRequest{
+func (a *NetworkPeeringApiService) DisablePeering(ctx context.Context, groupId string) DisablePeeringApiRequest {
+	return DisablePeeringApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -785,7 +785,7 @@ func (a *NetworkPeeringApiService) DisablePeering(ctx context.Context, groupId s
 // Execute executes the request
 //  @return PrivateIPMode
 // Deprecated
-func (a *NetworkPeeringApiService) DisablePeeringExecute(r NetworkPeeringApiDisablePeeringRequest) (*PrivateIPMode, *http.Response, error) {
+func (a *NetworkPeeringApiService) DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -878,7 +878,7 @@ func (a *NetworkPeeringApiService) DisablePeeringExecute(r NetworkPeeringApiDisa
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiGetPeeringConnectionRequest struct {
+type GetPeeringConnectionApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -890,7 +890,7 @@ type GetPeeringConnectionParams struct {
 		PeerId string
 }
 
-func (r NetworkPeeringApiGetPeeringConnectionRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
+func (r GetPeeringConnectionApiRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
 	return r.ApiService.GetPeeringConnectionExecute(r)
 }
 
@@ -902,10 +902,10 @@ Returns details about one specified network peering connection in the specified 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param peerId Unique 24-hexadecimal digit string that identifies the network peering connection that you want to retrieve.
- @return NetworkPeeringApiGetPeeringConnectionRequest
+ @return GetPeeringConnectionApiRequest
 */
-func (a *NetworkPeeringApiService) GetPeeringConnection(ctx context.Context, groupId string, peerId string) NetworkPeeringApiGetPeeringConnectionRequest {
-	return NetworkPeeringApiGetPeeringConnectionRequest{
+func (a *NetworkPeeringApiService) GetPeeringConnection(ctx context.Context, groupId string, peerId string) GetPeeringConnectionApiRequest {
+	return GetPeeringConnectionApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -915,7 +915,7 @@ func (a *NetworkPeeringApiService) GetPeeringConnection(ctx context.Context, gro
 
 // Execute executes the request
 //  @return GetPeeringConnection200Response
-func (a *NetworkPeeringApiService) GetPeeringConnectionExecute(r NetworkPeeringApiGetPeeringConnectionRequest) (*GetPeeringConnection200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1010,7 +1010,7 @@ func (a *NetworkPeeringApiService) GetPeeringConnectionExecute(r NetworkPeeringA
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiGetPeeringContainerRequest struct {
+type GetPeeringContainerApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -1022,7 +1022,7 @@ type GetPeeringContainerParams struct {
 		ContainerId string
 }
 
-func (r NetworkPeeringApiGetPeeringContainerRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
+func (r GetPeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
 	return r.ApiService.GetPeeringContainerExecute(r)
 }
 
@@ -1034,10 +1034,10 @@ Returns details about one network peering container in one specified project. Ne
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param containerId Unique 24-hexadecimal digit string that identifies the MongoDB Cloud network container that you want to remove.
- @return NetworkPeeringApiGetPeeringContainerRequest
+ @return GetPeeringContainerApiRequest
 */
-func (a *NetworkPeeringApiService) GetPeeringContainer(ctx context.Context, groupId string, containerId string) NetworkPeeringApiGetPeeringContainerRequest {
-	return NetworkPeeringApiGetPeeringContainerRequest{
+func (a *NetworkPeeringApiService) GetPeeringContainer(ctx context.Context, groupId string, containerId string) GetPeeringContainerApiRequest {
+	return GetPeeringContainerApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1047,7 +1047,7 @@ func (a *NetworkPeeringApiService) GetPeeringContainer(ctx context.Context, grou
 
 // Execute executes the request
 //  @return CloudProviderContainer
-func (a *NetworkPeeringApiService) GetPeeringContainerExecute(r NetworkPeeringApiGetPeeringContainerRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1142,7 +1142,7 @@ func (a *NetworkPeeringApiService) GetPeeringContainerExecute(r NetworkPeeringAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiListPeeringConnectionsRequest struct {
+type ListPeeringConnectionsApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -1161,30 +1161,30 @@ type ListPeeringConnectionsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r NetworkPeeringApiListPeeringConnectionsRequest) IncludeCount(includeCount bool) NetworkPeeringApiListPeeringConnectionsRequest {
+func (r ListPeeringConnectionsApiRequest) IncludeCount(includeCount bool) ListPeeringConnectionsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r NetworkPeeringApiListPeeringConnectionsRequest) ItemsPerPage(itemsPerPage int32) NetworkPeeringApiListPeeringConnectionsRequest {
+func (r ListPeeringConnectionsApiRequest) ItemsPerPage(itemsPerPage int32) ListPeeringConnectionsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r NetworkPeeringApiListPeeringConnectionsRequest) PageNum(pageNum int32) NetworkPeeringApiListPeeringConnectionsRequest {
+func (r ListPeeringConnectionsApiRequest) PageNum(pageNum int32) ListPeeringConnectionsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Cloud service provider to use for this VPC peering connection.
-func (r NetworkPeeringApiListPeeringConnectionsRequest) ProviderName(providerName string) NetworkPeeringApiListPeeringConnectionsRequest {
+func (r ListPeeringConnectionsApiRequest) ProviderName(providerName string) ListPeeringConnectionsApiRequest {
 	r.providerName = &providerName
 	return r
 }
 
-func (r NetworkPeeringApiListPeeringConnectionsRequest) Execute() (*ListPeeringConnections200Response, *http.Response, error) {
+func (r ListPeeringConnectionsApiRequest) Execute() (*ListPeeringConnections200Response, *http.Response, error) {
 	return r.ApiService.ListPeeringConnectionsExecute(r)
 }
 
@@ -1195,10 +1195,10 @@ Returns details about all network peering connections in the specified project. 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return NetworkPeeringApiListPeeringConnectionsRequest
+ @return ListPeeringConnectionsApiRequest
 */
-func (a *NetworkPeeringApiService) ListPeeringConnections(ctx context.Context, groupId string) NetworkPeeringApiListPeeringConnectionsRequest {
-	return NetworkPeeringApiListPeeringConnectionsRequest{
+func (a *NetworkPeeringApiService) ListPeeringConnections(ctx context.Context, groupId string) ListPeeringConnectionsApiRequest {
+	return ListPeeringConnectionsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1207,7 +1207,7 @@ func (a *NetworkPeeringApiService) ListPeeringConnections(ctx context.Context, g
 
 // Execute executes the request
 //  @return ListPeeringConnections200Response
-func (a *NetworkPeeringApiService) ListPeeringConnectionsExecute(r NetworkPeeringApiListPeeringConnectionsRequest) (*ListPeeringConnections200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*ListPeeringConnections200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1323,7 +1323,7 @@ func (a *NetworkPeeringApiService) ListPeeringConnectionsExecute(r NetworkPeerin
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiListPeeringContainerByCloudProviderRequest struct {
+type ListPeeringContainerByCloudProviderApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -1342,30 +1342,30 @@ type ListPeeringContainerByCloudProviderParams struct {
 }
 
 // Cloud service provider that serves the desired network peering containers.
-func (r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) ProviderName(providerName string) NetworkPeeringApiListPeeringContainerByCloudProviderRequest {
+func (r ListPeeringContainerByCloudProviderApiRequest) ProviderName(providerName string) ListPeeringContainerByCloudProviderApiRequest {
 	r.providerName = &providerName
 	return r
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) IncludeCount(includeCount bool) NetworkPeeringApiListPeeringContainerByCloudProviderRequest {
+func (r ListPeeringContainerByCloudProviderApiRequest) IncludeCount(includeCount bool) ListPeeringContainerByCloudProviderApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) ItemsPerPage(itemsPerPage int32) NetworkPeeringApiListPeeringContainerByCloudProviderRequest {
+func (r ListPeeringContainerByCloudProviderApiRequest) ItemsPerPage(itemsPerPage int32) ListPeeringContainerByCloudProviderApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) PageNum(pageNum int32) NetworkPeeringApiListPeeringContainerByCloudProviderRequest {
+func (r ListPeeringContainerByCloudProviderApiRequest) PageNum(pageNum int32) ListPeeringContainerByCloudProviderApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (r ListPeeringContainerByCloudProviderApiRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
 	return r.ApiService.ListPeeringContainerByCloudProviderExecute(r)
 }
 
@@ -1376,10 +1376,10 @@ Returns details about all network peering containers in the specified project fo
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return NetworkPeeringApiListPeeringContainerByCloudProviderRequest
+ @return ListPeeringContainerByCloudProviderApiRequest
 */
-func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProvider(ctx context.Context, groupId string) NetworkPeeringApiListPeeringContainerByCloudProviderRequest {
-	return NetworkPeeringApiListPeeringContainerByCloudProviderRequest{
+func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProvider(ctx context.Context, groupId string) ListPeeringContainerByCloudProviderApiRequest {
+	return ListPeeringContainerByCloudProviderApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1388,7 +1388,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProvider(ctx conte
 
 // Execute executes the request
 //  @return PaginatedCloudProviderContainer
-func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProviderExecute(r NetworkPeeringApiListPeeringContainerByCloudProviderRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1501,7 +1501,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProviderExecute(r 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiListPeeringContainersRequest struct {
+type ListPeeringContainersApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -1518,24 +1518,24 @@ type ListPeeringContainersParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r NetworkPeeringApiListPeeringContainersRequest) IncludeCount(includeCount bool) NetworkPeeringApiListPeeringContainersRequest {
+func (r ListPeeringContainersApiRequest) IncludeCount(includeCount bool) ListPeeringContainersApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r NetworkPeeringApiListPeeringContainersRequest) ItemsPerPage(itemsPerPage int32) NetworkPeeringApiListPeeringContainersRequest {
+func (r ListPeeringContainersApiRequest) ItemsPerPage(itemsPerPage int32) ListPeeringContainersApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r NetworkPeeringApiListPeeringContainersRequest) PageNum(pageNum int32) NetworkPeeringApiListPeeringContainersRequest {
+func (r ListPeeringContainersApiRequest) PageNum(pageNum int32) ListPeeringContainersApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r NetworkPeeringApiListPeeringContainersRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (r ListPeeringContainersApiRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
 	return r.ApiService.ListPeeringContainersExecute(r)
 }
 
@@ -1546,10 +1546,10 @@ Returns details about all network peering containers in the specified project. N
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return NetworkPeeringApiListPeeringContainersRequest
+ @return ListPeeringContainersApiRequest
 */
-func (a *NetworkPeeringApiService) ListPeeringContainers(ctx context.Context, groupId string) NetworkPeeringApiListPeeringContainersRequest {
-	return NetworkPeeringApiListPeeringContainersRequest{
+func (a *NetworkPeeringApiService) ListPeeringContainers(ctx context.Context, groupId string) ListPeeringContainersApiRequest {
+	return ListPeeringContainersApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1558,7 +1558,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainers(ctx context.Context, gr
 
 // Execute executes the request
 //  @return PaginatedCloudProviderContainer
-func (a *NetworkPeeringApiService) ListPeeringContainersExecute(r NetworkPeeringApiListPeeringContainersRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1667,7 +1667,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainersExecute(r NetworkPeering
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiUpdatePeeringConnectionRequest struct {
+type UpdatePeeringConnectionApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -1682,12 +1682,12 @@ type UpdatePeeringConnectionParams struct {
 }
 
 // Modify one network peering connection.
-func (r NetworkPeeringApiUpdatePeeringConnectionRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) NetworkPeeringApiUpdatePeeringConnectionRequest {
+func (r UpdatePeeringConnectionApiRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) UpdatePeeringConnectionApiRequest {
 	r.containerPeerViewRequest = &containerPeerViewRequest
 	return r
 }
 
-func (r NetworkPeeringApiUpdatePeeringConnectionRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
+func (r UpdatePeeringConnectionApiRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
 	return r.ApiService.UpdatePeeringConnectionExecute(r)
 }
 
@@ -1699,10 +1699,10 @@ Updates one specified network peering connection in the specified project. To us
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param peerId Unique 24-hexadecimal digit string that identifies the network peering connection that you want to update.
- @return NetworkPeeringApiUpdatePeeringConnectionRequest
+ @return UpdatePeeringConnectionApiRequest
 */
-func (a *NetworkPeeringApiService) UpdatePeeringConnection(ctx context.Context, groupId string, peerId string) NetworkPeeringApiUpdatePeeringConnectionRequest {
-	return NetworkPeeringApiUpdatePeeringConnectionRequest{
+func (a *NetworkPeeringApiService) UpdatePeeringConnection(ctx context.Context, groupId string, peerId string) UpdatePeeringConnectionApiRequest {
+	return UpdatePeeringConnectionApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1712,7 +1712,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringConnection(ctx context.Context, 
 
 // Execute executes the request
 //  @return GetPeeringConnection200Response
-func (a *NetworkPeeringApiService) UpdatePeeringConnectionExecute(r NetworkPeeringApiUpdatePeeringConnectionRequest) (*GetPeeringConnection200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1812,7 +1812,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringConnectionExecute(r NetworkPeeri
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiUpdatePeeringContainerRequest struct {
+type UpdatePeeringContainerApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -1827,12 +1827,12 @@ type UpdatePeeringContainerParams struct {
 }
 
 // Updates the network details and labels of one specified network peering container in the specified project.
-func (r NetworkPeeringApiUpdatePeeringContainerRequest) CloudProviderContainer(cloudProviderContainer CloudProviderContainer) NetworkPeeringApiUpdatePeeringContainerRequest {
+func (r UpdatePeeringContainerApiRequest) CloudProviderContainer(cloudProviderContainer CloudProviderContainer) UpdatePeeringContainerApiRequest {
 	r.cloudProviderContainer = &cloudProviderContainer
 	return r
 }
 
-func (r NetworkPeeringApiUpdatePeeringContainerRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
+func (r UpdatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
 	return r.ApiService.UpdatePeeringContainerExecute(r)
 }
 
@@ -1844,10 +1844,10 @@ Updates the network details and labels of one specified network peering containe
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param containerId Unique 24-hexadecimal digit string that identifies the MongoDB Cloud network container that you want to remove.
- @return NetworkPeeringApiUpdatePeeringContainerRequest
+ @return UpdatePeeringContainerApiRequest
 */
-func (a *NetworkPeeringApiService) UpdatePeeringContainer(ctx context.Context, groupId string, containerId string) NetworkPeeringApiUpdatePeeringContainerRequest {
-	return NetworkPeeringApiUpdatePeeringContainerRequest{
+func (a *NetworkPeeringApiService) UpdatePeeringContainer(ctx context.Context, groupId string, containerId string) UpdatePeeringContainerApiRequest {
+	return UpdatePeeringContainerApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1857,7 +1857,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringContainer(ctx context.Context, g
 
 // Execute executes the request
 //  @return CloudProviderContainer
-func (a *NetworkPeeringApiService) UpdatePeeringContainerExecute(r NetworkPeeringApiUpdatePeeringContainerRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1957,7 +1957,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringContainerExecute(r NetworkPeerin
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest struct {
+type VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest struct {
 	ctx context.Context
 	ApiService NetworkPeeringApi
 	groupId string
@@ -1967,7 +1967,7 @@ type VerifyConnectViaPeeringOnlyModeForOneProjectParams struct {
 		GroupId string
 }
 
-func (r NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest) Execute() (*PrivateIPMode, *http.Response, error) {
+func (r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
 	return r.ApiService.VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r)
 }
 
@@ -1978,12 +1978,12 @@ Verifies if someone set the specified project to **Connect via Peering Only** mo
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest
+ @return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 
 Deprecated
 */
-func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProject(ctx context.Context, groupId string) NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest {
-	return NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest{
+func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProject(ctx context.Context, groupId string) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest {
+	return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1993,7 +1993,7 @@ func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProject(
 // Execute executes the request
 //  @return PrivateIPMode
 // Deprecated
-func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest) (*PrivateIPMode, *http.Response, error) {
+func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -238,7 +238,7 @@ type NetworkPeeringApiCreatePeeringConnectionRequest struct {
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
 
-type NetworkPeeringApiCreatePeeringConnectionQueryParams struct {
+type NetworkPeeringApiCreatePeeringConnectionParams struct {
 		GroupId string
 		ContainerPeerViewRequest *ContainerPeerViewRequest
 }
@@ -372,7 +372,7 @@ type NetworkPeeringApiCreatePeeringContainerRequest struct {
 	cloudProviderContainer *CloudProviderContainer
 }
 
-type NetworkPeeringApiCreatePeeringContainerQueryParams struct {
+type NetworkPeeringApiCreatePeeringContainerParams struct {
 		GroupId string
 		CloudProviderContainer *CloudProviderContainer
 }
@@ -506,7 +506,7 @@ type NetworkPeeringApiDeletePeeringConnectionRequest struct {
 	peerId string
 }
 
-type NetworkPeeringApiDeletePeeringConnectionQueryParams struct {
+type NetworkPeeringApiDeletePeeringConnectionParams struct {
 		GroupId string
 		PeerId string
 }
@@ -627,7 +627,7 @@ type NetworkPeeringApiDeletePeeringContainerRequest struct {
 	containerId string
 }
 
-type NetworkPeeringApiDeletePeeringContainerQueryParams struct {
+type NetworkPeeringApiDeletePeeringContainerParams struct {
 		GroupId string
 		ContainerId string
 }
@@ -748,7 +748,7 @@ type NetworkPeeringApiDisablePeeringRequest struct {
 	privateIPMode *PrivateIPMode
 }
 
-type NetworkPeeringApiDisablePeeringQueryParams struct {
+type NetworkPeeringApiDisablePeeringParams struct {
 		GroupId string
 		PrivateIPMode *PrivateIPMode
 }
@@ -885,7 +885,7 @@ type NetworkPeeringApiGetPeeringConnectionRequest struct {
 	peerId string
 }
 
-type NetworkPeeringApiGetPeeringConnectionQueryParams struct {
+type NetworkPeeringApiGetPeeringConnectionParams struct {
 		GroupId string
 		PeerId string
 }
@@ -1017,7 +1017,7 @@ type NetworkPeeringApiGetPeeringContainerRequest struct {
 	containerId string
 }
 
-type NetworkPeeringApiGetPeeringContainerQueryParams struct {
+type NetworkPeeringApiGetPeeringContainerParams struct {
 		GroupId string
 		ContainerId string
 }
@@ -1152,7 +1152,7 @@ type NetworkPeeringApiListPeeringConnectionsRequest struct {
 	providerName *string
 }
 
-type NetworkPeeringApiListPeeringConnectionsQueryParams struct {
+type NetworkPeeringApiListPeeringConnectionsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1333,7 +1333,7 @@ type NetworkPeeringApiListPeeringContainerByCloudProviderRequest struct {
 	pageNum *int32
 }
 
-type NetworkPeeringApiListPeeringContainerByCloudProviderQueryParams struct {
+type NetworkPeeringApiListPeeringContainerByCloudProviderParams struct {
 		GroupId string
 		ProviderName *string
 		IncludeCount *bool
@@ -1510,7 +1510,7 @@ type NetworkPeeringApiListPeeringContainersRequest struct {
 	pageNum *int32
 }
 
-type NetworkPeeringApiListPeeringContainersQueryParams struct {
+type NetworkPeeringApiListPeeringContainersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1675,7 +1675,7 @@ type NetworkPeeringApiUpdatePeeringConnectionRequest struct {
 	containerPeerViewRequest *ContainerPeerViewRequest
 }
 
-type NetworkPeeringApiUpdatePeeringConnectionQueryParams struct {
+type NetworkPeeringApiUpdatePeeringConnectionParams struct {
 		GroupId string
 		PeerId string
 		ContainerPeerViewRequest *ContainerPeerViewRequest
@@ -1820,7 +1820,7 @@ type NetworkPeeringApiUpdatePeeringContainerRequest struct {
 	cloudProviderContainer *CloudProviderContainer
 }
 
-type NetworkPeeringApiUpdatePeeringContainerQueryParams struct {
+type NetworkPeeringApiUpdatePeeringContainerParams struct {
 		GroupId string
 		ContainerId string
 		CloudProviderContainer *CloudProviderContainer
@@ -1963,7 +1963,7 @@ type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectRequest struct
 	groupId string
 }
 
-type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectQueryParams struct {
+type NetworkPeeringApiVerifyConnectViaPeeringOnlyModeForOneProjectParams struct {
 		GroupId string
 }
 

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -132,6 +132,11 @@ type OnlineArchiveApiCreateOnlineArchiveRequest struct {
 	clusterName string
 	onlineArchive *OnlineArchive
 }
+type OnlineArchiveApiCreateOnlineArchiveQueryParams struct {
+		groupId string
+		clusterName string
+		onlineArchive *OnlineArchive
+}
 
 // Creates one online archive.
 func (r OnlineArchiveApiCreateOnlineArchiveRequest) OnlineArchive(onlineArchive OnlineArchive) OnlineArchiveApiCreateOnlineArchiveRequest {
@@ -271,6 +276,11 @@ type OnlineArchiveApiDeleteOnlineArchiveRequest struct {
 	archiveId string
 	clusterName string
 }
+type OnlineArchiveApiDeleteOnlineArchiveQueryParams struct {
+		groupId string
+		archiveId string
+		clusterName string
+}
 
 func (r OnlineArchiveApiDeleteOnlineArchiveRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOnlineArchiveExecute(r)
@@ -398,6 +408,13 @@ type OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest struct {
 	startDate *int64
 	endDate *int64
 	archiveOnly *bool
+}
+type OnlineArchiveApiDownloadOnlineArchiveQueryLogsQueryParams struct {
+		groupId string
+		clusterName string
+		startDate *int64
+		endDate *int64
+		archiveOnly *bool
 }
 
 // Date and time that specifies the starting point for the range of log messages to return. This resource expresses this value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).
@@ -558,6 +575,11 @@ type OnlineArchiveApiGetOnlineArchiveRequest struct {
 	archiveId string
 	clusterName string
 }
+type OnlineArchiveApiGetOnlineArchiveQueryParams struct {
+		groupId string
+		archiveId string
+		clusterName string
+}
 
 func (r OnlineArchiveApiGetOnlineArchiveRequest) Execute() (*OnlineArchive, *http.Response, error) {
 	return r.ApiService.GetOnlineArchiveExecute(r)
@@ -696,6 +718,13 @@ type OnlineArchiveApiListOnlineArchivesRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type OnlineArchiveApiListOnlineArchivesQueryParams struct {
+		groupId string
+		clusterName string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -864,6 +893,12 @@ type OnlineArchiveApiUpdateOnlineArchiveRequest struct {
 	archiveId string
 	clusterName string
 	onlineArchive *OnlineArchive
+}
+type OnlineArchiveApiUpdateOnlineArchiveQueryParams struct {
+		groupId string
+		archiveId string
+		clusterName string
+		onlineArchive *OnlineArchive
 }
 
 // Updates, pauses, or resumes one online archive.

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -31,13 +31,13 @@ type OnlineArchiveApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster that contains the collection for which you want to create one online archive.
-	@return OnlineArchiveApiCreateOnlineArchiveRequest
+	@return CreateOnlineArchiveApiRequest
 	*/
-	CreateOnlineArchive(ctx context.Context, groupId string, clusterName string) OnlineArchiveApiCreateOnlineArchiveRequest
+	CreateOnlineArchive(ctx context.Context, groupId string, clusterName string) CreateOnlineArchiveApiRequest
 
 	// CreateOnlineArchiveExecute executes the request
 	//  @return OnlineArchive
-	CreateOnlineArchiveExecute(r OnlineArchiveApiCreateOnlineArchiveRequest) (*OnlineArchive, *http.Response, error)
+	CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
 
 	/*
 	DeleteOnlineArchive Remove One Online Archive
@@ -48,12 +48,12 @@ type OnlineArchiveApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param archiveId Unique 24-hexadecimal digit string that identifies the online archive to delete.
 	@param clusterName Human-readable label that identifies the cluster that contains the collection from which you want to remove an online archive.
-	@return OnlineArchiveApiDeleteOnlineArchiveRequest
+	@return DeleteOnlineArchiveApiRequest
 	*/
-	DeleteOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) OnlineArchiveApiDeleteOnlineArchiveRequest
+	DeleteOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) DeleteOnlineArchiveApiRequest
 
 	// DeleteOnlineArchiveExecute executes the request
-	DeleteOnlineArchiveExecute(r OnlineArchiveApiDeleteOnlineArchiveRequest) (*http.Response, error)
+	DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (*http.Response, error)
 
 	/*
 	DownloadOnlineArchiveQueryLogs Download Online Archive Query Logs
@@ -63,13 +63,13 @@ type OnlineArchiveApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster that contains the collection for which you want to return the query logs from one online archive.
-	@return OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest
+	@return DownloadOnlineArchiveQueryLogsApiRequest
 	*/
-	DownloadOnlineArchiveQueryLogs(ctx context.Context, groupId string, clusterName string) OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest
+	DownloadOnlineArchiveQueryLogs(ctx context.Context, groupId string, clusterName string) DownloadOnlineArchiveQueryLogsApiRequest
 
 	// DownloadOnlineArchiveQueryLogsExecute executes the request
 	//  @return *os.File
-	DownloadOnlineArchiveQueryLogsExecute(r OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest) (*os.File, *http.Response, error)
+	DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error)
 
 	/*
 	GetOnlineArchive Return One Online Archive
@@ -80,13 +80,13 @@ type OnlineArchiveApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param archiveId Unique 24-hexadecimal digit string that identifies the online archive to return.
 	@param clusterName Human-readable label that identifies the cluster that contains the specified collection from which Application created the online archive.
-	@return OnlineArchiveApiGetOnlineArchiveRequest
+	@return GetOnlineArchiveApiRequest
 	*/
-	GetOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) OnlineArchiveApiGetOnlineArchiveRequest
+	GetOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) GetOnlineArchiveApiRequest
 
 	// GetOnlineArchiveExecute executes the request
 	//  @return OnlineArchive
-	GetOnlineArchiveExecute(r OnlineArchiveApiGetOnlineArchiveRequest) (*OnlineArchive, *http.Response, error)
+	GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
 
 	/*
 	ListOnlineArchives Return All Online Archives for One Cluster
@@ -96,13 +96,13 @@ type OnlineArchiveApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster that contains the collection for which you want to return the online archives.
-	@return OnlineArchiveApiListOnlineArchivesRequest
+	@return ListOnlineArchivesApiRequest
 	*/
-	ListOnlineArchives(ctx context.Context, groupId string, clusterName string) OnlineArchiveApiListOnlineArchivesRequest
+	ListOnlineArchives(ctx context.Context, groupId string, clusterName string) ListOnlineArchivesApiRequest
 
 	// ListOnlineArchivesExecute executes the request
 	//  @return PaginatedOnlineArchive
-	ListOnlineArchivesExecute(r OnlineArchiveApiListOnlineArchivesRequest) (*PaginatedOnlineArchive, *http.Response, error)
+	ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error)
 
 	/*
 	UpdateOnlineArchive Update One Online Archive
@@ -113,19 +113,19 @@ type OnlineArchiveApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param archiveId Unique 24-hexadecimal digit string that identifies the online archive to update.
 	@param clusterName Human-readable label that identifies the cluster that contains the specified collection from which Application created the online archive.
-	@return OnlineArchiveApiUpdateOnlineArchiveRequest
+	@return UpdateOnlineArchiveApiRequest
 	*/
-	UpdateOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) OnlineArchiveApiUpdateOnlineArchiveRequest
+	UpdateOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) UpdateOnlineArchiveApiRequest
 
 	// UpdateOnlineArchiveExecute executes the request
 	//  @return OnlineArchive
-	UpdateOnlineArchiveExecute(r OnlineArchiveApiUpdateOnlineArchiveRequest) (*OnlineArchive, *http.Response, error)
+	UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
 }
 
 // OnlineArchiveApiService OnlineArchiveApi service
 type OnlineArchiveApiService service
 
-type OnlineArchiveApiCreateOnlineArchiveRequest struct {
+type CreateOnlineArchiveApiRequest struct {
 	ctx context.Context
 	ApiService OnlineArchiveApi
 	groupId string
@@ -140,12 +140,12 @@ type CreateOnlineArchiveParams struct {
 }
 
 // Creates one online archive.
-func (r OnlineArchiveApiCreateOnlineArchiveRequest) OnlineArchive(onlineArchive OnlineArchive) OnlineArchiveApiCreateOnlineArchiveRequest {
+func (r CreateOnlineArchiveApiRequest) OnlineArchive(onlineArchive OnlineArchive) CreateOnlineArchiveApiRequest {
 	r.onlineArchive = &onlineArchive
 	return r
 }
 
-func (r OnlineArchiveApiCreateOnlineArchiveRequest) Execute() (*OnlineArchive, *http.Response, error) {
+func (r CreateOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
 	return r.ApiService.CreateOnlineArchiveExecute(r)
 }
 
@@ -157,10 +157,10 @@ Creates one online archive. This archive stores data from one cluster within one
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster that contains the collection for which you want to create one online archive.
- @return OnlineArchiveApiCreateOnlineArchiveRequest
+ @return CreateOnlineArchiveApiRequest
 */
-func (a *OnlineArchiveApiService) CreateOnlineArchive(ctx context.Context, groupId string, clusterName string) OnlineArchiveApiCreateOnlineArchiveRequest {
-	return OnlineArchiveApiCreateOnlineArchiveRequest{
+func (a *OnlineArchiveApiService) CreateOnlineArchive(ctx context.Context, groupId string, clusterName string) CreateOnlineArchiveApiRequest {
+	return CreateOnlineArchiveApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -170,7 +170,7 @@ func (a *OnlineArchiveApiService) CreateOnlineArchive(ctx context.Context, group
 
 // Execute executes the request
 //  @return OnlineArchive
-func (a *OnlineArchiveApiService) CreateOnlineArchiveExecute(r OnlineArchiveApiCreateOnlineArchiveRequest) (*OnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -270,7 +270,7 @@ func (a *OnlineArchiveApiService) CreateOnlineArchiveExecute(r OnlineArchiveApiC
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OnlineArchiveApiDeleteOnlineArchiveRequest struct {
+type DeleteOnlineArchiveApiRequest struct {
 	ctx context.Context
 	ApiService OnlineArchiveApi
 	groupId string
@@ -284,7 +284,7 @@ type DeleteOnlineArchiveParams struct {
 		ClusterName string
 }
 
-func (r OnlineArchiveApiDeleteOnlineArchiveRequest) Execute() (*http.Response, error) {
+func (r DeleteOnlineArchiveApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOnlineArchiveExecute(r)
 }
 
@@ -297,10 +297,10 @@ Removes one online archive. This archive stores data from one cluster within one
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param archiveId Unique 24-hexadecimal digit string that identifies the online archive to delete.
  @param clusterName Human-readable label that identifies the cluster that contains the collection from which you want to remove an online archive.
- @return OnlineArchiveApiDeleteOnlineArchiveRequest
+ @return DeleteOnlineArchiveApiRequest
 */
-func (a *OnlineArchiveApiService) DeleteOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) OnlineArchiveApiDeleteOnlineArchiveRequest {
-	return OnlineArchiveApiDeleteOnlineArchiveRequest{
+func (a *OnlineArchiveApiService) DeleteOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) DeleteOnlineArchiveApiRequest {
+	return DeleteOnlineArchiveApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -310,7 +310,7 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchive(ctx context.Context, group
 }
 
 // Execute executes the request
-func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r OnlineArchiveApiDeleteOnlineArchiveRequest) (*http.Response, error) {
+func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -402,7 +402,7 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r OnlineArchiveApiD
 	return localVarHTTPResponse, nil
 }
 
-type OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest struct {
+type DownloadOnlineArchiveQueryLogsApiRequest struct {
 	ctx context.Context
 	ApiService OnlineArchiveApi
 	groupId string
@@ -421,24 +421,24 @@ type DownloadOnlineArchiveQueryLogsParams struct {
 }
 
 // Date and time that specifies the starting point for the range of log messages to return. This resource expresses this value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).
-func (r OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest) StartDate(startDate int64) OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest {
+func (r DownloadOnlineArchiveQueryLogsApiRequest) StartDate(startDate int64) DownloadOnlineArchiveQueryLogsApiRequest {
 	r.startDate = &startDate
 	return r
 }
 
 // Date and time that specifies the end point for the range of log messages to return. This resource expresses this value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).
-func (r OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest) EndDate(endDate int64) OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest {
+func (r DownloadOnlineArchiveQueryLogsApiRequest) EndDate(endDate int64) DownloadOnlineArchiveQueryLogsApiRequest {
 	r.endDate = &endDate
 	return r
 }
 
 // Flag that indicates whether to download logs for queries against your online archive only or both your online archive and cluster.
-func (r OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest) ArchiveOnly(archiveOnly bool) OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest {
+func (r DownloadOnlineArchiveQueryLogsApiRequest) ArchiveOnly(archiveOnly bool) DownloadOnlineArchiveQueryLogsApiRequest {
 	r.archiveOnly = &archiveOnly
 	return r
 }
 
-func (r OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest) Execute() (*os.File, *http.Response, error) {
+func (r DownloadOnlineArchiveQueryLogsApiRequest) Execute() (*os.File, *http.Response, error) {
 	return r.ApiService.DownloadOnlineArchiveQueryLogsExecute(r)
 }
 
@@ -450,10 +450,10 @@ Downloads query logs for the specified online archive. To use this resource, the
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster that contains the collection for which you want to return the query logs from one online archive.
- @return OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest
+ @return DownloadOnlineArchiveQueryLogsApiRequest
 */
-func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogs(ctx context.Context, groupId string, clusterName string) OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest {
-	return OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest{
+func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogs(ctx context.Context, groupId string, clusterName string) DownloadOnlineArchiveQueryLogsApiRequest {
+	return DownloadOnlineArchiveQueryLogsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -463,7 +463,7 @@ func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogs(ctx context.Con
 
 // Execute executes the request
 //  @return *os.File
-func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogsExecute(r OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest) (*os.File, *http.Response, error) {
+func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -571,7 +571,7 @@ func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogsExecute(r Online
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OnlineArchiveApiGetOnlineArchiveRequest struct {
+type GetOnlineArchiveApiRequest struct {
 	ctx context.Context
 	ApiService OnlineArchiveApi
 	groupId string
@@ -585,7 +585,7 @@ type GetOnlineArchiveParams struct {
 		ClusterName string
 }
 
-func (r OnlineArchiveApiGetOnlineArchiveRequest) Execute() (*OnlineArchive, *http.Response, error) {
+func (r GetOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
 	return r.ApiService.GetOnlineArchiveExecute(r)
 }
 
@@ -598,10 +598,10 @@ Returns one online archive for one cluster. This archive stores data from one cl
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param archiveId Unique 24-hexadecimal digit string that identifies the online archive to return.
  @param clusterName Human-readable label that identifies the cluster that contains the specified collection from which Application created the online archive.
- @return OnlineArchiveApiGetOnlineArchiveRequest
+ @return GetOnlineArchiveApiRequest
 */
-func (a *OnlineArchiveApiService) GetOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) OnlineArchiveApiGetOnlineArchiveRequest {
-	return OnlineArchiveApiGetOnlineArchiveRequest{
+func (a *OnlineArchiveApiService) GetOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) GetOnlineArchiveApiRequest {
+	return GetOnlineArchiveApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -612,7 +612,7 @@ func (a *OnlineArchiveApiService) GetOnlineArchive(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return OnlineArchive
-func (a *OnlineArchiveApiService) GetOnlineArchiveExecute(r OnlineArchiveApiGetOnlineArchiveRequest) (*OnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -714,7 +714,7 @@ func (a *OnlineArchiveApiService) GetOnlineArchiveExecute(r OnlineArchiveApiGetO
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OnlineArchiveApiListOnlineArchivesRequest struct {
+type ListOnlineArchivesApiRequest struct {
 	ctx context.Context
 	ApiService OnlineArchiveApi
 	groupId string
@@ -733,24 +733,24 @@ type ListOnlineArchivesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r OnlineArchiveApiListOnlineArchivesRequest) IncludeCount(includeCount bool) OnlineArchiveApiListOnlineArchivesRequest {
+func (r ListOnlineArchivesApiRequest) IncludeCount(includeCount bool) ListOnlineArchivesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r OnlineArchiveApiListOnlineArchivesRequest) ItemsPerPage(itemsPerPage int32) OnlineArchiveApiListOnlineArchivesRequest {
+func (r ListOnlineArchivesApiRequest) ItemsPerPage(itemsPerPage int32) ListOnlineArchivesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r OnlineArchiveApiListOnlineArchivesRequest) PageNum(pageNum int32) OnlineArchiveApiListOnlineArchivesRequest {
+func (r ListOnlineArchivesApiRequest) PageNum(pageNum int32) ListOnlineArchivesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r OnlineArchiveApiListOnlineArchivesRequest) Execute() (*PaginatedOnlineArchive, *http.Response, error) {
+func (r ListOnlineArchivesApiRequest) Execute() (*PaginatedOnlineArchive, *http.Response, error) {
 	return r.ApiService.ListOnlineArchivesExecute(r)
 }
 
@@ -762,10 +762,10 @@ Returns details of all online archives. This archive stores data from one cluste
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster that contains the collection for which you want to return the online archives.
- @return OnlineArchiveApiListOnlineArchivesRequest
+ @return ListOnlineArchivesApiRequest
 */
-func (a *OnlineArchiveApiService) ListOnlineArchives(ctx context.Context, groupId string, clusterName string) OnlineArchiveApiListOnlineArchivesRequest {
-	return OnlineArchiveApiListOnlineArchivesRequest{
+func (a *OnlineArchiveApiService) ListOnlineArchives(ctx context.Context, groupId string, clusterName string) ListOnlineArchivesApiRequest {
+	return ListOnlineArchivesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -775,7 +775,7 @@ func (a *OnlineArchiveApiService) ListOnlineArchives(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return PaginatedOnlineArchive
-func (a *OnlineArchiveApiService) ListOnlineArchivesExecute(r OnlineArchiveApiListOnlineArchivesRequest) (*PaginatedOnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -891,7 +891,7 @@ func (a *OnlineArchiveApiService) ListOnlineArchivesExecute(r OnlineArchiveApiLi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OnlineArchiveApiUpdateOnlineArchiveRequest struct {
+type UpdateOnlineArchiveApiRequest struct {
 	ctx context.Context
 	ApiService OnlineArchiveApi
 	groupId string
@@ -908,12 +908,12 @@ type UpdateOnlineArchiveParams struct {
 }
 
 // Updates, pauses, or resumes one online archive.
-func (r OnlineArchiveApiUpdateOnlineArchiveRequest) OnlineArchive(onlineArchive OnlineArchive) OnlineArchiveApiUpdateOnlineArchiveRequest {
+func (r UpdateOnlineArchiveApiRequest) OnlineArchive(onlineArchive OnlineArchive) UpdateOnlineArchiveApiRequest {
 	r.onlineArchive = &onlineArchive
 	return r
 }
 
-func (r OnlineArchiveApiUpdateOnlineArchiveRequest) Execute() (*OnlineArchive, *http.Response, error) {
+func (r UpdateOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
 	return r.ApiService.UpdateOnlineArchiveExecute(r)
 }
 
@@ -926,10 +926,10 @@ Updates, pauses, or resumes one online archive. This archive stores data from on
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param archiveId Unique 24-hexadecimal digit string that identifies the online archive to update.
  @param clusterName Human-readable label that identifies the cluster that contains the specified collection from which Application created the online archive.
- @return OnlineArchiveApiUpdateOnlineArchiveRequest
+ @return UpdateOnlineArchiveApiRequest
 */
-func (a *OnlineArchiveApiService) UpdateOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) OnlineArchiveApiUpdateOnlineArchiveRequest {
-	return OnlineArchiveApiUpdateOnlineArchiveRequest{
+func (a *OnlineArchiveApiService) UpdateOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) UpdateOnlineArchiveApiRequest {
+	return UpdateOnlineArchiveApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -940,7 +940,7 @@ func (a *OnlineArchiveApiService) UpdateOnlineArchive(ctx context.Context, group
 
 // Execute executes the request
 //  @return OnlineArchive
-func (a *OnlineArchiveApiService) UpdateOnlineArchiveExecute(r OnlineArchiveApiUpdateOnlineArchiveRequest) (*OnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -133,7 +133,7 @@ type OnlineArchiveApiCreateOnlineArchiveRequest struct {
 	onlineArchive *OnlineArchive
 }
 
-type OnlineArchiveApiCreateOnlineArchiveQueryParams struct {
+type OnlineArchiveApiCreateOnlineArchiveParams struct {
 		GroupId string
 		ClusterName string
 		OnlineArchive *OnlineArchive
@@ -278,7 +278,7 @@ type OnlineArchiveApiDeleteOnlineArchiveRequest struct {
 	clusterName string
 }
 
-type OnlineArchiveApiDeleteOnlineArchiveQueryParams struct {
+type OnlineArchiveApiDeleteOnlineArchiveParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string
@@ -412,7 +412,7 @@ type OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest struct {
 	archiveOnly *bool
 }
 
-type OnlineArchiveApiDownloadOnlineArchiveQueryLogsQueryParams struct {
+type OnlineArchiveApiDownloadOnlineArchiveQueryLogsParams struct {
 		GroupId string
 		ClusterName string
 		StartDate *int64
@@ -579,7 +579,7 @@ type OnlineArchiveApiGetOnlineArchiveRequest struct {
 	clusterName string
 }
 
-type OnlineArchiveApiGetOnlineArchiveQueryParams struct {
+type OnlineArchiveApiGetOnlineArchiveParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string
@@ -724,7 +724,7 @@ type OnlineArchiveApiListOnlineArchivesRequest struct {
 	pageNum *int32
 }
 
-type OnlineArchiveApiListOnlineArchivesQueryParams struct {
+type OnlineArchiveApiListOnlineArchivesParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -900,7 +900,7 @@ type OnlineArchiveApiUpdateOnlineArchiveRequest struct {
 	onlineArchive *OnlineArchive
 }
 
-type OnlineArchiveApiUpdateOnlineArchiveQueryParams struct {
+type OnlineArchiveApiUpdateOnlineArchiveParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -133,7 +133,7 @@ type CreateOnlineArchiveApiRequest struct {
 	onlineArchive *OnlineArchive
 }
 
-type CreateOnlineArchiveParams struct {
+type CreateOnlineArchiveApiParams struct {
 		GroupId string
 		ClusterName string
 		OnlineArchive *OnlineArchive
@@ -278,7 +278,7 @@ type DeleteOnlineArchiveApiRequest struct {
 	clusterName string
 }
 
-type DeleteOnlineArchiveParams struct {
+type DeleteOnlineArchiveApiParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string
@@ -412,7 +412,7 @@ type DownloadOnlineArchiveQueryLogsApiRequest struct {
 	archiveOnly *bool
 }
 
-type DownloadOnlineArchiveQueryLogsParams struct {
+type DownloadOnlineArchiveQueryLogsApiParams struct {
 		GroupId string
 		ClusterName string
 		StartDate *int64
@@ -579,7 +579,7 @@ type GetOnlineArchiveApiRequest struct {
 	clusterName string
 }
 
-type GetOnlineArchiveParams struct {
+type GetOnlineArchiveApiParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string
@@ -724,7 +724,7 @@ type ListOnlineArchivesApiRequest struct {
 	pageNum *int32
 }
 
-type ListOnlineArchivesParams struct {
+type ListOnlineArchivesApiParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -900,7 +900,7 @@ type UpdateOnlineArchiveApiRequest struct {
 	onlineArchive *OnlineArchive
 }
 
-type UpdateOnlineArchiveParams struct {
+type UpdateOnlineArchiveApiParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -133,7 +133,7 @@ type OnlineArchiveApiCreateOnlineArchiveRequest struct {
 	onlineArchive *OnlineArchive
 }
 
-type OnlineArchiveApiCreateOnlineArchiveParams struct {
+type CreateOnlineArchiveParams struct {
 		GroupId string
 		ClusterName string
 		OnlineArchive *OnlineArchive
@@ -278,7 +278,7 @@ type OnlineArchiveApiDeleteOnlineArchiveRequest struct {
 	clusterName string
 }
 
-type OnlineArchiveApiDeleteOnlineArchiveParams struct {
+type DeleteOnlineArchiveParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string
@@ -412,7 +412,7 @@ type OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest struct {
 	archiveOnly *bool
 }
 
-type OnlineArchiveApiDownloadOnlineArchiveQueryLogsParams struct {
+type DownloadOnlineArchiveQueryLogsParams struct {
 		GroupId string
 		ClusterName string
 		StartDate *int64
@@ -579,7 +579,7 @@ type OnlineArchiveApiGetOnlineArchiveRequest struct {
 	clusterName string
 }
 
-type OnlineArchiveApiGetOnlineArchiveParams struct {
+type GetOnlineArchiveParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string
@@ -724,7 +724,7 @@ type OnlineArchiveApiListOnlineArchivesRequest struct {
 	pageNum *int32
 }
 
-type OnlineArchiveApiListOnlineArchivesParams struct {
+type ListOnlineArchivesParams struct {
 		GroupId string
 		ClusterName string
 		IncludeCount *bool
@@ -900,7 +900,7 @@ type OnlineArchiveApiUpdateOnlineArchiveRequest struct {
 	onlineArchive *OnlineArchive
 }
 
-type OnlineArchiveApiUpdateOnlineArchiveParams struct {
+type UpdateOnlineArchiveParams struct {
 		GroupId string
 		ArchiveId string
 		ClusterName string

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -132,10 +132,11 @@ type OnlineArchiveApiCreateOnlineArchiveRequest struct {
 	clusterName string
 	onlineArchive *OnlineArchive
 }
+
 type OnlineArchiveApiCreateOnlineArchiveQueryParams struct {
-		groupId string
-		clusterName string
-		onlineArchive *OnlineArchive
+		GroupId string
+		ClusterName string
+		OnlineArchive *OnlineArchive
 }
 
 // Creates one online archive.
@@ -276,10 +277,11 @@ type OnlineArchiveApiDeleteOnlineArchiveRequest struct {
 	archiveId string
 	clusterName string
 }
+
 type OnlineArchiveApiDeleteOnlineArchiveQueryParams struct {
-		groupId string
-		archiveId string
-		clusterName string
+		GroupId string
+		ArchiveId string
+		ClusterName string
 }
 
 func (r OnlineArchiveApiDeleteOnlineArchiveRequest) Execute() (*http.Response, error) {
@@ -409,12 +411,13 @@ type OnlineArchiveApiDownloadOnlineArchiveQueryLogsRequest struct {
 	endDate *int64
 	archiveOnly *bool
 }
+
 type OnlineArchiveApiDownloadOnlineArchiveQueryLogsQueryParams struct {
-		groupId string
-		clusterName string
-		startDate *int64
-		endDate *int64
-		archiveOnly *bool
+		GroupId string
+		ClusterName string
+		StartDate *int64
+		EndDate *int64
+		ArchiveOnly *bool
 }
 
 // Date and time that specifies the starting point for the range of log messages to return. This resource expresses this value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).
@@ -575,10 +578,11 @@ type OnlineArchiveApiGetOnlineArchiveRequest struct {
 	archiveId string
 	clusterName string
 }
+
 type OnlineArchiveApiGetOnlineArchiveQueryParams struct {
-		groupId string
-		archiveId string
-		clusterName string
+		GroupId string
+		ArchiveId string
+		ClusterName string
 }
 
 func (r OnlineArchiveApiGetOnlineArchiveRequest) Execute() (*OnlineArchive, *http.Response, error) {
@@ -719,12 +723,13 @@ type OnlineArchiveApiListOnlineArchivesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type OnlineArchiveApiListOnlineArchivesQueryParams struct {
-		groupId string
-		clusterName string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		ClusterName string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -894,11 +899,12 @@ type OnlineArchiveApiUpdateOnlineArchiveRequest struct {
 	clusterName string
 	onlineArchive *OnlineArchive
 }
+
 type OnlineArchiveApiUpdateOnlineArchiveQueryParams struct {
-		groupId string
-		archiveId string
-		clusterName string
-		onlineArchive *OnlineArchive
+		GroupId string
+		ArchiveId string
+		ClusterName string
+		OnlineArchive *OnlineArchive
 }
 
 // Updates, pauses, or resumes one online archive.

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -266,8 +266,9 @@ type OrganizationsApiCreateOrganizationRequest struct {
 	ApiService OrganizationsApi
 	createOrganizationRequest *CreateOrganizationRequest
 }
+
 type OrganizationsApiCreateOrganizationQueryParams struct {
-		createOrganizationRequest *CreateOrganizationRequest
+		CreateOrganizationRequest *CreateOrganizationRequest
 }
 
 // Organization that you want to create.
@@ -389,9 +390,10 @@ type OrganizationsApiCreateOrganizationInvitationRequest struct {
 	orgId string
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
+
 type OrganizationsApiCreateOrganizationInvitationQueryParams struct {
-		orgId string
-		organizationInvitationRequest *OrganizationInvitationRequest
+		OrgId string
+		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
 
 // Invites one MongoDB Cloud user to join the specified organization.
@@ -521,8 +523,9 @@ type OrganizationsApiDeleteOrganizationRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 }
+
 type OrganizationsApiDeleteOrganizationQueryParams struct {
-		orgId string
+		OrgId string
 }
 
 func (r OrganizationsApiDeleteOrganizationRequest) Execute() (*http.Response, error) {
@@ -635,9 +638,10 @@ type OrganizationsApiDeleteOrganizationInvitationRequest struct {
 	orgId string
 	invitationId string
 }
+
 type OrganizationsApiDeleteOrganizationInvitationQueryParams struct {
-		orgId string
-		invitationId string
+		OrgId string
+		InvitationId string
 }
 
 func (r OrganizationsApiDeleteOrganizationInvitationRequest) Execute() (*http.Response, error) {
@@ -748,8 +752,9 @@ type OrganizationsApiGetOrganizationRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 }
+
 type OrganizationsApiGetOrganizationQueryParams struct {
-		orgId string
+		OrgId string
 }
 
 func (r OrganizationsApiGetOrganizationRequest) Execute() (*Organization, *http.Response, error) {
@@ -869,9 +874,10 @@ type OrganizationsApiGetOrganizationInvitationRequest struct {
 	orgId string
 	invitationId string
 }
+
 type OrganizationsApiGetOrganizationInvitationQueryParams struct {
-		orgId string
-		invitationId string
+		OrgId string
+		InvitationId string
 }
 
 func (r OrganizationsApiGetOrganizationInvitationRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
@@ -999,8 +1005,9 @@ type OrganizationsApiGetOrganizationSettingsRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 }
+
 type OrganizationsApiGetOrganizationSettingsQueryParams struct {
-		orgId string
+		OrgId string
 }
 
 func (r OrganizationsApiGetOrganizationSettingsRequest) Execute() (*OrganizationSettings, *http.Response, error) {
@@ -1120,9 +1127,10 @@ type OrganizationsApiListOrganizationInvitationsRequest struct {
 	orgId string
 	username *string
 }
+
 type OrganizationsApiListOrganizationInvitationsQueryParams struct {
-		orgId string
-		username *string
+		OrgId string
+		Username *string
 }
 
 // Email address of the user account invited to this organization. If you exclude this parameter, this resource returns all pending invitations.
@@ -1254,12 +1262,13 @@ type OrganizationsApiListOrganizationProjectsRequest struct {
 	pageNum *int32
 	name *string
 }
+
 type OrganizationsApiListOrganizationProjectsQueryParams struct {
-		orgId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		name *string
+		OrgId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		Name *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1436,11 +1445,12 @@ type OrganizationsApiListOrganizationUsersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type OrganizationsApiListOrganizationUsersQueryParams struct {
-		orgId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		OrgId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1601,11 +1611,12 @@ type OrganizationsApiListOrganizationsRequest struct {
 	pageNum *int32
 	name *string
 }
+
 type OrganizationsApiListOrganizationsQueryParams struct {
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		name *string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		Name *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1764,9 +1775,10 @@ type OrganizationsApiRenameOrganizationRequest struct {
 	orgId string
 	organization *Organization
 }
+
 type OrganizationsApiRenameOrganizationQueryParams struct {
-		orgId string
-		organization *Organization
+		OrgId string
+		Organization *Organization
 }
 
 // Details to update on the specified organization.
@@ -1897,9 +1909,10 @@ type OrganizationsApiUpdateOrganizationInvitationRequest struct {
 	orgId string
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
+
 type OrganizationsApiUpdateOrganizationInvitationQueryParams struct {
-		orgId string
-		organizationInvitationRequest *OrganizationInvitationRequest
+		OrgId string
+		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
 
 // Updates the details of one pending invitation to the specified organization.
@@ -2031,10 +2044,11 @@ type OrganizationsApiUpdateOrganizationInvitationByIdRequest struct {
 	invitationId string
 	organizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
 }
+
 type OrganizationsApiUpdateOrganizationInvitationByIdQueryParams struct {
-		orgId string
-		invitationId string
-		organizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
+		OrgId string
+		InvitationId string
+		OrganizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
 }
 
 // Updates the details of one pending invitation to the specified organization.
@@ -2174,9 +2188,10 @@ type OrganizationsApiUpdateOrganizationSettingsRequest struct {
 	orgId string
 	organizationSettings *OrganizationSettings
 }
+
 type OrganizationsApiUpdateOrganizationSettingsQueryParams struct {
-		orgId string
-		organizationSettings *OrganizationSettings
+		OrgId string
+		OrganizationSettings *OrganizationSettings
 }
 
 // Details to update on the specified organization&#39;s settings.

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -266,6 +266,9 @@ type OrganizationsApiCreateOrganizationRequest struct {
 	ApiService OrganizationsApi
 	createOrganizationRequest *CreateOrganizationRequest
 }
+type OrganizationsApiCreateOrganizationQueryParams struct {
+		createOrganizationRequest *CreateOrganizationRequest
+}
 
 // Organization that you want to create.
 func (r OrganizationsApiCreateOrganizationRequest) CreateOrganizationRequest(createOrganizationRequest CreateOrganizationRequest) OrganizationsApiCreateOrganizationRequest {
@@ -385,6 +388,10 @@ type OrganizationsApiCreateOrganizationInvitationRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 	organizationInvitationRequest *OrganizationInvitationRequest
+}
+type OrganizationsApiCreateOrganizationInvitationQueryParams struct {
+		orgId string
+		organizationInvitationRequest *OrganizationInvitationRequest
 }
 
 // Invites one MongoDB Cloud user to join the specified organization.
@@ -514,6 +521,9 @@ type OrganizationsApiDeleteOrganizationRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 }
+type OrganizationsApiDeleteOrganizationQueryParams struct {
+		orgId string
+}
 
 func (r OrganizationsApiDeleteOrganizationRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOrganizationExecute(r)
@@ -625,6 +635,10 @@ type OrganizationsApiDeleteOrganizationInvitationRequest struct {
 	orgId string
 	invitationId string
 }
+type OrganizationsApiDeleteOrganizationInvitationQueryParams struct {
+		orgId string
+		invitationId string
+}
 
 func (r OrganizationsApiDeleteOrganizationInvitationRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOrganizationInvitationExecute(r)
@@ -733,6 +747,9 @@ type OrganizationsApiGetOrganizationRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
+}
+type OrganizationsApiGetOrganizationQueryParams struct {
+		orgId string
 }
 
 func (r OrganizationsApiGetOrganizationRequest) Execute() (*Organization, *http.Response, error) {
@@ -851,6 +868,10 @@ type OrganizationsApiGetOrganizationInvitationRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 	invitationId string
+}
+type OrganizationsApiGetOrganizationInvitationQueryParams struct {
+		orgId string
+		invitationId string
 }
 
 func (r OrganizationsApiGetOrganizationInvitationRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
@@ -978,6 +999,9 @@ type OrganizationsApiGetOrganizationSettingsRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 }
+type OrganizationsApiGetOrganizationSettingsQueryParams struct {
+		orgId string
+}
 
 func (r OrganizationsApiGetOrganizationSettingsRequest) Execute() (*OrganizationSettings, *http.Response, error) {
 	return r.ApiService.GetOrganizationSettingsExecute(r)
@@ -1095,6 +1119,10 @@ type OrganizationsApiListOrganizationInvitationsRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 	username *string
+}
+type OrganizationsApiListOrganizationInvitationsQueryParams struct {
+		orgId string
+		username *string
 }
 
 // Email address of the user account invited to this organization. If you exclude this parameter, this resource returns all pending invitations.
@@ -1225,6 +1253,13 @@ type OrganizationsApiListOrganizationProjectsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 	name *string
+}
+type OrganizationsApiListOrganizationProjectsQueryParams struct {
+		orgId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		name *string
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1401,6 +1436,12 @@ type OrganizationsApiListOrganizationUsersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type OrganizationsApiListOrganizationUsersQueryParams struct {
+		orgId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r OrganizationsApiListOrganizationUsersRequest) IncludeCount(includeCount bool) OrganizationsApiListOrganizationUsersRequest {
@@ -1560,6 +1601,12 @@ type OrganizationsApiListOrganizationsRequest struct {
 	pageNum *int32
 	name *string
 }
+type OrganizationsApiListOrganizationsQueryParams struct {
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		name *string
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r OrganizationsApiListOrganizationsRequest) IncludeCount(includeCount bool) OrganizationsApiListOrganizationsRequest {
@@ -1717,6 +1764,10 @@ type OrganizationsApiRenameOrganizationRequest struct {
 	orgId string
 	organization *Organization
 }
+type OrganizationsApiRenameOrganizationQueryParams struct {
+		orgId string
+		organization *Organization
+}
 
 // Details to update on the specified organization.
 func (r OrganizationsApiRenameOrganizationRequest) Organization(organization Organization) OrganizationsApiRenameOrganizationRequest {
@@ -1845,6 +1896,10 @@ type OrganizationsApiUpdateOrganizationInvitationRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 	organizationInvitationRequest *OrganizationInvitationRequest
+}
+type OrganizationsApiUpdateOrganizationInvitationQueryParams struct {
+		orgId string
+		organizationInvitationRequest *OrganizationInvitationRequest
 }
 
 // Updates the details of one pending invitation to the specified organization.
@@ -1975,6 +2030,11 @@ type OrganizationsApiUpdateOrganizationInvitationByIdRequest struct {
 	orgId string
 	invitationId string
 	organizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
+}
+type OrganizationsApiUpdateOrganizationInvitationByIdQueryParams struct {
+		orgId string
+		invitationId string
+		organizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
 }
 
 // Updates the details of one pending invitation to the specified organization.
@@ -2113,6 +2173,10 @@ type OrganizationsApiUpdateOrganizationSettingsRequest struct {
 	ApiService OrganizationsApi
 	orgId string
 	organizationSettings *OrganizationSettings
+}
+type OrganizationsApiUpdateOrganizationSettingsQueryParams struct {
+		orgId string
+		organizationSettings *OrganizationSettings
 }
 
 // Details to update on the specified organization&#39;s settings.

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -267,7 +267,7 @@ type OrganizationsApiCreateOrganizationRequest struct {
 	createOrganizationRequest *CreateOrganizationRequest
 }
 
-type OrganizationsApiCreateOrganizationQueryParams struct {
+type OrganizationsApiCreateOrganizationParams struct {
 		CreateOrganizationRequest *CreateOrganizationRequest
 }
 
@@ -391,7 +391,7 @@ type OrganizationsApiCreateOrganizationInvitationRequest struct {
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
 
-type OrganizationsApiCreateOrganizationInvitationQueryParams struct {
+type OrganizationsApiCreateOrganizationInvitationParams struct {
 		OrgId string
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
@@ -524,7 +524,7 @@ type OrganizationsApiDeleteOrganizationRequest struct {
 	orgId string
 }
 
-type OrganizationsApiDeleteOrganizationQueryParams struct {
+type OrganizationsApiDeleteOrganizationParams struct {
 		OrgId string
 }
 
@@ -639,7 +639,7 @@ type OrganizationsApiDeleteOrganizationInvitationRequest struct {
 	invitationId string
 }
 
-type OrganizationsApiDeleteOrganizationInvitationQueryParams struct {
+type OrganizationsApiDeleteOrganizationInvitationParams struct {
 		OrgId string
 		InvitationId string
 }
@@ -753,7 +753,7 @@ type OrganizationsApiGetOrganizationRequest struct {
 	orgId string
 }
 
-type OrganizationsApiGetOrganizationQueryParams struct {
+type OrganizationsApiGetOrganizationParams struct {
 		OrgId string
 }
 
@@ -875,7 +875,7 @@ type OrganizationsApiGetOrganizationInvitationRequest struct {
 	invitationId string
 }
 
-type OrganizationsApiGetOrganizationInvitationQueryParams struct {
+type OrganizationsApiGetOrganizationInvitationParams struct {
 		OrgId string
 		InvitationId string
 }
@@ -1006,7 +1006,7 @@ type OrganizationsApiGetOrganizationSettingsRequest struct {
 	orgId string
 }
 
-type OrganizationsApiGetOrganizationSettingsQueryParams struct {
+type OrganizationsApiGetOrganizationSettingsParams struct {
 		OrgId string
 }
 
@@ -1128,7 +1128,7 @@ type OrganizationsApiListOrganizationInvitationsRequest struct {
 	username *string
 }
 
-type OrganizationsApiListOrganizationInvitationsQueryParams struct {
+type OrganizationsApiListOrganizationInvitationsParams struct {
 		OrgId string
 		Username *string
 }
@@ -1263,7 +1263,7 @@ type OrganizationsApiListOrganizationProjectsRequest struct {
 	name *string
 }
 
-type OrganizationsApiListOrganizationProjectsQueryParams struct {
+type OrganizationsApiListOrganizationProjectsParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1446,7 +1446,7 @@ type OrganizationsApiListOrganizationUsersRequest struct {
 	pageNum *int32
 }
 
-type OrganizationsApiListOrganizationUsersQueryParams struct {
+type OrganizationsApiListOrganizationUsersParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1612,7 +1612,7 @@ type OrganizationsApiListOrganizationsRequest struct {
 	name *string
 }
 
-type OrganizationsApiListOrganizationsQueryParams struct {
+type OrganizationsApiListOrganizationsParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -1776,7 +1776,7 @@ type OrganizationsApiRenameOrganizationRequest struct {
 	organization *Organization
 }
 
-type OrganizationsApiRenameOrganizationQueryParams struct {
+type OrganizationsApiRenameOrganizationParams struct {
 		OrgId string
 		Organization *Organization
 }
@@ -1910,7 +1910,7 @@ type OrganizationsApiUpdateOrganizationInvitationRequest struct {
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
 
-type OrganizationsApiUpdateOrganizationInvitationQueryParams struct {
+type OrganizationsApiUpdateOrganizationInvitationParams struct {
 		OrgId string
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
@@ -2045,7 +2045,7 @@ type OrganizationsApiUpdateOrganizationInvitationByIdRequest struct {
 	organizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
 }
 
-type OrganizationsApiUpdateOrganizationInvitationByIdQueryParams struct {
+type OrganizationsApiUpdateOrganizationInvitationByIdParams struct {
 		OrgId string
 		InvitationId string
 		OrganizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
@@ -2189,7 +2189,7 @@ type OrganizationsApiUpdateOrganizationSettingsRequest struct {
 	organizationSettings *OrganizationSettings
 }
 
-type OrganizationsApiUpdateOrganizationSettingsQueryParams struct {
+type OrganizationsApiUpdateOrganizationSettingsParams struct {
 		OrgId string
 		OrganizationSettings *OrganizationSettings
 }

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -267,7 +267,7 @@ type OrganizationsApiCreateOrganizationRequest struct {
 	createOrganizationRequest *CreateOrganizationRequest
 }
 
-type OrganizationsApiCreateOrganizationParams struct {
+type CreateOrganizationParams struct {
 		CreateOrganizationRequest *CreateOrganizationRequest
 }
 
@@ -391,7 +391,7 @@ type OrganizationsApiCreateOrganizationInvitationRequest struct {
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
 
-type OrganizationsApiCreateOrganizationInvitationParams struct {
+type CreateOrganizationInvitationParams struct {
 		OrgId string
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
@@ -524,7 +524,7 @@ type OrganizationsApiDeleteOrganizationRequest struct {
 	orgId string
 }
 
-type OrganizationsApiDeleteOrganizationParams struct {
+type DeleteOrganizationParams struct {
 		OrgId string
 }
 
@@ -639,7 +639,7 @@ type OrganizationsApiDeleteOrganizationInvitationRequest struct {
 	invitationId string
 }
 
-type OrganizationsApiDeleteOrganizationInvitationParams struct {
+type DeleteOrganizationInvitationParams struct {
 		OrgId string
 		InvitationId string
 }
@@ -753,7 +753,7 @@ type OrganizationsApiGetOrganizationRequest struct {
 	orgId string
 }
 
-type OrganizationsApiGetOrganizationParams struct {
+type GetOrganizationParams struct {
 		OrgId string
 }
 
@@ -875,7 +875,7 @@ type OrganizationsApiGetOrganizationInvitationRequest struct {
 	invitationId string
 }
 
-type OrganizationsApiGetOrganizationInvitationParams struct {
+type GetOrganizationInvitationParams struct {
 		OrgId string
 		InvitationId string
 }
@@ -1006,7 +1006,7 @@ type OrganizationsApiGetOrganizationSettingsRequest struct {
 	orgId string
 }
 
-type OrganizationsApiGetOrganizationSettingsParams struct {
+type GetOrganizationSettingsParams struct {
 		OrgId string
 }
 
@@ -1128,7 +1128,7 @@ type OrganizationsApiListOrganizationInvitationsRequest struct {
 	username *string
 }
 
-type OrganizationsApiListOrganizationInvitationsParams struct {
+type ListOrganizationInvitationsParams struct {
 		OrgId string
 		Username *string
 }
@@ -1263,7 +1263,7 @@ type OrganizationsApiListOrganizationProjectsRequest struct {
 	name *string
 }
 
-type OrganizationsApiListOrganizationProjectsParams struct {
+type ListOrganizationProjectsParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1446,7 +1446,7 @@ type OrganizationsApiListOrganizationUsersRequest struct {
 	pageNum *int32
 }
 
-type OrganizationsApiListOrganizationUsersParams struct {
+type ListOrganizationUsersParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1612,7 +1612,7 @@ type OrganizationsApiListOrganizationsRequest struct {
 	name *string
 }
 
-type OrganizationsApiListOrganizationsParams struct {
+type ListOrganizationsParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -1776,7 +1776,7 @@ type OrganizationsApiRenameOrganizationRequest struct {
 	organization *Organization
 }
 
-type OrganizationsApiRenameOrganizationParams struct {
+type RenameOrganizationParams struct {
 		OrgId string
 		Organization *Organization
 }
@@ -1910,7 +1910,7 @@ type OrganizationsApiUpdateOrganizationInvitationRequest struct {
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
 
-type OrganizationsApiUpdateOrganizationInvitationParams struct {
+type UpdateOrganizationInvitationParams struct {
 		OrgId string
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
@@ -2045,7 +2045,7 @@ type OrganizationsApiUpdateOrganizationInvitationByIdRequest struct {
 	organizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
 }
 
-type OrganizationsApiUpdateOrganizationInvitationByIdParams struct {
+type UpdateOrganizationInvitationByIdParams struct {
 		OrgId string
 		InvitationId string
 		OrganizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
@@ -2189,7 +2189,7 @@ type OrganizationsApiUpdateOrganizationSettingsRequest struct {
 	organizationSettings *OrganizationSettings
 }
 
-type OrganizationsApiUpdateOrganizationSettingsParams struct {
+type UpdateOrganizationSettingsParams struct {
 		OrgId string
 		OrganizationSettings *OrganizationSettings
 }

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -267,7 +267,7 @@ type CreateOrganizationApiRequest struct {
 	createOrganizationRequest *CreateOrganizationRequest
 }
 
-type CreateOrganizationParams struct {
+type CreateOrganizationApiParams struct {
 		CreateOrganizationRequest *CreateOrganizationRequest
 }
 
@@ -391,7 +391,7 @@ type CreateOrganizationInvitationApiRequest struct {
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
 
-type CreateOrganizationInvitationParams struct {
+type CreateOrganizationInvitationApiParams struct {
 		OrgId string
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
@@ -524,7 +524,7 @@ type DeleteOrganizationApiRequest struct {
 	orgId string
 }
 
-type DeleteOrganizationParams struct {
+type DeleteOrganizationApiParams struct {
 		OrgId string
 }
 
@@ -639,7 +639,7 @@ type DeleteOrganizationInvitationApiRequest struct {
 	invitationId string
 }
 
-type DeleteOrganizationInvitationParams struct {
+type DeleteOrganizationInvitationApiParams struct {
 		OrgId string
 		InvitationId string
 }
@@ -753,7 +753,7 @@ type GetOrganizationApiRequest struct {
 	orgId string
 }
 
-type GetOrganizationParams struct {
+type GetOrganizationApiParams struct {
 		OrgId string
 }
 
@@ -875,7 +875,7 @@ type GetOrganizationInvitationApiRequest struct {
 	invitationId string
 }
 
-type GetOrganizationInvitationParams struct {
+type GetOrganizationInvitationApiParams struct {
 		OrgId string
 		InvitationId string
 }
@@ -1006,7 +1006,7 @@ type GetOrganizationSettingsApiRequest struct {
 	orgId string
 }
 
-type GetOrganizationSettingsParams struct {
+type GetOrganizationSettingsApiParams struct {
 		OrgId string
 }
 
@@ -1128,7 +1128,7 @@ type ListOrganizationInvitationsApiRequest struct {
 	username *string
 }
 
-type ListOrganizationInvitationsParams struct {
+type ListOrganizationInvitationsApiParams struct {
 		OrgId string
 		Username *string
 }
@@ -1263,7 +1263,7 @@ type ListOrganizationProjectsApiRequest struct {
 	name *string
 }
 
-type ListOrganizationProjectsParams struct {
+type ListOrganizationProjectsApiParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1446,7 +1446,7 @@ type ListOrganizationUsersApiRequest struct {
 	pageNum *int32
 }
 
-type ListOrganizationUsersParams struct {
+type ListOrganizationUsersApiParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1612,7 +1612,7 @@ type ListOrganizationsApiRequest struct {
 	name *string
 }
 
-type ListOrganizationsParams struct {
+type ListOrganizationsApiParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -1776,7 +1776,7 @@ type RenameOrganizationApiRequest struct {
 	organization *Organization
 }
 
-type RenameOrganizationParams struct {
+type RenameOrganizationApiParams struct {
 		OrgId string
 		Organization *Organization
 }
@@ -1910,7 +1910,7 @@ type UpdateOrganizationInvitationApiRequest struct {
 	organizationInvitationRequest *OrganizationInvitationRequest
 }
 
-type UpdateOrganizationInvitationParams struct {
+type UpdateOrganizationInvitationApiParams struct {
 		OrgId string
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
@@ -2045,7 +2045,7 @@ type UpdateOrganizationInvitationByIdApiRequest struct {
 	organizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
 }
 
-type UpdateOrganizationInvitationByIdParams struct {
+type UpdateOrganizationInvitationByIdApiParams struct {
 		OrgId string
 		InvitationId string
 		OrganizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
@@ -2189,7 +2189,7 @@ type UpdateOrganizationSettingsApiRequest struct {
 	organizationSettings *OrganizationSettings
 }
 
-type UpdateOrganizationSettingsParams struct {
+type UpdateOrganizationSettingsApiParams struct {
 		OrgId string
 		OrganizationSettings *OrganizationSettings
 }

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -28,13 +28,13 @@ type OrganizationsApi interface {
 	Creates one organization in MongoDB Cloud and links it to the requesting API Key's organization. To use this resource, the requesting API Key must have the Organization Owner role. The requesting API Key's organization must be a paying organization. To learn more, see [Configure a Paying Organization](https://www.mongodb.com/docs/atlas/billing/#configure-a-paying-organization) in the MongoDB Atlas documentation. This resource doesn't require the API Key to have an API Access List.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return OrganizationsApiCreateOrganizationRequest
+	@return CreateOrganizationApiRequest
 	*/
-	CreateOrganization(ctx context.Context) OrganizationsApiCreateOrganizationRequest
+	CreateOrganization(ctx context.Context) CreateOrganizationApiRequest
 
 	// CreateOrganizationExecute executes the request
 	//  @return CreateOrganizationResponse
-	CreateOrganizationExecute(r OrganizationsApiCreateOrganizationRequest) (*CreateOrganizationResponse, *http.Response, error)
+	CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error)
 
 	/*
 	CreateOrganizationInvitation Invite One MongoDB Cloud User to Join One Atlas Organization
@@ -43,13 +43,13 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiCreateOrganizationInvitationRequest
+	@return CreateOrganizationInvitationApiRequest
 	*/
-	CreateOrganizationInvitation(ctx context.Context, orgId string) OrganizationsApiCreateOrganizationInvitationRequest
+	CreateOrganizationInvitation(ctx context.Context, orgId string) CreateOrganizationInvitationApiRequest
 
 	// CreateOrganizationInvitationExecute executes the request
 	//  @return OrganizationInvitation
-	CreateOrganizationInvitationExecute(r OrganizationsApiCreateOrganizationInvitationRequest) (*OrganizationInvitation, *http.Response, error)
+	CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	DeleteOrganization Remove One Organization
@@ -62,12 +62,12 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiDeleteOrganizationRequest
+	@return DeleteOrganizationApiRequest
 	*/
-	DeleteOrganization(ctx context.Context, orgId string) OrganizationsApiDeleteOrganizationRequest
+	DeleteOrganization(ctx context.Context, orgId string) DeleteOrganizationApiRequest
 
 	// DeleteOrganizationExecute executes the request
-	DeleteOrganizationExecute(r OrganizationsApiDeleteOrganizationRequest) (*http.Response, error)
+	DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (*http.Response, error)
 
 	/*
 	DeleteOrganizationInvitation Cancel One Organization Invitation
@@ -77,12 +77,12 @@ type OrganizationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
-	@return OrganizationsApiDeleteOrganizationInvitationRequest
+	@return DeleteOrganizationInvitationApiRequest
 	*/
-	DeleteOrganizationInvitation(ctx context.Context, orgId string, invitationId string) OrganizationsApiDeleteOrganizationInvitationRequest
+	DeleteOrganizationInvitation(ctx context.Context, orgId string, invitationId string) DeleteOrganizationInvitationApiRequest
 
 	// DeleteOrganizationInvitationExecute executes the request
-	DeleteOrganizationInvitationExecute(r OrganizationsApiDeleteOrganizationInvitationRequest) (*http.Response, error)
+	DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (*http.Response, error)
 
 	/*
 	GetOrganization Return One Organization
@@ -91,13 +91,13 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiGetOrganizationRequest
+	@return GetOrganizationApiRequest
 	*/
-	GetOrganization(ctx context.Context, orgId string) OrganizationsApiGetOrganizationRequest
+	GetOrganization(ctx context.Context, orgId string) GetOrganizationApiRequest
 
 	// GetOrganizationExecute executes the request
 	//  @return Organization
-	GetOrganizationExecute(r OrganizationsApiGetOrganizationRequest) (*Organization, *http.Response, error)
+	GetOrganizationExecute(r GetOrganizationApiRequest) (*Organization, *http.Response, error)
 
 	/*
 	GetOrganizationInvitation Return One Organization Invitation
@@ -107,13 +107,13 @@ type OrganizationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
-	@return OrganizationsApiGetOrganizationInvitationRequest
+	@return GetOrganizationInvitationApiRequest
 	*/
-	GetOrganizationInvitation(ctx context.Context, orgId string, invitationId string) OrganizationsApiGetOrganizationInvitationRequest
+	GetOrganizationInvitation(ctx context.Context, orgId string, invitationId string) GetOrganizationInvitationApiRequest
 
 	// GetOrganizationInvitationExecute executes the request
 	//  @return OrganizationInvitation
-	GetOrganizationInvitationExecute(r OrganizationsApiGetOrganizationInvitationRequest) (*OrganizationInvitation, *http.Response, error)
+	GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	GetOrganizationSettings Return Settings for One Organization
@@ -122,13 +122,13 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiGetOrganizationSettingsRequest
+	@return GetOrganizationSettingsApiRequest
 	*/
-	GetOrganizationSettings(ctx context.Context, orgId string) OrganizationsApiGetOrganizationSettingsRequest
+	GetOrganizationSettings(ctx context.Context, orgId string) GetOrganizationSettingsApiRequest
 
 	// GetOrganizationSettingsExecute executes the request
 	//  @return OrganizationSettings
-	GetOrganizationSettingsExecute(r OrganizationsApiGetOrganizationSettingsRequest) (*OrganizationSettings, *http.Response, error)
+	GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 
 	/*
 	ListOrganizationInvitations Return All Organization Invitations
@@ -137,13 +137,13 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiListOrganizationInvitationsRequest
+	@return ListOrganizationInvitationsApiRequest
 	*/
-	ListOrganizationInvitations(ctx context.Context, orgId string) OrganizationsApiListOrganizationInvitationsRequest
+	ListOrganizationInvitations(ctx context.Context, orgId string) ListOrganizationInvitationsApiRequest
 
 	// ListOrganizationInvitationsExecute executes the request
 	//  @return []OrganizationInvitation
-	ListOrganizationInvitationsExecute(r OrganizationsApiListOrganizationInvitationsRequest) ([]OrganizationInvitation, *http.Response, error)
+	ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error)
 
 	/*
 	ListOrganizationProjects Return One or More Projects in One Organization
@@ -159,13 +159,13 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiListOrganizationProjectsRequest
+	@return ListOrganizationProjectsApiRequest
 	*/
-	ListOrganizationProjects(ctx context.Context, orgId string) OrganizationsApiListOrganizationProjectsRequest
+	ListOrganizationProjects(ctx context.Context, orgId string) ListOrganizationProjectsApiRequest
 
 	// ListOrganizationProjectsExecute executes the request
 	//  @return PaginatedAtlasGroup
-	ListOrganizationProjectsExecute(r OrganizationsApiListOrganizationProjectsRequest) (*PaginatedAtlasGroup, *http.Response, error)
+	ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
 	ListOrganizationUsers Return All MongoDB Cloud Users in One Organization
@@ -174,13 +174,13 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiListOrganizationUsersRequest
+	@return ListOrganizationUsersApiRequest
 	*/
-	ListOrganizationUsers(ctx context.Context, orgId string) OrganizationsApiListOrganizationUsersRequest
+	ListOrganizationUsers(ctx context.Context, orgId string) ListOrganizationUsersApiRequest
 
 	// ListOrganizationUsersExecute executes the request
 	//  @return PaginatedAppUser
-	ListOrganizationUsersExecute(r OrganizationsApiListOrganizationUsersRequest) (*PaginatedAppUser, *http.Response, error)
+	ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
 
 	/*
 	ListOrganizations Return All Organizations
@@ -188,13 +188,13 @@ To use this resource, the requesting API Key must have the Organization Member r
 	Returns all organizations to which you belong. To use this resource, the requesting API Key must have the Organization Member role. This resource doesn't require the API Key to have an Access List.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return OrganizationsApiListOrganizationsRequest
+	@return ListOrganizationsApiRequest
 	*/
-	ListOrganizations(ctx context.Context) OrganizationsApiListOrganizationsRequest
+	ListOrganizations(ctx context.Context) ListOrganizationsApiRequest
 
 	// ListOrganizationsExecute executes the request
 	//  @return PaginatedOrganization
-	ListOrganizationsExecute(r OrganizationsApiListOrganizationsRequest) (*PaginatedOrganization, *http.Response, error)
+	ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error)
 
 	/*
 	RenameOrganization Rename One Organization
@@ -203,13 +203,13 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiRenameOrganizationRequest
+	@return RenameOrganizationApiRequest
 	*/
-	RenameOrganization(ctx context.Context, orgId string) OrganizationsApiRenameOrganizationRequest
+	RenameOrganization(ctx context.Context, orgId string) RenameOrganizationApiRequest
 
 	// RenameOrganizationExecute executes the request
 	//  @return Organization
-	RenameOrganizationExecute(r OrganizationsApiRenameOrganizationRequest) (*Organization, *http.Response, error)
+	RenameOrganizationExecute(r RenameOrganizationApiRequest) (*Organization, *http.Response, error)
 
 	/*
 	UpdateOrganizationInvitation Update One Organization Invitation
@@ -218,13 +218,13 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiUpdateOrganizationInvitationRequest
+	@return UpdateOrganizationInvitationApiRequest
 	*/
-	UpdateOrganizationInvitation(ctx context.Context, orgId string) OrganizationsApiUpdateOrganizationInvitationRequest
+	UpdateOrganizationInvitation(ctx context.Context, orgId string) UpdateOrganizationInvitationApiRequest
 
 	// UpdateOrganizationInvitationExecute executes the request
 	//  @return OrganizationInvitation
-	UpdateOrganizationInvitationExecute(r OrganizationsApiUpdateOrganizationInvitationRequest) (*OrganizationInvitation, *http.Response, error)
+	UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	UpdateOrganizationInvitationById Update One Organization Invitation by Invitation ID
@@ -234,13 +234,13 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
-	@return OrganizationsApiUpdateOrganizationInvitationByIdRequest
+	@return UpdateOrganizationInvitationByIdApiRequest
 	*/
-	UpdateOrganizationInvitationById(ctx context.Context, orgId string, invitationId string) OrganizationsApiUpdateOrganizationInvitationByIdRequest
+	UpdateOrganizationInvitationById(ctx context.Context, orgId string, invitationId string) UpdateOrganizationInvitationByIdApiRequest
 
 	// UpdateOrganizationInvitationByIdExecute executes the request
 	//  @return OrganizationInvitation
-	UpdateOrganizationInvitationByIdExecute(r OrganizationsApiUpdateOrganizationInvitationByIdRequest) (*OrganizationInvitation, *http.Response, error)
+	UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	UpdateOrganizationSettings Update Settings for One Organization
@@ -249,19 +249,19 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return OrganizationsApiUpdateOrganizationSettingsRequest
+	@return UpdateOrganizationSettingsApiRequest
 	*/
-	UpdateOrganizationSettings(ctx context.Context, orgId string) OrganizationsApiUpdateOrganizationSettingsRequest
+	UpdateOrganizationSettings(ctx context.Context, orgId string) UpdateOrganizationSettingsApiRequest
 
 	// UpdateOrganizationSettingsExecute executes the request
 	//  @return OrganizationSettings
-	UpdateOrganizationSettingsExecute(r OrganizationsApiUpdateOrganizationSettingsRequest) (*OrganizationSettings, *http.Response, error)
+	UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 }
 
 // OrganizationsApiService OrganizationsApi service
 type OrganizationsApiService service
 
-type OrganizationsApiCreateOrganizationRequest struct {
+type CreateOrganizationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	createOrganizationRequest *CreateOrganizationRequest
@@ -272,12 +272,12 @@ type CreateOrganizationParams struct {
 }
 
 // Organization that you want to create.
-func (r OrganizationsApiCreateOrganizationRequest) CreateOrganizationRequest(createOrganizationRequest CreateOrganizationRequest) OrganizationsApiCreateOrganizationRequest {
+func (r CreateOrganizationApiRequest) CreateOrganizationRequest(createOrganizationRequest CreateOrganizationRequest) CreateOrganizationApiRequest {
 	r.createOrganizationRequest = &createOrganizationRequest
 	return r
 }
 
-func (r OrganizationsApiCreateOrganizationRequest) Execute() (*CreateOrganizationResponse, *http.Response, error) {
+func (r CreateOrganizationApiRequest) Execute() (*CreateOrganizationResponse, *http.Response, error) {
 	return r.ApiService.CreateOrganizationExecute(r)
 }
 
@@ -287,10 +287,10 @@ CreateOrganization Create One Organization
 Creates one organization in MongoDB Cloud and links it to the requesting API Key's organization. To use this resource, the requesting API Key must have the Organization Owner role. The requesting API Key's organization must be a paying organization. To learn more, see [Configure a Paying Organization](https://www.mongodb.com/docs/atlas/billing/#configure-a-paying-organization) in the MongoDB Atlas documentation. This resource doesn't require the API Key to have an API Access List.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return OrganizationsApiCreateOrganizationRequest
+ @return CreateOrganizationApiRequest
 */
-func (a *OrganizationsApiService) CreateOrganization(ctx context.Context) OrganizationsApiCreateOrganizationRequest {
-	return OrganizationsApiCreateOrganizationRequest{
+func (a *OrganizationsApiService) CreateOrganization(ctx context.Context) CreateOrganizationApiRequest {
+	return CreateOrganizationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -298,7 +298,7 @@ func (a *OrganizationsApiService) CreateOrganization(ctx context.Context) Organi
 
 // Execute executes the request
 //  @return CreateOrganizationResponse
-func (a *OrganizationsApiService) CreateOrganizationExecute(r OrganizationsApiCreateOrganizationRequest) (*CreateOrganizationResponse, *http.Response, error) {
+func (a *OrganizationsApiService) CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -384,7 +384,7 @@ func (a *OrganizationsApiService) CreateOrganizationExecute(r OrganizationsApiCr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiCreateOrganizationInvitationRequest struct {
+type CreateOrganizationInvitationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -397,12 +397,12 @@ type CreateOrganizationInvitationParams struct {
 }
 
 // Invites one MongoDB Cloud user to join the specified organization.
-func (r OrganizationsApiCreateOrganizationInvitationRequest) OrganizationInvitationRequest(organizationInvitationRequest OrganizationInvitationRequest) OrganizationsApiCreateOrganizationInvitationRequest {
+func (r CreateOrganizationInvitationApiRequest) OrganizationInvitationRequest(organizationInvitationRequest OrganizationInvitationRequest) CreateOrganizationInvitationApiRequest {
 	r.organizationInvitationRequest = &organizationInvitationRequest
 	return r
 }
 
-func (r OrganizationsApiCreateOrganizationInvitationRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
+func (r CreateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.CreateOrganizationInvitationExecute(r)
 }
 
@@ -413,10 +413,10 @@ Invites one MongoDB Cloud user to join the specified organization. The user must
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiCreateOrganizationInvitationRequest
+ @return CreateOrganizationInvitationApiRequest
 */
-func (a *OrganizationsApiService) CreateOrganizationInvitation(ctx context.Context, orgId string) OrganizationsApiCreateOrganizationInvitationRequest {
-	return OrganizationsApiCreateOrganizationInvitationRequest{
+func (a *OrganizationsApiService) CreateOrganizationInvitation(ctx context.Context, orgId string) CreateOrganizationInvitationApiRequest {
+	return CreateOrganizationInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -425,7 +425,7 @@ func (a *OrganizationsApiService) CreateOrganizationInvitation(ctx context.Conte
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) CreateOrganizationInvitationExecute(r OrganizationsApiCreateOrganizationInvitationRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -518,7 +518,7 @@ func (a *OrganizationsApiService) CreateOrganizationInvitationExecute(r Organiza
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiDeleteOrganizationRequest struct {
+type DeleteOrganizationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -528,7 +528,7 @@ type DeleteOrganizationParams struct {
 		OrgId string
 }
 
-func (r OrganizationsApiDeleteOrganizationRequest) Execute() (*http.Response, error) {
+func (r DeleteOrganizationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOrganizationExecute(r)
 }
 
@@ -543,10 +543,10 @@ Removes one specified organization. MongoDB Cloud imposes the following limits o
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiDeleteOrganizationRequest
+ @return DeleteOrganizationApiRequest
 */
-func (a *OrganizationsApiService) DeleteOrganization(ctx context.Context, orgId string) OrganizationsApiDeleteOrganizationRequest {
-	return OrganizationsApiDeleteOrganizationRequest{
+func (a *OrganizationsApiService) DeleteOrganization(ctx context.Context, orgId string) DeleteOrganizationApiRequest {
+	return DeleteOrganizationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -554,7 +554,7 @@ func (a *OrganizationsApiService) DeleteOrganization(ctx context.Context, orgId 
 }
 
 // Execute executes the request
-func (a *OrganizationsApiService) DeleteOrganizationExecute(r OrganizationsApiDeleteOrganizationRequest) (*http.Response, error) {
+func (a *OrganizationsApiService) DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -632,7 +632,7 @@ func (a *OrganizationsApiService) DeleteOrganizationExecute(r OrganizationsApiDe
 	return localVarHTTPResponse, nil
 }
 
-type OrganizationsApiDeleteOrganizationInvitationRequest struct {
+type DeleteOrganizationInvitationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -644,7 +644,7 @@ type DeleteOrganizationInvitationParams struct {
 		InvitationId string
 }
 
-func (r OrganizationsApiDeleteOrganizationInvitationRequest) Execute() (*http.Response, error) {
+func (r DeleteOrganizationInvitationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOrganizationInvitationExecute(r)
 }
 
@@ -656,10 +656,10 @@ Cancels one pending invitation sent to the specified MongoDB Cloud user to join 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
- @return OrganizationsApiDeleteOrganizationInvitationRequest
+ @return DeleteOrganizationInvitationApiRequest
 */
-func (a *OrganizationsApiService) DeleteOrganizationInvitation(ctx context.Context, orgId string, invitationId string) OrganizationsApiDeleteOrganizationInvitationRequest {
-	return OrganizationsApiDeleteOrganizationInvitationRequest{
+func (a *OrganizationsApiService) DeleteOrganizationInvitation(ctx context.Context, orgId string, invitationId string) DeleteOrganizationInvitationApiRequest {
+	return DeleteOrganizationInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -668,7 +668,7 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitation(ctx context.Conte
 }
 
 // Execute executes the request
-func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r OrganizationsApiDeleteOrganizationInvitationRequest) (*http.Response, error) {
+func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -747,7 +747,7 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r Organiza
 	return localVarHTTPResponse, nil
 }
 
-type OrganizationsApiGetOrganizationRequest struct {
+type GetOrganizationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -757,7 +757,7 @@ type GetOrganizationParams struct {
 		OrgId string
 }
 
-func (r OrganizationsApiGetOrganizationRequest) Execute() (*Organization, *http.Response, error) {
+func (r GetOrganizationApiRequest) Execute() (*Organization, *http.Response, error) {
 	return r.ApiService.GetOrganizationExecute(r)
 }
 
@@ -768,10 +768,10 @@ Returns one organization to which the requesting API key has access. To use this
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiGetOrganizationRequest
+ @return GetOrganizationApiRequest
 */
-func (a *OrganizationsApiService) GetOrganization(ctx context.Context, orgId string) OrganizationsApiGetOrganizationRequest {
-	return OrganizationsApiGetOrganizationRequest{
+func (a *OrganizationsApiService) GetOrganization(ctx context.Context, orgId string) GetOrganizationApiRequest {
+	return GetOrganizationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -780,7 +780,7 @@ func (a *OrganizationsApiService) GetOrganization(ctx context.Context, orgId str
 
 // Execute executes the request
 //  @return Organization
-func (a *OrganizationsApiService) GetOrganizationExecute(r OrganizationsApiGetOrganizationRequest) (*Organization, *http.Response, error) {
+func (a *OrganizationsApiService) GetOrganizationExecute(r GetOrganizationApiRequest) (*Organization, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -868,7 +868,7 @@ func (a *OrganizationsApiService) GetOrganizationExecute(r OrganizationsApiGetOr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiGetOrganizationInvitationRequest struct {
+type GetOrganizationInvitationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -880,7 +880,7 @@ type GetOrganizationInvitationParams struct {
 		InvitationId string
 }
 
-func (r OrganizationsApiGetOrganizationInvitationRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
+func (r GetOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.GetOrganizationInvitationExecute(r)
 }
 
@@ -892,10 +892,10 @@ Returns the details of one pending invitation to the specified organization. To 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
- @return OrganizationsApiGetOrganizationInvitationRequest
+ @return GetOrganizationInvitationApiRequest
 */
-func (a *OrganizationsApiService) GetOrganizationInvitation(ctx context.Context, orgId string, invitationId string) OrganizationsApiGetOrganizationInvitationRequest {
-	return OrganizationsApiGetOrganizationInvitationRequest{
+func (a *OrganizationsApiService) GetOrganizationInvitation(ctx context.Context, orgId string, invitationId string) GetOrganizationInvitationApiRequest {
+	return GetOrganizationInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -905,7 +905,7 @@ func (a *OrganizationsApiService) GetOrganizationInvitation(ctx context.Context,
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) GetOrganizationInvitationExecute(r OrganizationsApiGetOrganizationInvitationRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1000,7 +1000,7 @@ func (a *OrganizationsApiService) GetOrganizationInvitationExecute(r Organizatio
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiGetOrganizationSettingsRequest struct {
+type GetOrganizationSettingsApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -1010,7 +1010,7 @@ type GetOrganizationSettingsParams struct {
 		OrgId string
 }
 
-func (r OrganizationsApiGetOrganizationSettingsRequest) Execute() (*OrganizationSettings, *http.Response, error) {
+func (r GetOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
 	return r.ApiService.GetOrganizationSettingsExecute(r)
 }
 
@@ -1021,10 +1021,10 @@ Returns details about the specified organization's settings. To use this resourc
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiGetOrganizationSettingsRequest
+ @return GetOrganizationSettingsApiRequest
 */
-func (a *OrganizationsApiService) GetOrganizationSettings(ctx context.Context, orgId string) OrganizationsApiGetOrganizationSettingsRequest {
-	return OrganizationsApiGetOrganizationSettingsRequest{
+func (a *OrganizationsApiService) GetOrganizationSettings(ctx context.Context, orgId string) GetOrganizationSettingsApiRequest {
+	return GetOrganizationSettingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1033,7 +1033,7 @@ func (a *OrganizationsApiService) GetOrganizationSettings(ctx context.Context, o
 
 // Execute executes the request
 //  @return OrganizationSettings
-func (a *OrganizationsApiService) GetOrganizationSettingsExecute(r OrganizationsApiGetOrganizationSettingsRequest) (*OrganizationSettings, *http.Response, error) {
+func (a *OrganizationsApiService) GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1121,7 +1121,7 @@ func (a *OrganizationsApiService) GetOrganizationSettingsExecute(r Organizations
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiListOrganizationInvitationsRequest struct {
+type ListOrganizationInvitationsApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -1134,12 +1134,12 @@ type ListOrganizationInvitationsParams struct {
 }
 
 // Email address of the user account invited to this organization. If you exclude this parameter, this resource returns all pending invitations.
-func (r OrganizationsApiListOrganizationInvitationsRequest) Username(username string) OrganizationsApiListOrganizationInvitationsRequest {
+func (r ListOrganizationInvitationsApiRequest) Username(username string) ListOrganizationInvitationsApiRequest {
 	r.username = &username
 	return r
 }
 
-func (r OrganizationsApiListOrganizationInvitationsRequest) Execute() ([]OrganizationInvitation, *http.Response, error) {
+func (r ListOrganizationInvitationsApiRequest) Execute() ([]OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.ListOrganizationInvitationsExecute(r)
 }
 
@@ -1150,10 +1150,10 @@ Returns all pending invitations to the specified organization. To use this resou
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiListOrganizationInvitationsRequest
+ @return ListOrganizationInvitationsApiRequest
 */
-func (a *OrganizationsApiService) ListOrganizationInvitations(ctx context.Context, orgId string) OrganizationsApiListOrganizationInvitationsRequest {
-	return OrganizationsApiListOrganizationInvitationsRequest{
+func (a *OrganizationsApiService) ListOrganizationInvitations(ctx context.Context, orgId string) ListOrganizationInvitationsApiRequest {
+	return ListOrganizationInvitationsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1162,7 +1162,7 @@ func (a *OrganizationsApiService) ListOrganizationInvitations(ctx context.Contex
 
 // Execute executes the request
 //  @return []OrganizationInvitation
-func (a *OrganizationsApiService) ListOrganizationInvitationsExecute(r OrganizationsApiListOrganizationInvitationsRequest) ([]OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1253,7 +1253,7 @@ func (a *OrganizationsApiService) ListOrganizationInvitationsExecute(r Organizat
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiListOrganizationProjectsRequest struct {
+type ListOrganizationProjectsApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -1272,30 +1272,30 @@ type ListOrganizationProjectsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r OrganizationsApiListOrganizationProjectsRequest) IncludeCount(includeCount bool) OrganizationsApiListOrganizationProjectsRequest {
+func (r ListOrganizationProjectsApiRequest) IncludeCount(includeCount bool) ListOrganizationProjectsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r OrganizationsApiListOrganizationProjectsRequest) ItemsPerPage(itemsPerPage int32) OrganizationsApiListOrganizationProjectsRequest {
+func (r ListOrganizationProjectsApiRequest) ItemsPerPage(itemsPerPage int32) ListOrganizationProjectsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r OrganizationsApiListOrganizationProjectsRequest) PageNum(pageNum int32) OrganizationsApiListOrganizationProjectsRequest {
+func (r ListOrganizationProjectsApiRequest) PageNum(pageNum int32) ListOrganizationProjectsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Human-readable label of the project to use to filter the returned list. Performs a case-insensitive search for a project within the organization which is prefixed by the specified name.
-func (r OrganizationsApiListOrganizationProjectsRequest) Name(name string) OrganizationsApiListOrganizationProjectsRequest {
+func (r ListOrganizationProjectsApiRequest) Name(name string) ListOrganizationProjectsApiRequest {
 	r.name = &name
 	return r
 }
 
-func (r OrganizationsApiListOrganizationProjectsRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
+func (r ListOrganizationProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
 	return r.ApiService.ListOrganizationProjectsExecute(r)
 }
 
@@ -1313,10 +1313,10 @@ To use this resource, the requesting API Key must have the Organization Member r
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiListOrganizationProjectsRequest
+ @return ListOrganizationProjectsApiRequest
 */
-func (a *OrganizationsApiService) ListOrganizationProjects(ctx context.Context, orgId string) OrganizationsApiListOrganizationProjectsRequest {
-	return OrganizationsApiListOrganizationProjectsRequest{
+func (a *OrganizationsApiService) ListOrganizationProjects(ctx context.Context, orgId string) ListOrganizationProjectsApiRequest {
+	return ListOrganizationProjectsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1325,7 +1325,7 @@ func (a *OrganizationsApiService) ListOrganizationProjects(ctx context.Context, 
 
 // Execute executes the request
 //  @return PaginatedAtlasGroup
-func (a *OrganizationsApiService) ListOrganizationProjectsExecute(r OrganizationsApiListOrganizationProjectsRequest) (*PaginatedAtlasGroup, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1437,7 +1437,7 @@ func (a *OrganizationsApiService) ListOrganizationProjectsExecute(r Organization
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiListOrganizationUsersRequest struct {
+type ListOrganizationUsersApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -1454,24 +1454,24 @@ type ListOrganizationUsersParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r OrganizationsApiListOrganizationUsersRequest) IncludeCount(includeCount bool) OrganizationsApiListOrganizationUsersRequest {
+func (r ListOrganizationUsersApiRequest) IncludeCount(includeCount bool) ListOrganizationUsersApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r OrganizationsApiListOrganizationUsersRequest) ItemsPerPage(itemsPerPage int32) OrganizationsApiListOrganizationUsersRequest {
+func (r ListOrganizationUsersApiRequest) ItemsPerPage(itemsPerPage int32) ListOrganizationUsersApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r OrganizationsApiListOrganizationUsersRequest) PageNum(pageNum int32) OrganizationsApiListOrganizationUsersRequest {
+func (r ListOrganizationUsersApiRequest) PageNum(pageNum int32) ListOrganizationUsersApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r OrganizationsApiListOrganizationUsersRequest) Execute() (*PaginatedAppUser, *http.Response, error) {
+func (r ListOrganizationUsersApiRequest) Execute() (*PaginatedAppUser, *http.Response, error) {
 	return r.ApiService.ListOrganizationUsersExecute(r)
 }
 
@@ -1482,10 +1482,10 @@ Returns details about the MongoDB Cloud users associated with the specified orga
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiListOrganizationUsersRequest
+ @return ListOrganizationUsersApiRequest
 */
-func (a *OrganizationsApiService) ListOrganizationUsers(ctx context.Context, orgId string) OrganizationsApiListOrganizationUsersRequest {
-	return OrganizationsApiListOrganizationUsersRequest{
+func (a *OrganizationsApiService) ListOrganizationUsers(ctx context.Context, orgId string) ListOrganizationUsersApiRequest {
+	return ListOrganizationUsersApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1494,7 +1494,7 @@ func (a *OrganizationsApiService) ListOrganizationUsers(ctx context.Context, org
 
 // Execute executes the request
 //  @return PaginatedAppUser
-func (a *OrganizationsApiService) ListOrganizationUsersExecute(r OrganizationsApiListOrganizationUsersRequest) (*PaginatedAppUser, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1603,7 +1603,7 @@ func (a *OrganizationsApiService) ListOrganizationUsersExecute(r OrganizationsAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiListOrganizationsRequest struct {
+type ListOrganizationsApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	includeCount *bool
@@ -1620,30 +1620,30 @@ type ListOrganizationsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r OrganizationsApiListOrganizationsRequest) IncludeCount(includeCount bool) OrganizationsApiListOrganizationsRequest {
+func (r ListOrganizationsApiRequest) IncludeCount(includeCount bool) ListOrganizationsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r OrganizationsApiListOrganizationsRequest) ItemsPerPage(itemsPerPage int32) OrganizationsApiListOrganizationsRequest {
+func (r ListOrganizationsApiRequest) ItemsPerPage(itemsPerPage int32) ListOrganizationsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r OrganizationsApiListOrganizationsRequest) PageNum(pageNum int32) OrganizationsApiListOrganizationsRequest {
+func (r ListOrganizationsApiRequest) PageNum(pageNum int32) ListOrganizationsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Human-readable label of the organization to use to filter the returned list. Performs a case-insensitive search for an organization that starts with the specified name.
-func (r OrganizationsApiListOrganizationsRequest) Name(name string) OrganizationsApiListOrganizationsRequest {
+func (r ListOrganizationsApiRequest) Name(name string) ListOrganizationsApiRequest {
 	r.name = &name
 	return r
 }
 
-func (r OrganizationsApiListOrganizationsRequest) Execute() (*PaginatedOrganization, *http.Response, error) {
+func (r ListOrganizationsApiRequest) Execute() (*PaginatedOrganization, *http.Response, error) {
 	return r.ApiService.ListOrganizationsExecute(r)
 }
 
@@ -1653,10 +1653,10 @@ ListOrganizations Return All Organizations
 Returns all organizations to which you belong. To use this resource, the requesting API Key must have the Organization Member role. This resource doesn't require the API Key to have an Access List.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return OrganizationsApiListOrganizationsRequest
+ @return ListOrganizationsApiRequest
 */
-func (a *OrganizationsApiService) ListOrganizations(ctx context.Context) OrganizationsApiListOrganizationsRequest {
-	return OrganizationsApiListOrganizationsRequest{
+func (a *OrganizationsApiService) ListOrganizations(ctx context.Context) ListOrganizationsApiRequest {
+	return ListOrganizationsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -1664,7 +1664,7 @@ func (a *OrganizationsApiService) ListOrganizations(ctx context.Context) Organiz
 
 // Execute executes the request
 //  @return PaginatedOrganization
-func (a *OrganizationsApiService) ListOrganizationsExecute(r OrganizationsApiListOrganizationsRequest) (*PaginatedOrganization, *http.Response, error) {
+func (a *OrganizationsApiService) ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1769,7 +1769,7 @@ func (a *OrganizationsApiService) ListOrganizationsExecute(r OrganizationsApiLis
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiRenameOrganizationRequest struct {
+type RenameOrganizationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -1782,12 +1782,12 @@ type RenameOrganizationParams struct {
 }
 
 // Details to update on the specified organization.
-func (r OrganizationsApiRenameOrganizationRequest) Organization(organization Organization) OrganizationsApiRenameOrganizationRequest {
+func (r RenameOrganizationApiRequest) Organization(organization Organization) RenameOrganizationApiRequest {
 	r.organization = &organization
 	return r
 }
 
-func (r OrganizationsApiRenameOrganizationRequest) Execute() (*Organization, *http.Response, error) {
+func (r RenameOrganizationApiRequest) Execute() (*Organization, *http.Response, error) {
 	return r.ApiService.RenameOrganizationExecute(r)
 }
 
@@ -1798,10 +1798,10 @@ Renames one organization. To use this resource, the requesting API Key must have
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiRenameOrganizationRequest
+ @return RenameOrganizationApiRequest
 */
-func (a *OrganizationsApiService) RenameOrganization(ctx context.Context, orgId string) OrganizationsApiRenameOrganizationRequest {
-	return OrganizationsApiRenameOrganizationRequest{
+func (a *OrganizationsApiService) RenameOrganization(ctx context.Context, orgId string) RenameOrganizationApiRequest {
+	return RenameOrganizationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1810,7 +1810,7 @@ func (a *OrganizationsApiService) RenameOrganization(ctx context.Context, orgId 
 
 // Execute executes the request
 //  @return Organization
-func (a *OrganizationsApiService) RenameOrganizationExecute(r OrganizationsApiRenameOrganizationRequest) (*Organization, *http.Response, error) {
+func (a *OrganizationsApiService) RenameOrganizationExecute(r RenameOrganizationApiRequest) (*Organization, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1903,7 +1903,7 @@ func (a *OrganizationsApiService) RenameOrganizationExecute(r OrganizationsApiRe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiUpdateOrganizationInvitationRequest struct {
+type UpdateOrganizationInvitationApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -1916,12 +1916,12 @@ type UpdateOrganizationInvitationParams struct {
 }
 
 // Updates the details of one pending invitation to the specified organization.
-func (r OrganizationsApiUpdateOrganizationInvitationRequest) OrganizationInvitationRequest(organizationInvitationRequest OrganizationInvitationRequest) OrganizationsApiUpdateOrganizationInvitationRequest {
+func (r UpdateOrganizationInvitationApiRequest) OrganizationInvitationRequest(organizationInvitationRequest OrganizationInvitationRequest) UpdateOrganizationInvitationApiRequest {
 	r.organizationInvitationRequest = &organizationInvitationRequest
 	return r
 }
 
-func (r OrganizationsApiUpdateOrganizationInvitationRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
+func (r UpdateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.UpdateOrganizationInvitationExecute(r)
 }
 
@@ -1932,10 +1932,10 @@ Updates the details of one pending invitation to the specified organization. To 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiUpdateOrganizationInvitationRequest
+ @return UpdateOrganizationInvitationApiRequest
 */
-func (a *OrganizationsApiService) UpdateOrganizationInvitation(ctx context.Context, orgId string) OrganizationsApiUpdateOrganizationInvitationRequest {
-	return OrganizationsApiUpdateOrganizationInvitationRequest{
+func (a *OrganizationsApiService) UpdateOrganizationInvitation(ctx context.Context, orgId string) UpdateOrganizationInvitationApiRequest {
+	return UpdateOrganizationInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1944,7 +1944,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitation(ctx context.Conte
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) UpdateOrganizationInvitationExecute(r OrganizationsApiUpdateOrganizationInvitationRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2037,7 +2037,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationExecute(r Organiza
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiUpdateOrganizationInvitationByIdRequest struct {
+type UpdateOrganizationInvitationByIdApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -2052,12 +2052,12 @@ type UpdateOrganizationInvitationByIdParams struct {
 }
 
 // Updates the details of one pending invitation to the specified organization.
-func (r OrganizationsApiUpdateOrganizationInvitationByIdRequest) OrganizationInvitationUpdateRequest(organizationInvitationUpdateRequest OrganizationInvitationUpdateRequest) OrganizationsApiUpdateOrganizationInvitationByIdRequest {
+func (r UpdateOrganizationInvitationByIdApiRequest) OrganizationInvitationUpdateRequest(organizationInvitationUpdateRequest OrganizationInvitationUpdateRequest) UpdateOrganizationInvitationByIdApiRequest {
 	r.organizationInvitationUpdateRequest = &organizationInvitationUpdateRequest
 	return r
 }
 
-func (r OrganizationsApiUpdateOrganizationInvitationByIdRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
+func (r UpdateOrganizationInvitationByIdApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.UpdateOrganizationInvitationByIdExecute(r)
 }
 
@@ -2069,10 +2069,10 @@ Updates the details of one pending invitation to the specified organization. To 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
- @return OrganizationsApiUpdateOrganizationInvitationByIdRequest
+ @return UpdateOrganizationInvitationByIdApiRequest
 */
-func (a *OrganizationsApiService) UpdateOrganizationInvitationById(ctx context.Context, orgId string, invitationId string) OrganizationsApiUpdateOrganizationInvitationByIdRequest {
-	return OrganizationsApiUpdateOrganizationInvitationByIdRequest{
+func (a *OrganizationsApiService) UpdateOrganizationInvitationById(ctx context.Context, orgId string, invitationId string) UpdateOrganizationInvitationByIdApiRequest {
+	return UpdateOrganizationInvitationByIdApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -2082,7 +2082,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationById(ctx context.C
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdExecute(r OrganizationsApiUpdateOrganizationInvitationByIdRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2182,7 +2182,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdExecute(r Orga
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type OrganizationsApiUpdateOrganizationSettingsRequest struct {
+type UpdateOrganizationSettingsApiRequest struct {
 	ctx context.Context
 	ApiService OrganizationsApi
 	orgId string
@@ -2195,12 +2195,12 @@ type UpdateOrganizationSettingsParams struct {
 }
 
 // Details to update on the specified organization&#39;s settings.
-func (r OrganizationsApiUpdateOrganizationSettingsRequest) OrganizationSettings(organizationSettings OrganizationSettings) OrganizationsApiUpdateOrganizationSettingsRequest {
+func (r UpdateOrganizationSettingsApiRequest) OrganizationSettings(organizationSettings OrganizationSettings) UpdateOrganizationSettingsApiRequest {
 	r.organizationSettings = &organizationSettings
 	return r
 }
 
-func (r OrganizationsApiUpdateOrganizationSettingsRequest) Execute() (*OrganizationSettings, *http.Response, error) {
+func (r UpdateOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
 	return r.ApiService.UpdateOrganizationSettingsExecute(r)
 }
 
@@ -2211,10 +2211,10 @@ Updates the organization's settings. To use this resource, the requesting API Ke
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return OrganizationsApiUpdateOrganizationSettingsRequest
+ @return UpdateOrganizationSettingsApiRequest
 */
-func (a *OrganizationsApiService) UpdateOrganizationSettings(ctx context.Context, orgId string) OrganizationsApiUpdateOrganizationSettingsRequest {
-	return OrganizationsApiUpdateOrganizationSettingsRequest{
+func (a *OrganizationsApiService) UpdateOrganizationSettings(ctx context.Context, orgId string) UpdateOrganizationSettingsApiRequest {
+	return UpdateOrganizationSettingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -2223,7 +2223,7 @@ func (a *OrganizationsApiService) UpdateOrganizationSettings(ctx context.Context
 
 // Execute executes the request
 //  @return OrganizationSettings
-func (a *OrganizationsApiService) UpdateOrganizationSettingsExecute(r OrganizationsApiUpdateOrganizationSettingsRequest) (*OrganizationSettings, *http.Response, error) {
+func (a *OrganizationsApiService) UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -109,7 +109,7 @@ type PerformanceAdvisorApiDisableSlowOperationThresholdingRequest struct {
 	groupId string
 }
 
-type PerformanceAdvisorApiDisableSlowOperationThresholdingParams struct {
+type DisableSlowOperationThresholdingParams struct {
 		GroupId string
 }
 
@@ -219,7 +219,7 @@ type PerformanceAdvisorApiEnableSlowOperationThresholdingRequest struct {
 	groupId string
 }
 
-type PerformanceAdvisorApiEnableSlowOperationThresholdingParams struct {
+type EnableSlowOperationThresholdingParams struct {
 		GroupId string
 }
 
@@ -334,7 +334,7 @@ type PerformanceAdvisorApiListSlowQueriesRequest struct {
 	since *int64
 }
 
-type PerformanceAdvisorApiListSlowQueriesParams struct {
+type ListSlowQueriesParams struct {
 		GroupId string
 		ProcessId string
 		Duration *int64
@@ -514,7 +514,7 @@ type PerformanceAdvisorApiListSlowQueryNamespacesRequest struct {
 	since *int64
 }
 
-type PerformanceAdvisorApiListSlowQueryNamespacesParams struct {
+type ListSlowQueryNamespacesParams struct {
 		GroupId string
 		ProcessId string
 		Duration *int64
@@ -668,7 +668,7 @@ type PerformanceAdvisorApiListSuggestedIndexesRequest struct {
 	since *float32
 }
 
-type PerformanceAdvisorApiListSuggestedIndexesParams struct {
+type ListSuggestedIndexesParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -109,7 +109,7 @@ type PerformanceAdvisorApiDisableSlowOperationThresholdingRequest struct {
 	groupId string
 }
 
-type PerformanceAdvisorApiDisableSlowOperationThresholdingQueryParams struct {
+type PerformanceAdvisorApiDisableSlowOperationThresholdingParams struct {
 		GroupId string
 }
 
@@ -219,7 +219,7 @@ type PerformanceAdvisorApiEnableSlowOperationThresholdingRequest struct {
 	groupId string
 }
 
-type PerformanceAdvisorApiEnableSlowOperationThresholdingQueryParams struct {
+type PerformanceAdvisorApiEnableSlowOperationThresholdingParams struct {
 		GroupId string
 }
 
@@ -334,7 +334,7 @@ type PerformanceAdvisorApiListSlowQueriesRequest struct {
 	since *int64
 }
 
-type PerformanceAdvisorApiListSlowQueriesQueryParams struct {
+type PerformanceAdvisorApiListSlowQueriesParams struct {
 		GroupId string
 		ProcessId string
 		Duration *int64
@@ -514,7 +514,7 @@ type PerformanceAdvisorApiListSlowQueryNamespacesRequest struct {
 	since *int64
 }
 
-type PerformanceAdvisorApiListSlowQueryNamespacesQueryParams struct {
+type PerformanceAdvisorApiListSlowQueryNamespacesParams struct {
 		GroupId string
 		ProcessId string
 		Duration *int64
@@ -668,7 +668,7 @@ type PerformanceAdvisorApiListSuggestedIndexesRequest struct {
 	since *float32
 }
 
-type PerformanceAdvisorApiListSuggestedIndexesQueryParams struct {
+type PerformanceAdvisorApiListSuggestedIndexesParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -30,12 +30,12 @@ type PerformanceAdvisorApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return PerformanceAdvisorApiDisableSlowOperationThresholdingRequest
+	@return DisableSlowOperationThresholdingApiRequest
 	*/
-	DisableSlowOperationThresholding(ctx context.Context, groupId string) PerformanceAdvisorApiDisableSlowOperationThresholdingRequest
+	DisableSlowOperationThresholding(ctx context.Context, groupId string) DisableSlowOperationThresholdingApiRequest
 
 	// DisableSlowOperationThresholdingExecute executes the request
-	DisableSlowOperationThresholdingExecute(r PerformanceAdvisorApiDisableSlowOperationThresholdingRequest) (*http.Response, error)
+	DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
 	EnableSlowOperationThresholding Enable Managed Slow Operation Threshold
@@ -44,12 +44,12 @@ type PerformanceAdvisorApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return PerformanceAdvisorApiEnableSlowOperationThresholdingRequest
+	@return EnableSlowOperationThresholdingApiRequest
 	*/
-	EnableSlowOperationThresholding(ctx context.Context, groupId string) PerformanceAdvisorApiEnableSlowOperationThresholdingRequest
+	EnableSlowOperationThresholding(ctx context.Context, groupId string) EnableSlowOperationThresholdingApiRequest
 
 	// EnableSlowOperationThresholdingExecute executes the request
-	EnableSlowOperationThresholdingExecute(r PerformanceAdvisorApiEnableSlowOperationThresholdingRequest) (*http.Response, error)
+	EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
 	ListSlowQueries Return Slow Queries
@@ -59,13 +59,13 @@ type PerformanceAdvisorApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of host and port that serves the MongoDB process. The host must be the hostname, FQDN, IPv4 address, or IPv6 address of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return PerformanceAdvisorApiListSlowQueriesRequest
+	@return ListSlowQueriesApiRequest
 	*/
-	ListSlowQueries(ctx context.Context, groupId string, processId string) PerformanceAdvisorApiListSlowQueriesRequest
+	ListSlowQueries(ctx context.Context, groupId string, processId string) ListSlowQueriesApiRequest
 
 	// ListSlowQueriesExecute executes the request
 	//  @return PerformanceAdvisorSlowQueryList
-	ListSlowQueriesExecute(r PerformanceAdvisorApiListSlowQueriesRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error)
+	ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error)
 
 	/*
 	ListSlowQueryNamespaces Return All Namespaces for One Host
@@ -75,13 +75,13 @@ type PerformanceAdvisorApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of host and port that serves the MongoDB process. The host must be the hostname, FQDN, IPv4 address, or IPv6 address of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return PerformanceAdvisorApiListSlowQueryNamespacesRequest
+	@return ListSlowQueryNamespacesApiRequest
 	*/
-	ListSlowQueryNamespaces(ctx context.Context, groupId string, processId string) PerformanceAdvisorApiListSlowQueryNamespacesRequest
+	ListSlowQueryNamespaces(ctx context.Context, groupId string, processId string) ListSlowQueryNamespacesApiRequest
 
 	// ListSlowQueryNamespacesExecute executes the request
 	//  @return Namespaces
-	ListSlowQueryNamespacesExecute(r PerformanceAdvisorApiListSlowQueryNamespacesRequest) (*Namespaces, *http.Response, error)
+	ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error)
 
 	/*
 	ListSuggestedIndexes Return Suggested Indexes
@@ -91,19 +91,19 @@ type PerformanceAdvisorApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param processId Combination of host and port that serves the MongoDB process. The host must be the hostname, FQDN, IPv4 address, or IPv6 address of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
-	@return PerformanceAdvisorApiListSuggestedIndexesRequest
+	@return ListSuggestedIndexesApiRequest
 	*/
-	ListSuggestedIndexes(ctx context.Context, groupId string, processId string) PerformanceAdvisorApiListSuggestedIndexesRequest
+	ListSuggestedIndexes(ctx context.Context, groupId string, processId string) ListSuggestedIndexesApiRequest
 
 	// ListSuggestedIndexesExecute executes the request
 	//  @return PerformanceAdvisorResponse
-	ListSuggestedIndexesExecute(r PerformanceAdvisorApiListSuggestedIndexesRequest) (*PerformanceAdvisorResponse, *http.Response, error)
+	ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error)
 }
 
 // PerformanceAdvisorApiService PerformanceAdvisorApi service
 type PerformanceAdvisorApiService service
 
-type PerformanceAdvisorApiDisableSlowOperationThresholdingRequest struct {
+type DisableSlowOperationThresholdingApiRequest struct {
 	ctx context.Context
 	ApiService PerformanceAdvisorApi
 	groupId string
@@ -113,7 +113,7 @@ type DisableSlowOperationThresholdingParams struct {
 		GroupId string
 }
 
-func (r PerformanceAdvisorApiDisableSlowOperationThresholdingRequest) Execute() (*http.Response, error) {
+func (r DisableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DisableSlowOperationThresholdingExecute(r)
 }
 
@@ -124,10 +124,10 @@ Disables the slow operation threshold that MongoDB Cloud calculated for the spec
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return PerformanceAdvisorApiDisableSlowOperationThresholdingRequest
+ @return DisableSlowOperationThresholdingApiRequest
 */
-func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholding(ctx context.Context, groupId string) PerformanceAdvisorApiDisableSlowOperationThresholdingRequest {
-	return PerformanceAdvisorApiDisableSlowOperationThresholdingRequest{
+func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholding(ctx context.Context, groupId string) DisableSlowOperationThresholdingApiRequest {
+	return DisableSlowOperationThresholdingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -135,7 +135,7 @@ func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholding(ctx cont
 }
 
 // Execute executes the request
-func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingExecute(r PerformanceAdvisorApiDisableSlowOperationThresholdingRequest) (*http.Response, error) {
+func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -213,7 +213,7 @@ func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingExecute(r
 	return localVarHTTPResponse, nil
 }
 
-type PerformanceAdvisorApiEnableSlowOperationThresholdingRequest struct {
+type EnableSlowOperationThresholdingApiRequest struct {
 	ctx context.Context
 	ApiService PerformanceAdvisorApi
 	groupId string
@@ -223,7 +223,7 @@ type EnableSlowOperationThresholdingParams struct {
 		GroupId string
 }
 
-func (r PerformanceAdvisorApiEnableSlowOperationThresholdingRequest) Execute() (*http.Response, error) {
+func (r EnableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.EnableSlowOperationThresholdingExecute(r)
 }
 
@@ -234,10 +234,10 @@ Enables MongoDB Cloud to use its slow operation threshold for the specified proj
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return PerformanceAdvisorApiEnableSlowOperationThresholdingRequest
+ @return EnableSlowOperationThresholdingApiRequest
 */
-func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholding(ctx context.Context, groupId string) PerformanceAdvisorApiEnableSlowOperationThresholdingRequest {
-	return PerformanceAdvisorApiEnableSlowOperationThresholdingRequest{
+func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholding(ctx context.Context, groupId string) EnableSlowOperationThresholdingApiRequest {
+	return EnableSlowOperationThresholdingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -245,7 +245,7 @@ func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholding(ctx conte
 }
 
 // Execute executes the request
-func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingExecute(r PerformanceAdvisorApiEnableSlowOperationThresholdingRequest) (*http.Response, error) {
+func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -323,7 +323,7 @@ func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingExecute(r 
 	return localVarHTTPResponse, nil
 }
 
-type PerformanceAdvisorApiListSlowQueriesRequest struct {
+type ListSlowQueriesApiRequest struct {
 	ctx context.Context
 	ApiService PerformanceAdvisorApi
 	groupId string
@@ -344,30 +344,30 @@ type ListSlowQueriesParams struct {
 }
 
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
-func (r PerformanceAdvisorApiListSlowQueriesRequest) Duration(duration int64) PerformanceAdvisorApiListSlowQueriesRequest {
+func (r ListSlowQueriesApiRequest) Duration(duration int64) ListSlowQueriesApiRequest {
 	r.duration = &duration
 	return r
 }
 
 // Namespaces from which to retrieve suggested indexes. A namespace consists of one database and one collection resource written as &#x60;.&#x60;: &#x60;&lt;database&gt;.&lt;collection&gt;&#x60;. To include multiple namespaces, pass the parameter multiple times delimited with an ampersand (&#x60;&amp;&#x60;) between each namespace. Omit this parameter to return results for all namespaces.
-func (r PerformanceAdvisorApiListSlowQueriesRequest) Namespaces(namespaces []string) PerformanceAdvisorApiListSlowQueriesRequest {
+func (r ListSlowQueriesApiRequest) Namespaces(namespaces []string) ListSlowQueriesApiRequest {
 	r.namespaces = &namespaces
 	return r
 }
 
 // Maximum number of lines from the log to return.
-func (r PerformanceAdvisorApiListSlowQueriesRequest) NLogs(nLogs int64) PerformanceAdvisorApiListSlowQueriesRequest {
+func (r ListSlowQueriesApiRequest) NLogs(nLogs int64) ListSlowQueriesApiRequest {
 	r.nLogs = &nLogs
 	return r
 }
 
 // Date and time from which the query retrieves the suggested indexes. This parameter expresses its value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).  - If you don&#39;t specify the **duration** parameter, the endpoint returns data covering from the **since** value and the current time. - If you specify neither the **duration** nor the **since** parameters, the endpoint returns data from the previous 24 hours.
-func (r PerformanceAdvisorApiListSlowQueriesRequest) Since(since int64) PerformanceAdvisorApiListSlowQueriesRequest {
+func (r ListSlowQueriesApiRequest) Since(since int64) ListSlowQueriesApiRequest {
 	r.since = &since
 	return r
 }
 
-func (r PerformanceAdvisorApiListSlowQueriesRequest) Execute() (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
+func (r ListSlowQueriesApiRequest) Execute() (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
 	return r.ApiService.ListSlowQueriesExecute(r)
 }
 
@@ -379,10 +379,10 @@ Returns log lines for slow queries that the Performance Advisor and Query Profil
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of host and port that serves the MongoDB process. The host must be the hostname, FQDN, IPv4 address, or IPv6 address of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return PerformanceAdvisorApiListSlowQueriesRequest
+ @return ListSlowQueriesApiRequest
 */
-func (a *PerformanceAdvisorApiService) ListSlowQueries(ctx context.Context, groupId string, processId string) PerformanceAdvisorApiListSlowQueriesRequest {
-	return PerformanceAdvisorApiListSlowQueriesRequest{
+func (a *PerformanceAdvisorApiService) ListSlowQueries(ctx context.Context, groupId string, processId string) ListSlowQueriesApiRequest {
+	return ListSlowQueriesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -392,7 +392,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueries(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PerformanceAdvisorSlowQueryList
-func (a *PerformanceAdvisorApiService) ListSlowQueriesExecute(r PerformanceAdvisorApiListSlowQueriesRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -505,7 +505,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueriesExecute(r PerformanceAdvis
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PerformanceAdvisorApiListSlowQueryNamespacesRequest struct {
+type ListSlowQueryNamespacesApiRequest struct {
 	ctx context.Context
 	ApiService PerformanceAdvisorApi
 	groupId string
@@ -522,18 +522,18 @@ type ListSlowQueryNamespacesParams struct {
 }
 
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
-func (r PerformanceAdvisorApiListSlowQueryNamespacesRequest) Duration(duration int64) PerformanceAdvisorApiListSlowQueryNamespacesRequest {
+func (r ListSlowQueryNamespacesApiRequest) Duration(duration int64) ListSlowQueryNamespacesApiRequest {
 	r.duration = &duration
 	return r
 }
 
 // Date and time from which the query retrieves the suggested indexes. This parameter expresses its value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).  - If you don&#39;t specify the **duration** parameter, the endpoint returns data covering from the **since** value and the current time. - If you specify neither the **duration** nor the **since** parameters, the endpoint returns data from the previous 24 hours.
-func (r PerformanceAdvisorApiListSlowQueryNamespacesRequest) Since(since int64) PerformanceAdvisorApiListSlowQueryNamespacesRequest {
+func (r ListSlowQueryNamespacesApiRequest) Since(since int64) ListSlowQueryNamespacesApiRequest {
 	r.since = &since
 	return r
 }
 
-func (r PerformanceAdvisorApiListSlowQueryNamespacesRequest) Execute() (*Namespaces, *http.Response, error) {
+func (r ListSlowQueryNamespacesApiRequest) Execute() (*Namespaces, *http.Response, error) {
 	return r.ApiService.ListSlowQueryNamespacesExecute(r)
 }
 
@@ -545,10 +545,10 @@ Returns up to 20 namespaces for collections experiencing slow queries on the spe
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of host and port that serves the MongoDB process. The host must be the hostname, FQDN, IPv4 address, or IPv6 address of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return PerformanceAdvisorApiListSlowQueryNamespacesRequest
+ @return ListSlowQueryNamespacesApiRequest
 */
-func (a *PerformanceAdvisorApiService) ListSlowQueryNamespaces(ctx context.Context, groupId string, processId string) PerformanceAdvisorApiListSlowQueryNamespacesRequest {
-	return PerformanceAdvisorApiListSlowQueryNamespacesRequest{
+func (a *PerformanceAdvisorApiService) ListSlowQueryNamespaces(ctx context.Context, groupId string, processId string) ListSlowQueryNamespacesApiRequest {
+	return ListSlowQueryNamespacesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -558,7 +558,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueryNamespaces(ctx context.Conte
 
 // Execute executes the request
 //  @return Namespaces
-func (a *PerformanceAdvisorApiService) ListSlowQueryNamespacesExecute(r PerformanceAdvisorApiListSlowQueryNamespacesRequest) (*Namespaces, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -653,7 +653,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueryNamespacesExecute(r Performa
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PerformanceAdvisorApiListSuggestedIndexesRequest struct {
+type ListSuggestedIndexesApiRequest struct {
 	ctx context.Context
 	ApiService PerformanceAdvisorApi
 	groupId string
@@ -682,54 +682,54 @@ type ListSuggestedIndexesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) IncludeCount(includeCount bool) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) IncludeCount(includeCount bool) ListSuggestedIndexesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) ItemsPerPage(itemsPerPage int32) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) ItemsPerPage(itemsPerPage int32) ListSuggestedIndexesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) PageNum(pageNum int32) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) PageNum(pageNum int32) ListSuggestedIndexesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) Duration(duration float32) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) Duration(duration float32) ListSuggestedIndexesApiRequest {
 	r.duration = &duration
 	return r
 }
 
 // Namespaces from which to retrieve suggested indexes. A namespace consists of one database and one collection resource written as &#x60;.&#x60;: &#x60;&lt;database&gt;.&lt;collection&gt;&#x60;. To include multiple namespaces, pass the parameter multiple times delimited with an ampersand (&#x60;&amp;&#x60;) between each namespace. Omit this parameter to return results for all namespaces.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) Namespaces(namespaces []string) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) Namespaces(namespaces []string) ListSuggestedIndexesApiRequest {
 	r.namespaces = &namespaces
 	return r
 }
 
 // Maximum number of example queries that benefit from the suggested index.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) NExamples(nExamples int64) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) NExamples(nExamples int64) ListSuggestedIndexesApiRequest {
 	r.nExamples = &nExamples
 	return r
 }
 
 // Number that indicates the maximum indexes to suggest.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) NIndexes(nIndexes int64) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) NIndexes(nIndexes int64) ListSuggestedIndexesApiRequest {
 	r.nIndexes = &nIndexes
 	return r
 }
 
 // Date and time from which the query retrieves the suggested indexes. This parameter expresses its value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).  - If you don&#39;t specify the **duration** parameter, the endpoint returns data covering from the **since** value and the current time. - If you specify neither the **duration** nor the **since** parameters, the endpoint returns data from the previous 24 hours.
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) Since(since float32) PerformanceAdvisorApiListSuggestedIndexesRequest {
+func (r ListSuggestedIndexesApiRequest) Since(since float32) ListSuggestedIndexesApiRequest {
 	r.since = &since
 	return r
 }
 
-func (r PerformanceAdvisorApiListSuggestedIndexesRequest) Execute() (*PerformanceAdvisorResponse, *http.Response, error) {
+func (r ListSuggestedIndexesApiRequest) Execute() (*PerformanceAdvisorResponse, *http.Response, error) {
 	return r.ApiService.ListSuggestedIndexesExecute(r)
 }
 
@@ -741,10 +741,10 @@ Returns the indexes that the Performance Advisor suggests. The Performance Advis
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param processId Combination of host and port that serves the MongoDB process. The host must be the hostname, FQDN, IPv4 address, or IPv6 address of the host that runs the MongoDB process (`mongod` or `mongos`). The port must be the IANA port on which the MongoDB process listens for requests.
- @return PerformanceAdvisorApiListSuggestedIndexesRequest
+ @return ListSuggestedIndexesApiRequest
 */
-func (a *PerformanceAdvisorApiService) ListSuggestedIndexes(ctx context.Context, groupId string, processId string) PerformanceAdvisorApiListSuggestedIndexesRequest {
-	return PerformanceAdvisorApiListSuggestedIndexesRequest{
+func (a *PerformanceAdvisorApiService) ListSuggestedIndexes(ctx context.Context, groupId string, processId string) ListSuggestedIndexesApiRequest {
+	return ListSuggestedIndexesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -754,7 +754,7 @@ func (a *PerformanceAdvisorApiService) ListSuggestedIndexes(ctx context.Context,
 
 // Execute executes the request
 //  @return PerformanceAdvisorResponse
-func (a *PerformanceAdvisorApiService) ListSuggestedIndexesExecute(r PerformanceAdvisorApiListSuggestedIndexesRequest) (*PerformanceAdvisorResponse, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -108,6 +108,9 @@ type PerformanceAdvisorApiDisableSlowOperationThresholdingRequest struct {
 	ApiService PerformanceAdvisorApi
 	groupId string
 }
+type PerformanceAdvisorApiDisableSlowOperationThresholdingQueryParams struct {
+		groupId string
+}
 
 func (r PerformanceAdvisorApiDisableSlowOperationThresholdingRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DisableSlowOperationThresholdingExecute(r)
@@ -213,6 +216,9 @@ type PerformanceAdvisorApiEnableSlowOperationThresholdingRequest struct {
 	ctx context.Context
 	ApiService PerformanceAdvisorApi
 	groupId string
+}
+type PerformanceAdvisorApiEnableSlowOperationThresholdingQueryParams struct {
+		groupId string
 }
 
 func (r PerformanceAdvisorApiEnableSlowOperationThresholdingRequest) Execute() (*http.Response, error) {
@@ -324,6 +330,14 @@ type PerformanceAdvisorApiListSlowQueriesRequest struct {
 	namespaces *[]string
 	nLogs *int64
 	since *int64
+}
+type PerformanceAdvisorApiListSlowQueriesQueryParams struct {
+		groupId string
+		processId string
+		duration *int64
+		namespaces *[]string
+		nLogs *int64
+		since *int64
 }
 
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
@@ -496,6 +510,12 @@ type PerformanceAdvisorApiListSlowQueryNamespacesRequest struct {
 	duration *int64
 	since *int64
 }
+type PerformanceAdvisorApiListSlowQueryNamespacesQueryParams struct {
+		groupId string
+		processId string
+		duration *int64
+		since *int64
+}
 
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
 func (r PerformanceAdvisorApiListSlowQueryNamespacesRequest) Duration(duration int64) PerformanceAdvisorApiListSlowQueryNamespacesRequest {
@@ -642,6 +662,18 @@ type PerformanceAdvisorApiListSuggestedIndexesRequest struct {
 	nExamples *int64
 	nIndexes *int64
 	since *float32
+}
+type PerformanceAdvisorApiListSuggestedIndexesQueryParams struct {
+		groupId string
+		processId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		duration *float32
+		namespaces *[]string
+		nExamples *int64
+		nIndexes *int64
+		since *float32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -109,7 +109,7 @@ type DisableSlowOperationThresholdingApiRequest struct {
 	groupId string
 }
 
-type DisableSlowOperationThresholdingParams struct {
+type DisableSlowOperationThresholdingApiParams struct {
 		GroupId string
 }
 
@@ -219,7 +219,7 @@ type EnableSlowOperationThresholdingApiRequest struct {
 	groupId string
 }
 
-type EnableSlowOperationThresholdingParams struct {
+type EnableSlowOperationThresholdingApiParams struct {
 		GroupId string
 }
 
@@ -334,7 +334,7 @@ type ListSlowQueriesApiRequest struct {
 	since *int64
 }
 
-type ListSlowQueriesParams struct {
+type ListSlowQueriesApiParams struct {
 		GroupId string
 		ProcessId string
 		Duration *int64
@@ -514,7 +514,7 @@ type ListSlowQueryNamespacesApiRequest struct {
 	since *int64
 }
 
-type ListSlowQueryNamespacesParams struct {
+type ListSlowQueryNamespacesApiParams struct {
 		GroupId string
 		ProcessId string
 		Duration *int64
@@ -668,7 +668,7 @@ type ListSuggestedIndexesApiRequest struct {
 	since *float32
 }
 
-type ListSuggestedIndexesParams struct {
+type ListSuggestedIndexesApiParams struct {
 		GroupId string
 		ProcessId string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -108,8 +108,9 @@ type PerformanceAdvisorApiDisableSlowOperationThresholdingRequest struct {
 	ApiService PerformanceAdvisorApi
 	groupId string
 }
+
 type PerformanceAdvisorApiDisableSlowOperationThresholdingQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r PerformanceAdvisorApiDisableSlowOperationThresholdingRequest) Execute() (*http.Response, error) {
@@ -217,8 +218,9 @@ type PerformanceAdvisorApiEnableSlowOperationThresholdingRequest struct {
 	ApiService PerformanceAdvisorApi
 	groupId string
 }
+
 type PerformanceAdvisorApiEnableSlowOperationThresholdingQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r PerformanceAdvisorApiEnableSlowOperationThresholdingRequest) Execute() (*http.Response, error) {
@@ -331,13 +333,14 @@ type PerformanceAdvisorApiListSlowQueriesRequest struct {
 	nLogs *int64
 	since *int64
 }
+
 type PerformanceAdvisorApiListSlowQueriesQueryParams struct {
-		groupId string
-		processId string
-		duration *int64
-		namespaces *[]string
-		nLogs *int64
-		since *int64
+		GroupId string
+		ProcessId string
+		Duration *int64
+		Namespaces *[]string
+		NLogs *int64
+		Since *int64
 }
 
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
@@ -510,11 +513,12 @@ type PerformanceAdvisorApiListSlowQueryNamespacesRequest struct {
 	duration *int64
 	since *int64
 }
+
 type PerformanceAdvisorApiListSlowQueryNamespacesQueryParams struct {
-		groupId string
-		processId string
-		duration *int64
-		since *int64
+		GroupId string
+		ProcessId string
+		Duration *int64
+		Since *int64
 }
 
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
@@ -663,17 +667,18 @@ type PerformanceAdvisorApiListSuggestedIndexesRequest struct {
 	nIndexes *int64
 	since *float32
 }
+
 type PerformanceAdvisorApiListSuggestedIndexesQueryParams struct {
-		groupId string
-		processId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		duration *float32
-		namespaces *[]string
-		nExamples *int64
-		nIndexes *int64
-		since *float32
+		GroupId string
+		ProcessId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		Duration *float32
+		Namespaces *[]string
+		NExamples *int64
+		NIndexes *int64
+		Since *float32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -181,7 +181,7 @@ type CreatePrivateEndpointApiRequest struct {
 	createPrivateEndpointRequest *CreatePrivateEndpointRequest
 }
 
-type CreatePrivateEndpointParams struct {
+type CreatePrivateEndpointApiParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -329,7 +329,7 @@ type CreatePrivateEndpointServiceApiRequest struct {
 	createEndpointServiceRequest *CreateEndpointServiceRequest
 }
 
-type CreatePrivateEndpointServiceParams struct {
+type CreatePrivateEndpointServiceApiParams struct {
 		GroupId string
 		CreateEndpointServiceRequest *CreateEndpointServiceRequest
 }
@@ -465,7 +465,7 @@ type DeletePrivateEndpointApiRequest struct {
 	endpointServiceId string
 }
 
-type DeletePrivateEndpointParams struct {
+type DeletePrivateEndpointApiParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointId string
@@ -595,7 +595,7 @@ type DeletePrivateEndpointServiceApiRequest struct {
 	endpointServiceId string
 }
 
-type DeletePrivateEndpointServiceParams struct {
+type DeletePrivateEndpointServiceApiParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -722,7 +722,7 @@ type GetPrivateEndpointApiRequest struct {
 	endpointServiceId string
 }
 
-type GetPrivateEndpointParams struct {
+type GetPrivateEndpointApiParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointId string
@@ -863,7 +863,7 @@ type GetPrivateEndpointServiceApiRequest struct {
 	endpointServiceId string
 }
 
-type GetPrivateEndpointServiceParams struct {
+type GetPrivateEndpointServiceApiParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -998,7 +998,7 @@ type GetRegionalizedPrivateEndpointSettingApiRequest struct {
 	groupId string
 }
 
-type GetRegionalizedPrivateEndpointSettingParams struct {
+type GetRegionalizedPrivateEndpointSettingApiParams struct {
 		GroupId string
 }
 
@@ -1120,7 +1120,7 @@ type ListPrivateEndpointServicesApiRequest struct {
 	cloudProvider string
 }
 
-type ListPrivateEndpointServicesParams struct {
+type ListPrivateEndpointServicesApiParams struct {
 		GroupId string
 		CloudProvider string
 }
@@ -1246,7 +1246,7 @@ type ToggleRegionalizedPrivateEndpointSettingApiRequest struct {
 	projectSettingItem *ProjectSettingItem
 }
 
-type ToggleRegionalizedPrivateEndpointSettingParams struct {
+type ToggleRegionalizedPrivateEndpointSettingApiParams struct {
 		GroupId string
 		ProjectSettingItem *ProjectSettingItem
 }

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -181,7 +181,7 @@ type PrivateEndpointServicesApiCreatePrivateEndpointRequest struct {
 	createPrivateEndpointRequest *CreatePrivateEndpointRequest
 }
 
-type PrivateEndpointServicesApiCreatePrivateEndpointQueryParams struct {
+type PrivateEndpointServicesApiCreatePrivateEndpointParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -329,7 +329,7 @@ type PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest struct {
 	createEndpointServiceRequest *CreateEndpointServiceRequest
 }
 
-type PrivateEndpointServicesApiCreatePrivateEndpointServiceQueryParams struct {
+type PrivateEndpointServicesApiCreatePrivateEndpointServiceParams struct {
 		GroupId string
 		CreateEndpointServiceRequest *CreateEndpointServiceRequest
 }
@@ -465,7 +465,7 @@ type PrivateEndpointServicesApiDeletePrivateEndpointRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiDeletePrivateEndpointQueryParams struct {
+type PrivateEndpointServicesApiDeletePrivateEndpointParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointId string
@@ -595,7 +595,7 @@ type PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiDeletePrivateEndpointServiceQueryParams struct {
+type PrivateEndpointServicesApiDeletePrivateEndpointServiceParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -722,7 +722,7 @@ type PrivateEndpointServicesApiGetPrivateEndpointRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiGetPrivateEndpointQueryParams struct {
+type PrivateEndpointServicesApiGetPrivateEndpointParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointId string
@@ -863,7 +863,7 @@ type PrivateEndpointServicesApiGetPrivateEndpointServiceRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiGetPrivateEndpointServiceQueryParams struct {
+type PrivateEndpointServicesApiGetPrivateEndpointServiceParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -998,7 +998,7 @@ type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest stru
 	groupId string
 }
 
-type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingQueryParams struct {
+type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingParams struct {
 		GroupId string
 }
 
@@ -1120,7 +1120,7 @@ type PrivateEndpointServicesApiListPrivateEndpointServicesRequest struct {
 	cloudProvider string
 }
 
-type PrivateEndpointServicesApiListPrivateEndpointServicesQueryParams struct {
+type PrivateEndpointServicesApiListPrivateEndpointServicesParams struct {
 		GroupId string
 		CloudProvider string
 }
@@ -1246,7 +1246,7 @@ type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest s
 	projectSettingItem *ProjectSettingItem
 }
 
-type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingQueryParams struct {
+type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingParams struct {
 		GroupId string
 		ProjectSettingItem *ProjectSettingItem
 }

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -31,13 +31,13 @@ type PrivateEndpointServicesApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param cloudProvider Cloud service provider that manages this private endpoint.
 	@param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service for which you want to create a private endpoint.
-	@return PrivateEndpointServicesApiCreatePrivateEndpointRequest
+	@return CreatePrivateEndpointApiRequest
 	*/
-	CreatePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) PrivateEndpointServicesApiCreatePrivateEndpointRequest
+	CreatePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) CreatePrivateEndpointApiRequest
 
 	// CreatePrivateEndpointExecute executes the request
 	//  @return Endpoint
-	CreatePrivateEndpointExecute(r PrivateEndpointServicesApiCreatePrivateEndpointRequest) (*Endpoint, *http.Response, error)
+	CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*Endpoint, *http.Response, error)
 
 	/*
 	CreatePrivateEndpointService Create One Private Endpoint Service for One Provider
@@ -46,13 +46,13 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest
+	@return CreatePrivateEndpointServiceApiRequest
 	*/
-	CreatePrivateEndpointService(ctx context.Context, groupId string) PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest
+	CreatePrivateEndpointService(ctx context.Context, groupId string) CreatePrivateEndpointServiceApiRequest
 
 	// CreatePrivateEndpointServiceExecute executes the request
 	//  @return EndpointService
-	CreatePrivateEndpointServiceExecute(r PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest) (*EndpointService, *http.Response, error)
+	CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
 	DeletePrivateEndpoint Remove One Private Endpoint for One Provider
@@ -64,12 +64,12 @@ type PrivateEndpointServicesApi interface {
 	@param cloudProvider Cloud service provider that manages this private endpoint.
 	@param endpointId Unique string that identifies the private endpoint you want to delete. The format of the **endpointId** parameter differs for AWS and Azure. You must URL encode the **endpointId** for Azure private endpoints.
 	@param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service from which you want to delete a private endpoint.
-	@return PrivateEndpointServicesApiDeletePrivateEndpointRequest
+	@return DeletePrivateEndpointApiRequest
 	*/
-	DeletePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) PrivateEndpointServicesApiDeletePrivateEndpointRequest
+	DeletePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) DeletePrivateEndpointApiRequest
 
 	// DeletePrivateEndpointExecute executes the request
-	DeletePrivateEndpointExecute(r PrivateEndpointServicesApiDeletePrivateEndpointRequest) (*http.Response, error)
+	DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (*http.Response, error)
 
 	/*
 	DeletePrivateEndpointService Remove One Private Endpoint Service for One Provider
@@ -80,12 +80,12 @@ type PrivateEndpointServicesApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param cloudProvider Cloud service provider that manages this private endpoint service.
 	@param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service that you want to delete.
-	@return PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest
+	@return DeletePrivateEndpointServiceApiRequest
 	*/
-	DeletePrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest
+	DeletePrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) DeletePrivateEndpointServiceApiRequest
 
 	// DeletePrivateEndpointServiceExecute executes the request
-	DeletePrivateEndpointServiceExecute(r PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest) (*http.Response, error)
+	DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (*http.Response, error)
 
 	/*
 	GetPrivateEndpoint Return One Private Endpoint for One Provider
@@ -97,13 +97,13 @@ type PrivateEndpointServicesApi interface {
 	@param cloudProvider Cloud service provider that manages this private endpoint.
 	@param endpointId Unique string that identifies the private endpoint you want to return. The format of the **endpointId** parameter differs for AWS and Azure. You must URL encode the **endpointId** for Azure private endpoints.
 	@param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service for which you want to return a private endpoint.
-	@return PrivateEndpointServicesApiGetPrivateEndpointRequest
+	@return GetPrivateEndpointApiRequest
 	*/
-	GetPrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) PrivateEndpointServicesApiGetPrivateEndpointRequest
+	GetPrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) GetPrivateEndpointApiRequest
 
 	// GetPrivateEndpointExecute executes the request
 	//  @return Endpoint
-	GetPrivateEndpointExecute(r PrivateEndpointServicesApiGetPrivateEndpointRequest) (*Endpoint, *http.Response, error)
+	GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*Endpoint, *http.Response, error)
 
 	/*
 	GetPrivateEndpointService Return One Private Endpoint Service for One Provider
@@ -114,13 +114,13 @@ type PrivateEndpointServicesApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param cloudProvider Cloud service provider that manages this private endpoint service.
 	@param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service that you want to return.
-	@return PrivateEndpointServicesApiGetPrivateEndpointServiceRequest
+	@return GetPrivateEndpointServiceApiRequest
 	*/
-	GetPrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) PrivateEndpointServicesApiGetPrivateEndpointServiceRequest
+	GetPrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) GetPrivateEndpointServiceApiRequest
 
 	// GetPrivateEndpointServiceExecute executes the request
 	//  @return EndpointService
-	GetPrivateEndpointServiceExecute(r PrivateEndpointServicesApiGetPrivateEndpointServiceRequest) (*EndpointService, *http.Response, error)
+	GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
 	GetRegionalizedPrivateEndpointSetting Return Regionalized Private Endpoint Status
@@ -129,13 +129,13 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest
+	@return GetRegionalizedPrivateEndpointSettingApiRequest
 	*/
-	GetRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest
+	GetRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) GetRegionalizedPrivateEndpointSettingApiRequest
 
 	// GetRegionalizedPrivateEndpointSettingExecute executes the request
 	//  @return ProjectSettingItem
-	GetRegionalizedPrivateEndpointSettingExecute(r PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest) (*ProjectSettingItem, *http.Response, error)
+	GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 
 	/*
 	ListPrivateEndpointServices Return All Private Endpoint Services for One Provider
@@ -145,13 +145,13 @@ type PrivateEndpointServicesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param cloudProvider Cloud service provider that manages this private endpoint service.
-	@return PrivateEndpointServicesApiListPrivateEndpointServicesRequest
+	@return ListPrivateEndpointServicesApiRequest
 	*/
-	ListPrivateEndpointServices(ctx context.Context, groupId string, cloudProvider string) PrivateEndpointServicesApiListPrivateEndpointServicesRequest
+	ListPrivateEndpointServices(ctx context.Context, groupId string, cloudProvider string) ListPrivateEndpointServicesApiRequest
 
 	// ListPrivateEndpointServicesExecute executes the request
 	//  @return PaginatedPrivateLinkConnection
-	ListPrivateEndpointServicesExecute(r PrivateEndpointServicesApiListPrivateEndpointServicesRequest) (*PaginatedPrivateLinkConnection, *http.Response, error)
+	ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) (*PaginatedPrivateLinkConnection, *http.Response, error)
 
 	/*
 	ToggleRegionalizedPrivateEndpointSetting Toggle Regionalized Private Endpoint Status
@@ -160,19 +160,19 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest
+	@return ToggleRegionalizedPrivateEndpointSettingApiRequest
 	*/
-	ToggleRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest
+	ToggleRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) ToggleRegionalizedPrivateEndpointSettingApiRequest
 
 	// ToggleRegionalizedPrivateEndpointSettingExecute executes the request
 	//  @return ProjectSettingItem
-	ToggleRegionalizedPrivateEndpointSettingExecute(r PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest) (*ProjectSettingItem, *http.Response, error)
+	ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 }
 
 // PrivateEndpointServicesApiService PrivateEndpointServicesApi service
 type PrivateEndpointServicesApiService service
 
-type PrivateEndpointServicesApiCreatePrivateEndpointRequest struct {
+type CreatePrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -189,12 +189,12 @@ type CreatePrivateEndpointParams struct {
 }
 
 // Creates one private endpoint for the specified cloud service provider.
-func (r PrivateEndpointServicesApiCreatePrivateEndpointRequest) CreatePrivateEndpointRequest(createPrivateEndpointRequest CreatePrivateEndpointRequest) PrivateEndpointServicesApiCreatePrivateEndpointRequest {
+func (r CreatePrivateEndpointApiRequest) CreatePrivateEndpointRequest(createPrivateEndpointRequest CreatePrivateEndpointRequest) CreatePrivateEndpointApiRequest {
 	r.createPrivateEndpointRequest = &createPrivateEndpointRequest
 	return r
 }
 
-func (r PrivateEndpointServicesApiCreatePrivateEndpointRequest) Execute() (*Endpoint, *http.Response, error) {
+func (r CreatePrivateEndpointApiRequest) Execute() (*Endpoint, *http.Response, error) {
 	return r.ApiService.CreatePrivateEndpointExecute(r)
 }
 
@@ -207,10 +207,10 @@ Creates one private endpoint for the specified cloud service provider. This clou
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param cloudProvider Cloud service provider that manages this private endpoint.
  @param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service for which you want to create a private endpoint.
- @return PrivateEndpointServicesApiCreatePrivateEndpointRequest
+ @return CreatePrivateEndpointApiRequest
 */
-func (a *PrivateEndpointServicesApiService) CreatePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) PrivateEndpointServicesApiCreatePrivateEndpointRequest {
-	return PrivateEndpointServicesApiCreatePrivateEndpointRequest{
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) CreatePrivateEndpointApiRequest {
+	return CreatePrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -221,7 +221,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpoint(ctx context.Co
 
 // Execute executes the request
 //  @return Endpoint
-func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointExecute(r PrivateEndpointServicesApiCreatePrivateEndpointRequest) (*Endpoint, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*Endpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -322,7 +322,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointExecute(r Priva
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest struct {
+type CreatePrivateEndpointServiceApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -335,12 +335,12 @@ type CreatePrivateEndpointServiceParams struct {
 }
 
 // Creates one private endpoint for the specified cloud service provider.
-func (r PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest) CreateEndpointServiceRequest(createEndpointServiceRequest CreateEndpointServiceRequest) PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest {
+func (r CreatePrivateEndpointServiceApiRequest) CreateEndpointServiceRequest(createEndpointServiceRequest CreateEndpointServiceRequest) CreatePrivateEndpointServiceApiRequest {
 	r.createEndpointServiceRequest = &createEndpointServiceRequest
 	return r
 }
 
-func (r PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest) Execute() (*EndpointService, *http.Response, error) {
+func (r CreatePrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.Response, error) {
 	return r.ApiService.CreatePrivateEndpointServiceExecute(r)
 }
 
@@ -351,10 +351,10 @@ Creates one private endpoint service for the specified cloud service provider. T
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest
+ @return CreatePrivateEndpointServiceApiRequest
 */
-func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointService(ctx context.Context, groupId string) PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest {
-	return PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest{
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointService(ctx context.Context, groupId string) CreatePrivateEndpointServiceApiRequest {
+	return CreatePrivateEndpointServiceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -363,7 +363,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointService(ctx con
 
 // Execute executes the request
 //  @return EndpointService
-func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceExecute(r PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest) (*EndpointService, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -456,7 +456,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceExecute(
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiDeletePrivateEndpointRequest struct {
+type DeletePrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -472,7 +472,7 @@ type DeletePrivateEndpointParams struct {
 		EndpointServiceId string
 }
 
-func (r PrivateEndpointServicesApiDeletePrivateEndpointRequest) Execute() (*http.Response, error) {
+func (r DeletePrivateEndpointApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePrivateEndpointExecute(r)
 }
 
@@ -486,10 +486,10 @@ Removes one private endpoint from the specified project. This cloud service prov
  @param cloudProvider Cloud service provider that manages this private endpoint.
  @param endpointId Unique string that identifies the private endpoint you want to delete. The format of the **endpointId** parameter differs for AWS and Azure. You must URL encode the **endpointId** for Azure private endpoints.
  @param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service from which you want to delete a private endpoint.
- @return PrivateEndpointServicesApiDeletePrivateEndpointRequest
+ @return DeletePrivateEndpointApiRequest
 */
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) PrivateEndpointServicesApiDeletePrivateEndpointRequest {
-	return PrivateEndpointServicesApiDeletePrivateEndpointRequest{
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) DeletePrivateEndpointApiRequest {
+	return DeletePrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -500,7 +500,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpoint(ctx context.Co
 }
 
 // Execute executes the request
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r PrivateEndpointServicesApiDeletePrivateEndpointRequest) (*http.Response, error) {
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -587,7 +587,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r Priva
 	return localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest struct {
+type DeletePrivateEndpointServiceApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -601,7 +601,7 @@ type DeletePrivateEndpointServiceParams struct {
 		EndpointServiceId string
 }
 
-func (r PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest) Execute() (*http.Response, error) {
+func (r DeletePrivateEndpointServiceApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePrivateEndpointServiceExecute(r)
 }
 
@@ -614,10 +614,10 @@ Removes one private endpoint service from the specified project. This cloud serv
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param cloudProvider Cloud service provider that manages this private endpoint service.
  @param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service that you want to delete.
- @return PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest
+ @return DeletePrivateEndpointServiceApiRequest
 */
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest {
-	return PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest{
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) DeletePrivateEndpointServiceApiRequest {
+	return DeletePrivateEndpointServiceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -627,7 +627,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointService(ctx con
 }
 
 // Execute executes the request
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(r PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest) (*http.Response, error) {
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -713,7 +713,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(
 	return localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiGetPrivateEndpointRequest struct {
+type GetPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -729,7 +729,7 @@ type GetPrivateEndpointParams struct {
 		EndpointServiceId string
 }
 
-func (r PrivateEndpointServicesApiGetPrivateEndpointRequest) Execute() (*Endpoint, *http.Response, error) {
+func (r GetPrivateEndpointApiRequest) Execute() (*Endpoint, *http.Response, error) {
 	return r.ApiService.GetPrivateEndpointExecute(r)
 }
 
@@ -743,10 +743,10 @@ Returns the connection state of the specified private endpoint. The private endp
  @param cloudProvider Cloud service provider that manages this private endpoint.
  @param endpointId Unique string that identifies the private endpoint you want to return. The format of the **endpointId** parameter differs for AWS and Azure. You must URL encode the **endpointId** for Azure private endpoints.
  @param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service for which you want to return a private endpoint.
- @return PrivateEndpointServicesApiGetPrivateEndpointRequest
+ @return GetPrivateEndpointApiRequest
 */
-func (a *PrivateEndpointServicesApiService) GetPrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) PrivateEndpointServicesApiGetPrivateEndpointRequest {
-	return PrivateEndpointServicesApiGetPrivateEndpointRequest{
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) GetPrivateEndpointApiRequest {
+	return GetPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -758,7 +758,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpoint(ctx context.Conte
 
 // Execute executes the request
 //  @return Endpoint
-func (a *PrivateEndpointServicesApiService) GetPrivateEndpointExecute(r PrivateEndpointServicesApiGetPrivateEndpointRequest) (*Endpoint, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*Endpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -855,7 +855,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointExecute(r PrivateE
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiGetPrivateEndpointServiceRequest struct {
+type GetPrivateEndpointServiceApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -869,7 +869,7 @@ type GetPrivateEndpointServiceParams struct {
 		EndpointServiceId string
 }
 
-func (r PrivateEndpointServicesApiGetPrivateEndpointServiceRequest) Execute() (*EndpointService, *http.Response, error) {
+func (r GetPrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.Response, error) {
 	return r.ApiService.GetPrivateEndpointServiceExecute(r)
 }
 
@@ -882,10 +882,10 @@ Returns the name, interfaces, and state of the specified private endpoint servic
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param cloudProvider Cloud service provider that manages this private endpoint service.
  @param endpointServiceId Unique 24-hexadecimal digit string that identifies the private endpoint service that you want to return.
- @return PrivateEndpointServicesApiGetPrivateEndpointServiceRequest
+ @return GetPrivateEndpointServiceApiRequest
 */
-func (a *PrivateEndpointServicesApiService) GetPrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) PrivateEndpointServicesApiGetPrivateEndpointServiceRequest {
-	return PrivateEndpointServicesApiGetPrivateEndpointServiceRequest{
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) GetPrivateEndpointServiceApiRequest {
+	return GetPrivateEndpointServiceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -896,7 +896,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointService(ctx contex
 
 // Execute executes the request
 //  @return EndpointService
-func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceExecute(r PrivateEndpointServicesApiGetPrivateEndpointServiceRequest) (*EndpointService, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -992,7 +992,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceExecute(r P
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest struct {
+type GetRegionalizedPrivateEndpointSettingApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -1002,7 +1002,7 @@ type GetRegionalizedPrivateEndpointSettingParams struct {
 		GroupId string
 }
 
-func (r PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
+func (r GetRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
 	return r.ApiService.GetRegionalizedPrivateEndpointSettingExecute(r)
 }
 
@@ -1013,10 +1013,10 @@ Checks whether each region in the specified cloud service provider can create mu
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest
+ @return GetRegionalizedPrivateEndpointSettingApiRequest
 */
-func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest {
-	return PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest{
+func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) GetRegionalizedPrivateEndpointSettingApiRequest {
+	return GetRegionalizedPrivateEndpointSettingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1025,7 +1025,7 @@ func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettin
 
 // Execute executes the request
 //  @return ProjectSettingItem
-func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettingExecute(r PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest) (*ProjectSettingItem, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1113,7 +1113,7 @@ func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettin
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiListPrivateEndpointServicesRequest struct {
+type ListPrivateEndpointServicesApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -1125,7 +1125,7 @@ type ListPrivateEndpointServicesParams struct {
 		CloudProvider string
 }
 
-func (r PrivateEndpointServicesApiListPrivateEndpointServicesRequest) Execute() (*PaginatedPrivateLinkConnection, *http.Response, error) {
+func (r ListPrivateEndpointServicesApiRequest) Execute() (*PaginatedPrivateLinkConnection, *http.Response, error) {
 	return r.ApiService.ListPrivateEndpointServicesExecute(r)
 }
 
@@ -1137,10 +1137,10 @@ Returns the name, interfaces, and state of all private endpoint services for the
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param cloudProvider Cloud service provider that manages this private endpoint service.
- @return PrivateEndpointServicesApiListPrivateEndpointServicesRequest
+ @return ListPrivateEndpointServicesApiRequest
 */
-func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServices(ctx context.Context, groupId string, cloudProvider string) PrivateEndpointServicesApiListPrivateEndpointServicesRequest {
-	return PrivateEndpointServicesApiListPrivateEndpointServicesRequest{
+func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServices(ctx context.Context, groupId string, cloudProvider string) ListPrivateEndpointServicesApiRequest {
+	return ListPrivateEndpointServicesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1150,7 +1150,7 @@ func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServices(ctx cont
 
 // Execute executes the request
 //  @return PaginatedPrivateLinkConnection
-func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesExecute(r PrivateEndpointServicesApiListPrivateEndpointServicesRequest) (*PaginatedPrivateLinkConnection, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) (*PaginatedPrivateLinkConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1239,7 +1239,7 @@ func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesExecute(r
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest struct {
+type ToggleRegionalizedPrivateEndpointSettingApiRequest struct {
 	ctx context.Context
 	ApiService PrivateEndpointServicesApi
 	groupId string
@@ -1252,12 +1252,12 @@ type ToggleRegionalizedPrivateEndpointSettingParams struct {
 }
 
 // Enables or disables the ability to create multiple private endpoints per region in all cloud service providers in one project.
-func (r PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest) ProjectSettingItem(projectSettingItem ProjectSettingItem) PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest {
+func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) ProjectSettingItem(projectSettingItem ProjectSettingItem) ToggleRegionalizedPrivateEndpointSettingApiRequest {
 	r.projectSettingItem = &projectSettingItem
 	return r
 }
 
-func (r PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
+func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
 	return r.ApiService.ToggleRegionalizedPrivateEndpointSettingExecute(r)
 }
 
@@ -1268,10 +1268,10 @@ Enables or disables the ability to create multiple private endpoints per region 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest
+ @return ToggleRegionalizedPrivateEndpointSettingApiRequest
 */
-func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest {
-	return PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest{
+func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) ToggleRegionalizedPrivateEndpointSettingApiRequest {
+	return ToggleRegionalizedPrivateEndpointSettingApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1280,7 +1280,7 @@ func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSet
 
 // Execute executes the request
 //  @return ProjectSettingItem
-func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSettingExecute(r PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest) (*ProjectSettingItem, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -181,7 +181,7 @@ type PrivateEndpointServicesApiCreatePrivateEndpointRequest struct {
 	createPrivateEndpointRequest *CreatePrivateEndpointRequest
 }
 
-type PrivateEndpointServicesApiCreatePrivateEndpointParams struct {
+type CreatePrivateEndpointParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -329,7 +329,7 @@ type PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest struct {
 	createEndpointServiceRequest *CreateEndpointServiceRequest
 }
 
-type PrivateEndpointServicesApiCreatePrivateEndpointServiceParams struct {
+type CreatePrivateEndpointServiceParams struct {
 		GroupId string
 		CreateEndpointServiceRequest *CreateEndpointServiceRequest
 }
@@ -465,7 +465,7 @@ type PrivateEndpointServicesApiDeletePrivateEndpointRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiDeletePrivateEndpointParams struct {
+type DeletePrivateEndpointParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointId string
@@ -595,7 +595,7 @@ type PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiDeletePrivateEndpointServiceParams struct {
+type DeletePrivateEndpointServiceParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -722,7 +722,7 @@ type PrivateEndpointServicesApiGetPrivateEndpointRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiGetPrivateEndpointParams struct {
+type GetPrivateEndpointParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointId string
@@ -863,7 +863,7 @@ type PrivateEndpointServicesApiGetPrivateEndpointServiceRequest struct {
 	endpointServiceId string
 }
 
-type PrivateEndpointServicesApiGetPrivateEndpointServiceParams struct {
+type GetPrivateEndpointServiceParams struct {
 		GroupId string
 		CloudProvider string
 		EndpointServiceId string
@@ -998,7 +998,7 @@ type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest stru
 	groupId string
 }
 
-type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingParams struct {
+type GetRegionalizedPrivateEndpointSettingParams struct {
 		GroupId string
 }
 
@@ -1120,7 +1120,7 @@ type PrivateEndpointServicesApiListPrivateEndpointServicesRequest struct {
 	cloudProvider string
 }
 
-type PrivateEndpointServicesApiListPrivateEndpointServicesParams struct {
+type ListPrivateEndpointServicesParams struct {
 		GroupId string
 		CloudProvider string
 }
@@ -1246,7 +1246,7 @@ type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest s
 	projectSettingItem *ProjectSettingItem
 }
 
-type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingParams struct {
+type ToggleRegionalizedPrivateEndpointSettingParams struct {
 		GroupId string
 		ProjectSettingItem *ProjectSettingItem
 }

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -180,6 +180,12 @@ type PrivateEndpointServicesApiCreatePrivateEndpointRequest struct {
 	endpointServiceId string
 	createPrivateEndpointRequest *CreatePrivateEndpointRequest
 }
+type PrivateEndpointServicesApiCreatePrivateEndpointQueryParams struct {
+		groupId string
+		cloudProvider string
+		endpointServiceId string
+		createPrivateEndpointRequest *CreatePrivateEndpointRequest
+}
 
 // Creates one private endpoint for the specified cloud service provider.
 func (r PrivateEndpointServicesApiCreatePrivateEndpointRequest) CreatePrivateEndpointRequest(createPrivateEndpointRequest CreatePrivateEndpointRequest) PrivateEndpointServicesApiCreatePrivateEndpointRequest {
@@ -321,6 +327,10 @@ type PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest struct {
 	groupId string
 	createEndpointServiceRequest *CreateEndpointServiceRequest
 }
+type PrivateEndpointServicesApiCreatePrivateEndpointServiceQueryParams struct {
+		groupId string
+		createEndpointServiceRequest *CreateEndpointServiceRequest
+}
 
 // Creates one private endpoint for the specified cloud service provider.
 func (r PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest) CreateEndpointServiceRequest(createEndpointServiceRequest CreateEndpointServiceRequest) PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest {
@@ -452,6 +462,12 @@ type PrivateEndpointServicesApiDeletePrivateEndpointRequest struct {
 	endpointId string
 	endpointServiceId string
 }
+type PrivateEndpointServicesApiDeletePrivateEndpointQueryParams struct {
+		groupId string
+		cloudProvider string
+		endpointId string
+		endpointServiceId string
+}
 
 func (r PrivateEndpointServicesApiDeletePrivateEndpointRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePrivateEndpointExecute(r)
@@ -575,6 +591,11 @@ type PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest struct {
 	cloudProvider string
 	endpointServiceId string
 }
+type PrivateEndpointServicesApiDeletePrivateEndpointServiceQueryParams struct {
+		groupId string
+		cloudProvider string
+		endpointServiceId string
+}
 
 func (r PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePrivateEndpointServiceExecute(r)
@@ -695,6 +716,12 @@ type PrivateEndpointServicesApiGetPrivateEndpointRequest struct {
 	cloudProvider string
 	endpointId string
 	endpointServiceId string
+}
+type PrivateEndpointServicesApiGetPrivateEndpointQueryParams struct {
+		groupId string
+		cloudProvider string
+		endpointId string
+		endpointServiceId string
 }
 
 func (r PrivateEndpointServicesApiGetPrivateEndpointRequest) Execute() (*Endpoint, *http.Response, error) {
@@ -830,6 +857,11 @@ type PrivateEndpointServicesApiGetPrivateEndpointServiceRequest struct {
 	cloudProvider string
 	endpointServiceId string
 }
+type PrivateEndpointServicesApiGetPrivateEndpointServiceQueryParams struct {
+		groupId string
+		cloudProvider string
+		endpointServiceId string
+}
 
 func (r PrivateEndpointServicesApiGetPrivateEndpointServiceRequest) Execute() (*EndpointService, *http.Response, error) {
 	return r.ApiService.GetPrivateEndpointServiceExecute(r)
@@ -959,6 +991,9 @@ type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest stru
 	ApiService PrivateEndpointServicesApi
 	groupId string
 }
+type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingQueryParams struct {
+		groupId string
+}
 
 func (r PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
 	return r.ApiService.GetRegionalizedPrivateEndpointSettingExecute(r)
@@ -1076,6 +1111,10 @@ type PrivateEndpointServicesApiListPrivateEndpointServicesRequest struct {
 	ApiService PrivateEndpointServicesApi
 	groupId string
 	cloudProvider string
+}
+type PrivateEndpointServicesApiListPrivateEndpointServicesQueryParams struct {
+		groupId string
+		cloudProvider string
 }
 
 func (r PrivateEndpointServicesApiListPrivateEndpointServicesRequest) Execute() (*PaginatedPrivateLinkConnection, *http.Response, error) {
@@ -1197,6 +1236,10 @@ type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest s
 	ApiService PrivateEndpointServicesApi
 	groupId string
 	projectSettingItem *ProjectSettingItem
+}
+type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingQueryParams struct {
+		groupId string
+		projectSettingItem *ProjectSettingItem
 }
 
 // Enables or disables the ability to create multiple private endpoints per region in all cloud service providers in one project.

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -180,11 +180,12 @@ type PrivateEndpointServicesApiCreatePrivateEndpointRequest struct {
 	endpointServiceId string
 	createPrivateEndpointRequest *CreatePrivateEndpointRequest
 }
+
 type PrivateEndpointServicesApiCreatePrivateEndpointQueryParams struct {
-		groupId string
-		cloudProvider string
-		endpointServiceId string
-		createPrivateEndpointRequest *CreatePrivateEndpointRequest
+		GroupId string
+		CloudProvider string
+		EndpointServiceId string
+		CreatePrivateEndpointRequest *CreatePrivateEndpointRequest
 }
 
 // Creates one private endpoint for the specified cloud service provider.
@@ -327,9 +328,10 @@ type PrivateEndpointServicesApiCreatePrivateEndpointServiceRequest struct {
 	groupId string
 	createEndpointServiceRequest *CreateEndpointServiceRequest
 }
+
 type PrivateEndpointServicesApiCreatePrivateEndpointServiceQueryParams struct {
-		groupId string
-		createEndpointServiceRequest *CreateEndpointServiceRequest
+		GroupId string
+		CreateEndpointServiceRequest *CreateEndpointServiceRequest
 }
 
 // Creates one private endpoint for the specified cloud service provider.
@@ -462,11 +464,12 @@ type PrivateEndpointServicesApiDeletePrivateEndpointRequest struct {
 	endpointId string
 	endpointServiceId string
 }
+
 type PrivateEndpointServicesApiDeletePrivateEndpointQueryParams struct {
-		groupId string
-		cloudProvider string
-		endpointId string
-		endpointServiceId string
+		GroupId string
+		CloudProvider string
+		EndpointId string
+		EndpointServiceId string
 }
 
 func (r PrivateEndpointServicesApiDeletePrivateEndpointRequest) Execute() (*http.Response, error) {
@@ -591,10 +594,11 @@ type PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest struct {
 	cloudProvider string
 	endpointServiceId string
 }
+
 type PrivateEndpointServicesApiDeletePrivateEndpointServiceQueryParams struct {
-		groupId string
-		cloudProvider string
-		endpointServiceId string
+		GroupId string
+		CloudProvider string
+		EndpointServiceId string
 }
 
 func (r PrivateEndpointServicesApiDeletePrivateEndpointServiceRequest) Execute() (*http.Response, error) {
@@ -717,11 +721,12 @@ type PrivateEndpointServicesApiGetPrivateEndpointRequest struct {
 	endpointId string
 	endpointServiceId string
 }
+
 type PrivateEndpointServicesApiGetPrivateEndpointQueryParams struct {
-		groupId string
-		cloudProvider string
-		endpointId string
-		endpointServiceId string
+		GroupId string
+		CloudProvider string
+		EndpointId string
+		EndpointServiceId string
 }
 
 func (r PrivateEndpointServicesApiGetPrivateEndpointRequest) Execute() (*Endpoint, *http.Response, error) {
@@ -857,10 +862,11 @@ type PrivateEndpointServicesApiGetPrivateEndpointServiceRequest struct {
 	cloudProvider string
 	endpointServiceId string
 }
+
 type PrivateEndpointServicesApiGetPrivateEndpointServiceQueryParams struct {
-		groupId string
-		cloudProvider string
-		endpointServiceId string
+		GroupId string
+		CloudProvider string
+		EndpointServiceId string
 }
 
 func (r PrivateEndpointServicesApiGetPrivateEndpointServiceRequest) Execute() (*EndpointService, *http.Response, error) {
@@ -991,8 +997,9 @@ type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest stru
 	ApiService PrivateEndpointServicesApi
 	groupId string
 }
+
 type PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r PrivateEndpointServicesApiGetRegionalizedPrivateEndpointSettingRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
@@ -1112,9 +1119,10 @@ type PrivateEndpointServicesApiListPrivateEndpointServicesRequest struct {
 	groupId string
 	cloudProvider string
 }
+
 type PrivateEndpointServicesApiListPrivateEndpointServicesQueryParams struct {
-		groupId string
-		cloudProvider string
+		GroupId string
+		CloudProvider string
 }
 
 func (r PrivateEndpointServicesApiListPrivateEndpointServicesRequest) Execute() (*PaginatedPrivateLinkConnection, *http.Response, error) {
@@ -1237,9 +1245,10 @@ type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingRequest s
 	groupId string
 	projectSettingItem *ProjectSettingItem
 }
+
 type PrivateEndpointServicesApiToggleRegionalizedPrivateEndpointSettingQueryParams struct {
-		groupId string
-		projectSettingItem *ProjectSettingItem
+		GroupId string
+		ProjectSettingItem *ProjectSettingItem
 }
 
 // Enables or disables the ability to create multiple private endpoints per region in all cloud service providers in one project.

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -30,13 +30,13 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that you want to assign to one project.
-	@return ProgrammaticAPIKeysApiAddProjectApiKeyRequest
+	@return AddProjectApiKeyApiRequest
 	*/
-	AddProjectApiKey(ctx context.Context, groupId string, apiUserId string) ProgrammaticAPIKeysApiAddProjectApiKeyRequest
+	AddProjectApiKey(ctx context.Context, groupId string, apiUserId string) AddProjectApiKeyApiRequest
 
 	// AddProjectApiKeyExecute executes the request
 	//  @return ApiUser
-	AddProjectApiKeyExecute(r ProgrammaticAPIKeysApiAddProjectApiKeyRequest) (*ApiUser, *http.Response, error)
+	AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	CreateApiKey Create One Organization API Key
@@ -45,13 +45,13 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return ProgrammaticAPIKeysApiCreateApiKeyRequest
+	@return CreateApiKeyApiRequest
 	*/
-	CreateApiKey(ctx context.Context, orgId string) ProgrammaticAPIKeysApiCreateApiKeyRequest
+	CreateApiKey(ctx context.Context, orgId string) CreateApiKeyApiRequest
 
 	// CreateApiKeyExecute executes the request
 	//  @return ApiUser
-	CreateApiKeyExecute(r ProgrammaticAPIKeysApiCreateApiKeyRequest) (*ApiUser, *http.Response, error)
+	CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	CreateApiKeyAccessList Create Access List Entries for One Organization API Key
@@ -61,13 +61,13 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for which you want to create a new access list entry.
-	@return ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest
+	@return CreateApiKeyAccessListApiRequest
 	*/
-	CreateApiKeyAccessList(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest
+	CreateApiKeyAccessList(ctx context.Context, orgId string, apiUserId string) CreateApiKeyAccessListApiRequest
 
 	// CreateApiKeyAccessListExecute executes the request
 	//  @return UserAccessList
-	CreateApiKeyAccessListExecute(r ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest) (*UserAccessList, *http.Response, error)
+	CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
 
 	/*
 	CreateProjectApiKey Create and Assign One Organization API Key to One Project
@@ -76,13 +76,13 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProgrammaticAPIKeysApiCreateProjectApiKeyRequest
+	@return CreateProjectApiKeyApiRequest
 	*/
-	CreateProjectApiKey(ctx context.Context, groupId string) ProgrammaticAPIKeysApiCreateProjectApiKeyRequest
+	CreateProjectApiKey(ctx context.Context, groupId string) CreateProjectApiKeyApiRequest
 
 	// CreateProjectApiKeyExecute executes the request
 	//  @return ApiUser
-	CreateProjectApiKeyExecute(r ProgrammaticAPIKeysApiCreateProjectApiKeyRequest) (*ApiUser, *http.Response, error)
+	CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	DeleteApiKey Remove One Organization API Key
@@ -92,12 +92,12 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key.
-	@return ProgrammaticAPIKeysApiDeleteApiKeyRequest
+	@return DeleteApiKeyApiRequest
 	*/
-	DeleteApiKey(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiDeleteApiKeyRequest
+	DeleteApiKey(ctx context.Context, orgId string, apiUserId string) DeleteApiKeyApiRequest
 
 	// DeleteApiKeyExecute executes the request
-	DeleteApiKeyExecute(r ProgrammaticAPIKeysApiDeleteApiKeyRequest) (*http.Response, error)
+	DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (*http.Response, error)
 
 	/*
 	DeleteApiKeyAccessListEntry Remove One Access List Entry for One Organization API Key
@@ -108,12 +108,12 @@ type ProgrammaticAPIKeysApi interface {
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for which you want to remove access list entries.
 	@param ipAddress One IP address or multiple IP addresses represented as one CIDR block to limit requests to API resources in the specified organization. When adding a CIDR block with a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.
-	@return ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest
+	@return DeleteApiKeyAccessListEntryApiRequest
 	*/
-	DeleteApiKeyAccessListEntry(ctx context.Context, orgId string, apiUserId string, ipAddress string) ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest
+	DeleteApiKeyAccessListEntry(ctx context.Context, orgId string, apiUserId string, ipAddress string) DeleteApiKeyAccessListEntryApiRequest
 
 	// DeleteApiKeyAccessListEntryExecute executes the request
-	DeleteApiKeyAccessListEntryExecute(r ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest) (*http.Response, error)
+	DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (*http.Response, error)
 
 	/*
 	GetApiKey Return One Organization API Key
@@ -123,13 +123,13 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that  you want to update.
-	@return ProgrammaticAPIKeysApiGetApiKeyRequest
+	@return GetApiKeyApiRequest
 	*/
-	GetApiKey(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiGetApiKeyRequest
+	GetApiKey(ctx context.Context, orgId string, apiUserId string) GetApiKeyApiRequest
 
 	// GetApiKeyExecute executes the request
 	//  @return ApiUser
-	GetApiKeyExecute(r ProgrammaticAPIKeysApiGetApiKeyRequest) (*ApiUser, *http.Response, error)
+	GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	GetApiKeyAccessList Return One Access List Entry for One Organization API Key
@@ -140,13 +140,13 @@ type ProgrammaticAPIKeysApi interface {
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param ipAddress One IP address or multiple IP addresses represented as one CIDR block to limit  requests to API resources in the specified organization. When adding a CIDR block with a subnet mask, such as  192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for  which you want to return access list entries.
-	@return ProgrammaticAPIKeysApiGetApiKeyAccessListRequest
+	@return GetApiKeyAccessListApiRequest
 	*/
-	GetApiKeyAccessList(ctx context.Context, orgId string, ipAddress string, apiUserId string) ProgrammaticAPIKeysApiGetApiKeyAccessListRequest
+	GetApiKeyAccessList(ctx context.Context, orgId string, ipAddress string, apiUserId string) GetApiKeyAccessListApiRequest
 
 	// GetApiKeyAccessListExecute executes the request
 	//  @return UserAccessList
-	GetApiKeyAccessListExecute(r ProgrammaticAPIKeysApiGetApiKeyAccessListRequest) (*UserAccessList, *http.Response, error)
+	GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
 
 	/*
 	ListApiKeyAccessListsEntries Return All Access List Entries for One Organization API Key
@@ -156,13 +156,13 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for which you want to return access list entries.
-	@return ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest
+	@return ListApiKeyAccessListsEntriesApiRequest
 	*/
-	ListApiKeyAccessListsEntries(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest
+	ListApiKeyAccessListsEntries(ctx context.Context, orgId string, apiUserId string) ListApiKeyAccessListsEntriesApiRequest
 
 	// ListApiKeyAccessListsEntriesExecute executes the request
 	//  @return PaginatedApiUserAccessList
-	ListApiKeyAccessListsEntriesExecute(r ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest) (*PaginatedApiUserAccessList, *http.Response, error)
+	ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
 
 	/*
 	ListApiKeys Return All Organization API Keys
@@ -171,13 +171,13 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return ProgrammaticAPIKeysApiListApiKeysRequest
+	@return ListApiKeysApiRequest
 	*/
-	ListApiKeys(ctx context.Context, orgId string) ProgrammaticAPIKeysApiListApiKeysRequest
+	ListApiKeys(ctx context.Context, orgId string) ListApiKeysApiRequest
 
 	// ListApiKeysExecute executes the request
 	//  @return PaginatedApiApiUser
-	ListApiKeysExecute(r ProgrammaticAPIKeysApiListApiKeysRequest) (*PaginatedApiApiUser, *http.Response, error)
+	ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
 	ListProjectApiKeys Return All Organization API Keys Assigned to One Project
@@ -186,13 +186,13 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProgrammaticAPIKeysApiListProjectApiKeysRequest
+	@return ListProjectApiKeysApiRequest
 	*/
-	ListProjectApiKeys(ctx context.Context, groupId string) ProgrammaticAPIKeysApiListProjectApiKeysRequest
+	ListProjectApiKeys(ctx context.Context, groupId string) ListProjectApiKeysApiRequest
 
 	// ListProjectApiKeysExecute executes the request
 	//  @return PaginatedApiApiUser
-	ListProjectApiKeysExecute(r ProgrammaticAPIKeysApiListProjectApiKeysRequest) (*PaginatedApiApiUser, *http.Response, error)
+	ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
 	RemoveProjectApiKey Unassign One Organization API Key from One Project
@@ -202,12 +202,12 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that you want to unassign from one project.
-	@return ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest
+	@return RemoveProjectApiKeyApiRequest
 	*/
-	RemoveProjectApiKey(ctx context.Context, groupId string, apiUserId string) ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest
+	RemoveProjectApiKey(ctx context.Context, groupId string, apiUserId string) RemoveProjectApiKeyApiRequest
 
 	// RemoveProjectApiKeyExecute executes the request
-	RemoveProjectApiKeyExecute(r ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest) (*http.Response, error)
+	RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (*http.Response, error)
 
 	/*
 	UpdateApiKey Update One Organization API Key
@@ -217,13 +217,13 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key you  want to update.
-	@return ProgrammaticAPIKeysApiUpdateApiKeyRequest
+	@return UpdateApiKeyApiRequest
 	*/
-	UpdateApiKey(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiUpdateApiKeyRequest
+	UpdateApiKey(ctx context.Context, orgId string, apiUserId string) UpdateApiKeyApiRequest
 
 	// UpdateApiKeyExecute executes the request
 	//  @return ApiUser
-	UpdateApiKeyExecute(r ProgrammaticAPIKeysApiUpdateApiKeyRequest) (*ApiUser, *http.Response, error)
+	UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	UpdateApiKeyRoles Update Roles of One Organization API Key to One Project
@@ -233,19 +233,19 @@ type ProgrammaticAPIKeysApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that you want to unassign from one project.
-	@return ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest
+	@return UpdateApiKeyRolesApiRequest
 	*/
-	UpdateApiKeyRoles(ctx context.Context, groupId string, apiUserId string) ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest
+	UpdateApiKeyRoles(ctx context.Context, groupId string, apiUserId string) UpdateApiKeyRolesApiRequest
 
 	// UpdateApiKeyRolesExecute executes the request
 	//  @return ApiUser
-	UpdateApiKeyRolesExecute(r ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest) (*ApiUser, *http.Response, error)
+	UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiUser, *http.Response, error)
 }
 
 // ProgrammaticAPIKeysApiService ProgrammaticAPIKeysApi service
 type ProgrammaticAPIKeysApiService service
 
-type ProgrammaticAPIKeysApiAddProjectApiKeyRequest struct {
+type AddProjectApiKeyApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	groupId string
@@ -260,12 +260,12 @@ type AddProjectApiKeyParams struct {
 }
 
 // Organization API key to be assigned to the specified project.
-func (r ProgrammaticAPIKeysApiAddProjectApiKeyRequest) UserRoleAssignment(userRoleAssignment []UserRoleAssignment) ProgrammaticAPIKeysApiAddProjectApiKeyRequest {
+func (r AddProjectApiKeyApiRequest) UserRoleAssignment(userRoleAssignment []UserRoleAssignment) AddProjectApiKeyApiRequest {
 	r.userRoleAssignment = &userRoleAssignment
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiAddProjectApiKeyRequest) Execute() (*ApiUser, *http.Response, error) {
+func (r AddProjectApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.AddProjectApiKeyExecute(r)
 }
 
@@ -277,10 +277,10 @@ Assigns the specified organization API key to the specified project. Users with 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that you want to assign to one project.
- @return ProgrammaticAPIKeysApiAddProjectApiKeyRequest
+ @return AddProjectApiKeyApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) AddProjectApiKey(ctx context.Context, groupId string, apiUserId string) ProgrammaticAPIKeysApiAddProjectApiKeyRequest {
-	return ProgrammaticAPIKeysApiAddProjectApiKeyRequest{
+func (a *ProgrammaticAPIKeysApiService) AddProjectApiKey(ctx context.Context, groupId string, apiUserId string) AddProjectApiKeyApiRequest {
+	return AddProjectApiKeyApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -290,7 +290,7 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKey(ctx context.Context, gr
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r ProgrammaticAPIKeysApiAddProjectApiKeyRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -390,7 +390,7 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r ProgrammaticAP
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiCreateApiKeyRequest struct {
+type CreateApiKeyApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -403,12 +403,12 @@ type CreateApiKeyParams struct {
 }
 
 // Organization API Key to be created. This request requires a minimum of one of the two body parameters.
-func (r ProgrammaticAPIKeysApiCreateApiKeyRequest) CreateApiKey(createApiKey CreateApiKey) ProgrammaticAPIKeysApiCreateApiKeyRequest {
+func (r CreateApiKeyApiRequest) CreateApiKey(createApiKey CreateApiKey) CreateApiKeyApiRequest {
 	r.createApiKey = &createApiKey
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiCreateApiKeyRequest) Execute() (*ApiUser, *http.Response, error) {
+func (r CreateApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.CreateApiKeyExecute(r)
 }
 
@@ -419,10 +419,10 @@ Creates one API key for the specified organization. An organization API key gran
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return ProgrammaticAPIKeysApiCreateApiKeyRequest
+ @return CreateApiKeyApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) CreateApiKey(ctx context.Context, orgId string) ProgrammaticAPIKeysApiCreateApiKeyRequest {
-	return ProgrammaticAPIKeysApiCreateApiKeyRequest{
+func (a *ProgrammaticAPIKeysApiService) CreateApiKey(ctx context.Context, orgId string) CreateApiKeyApiRequest {
+	return CreateApiKeyApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -431,7 +431,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKey(ctx context.Context, orgId 
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) CreateApiKeyExecute(r ProgrammaticAPIKeysApiCreateApiKeyRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -524,7 +524,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKeyExecute(r ProgrammaticAPIKey
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest struct {
+type CreateApiKeyAccessListApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -545,30 +545,30 @@ type CreateApiKeyAccessListParams struct {
 }
 
 // Access list entries to be created for the specified organization API key.
-func (r ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest) UserAccessList(userAccessList []UserAccessList) ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest {
+func (r CreateApiKeyAccessListApiRequest) UserAccessList(userAccessList []UserAccessList) CreateApiKeyAccessListApiRequest {
 	r.userAccessList = &userAccessList
 	return r
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest) IncludeCount(includeCount bool) ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest {
+func (r CreateApiKeyAccessListApiRequest) IncludeCount(includeCount bool) CreateApiKeyAccessListApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest) ItemsPerPage(itemsPerPage int32) ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest {
+func (r CreateApiKeyAccessListApiRequest) ItemsPerPage(itemsPerPage int32) CreateApiKeyAccessListApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest) PageNum(pageNum int32) ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest {
+func (r CreateApiKeyAccessListApiRequest) PageNum(pageNum int32) CreateApiKeyAccessListApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest) Execute() (*UserAccessList, *http.Response, error) {
+func (r CreateApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
 	return r.ApiService.CreateApiKeyAccessListExecute(r)
 }
 
@@ -580,10 +580,10 @@ Creates the access list entries for the specified organization API key. Resource
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for which you want to create a new access list entry.
- @return ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest
+ @return CreateApiKeyAccessListApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessList(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest {
-	return ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest{
+func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessList(ctx context.Context, orgId string, apiUserId string) CreateApiKeyAccessListApiRequest {
+	return CreateApiKeyAccessListApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -593,7 +593,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessList(ctx context.Conte
 
 // Execute executes the request
 //  @return UserAccessList
-func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessListExecute(r ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest) (*UserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -714,7 +714,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessListExecute(r Programm
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiCreateProjectApiKeyRequest struct {
+type CreateProjectApiKeyApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	groupId string
@@ -727,12 +727,12 @@ type CreateProjectApiKeyParams struct {
 }
 
 // Organization API key to be created and assigned to the specified project. This request requires a minimum of one of the two body parameters.
-func (r ProgrammaticAPIKeysApiCreateProjectApiKeyRequest) CreateApiKey(createApiKey CreateApiKey) ProgrammaticAPIKeysApiCreateProjectApiKeyRequest {
+func (r CreateProjectApiKeyApiRequest) CreateApiKey(createApiKey CreateApiKey) CreateProjectApiKeyApiRequest {
 	r.createApiKey = &createApiKey
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiCreateProjectApiKeyRequest) Execute() (*ApiUser, *http.Response, error) {
+func (r CreateProjectApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.CreateProjectApiKeyExecute(r)
 }
 
@@ -743,10 +743,10 @@ Creates and assigns the specified organization API key to the specified project.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProgrammaticAPIKeysApiCreateProjectApiKeyRequest
+ @return CreateProjectApiKeyApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKey(ctx context.Context, groupId string) ProgrammaticAPIKeysApiCreateProjectApiKeyRequest {
-	return ProgrammaticAPIKeysApiCreateProjectApiKeyRequest{
+func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKey(ctx context.Context, groupId string) CreateProjectApiKeyApiRequest {
+	return CreateProjectApiKeyApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -755,7 +755,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKey(ctx context.Context,
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyExecute(r ProgrammaticAPIKeysApiCreateProjectApiKeyRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -848,7 +848,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyExecute(r Programmati
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiDeleteApiKeyRequest struct {
+type DeleteApiKeyApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -860,7 +860,7 @@ type DeleteApiKeyParams struct {
 		ApiUserId string
 }
 
-func (r ProgrammaticAPIKeysApiDeleteApiKeyRequest) Execute() (*http.Response, error) {
+func (r DeleteApiKeyApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteApiKeyExecute(r)
 }
 
@@ -872,10 +872,10 @@ Removes one organization API key from the specified organization. When you remov
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key.
- @return ProgrammaticAPIKeysApiDeleteApiKeyRequest
+ @return DeleteApiKeyApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKey(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiDeleteApiKeyRequest {
-	return ProgrammaticAPIKeysApiDeleteApiKeyRequest{
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKey(ctx context.Context, orgId string, apiUserId string) DeleteApiKeyApiRequest {
+	return DeleteApiKeyApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -884,7 +884,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKey(ctx context.Context, orgId 
 }
 
 // Execute executes the request
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r ProgrammaticAPIKeysApiDeleteApiKeyRequest) (*http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -969,7 +969,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r ProgrammaticAPIKey
 	return localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest struct {
+type DeleteApiKeyAccessListEntryApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -983,7 +983,7 @@ type DeleteApiKeyAccessListEntryParams struct {
 		IpAddress string
 }
 
-func (r ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest) Execute() (*http.Response, error) {
+func (r DeleteApiKeyAccessListEntryApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteApiKeyAccessListEntryExecute(r)
 }
 
@@ -996,10 +996,10 @@ Removes the specified access list entry from the specified organization API key.
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for which you want to remove access list entries.
  @param ipAddress One IP address or multiple IP addresses represented as one CIDR block to limit requests to API resources in the specified organization. When adding a CIDR block with a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.
- @return ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest
+ @return DeleteApiKeyAccessListEntryApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntry(ctx context.Context, orgId string, apiUserId string, ipAddress string) ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest {
-	return ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest{
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntry(ctx context.Context, orgId string, apiUserId string, ipAddress string) DeleteApiKeyAccessListEntryApiRequest {
+	return DeleteApiKeyAccessListEntryApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1009,7 +1009,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntry(ctx context.
 }
 
 // Execute executes the request
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest) (*http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1095,7 +1095,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r Pro
 	return localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiGetApiKeyRequest struct {
+type GetApiKeyApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -1107,7 +1107,7 @@ type GetApiKeyParams struct {
 		ApiUserId string
 }
 
-func (r ProgrammaticAPIKeysApiGetApiKeyRequest) Execute() (*ApiUser, *http.Response, error) {
+func (r GetApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.GetApiKeyExecute(r)
 }
 
@@ -1119,10 +1119,10 @@ Returns one organization API key. The organization API keys grant programmatic a
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that  you want to update.
- @return ProgrammaticAPIKeysApiGetApiKeyRequest
+ @return GetApiKeyApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) GetApiKey(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiGetApiKeyRequest {
-	return ProgrammaticAPIKeysApiGetApiKeyRequest{
+func (a *ProgrammaticAPIKeysApiService) GetApiKey(ctx context.Context, orgId string, apiUserId string) GetApiKeyApiRequest {
+	return GetApiKeyApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1132,7 +1132,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKey(ctx context.Context, orgId str
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) GetApiKeyExecute(r ProgrammaticAPIKeysApiGetApiKeyRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1227,7 +1227,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyExecute(r ProgrammaticAPIKeysAp
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiGetApiKeyAccessListRequest struct {
+type GetApiKeyAccessListApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -1241,7 +1241,7 @@ type GetApiKeyAccessListParams struct {
 		ApiUserId string
 }
 
-func (r ProgrammaticAPIKeysApiGetApiKeyAccessListRequest) Execute() (*UserAccessList, *http.Response, error) {
+func (r GetApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
 	return r.ApiService.GetApiKeyAccessListExecute(r)
 }
 
@@ -1254,10 +1254,10 @@ Returns one access list entry for the specified organization API key. Resources 
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param ipAddress One IP address or multiple IP addresses represented as one CIDR block to limit  requests to API resources in the specified organization. When adding a CIDR block with a subnet mask, such as  192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for  which you want to return access list entries.
- @return ProgrammaticAPIKeysApiGetApiKeyAccessListRequest
+ @return GetApiKeyAccessListApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessList(ctx context.Context, orgId string, ipAddress string, apiUserId string) ProgrammaticAPIKeysApiGetApiKeyAccessListRequest {
-	return ProgrammaticAPIKeysApiGetApiKeyAccessListRequest{
+func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessList(ctx context.Context, orgId string, ipAddress string, apiUserId string) GetApiKeyAccessListApiRequest {
+	return GetApiKeyAccessListApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1268,7 +1268,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessList(ctx context.Context,
 
 // Execute executes the request
 //  @return UserAccessList
-func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListExecute(r ProgrammaticAPIKeysApiGetApiKeyAccessListRequest) (*UserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1364,7 +1364,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListExecute(r Programmati
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest struct {
+type ListApiKeyAccessListsEntriesApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -1383,24 +1383,24 @@ type ListApiKeyAccessListsEntriesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest) IncludeCount(includeCount bool) ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest {
+func (r ListApiKeyAccessListsEntriesApiRequest) IncludeCount(includeCount bool) ListApiKeyAccessListsEntriesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest) ItemsPerPage(itemsPerPage int32) ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest {
+func (r ListApiKeyAccessListsEntriesApiRequest) ItemsPerPage(itemsPerPage int32) ListApiKeyAccessListsEntriesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest) PageNum(pageNum int32) ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest {
+func (r ListApiKeyAccessListsEntriesApiRequest) PageNum(pageNum int32) ListApiKeyAccessListsEntriesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest) Execute() (*PaginatedApiUserAccessList, *http.Response, error) {
+func (r ListApiKeyAccessListsEntriesApiRequest) Execute() (*PaginatedApiUserAccessList, *http.Response, error) {
 	return r.ApiService.ListApiKeyAccessListsEntriesExecute(r)
 }
 
@@ -1412,10 +1412,10 @@ Returns all access list entries that you configured for the specified organizati
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key for which you want to return access list entries.
- @return ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest
+ @return ListApiKeyAccessListsEntriesApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntries(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest {
-	return ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest{
+func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntries(ctx context.Context, orgId string, apiUserId string) ListApiKeyAccessListsEntriesApiRequest {
+	return ListApiKeyAccessListsEntriesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1425,7 +1425,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntries(ctx context
 
 // Execute executes the request
 //  @return PaginatedApiUserAccessList
-func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntriesExecute(r ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1541,7 +1541,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntriesExecute(r Pr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiListApiKeysRequest struct {
+type ListApiKeysApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -1558,24 +1558,24 @@ type ListApiKeysParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProgrammaticAPIKeysApiListApiKeysRequest) IncludeCount(includeCount bool) ProgrammaticAPIKeysApiListApiKeysRequest {
+func (r ListApiKeysApiRequest) IncludeCount(includeCount bool) ListApiKeysApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProgrammaticAPIKeysApiListApiKeysRequest) ItemsPerPage(itemsPerPage int32) ProgrammaticAPIKeysApiListApiKeysRequest {
+func (r ListApiKeysApiRequest) ItemsPerPage(itemsPerPage int32) ListApiKeysApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProgrammaticAPIKeysApiListApiKeysRequest) PageNum(pageNum int32) ProgrammaticAPIKeysApiListApiKeysRequest {
+func (r ListApiKeysApiRequest) PageNum(pageNum int32) ListApiKeysApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiListApiKeysRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
+func (r ListApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
 	return r.ApiService.ListApiKeysExecute(r)
 }
 
@@ -1586,10 +1586,10 @@ Returns all organization API keys for the specified organization. The organizati
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return ProgrammaticAPIKeysApiListApiKeysRequest
+ @return ListApiKeysApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) ListApiKeys(ctx context.Context, orgId string) ProgrammaticAPIKeysApiListApiKeysRequest {
-	return ProgrammaticAPIKeysApiListApiKeysRequest{
+func (a *ProgrammaticAPIKeysApiService) ListApiKeys(ctx context.Context, orgId string) ListApiKeysApiRequest {
+	return ListApiKeysApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1598,7 +1598,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeys(ctx context.Context, orgId s
 
 // Execute executes the request
 //  @return PaginatedApiApiUser
-func (a *ProgrammaticAPIKeysApiService) ListApiKeysExecute(r ProgrammaticAPIKeysApiListApiKeysRequest) (*PaginatedApiApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1707,7 +1707,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeysExecute(r ProgrammaticAPIKeys
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiListProjectApiKeysRequest struct {
+type ListProjectApiKeysApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	groupId string
@@ -1724,24 +1724,24 @@ type ListProjectApiKeysParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProgrammaticAPIKeysApiListProjectApiKeysRequest) IncludeCount(includeCount bool) ProgrammaticAPIKeysApiListProjectApiKeysRequest {
+func (r ListProjectApiKeysApiRequest) IncludeCount(includeCount bool) ListProjectApiKeysApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProgrammaticAPIKeysApiListProjectApiKeysRequest) ItemsPerPage(itemsPerPage int32) ProgrammaticAPIKeysApiListProjectApiKeysRequest {
+func (r ListProjectApiKeysApiRequest) ItemsPerPage(itemsPerPage int32) ListProjectApiKeysApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProgrammaticAPIKeysApiListProjectApiKeysRequest) PageNum(pageNum int32) ProgrammaticAPIKeysApiListProjectApiKeysRequest {
+func (r ListProjectApiKeysApiRequest) PageNum(pageNum int32) ListProjectApiKeysApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiListProjectApiKeysRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
+func (r ListProjectApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
 	return r.ApiService.ListProjectApiKeysExecute(r)
 }
 
@@ -1752,10 +1752,10 @@ Returns all organization API keys that you assigned to the specified project. Us
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProgrammaticAPIKeysApiListProjectApiKeysRequest
+ @return ListProjectApiKeysApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeys(ctx context.Context, groupId string) ProgrammaticAPIKeysApiListProjectApiKeysRequest {
-	return ProgrammaticAPIKeysApiListProjectApiKeysRequest{
+func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeys(ctx context.Context, groupId string) ListProjectApiKeysApiRequest {
+	return ListProjectApiKeysApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1764,7 +1764,7 @@ func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeys(ctx context.Context, 
 
 // Execute executes the request
 //  @return PaginatedApiApiUser
-func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeysExecute(r ProgrammaticAPIKeysApiListProjectApiKeysRequest) (*PaginatedApiApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1873,7 +1873,7 @@ func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeysExecute(r Programmatic
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest struct {
+type RemoveProjectApiKeyApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	groupId string
@@ -1885,7 +1885,7 @@ type RemoveProjectApiKeyParams struct {
 		ApiUserId string
 }
 
-func (r ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest) Execute() (*http.Response, error) {
+func (r RemoveProjectApiKeyApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectApiKeyExecute(r)
 }
 
@@ -1897,10 +1897,10 @@ Removes one organization API key from the specified project. To use this resourc
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that you want to unassign from one project.
- @return ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest
+ @return RemoveProjectApiKeyApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKey(ctx context.Context, groupId string, apiUserId string) ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest {
-	return ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest{
+func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKey(ctx context.Context, groupId string, apiUserId string) RemoveProjectApiKeyApiRequest {
+	return RemoveProjectApiKeyApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1909,7 +1909,7 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKey(ctx context.Context,
 }
 
 // Execute executes the request
-func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest) (*http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1994,7 +1994,7 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r Programmati
 	return localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiUpdateApiKeyRequest struct {
+type UpdateApiKeyApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
@@ -2009,12 +2009,12 @@ type UpdateApiKeyParams struct {
 }
 
 // Organization API key to be updated. This request requires a minimum of one of the two body parameters.
-func (r ProgrammaticAPIKeysApiUpdateApiKeyRequest) ApiUser(apiUser ApiUser) ProgrammaticAPIKeysApiUpdateApiKeyRequest {
+func (r UpdateApiKeyApiRequest) ApiUser(apiUser ApiUser) UpdateApiKeyApiRequest {
 	r.apiUser = &apiUser
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiUpdateApiKeyRequest) Execute() (*ApiUser, *http.Response, error) {
+func (r UpdateApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.UpdateApiKeyExecute(r)
 }
 
@@ -2026,10 +2026,10 @@ Updates one organization API key in the specified organization. The organization
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key you  want to update.
- @return ProgrammaticAPIKeysApiUpdateApiKeyRequest
+ @return UpdateApiKeyApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) UpdateApiKey(ctx context.Context, orgId string, apiUserId string) ProgrammaticAPIKeysApiUpdateApiKeyRequest {
-	return ProgrammaticAPIKeysApiUpdateApiKeyRequest{
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKey(ctx context.Context, orgId string, apiUserId string) UpdateApiKeyApiRequest {
+	return UpdateApiKeyApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -2039,7 +2039,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKey(ctx context.Context, orgId 
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyExecute(r ProgrammaticAPIKeysApiUpdateApiKeyRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2139,7 +2139,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyExecute(r ProgrammaticAPIKey
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest struct {
+type UpdateApiKeyRolesApiRequest struct {
 	ctx context.Context
 	ApiService ProgrammaticAPIKeysApi
 	groupId string
@@ -2160,30 +2160,30 @@ type UpdateApiKeyRolesParams struct {
 }
 
 // Organization API Key to be updated. This request requires a minimum of one of the two body parameters.
-func (r ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest) CreateApiKey(createApiKey CreateApiKey) ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest {
+func (r UpdateApiKeyRolesApiRequest) CreateApiKey(createApiKey CreateApiKey) UpdateApiKeyRolesApiRequest {
 	r.createApiKey = &createApiKey
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest) PageNum(pageNum int32) ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest {
+func (r UpdateApiKeyRolesApiRequest) PageNum(pageNum int32) UpdateApiKeyRolesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest) ItemsPerPage(itemsPerPage int32) ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest {
+func (r UpdateApiKeyRolesApiRequest) ItemsPerPage(itemsPerPage int32) UpdateApiKeyRolesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest) IncludeCount(includeCount bool) ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest {
+func (r UpdateApiKeyRolesApiRequest) IncludeCount(includeCount bool) UpdateApiKeyRolesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
-func (r ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest) Execute() (*ApiUser, *http.Response, error) {
+func (r UpdateApiKeyRolesApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.UpdateApiKeyRolesExecute(r)
 }
 
@@ -2195,10 +2195,10 @@ Updates the roles of the organization API key that you specify for the project t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param apiUserId Unique 24-hexadecimal digit string that identifies this organization API key that you want to unassign from one project.
- @return ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest
+ @return UpdateApiKeyRolesApiRequest
 */
-func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRoles(ctx context.Context, groupId string, apiUserId string) ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest {
-	return ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest{
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRoles(ctx context.Context, groupId string, apiUserId string) UpdateApiKeyRolesApiRequest {
+	return UpdateApiKeyRolesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2208,7 +2208,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRoles(ctx context.Context, g
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRolesExecute(r ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -253,7 +253,7 @@ type AddProjectApiKeyApiRequest struct {
 	userRoleAssignment *[]UserRoleAssignment
 }
 
-type AddProjectApiKeyParams struct {
+type AddProjectApiKeyApiParams struct {
 		GroupId string
 		ApiUserId string
 		UserRoleAssignment *[]UserRoleAssignment
@@ -397,7 +397,7 @@ type CreateApiKeyApiRequest struct {
 	createApiKey *CreateApiKey
 }
 
-type CreateApiKeyParams struct {
+type CreateApiKeyApiParams struct {
 		OrgId string
 		CreateApiKey *CreateApiKey
 }
@@ -535,7 +535,7 @@ type CreateApiKeyAccessListApiRequest struct {
 	pageNum *int32
 }
 
-type CreateApiKeyAccessListParams struct {
+type CreateApiKeyAccessListApiParams struct {
 		OrgId string
 		ApiUserId string
 		UserAccessList *[]UserAccessList
@@ -721,7 +721,7 @@ type CreateProjectApiKeyApiRequest struct {
 	createApiKey *CreateApiKey
 }
 
-type CreateProjectApiKeyParams struct {
+type CreateProjectApiKeyApiParams struct {
 		GroupId string
 		CreateApiKey *CreateApiKey
 }
@@ -855,7 +855,7 @@ type DeleteApiKeyApiRequest struct {
 	apiUserId string
 }
 
-type DeleteApiKeyParams struct {
+type DeleteApiKeyApiParams struct {
 		OrgId string
 		ApiUserId string
 }
@@ -977,7 +977,7 @@ type DeleteApiKeyAccessListEntryApiRequest struct {
 	ipAddress string
 }
 
-type DeleteApiKeyAccessListEntryParams struct {
+type DeleteApiKeyAccessListEntryApiParams struct {
 		OrgId string
 		ApiUserId string
 		IpAddress string
@@ -1102,7 +1102,7 @@ type GetApiKeyApiRequest struct {
 	apiUserId string
 }
 
-type GetApiKeyParams struct {
+type GetApiKeyApiParams struct {
 		OrgId string
 		ApiUserId string
 }
@@ -1235,7 +1235,7 @@ type GetApiKeyAccessListApiRequest struct {
 	apiUserId string
 }
 
-type GetApiKeyAccessListParams struct {
+type GetApiKeyAccessListApiParams struct {
 		OrgId string
 		IpAddress string
 		ApiUserId string
@@ -1374,7 +1374,7 @@ type ListApiKeyAccessListsEntriesApiRequest struct {
 	pageNum *int32
 }
 
-type ListApiKeyAccessListsEntriesParams struct {
+type ListApiKeyAccessListsEntriesApiParams struct {
 		OrgId string
 		ApiUserId string
 		IncludeCount *bool
@@ -1550,7 +1550,7 @@ type ListApiKeysApiRequest struct {
 	pageNum *int32
 }
 
-type ListApiKeysParams struct {
+type ListApiKeysApiParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1716,7 +1716,7 @@ type ListProjectApiKeysApiRequest struct {
 	pageNum *int32
 }
 
-type ListProjectApiKeysParams struct {
+type ListProjectApiKeysApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1880,7 +1880,7 @@ type RemoveProjectApiKeyApiRequest struct {
 	apiUserId string
 }
 
-type RemoveProjectApiKeyParams struct {
+type RemoveProjectApiKeyApiParams struct {
 		GroupId string
 		ApiUserId string
 }
@@ -2002,7 +2002,7 @@ type UpdateApiKeyApiRequest struct {
 	apiUser *ApiUser
 }
 
-type UpdateApiKeyParams struct {
+type UpdateApiKeyApiParams struct {
 		OrgId string
 		ApiUserId string
 		ApiUser *ApiUser
@@ -2150,7 +2150,7 @@ type UpdateApiKeyRolesApiRequest struct {
 	includeCount *bool
 }
 
-type UpdateApiKeyRolesParams struct {
+type UpdateApiKeyRolesApiParams struct {
 		GroupId string
 		ApiUserId string
 		CreateApiKey *CreateApiKey

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -253,7 +253,7 @@ type ProgrammaticAPIKeysApiAddProjectApiKeyRequest struct {
 	userRoleAssignment *[]UserRoleAssignment
 }
 
-type ProgrammaticAPIKeysApiAddProjectApiKeyQueryParams struct {
+type ProgrammaticAPIKeysApiAddProjectApiKeyParams struct {
 		GroupId string
 		ApiUserId string
 		UserRoleAssignment *[]UserRoleAssignment
@@ -397,7 +397,7 @@ type ProgrammaticAPIKeysApiCreateApiKeyRequest struct {
 	createApiKey *CreateApiKey
 }
 
-type ProgrammaticAPIKeysApiCreateApiKeyQueryParams struct {
+type ProgrammaticAPIKeysApiCreateApiKeyParams struct {
 		OrgId string
 		CreateApiKey *CreateApiKey
 }
@@ -535,7 +535,7 @@ type ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiCreateApiKeyAccessListQueryParams struct {
+type ProgrammaticAPIKeysApiCreateApiKeyAccessListParams struct {
 		OrgId string
 		ApiUserId string
 		UserAccessList *[]UserAccessList
@@ -721,7 +721,7 @@ type ProgrammaticAPIKeysApiCreateProjectApiKeyRequest struct {
 	createApiKey *CreateApiKey
 }
 
-type ProgrammaticAPIKeysApiCreateProjectApiKeyQueryParams struct {
+type ProgrammaticAPIKeysApiCreateProjectApiKeyParams struct {
 		GroupId string
 		CreateApiKey *CreateApiKey
 }
@@ -855,7 +855,7 @@ type ProgrammaticAPIKeysApiDeleteApiKeyRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiDeleteApiKeyQueryParams struct {
+type ProgrammaticAPIKeysApiDeleteApiKeyParams struct {
 		OrgId string
 		ApiUserId string
 }
@@ -977,7 +977,7 @@ type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest struct {
 	ipAddress string
 }
 
-type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryQueryParams struct {
+type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryParams struct {
 		OrgId string
 		ApiUserId string
 		IpAddress string
@@ -1102,7 +1102,7 @@ type ProgrammaticAPIKeysApiGetApiKeyRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiGetApiKeyQueryParams struct {
+type ProgrammaticAPIKeysApiGetApiKeyParams struct {
 		OrgId string
 		ApiUserId string
 }
@@ -1235,7 +1235,7 @@ type ProgrammaticAPIKeysApiGetApiKeyAccessListRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiGetApiKeyAccessListQueryParams struct {
+type ProgrammaticAPIKeysApiGetApiKeyAccessListParams struct {
 		OrgId string
 		IpAddress string
 		ApiUserId string
@@ -1374,7 +1374,7 @@ type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesQueryParams struct {
+type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesParams struct {
 		OrgId string
 		ApiUserId string
 		IncludeCount *bool
@@ -1550,7 +1550,7 @@ type ProgrammaticAPIKeysApiListApiKeysRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiListApiKeysQueryParams struct {
+type ProgrammaticAPIKeysApiListApiKeysParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1716,7 +1716,7 @@ type ProgrammaticAPIKeysApiListProjectApiKeysRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiListProjectApiKeysQueryParams struct {
+type ProgrammaticAPIKeysApiListProjectApiKeysParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1880,7 +1880,7 @@ type ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiRemoveProjectApiKeyQueryParams struct {
+type ProgrammaticAPIKeysApiRemoveProjectApiKeyParams struct {
 		GroupId string
 		ApiUserId string
 }
@@ -2002,7 +2002,7 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRequest struct {
 	apiUser *ApiUser
 }
 
-type ProgrammaticAPIKeysApiUpdateApiKeyQueryParams struct {
+type ProgrammaticAPIKeysApiUpdateApiKeyParams struct {
 		OrgId string
 		ApiUserId string
 		ApiUser *ApiUser
@@ -2150,7 +2150,7 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest struct {
 	includeCount *bool
 }
 
-type ProgrammaticAPIKeysApiUpdateApiKeyRolesQueryParams struct {
+type ProgrammaticAPIKeysApiUpdateApiKeyRolesParams struct {
 		GroupId string
 		ApiUserId string
 		CreateApiKey *CreateApiKey

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -253,7 +253,7 @@ type ProgrammaticAPIKeysApiAddProjectApiKeyRequest struct {
 	userRoleAssignment *[]UserRoleAssignment
 }
 
-type ProgrammaticAPIKeysApiAddProjectApiKeyParams struct {
+type AddProjectApiKeyParams struct {
 		GroupId string
 		ApiUserId string
 		UserRoleAssignment *[]UserRoleAssignment
@@ -397,7 +397,7 @@ type ProgrammaticAPIKeysApiCreateApiKeyRequest struct {
 	createApiKey *CreateApiKey
 }
 
-type ProgrammaticAPIKeysApiCreateApiKeyParams struct {
+type CreateApiKeyParams struct {
 		OrgId string
 		CreateApiKey *CreateApiKey
 }
@@ -535,7 +535,7 @@ type ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiCreateApiKeyAccessListParams struct {
+type CreateApiKeyAccessListParams struct {
 		OrgId string
 		ApiUserId string
 		UserAccessList *[]UserAccessList
@@ -721,7 +721,7 @@ type ProgrammaticAPIKeysApiCreateProjectApiKeyRequest struct {
 	createApiKey *CreateApiKey
 }
 
-type ProgrammaticAPIKeysApiCreateProjectApiKeyParams struct {
+type CreateProjectApiKeyParams struct {
 		GroupId string
 		CreateApiKey *CreateApiKey
 }
@@ -855,7 +855,7 @@ type ProgrammaticAPIKeysApiDeleteApiKeyRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiDeleteApiKeyParams struct {
+type DeleteApiKeyParams struct {
 		OrgId string
 		ApiUserId string
 }
@@ -977,7 +977,7 @@ type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest struct {
 	ipAddress string
 }
 
-type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryParams struct {
+type DeleteApiKeyAccessListEntryParams struct {
 		OrgId string
 		ApiUserId string
 		IpAddress string
@@ -1102,7 +1102,7 @@ type ProgrammaticAPIKeysApiGetApiKeyRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiGetApiKeyParams struct {
+type GetApiKeyParams struct {
 		OrgId string
 		ApiUserId string
 }
@@ -1235,7 +1235,7 @@ type ProgrammaticAPIKeysApiGetApiKeyAccessListRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiGetApiKeyAccessListParams struct {
+type GetApiKeyAccessListParams struct {
 		OrgId string
 		IpAddress string
 		ApiUserId string
@@ -1374,7 +1374,7 @@ type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesParams struct {
+type ListApiKeyAccessListsEntriesParams struct {
 		OrgId string
 		ApiUserId string
 		IncludeCount *bool
@@ -1550,7 +1550,7 @@ type ProgrammaticAPIKeysApiListApiKeysRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiListApiKeysParams struct {
+type ListApiKeysParams struct {
 		OrgId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1716,7 +1716,7 @@ type ProgrammaticAPIKeysApiListProjectApiKeysRequest struct {
 	pageNum *int32
 }
 
-type ProgrammaticAPIKeysApiListProjectApiKeysParams struct {
+type ListProjectApiKeysParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1880,7 +1880,7 @@ type ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest struct {
 	apiUserId string
 }
 
-type ProgrammaticAPIKeysApiRemoveProjectApiKeyParams struct {
+type RemoveProjectApiKeyParams struct {
 		GroupId string
 		ApiUserId string
 }
@@ -2002,7 +2002,7 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRequest struct {
 	apiUser *ApiUser
 }
 
-type ProgrammaticAPIKeysApiUpdateApiKeyParams struct {
+type UpdateApiKeyParams struct {
 		OrgId string
 		ApiUserId string
 		ApiUser *ApiUser
@@ -2150,7 +2150,7 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest struct {
 	includeCount *bool
 }
 
-type ProgrammaticAPIKeysApiUpdateApiKeyRolesParams struct {
+type UpdateApiKeyRolesParams struct {
 		GroupId string
 		ApiUserId string
 		CreateApiKey *CreateApiKey

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -252,6 +252,11 @@ type ProgrammaticAPIKeysApiAddProjectApiKeyRequest struct {
 	apiUserId string
 	userRoleAssignment *[]UserRoleAssignment
 }
+type ProgrammaticAPIKeysApiAddProjectApiKeyQueryParams struct {
+		groupId string
+		apiUserId string
+		userRoleAssignment *[]UserRoleAssignment
+}
 
 // Organization API key to be assigned to the specified project.
 func (r ProgrammaticAPIKeysApiAddProjectApiKeyRequest) UserRoleAssignment(userRoleAssignment []UserRoleAssignment) ProgrammaticAPIKeysApiAddProjectApiKeyRequest {
@@ -390,6 +395,10 @@ type ProgrammaticAPIKeysApiCreateApiKeyRequest struct {
 	orgId string
 	createApiKey *CreateApiKey
 }
+type ProgrammaticAPIKeysApiCreateApiKeyQueryParams struct {
+		orgId string
+		createApiKey *CreateApiKey
+}
 
 // Organization API Key to be created. This request requires a minimum of one of the two body parameters.
 func (r ProgrammaticAPIKeysApiCreateApiKeyRequest) CreateApiKey(createApiKey CreateApiKey) ProgrammaticAPIKeysApiCreateApiKeyRequest {
@@ -522,6 +531,14 @@ type ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type ProgrammaticAPIKeysApiCreateApiKeyAccessListQueryParams struct {
+		orgId string
+		apiUserId string
+		userAccessList *[]UserAccessList
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Access list entries to be created for the specified organization API key.
@@ -700,6 +717,10 @@ type ProgrammaticAPIKeysApiCreateProjectApiKeyRequest struct {
 	groupId string
 	createApiKey *CreateApiKey
 }
+type ProgrammaticAPIKeysApiCreateProjectApiKeyQueryParams struct {
+		groupId string
+		createApiKey *CreateApiKey
+}
 
 // Organization API key to be created and assigned to the specified project. This request requires a minimum of one of the two body parameters.
 func (r ProgrammaticAPIKeysApiCreateProjectApiKeyRequest) CreateApiKey(createApiKey CreateApiKey) ProgrammaticAPIKeysApiCreateProjectApiKeyRequest {
@@ -829,6 +850,10 @@ type ProgrammaticAPIKeysApiDeleteApiKeyRequest struct {
 	orgId string
 	apiUserId string
 }
+type ProgrammaticAPIKeysApiDeleteApiKeyQueryParams struct {
+		orgId string
+		apiUserId string
+}
 
 func (r ProgrammaticAPIKeysApiDeleteApiKeyRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteApiKeyExecute(r)
@@ -945,6 +970,11 @@ type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest struct {
 	orgId string
 	apiUserId string
 	ipAddress string
+}
+type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryQueryParams struct {
+		orgId string
+		apiUserId string
+		ipAddress string
 }
 
 func (r ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest) Execute() (*http.Response, error) {
@@ -1064,6 +1094,10 @@ type ProgrammaticAPIKeysApiGetApiKeyRequest struct {
 	ApiService ProgrammaticAPIKeysApi
 	orgId string
 	apiUserId string
+}
+type ProgrammaticAPIKeysApiGetApiKeyQueryParams struct {
+		orgId string
+		apiUserId string
 }
 
 func (r ProgrammaticAPIKeysApiGetApiKeyRequest) Execute() (*ApiUser, *http.Response, error) {
@@ -1192,6 +1226,11 @@ type ProgrammaticAPIKeysApiGetApiKeyAccessListRequest struct {
 	orgId string
 	ipAddress string
 	apiUserId string
+}
+type ProgrammaticAPIKeysApiGetApiKeyAccessListQueryParams struct {
+		orgId string
+		ipAddress string
+		apiUserId string
 }
 
 func (r ProgrammaticAPIKeysApiGetApiKeyAccessListRequest) Execute() (*UserAccessList, *http.Response, error) {
@@ -1325,6 +1364,13 @@ type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesQueryParams struct {
+		orgId string
+		apiUserId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1494,6 +1540,12 @@ type ProgrammaticAPIKeysApiListApiKeysRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type ProgrammaticAPIKeysApiListApiKeysQueryParams struct {
+		orgId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ProgrammaticAPIKeysApiListApiKeysRequest) IncludeCount(includeCount bool) ProgrammaticAPIKeysApiListApiKeysRequest {
@@ -1653,6 +1705,12 @@ type ProgrammaticAPIKeysApiListProjectApiKeysRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type ProgrammaticAPIKeysApiListProjectApiKeysQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ProgrammaticAPIKeysApiListProjectApiKeysRequest) IncludeCount(includeCount bool) ProgrammaticAPIKeysApiListProjectApiKeysRequest {
@@ -1810,6 +1868,10 @@ type ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest struct {
 	groupId string
 	apiUserId string
 }
+type ProgrammaticAPIKeysApiRemoveProjectApiKeyQueryParams struct {
+		groupId string
+		apiUserId string
+}
 
 func (r ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectApiKeyExecute(r)
@@ -1926,6 +1988,11 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRequest struct {
 	orgId string
 	apiUserId string
 	apiUser *ApiUser
+}
+type ProgrammaticAPIKeysApiUpdateApiKeyQueryParams struct {
+		orgId string
+		apiUserId string
+		apiUser *ApiUser
 }
 
 // Organization API key to be updated. This request requires a minimum of one of the two body parameters.
@@ -2068,6 +2135,14 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest struct {
 	pageNum *int32
 	itemsPerPage *int32
 	includeCount *bool
+}
+type ProgrammaticAPIKeysApiUpdateApiKeyRolesQueryParams struct {
+		groupId string
+		apiUserId string
+		createApiKey *CreateApiKey
+		pageNum *int32
+		itemsPerPage *int32
+		includeCount *bool
 }
 
 // Organization API Key to be updated. This request requires a minimum of one of the two body parameters.

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -252,10 +252,11 @@ type ProgrammaticAPIKeysApiAddProjectApiKeyRequest struct {
 	apiUserId string
 	userRoleAssignment *[]UserRoleAssignment
 }
+
 type ProgrammaticAPIKeysApiAddProjectApiKeyQueryParams struct {
-		groupId string
-		apiUserId string
-		userRoleAssignment *[]UserRoleAssignment
+		GroupId string
+		ApiUserId string
+		UserRoleAssignment *[]UserRoleAssignment
 }
 
 // Organization API key to be assigned to the specified project.
@@ -395,9 +396,10 @@ type ProgrammaticAPIKeysApiCreateApiKeyRequest struct {
 	orgId string
 	createApiKey *CreateApiKey
 }
+
 type ProgrammaticAPIKeysApiCreateApiKeyQueryParams struct {
-		orgId string
-		createApiKey *CreateApiKey
+		OrgId string
+		CreateApiKey *CreateApiKey
 }
 
 // Organization API Key to be created. This request requires a minimum of one of the two body parameters.
@@ -532,13 +534,14 @@ type ProgrammaticAPIKeysApiCreateApiKeyAccessListRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ProgrammaticAPIKeysApiCreateApiKeyAccessListQueryParams struct {
-		orgId string
-		apiUserId string
-		userAccessList *[]UserAccessList
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		OrgId string
+		ApiUserId string
+		UserAccessList *[]UserAccessList
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Access list entries to be created for the specified organization API key.
@@ -717,9 +720,10 @@ type ProgrammaticAPIKeysApiCreateProjectApiKeyRequest struct {
 	groupId string
 	createApiKey *CreateApiKey
 }
+
 type ProgrammaticAPIKeysApiCreateProjectApiKeyQueryParams struct {
-		groupId string
-		createApiKey *CreateApiKey
+		GroupId string
+		CreateApiKey *CreateApiKey
 }
 
 // Organization API key to be created and assigned to the specified project. This request requires a minimum of one of the two body parameters.
@@ -850,9 +854,10 @@ type ProgrammaticAPIKeysApiDeleteApiKeyRequest struct {
 	orgId string
 	apiUserId string
 }
+
 type ProgrammaticAPIKeysApiDeleteApiKeyQueryParams struct {
-		orgId string
-		apiUserId string
+		OrgId string
+		ApiUserId string
 }
 
 func (r ProgrammaticAPIKeysApiDeleteApiKeyRequest) Execute() (*http.Response, error) {
@@ -971,10 +976,11 @@ type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest struct {
 	apiUserId string
 	ipAddress string
 }
+
 type ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryQueryParams struct {
-		orgId string
-		apiUserId string
-		ipAddress string
+		OrgId string
+		ApiUserId string
+		IpAddress string
 }
 
 func (r ProgrammaticAPIKeysApiDeleteApiKeyAccessListEntryRequest) Execute() (*http.Response, error) {
@@ -1095,9 +1101,10 @@ type ProgrammaticAPIKeysApiGetApiKeyRequest struct {
 	orgId string
 	apiUserId string
 }
+
 type ProgrammaticAPIKeysApiGetApiKeyQueryParams struct {
-		orgId string
-		apiUserId string
+		OrgId string
+		ApiUserId string
 }
 
 func (r ProgrammaticAPIKeysApiGetApiKeyRequest) Execute() (*ApiUser, *http.Response, error) {
@@ -1227,10 +1234,11 @@ type ProgrammaticAPIKeysApiGetApiKeyAccessListRequest struct {
 	ipAddress string
 	apiUserId string
 }
+
 type ProgrammaticAPIKeysApiGetApiKeyAccessListQueryParams struct {
-		orgId string
-		ipAddress string
-		apiUserId string
+		OrgId string
+		IpAddress string
+		ApiUserId string
 }
 
 func (r ProgrammaticAPIKeysApiGetApiKeyAccessListRequest) Execute() (*UserAccessList, *http.Response, error) {
@@ -1365,12 +1373,13 @@ type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ProgrammaticAPIKeysApiListApiKeyAccessListsEntriesQueryParams struct {
-		orgId string
-		apiUserId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		OrgId string
+		ApiUserId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1540,11 +1549,12 @@ type ProgrammaticAPIKeysApiListApiKeysRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ProgrammaticAPIKeysApiListApiKeysQueryParams struct {
-		orgId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		OrgId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1705,11 +1715,12 @@ type ProgrammaticAPIKeysApiListProjectApiKeysRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ProgrammaticAPIKeysApiListProjectApiKeysQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1868,9 +1879,10 @@ type ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest struct {
 	groupId string
 	apiUserId string
 }
+
 type ProgrammaticAPIKeysApiRemoveProjectApiKeyQueryParams struct {
-		groupId string
-		apiUserId string
+		GroupId string
+		ApiUserId string
 }
 
 func (r ProgrammaticAPIKeysApiRemoveProjectApiKeyRequest) Execute() (*http.Response, error) {
@@ -1989,10 +2001,11 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRequest struct {
 	apiUserId string
 	apiUser *ApiUser
 }
+
 type ProgrammaticAPIKeysApiUpdateApiKeyQueryParams struct {
-		orgId string
-		apiUserId string
-		apiUser *ApiUser
+		OrgId string
+		ApiUserId string
+		ApiUser *ApiUser
 }
 
 // Organization API key to be updated. This request requires a minimum of one of the two body parameters.
@@ -2136,13 +2149,14 @@ type ProgrammaticAPIKeysApiUpdateApiKeyRolesRequest struct {
 	itemsPerPage *int32
 	includeCount *bool
 }
+
 type ProgrammaticAPIKeysApiUpdateApiKeyRolesQueryParams struct {
-		groupId string
-		apiUserId string
-		createApiKey *CreateApiKey
-		pageNum *int32
-		itemsPerPage *int32
-		includeCount *bool
+		GroupId string
+		ApiUserId string
+		CreateApiKey *CreateApiKey
+		PageNum *int32
+		ItemsPerPage *int32
+		IncludeCount *bool
 }
 
 // Organization API Key to be updated. This request requires a minimum of one of the two body parameters.

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -112,12 +112,13 @@ type ProjectIPAccessListApiCreateProjectIpAccessListRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ProjectIPAccessListApiCreateProjectIpAccessListQueryParams struct {
-		groupId string
-		networkPermissionEntry *[]NetworkPermissionEntry
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		NetworkPermissionEntry *[]NetworkPermissionEntry
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // One or more access list entries to add to the specified project.
@@ -287,9 +288,10 @@ type ProjectIPAccessListApiDeleteProjectIpAccessListRequest struct {
 	groupId string
 	entryValue string
 }
+
 type ProjectIPAccessListApiDeleteProjectIpAccessListQueryParams struct {
-		groupId string
-		entryValue string
+		GroupId string
+		EntryValue string
 }
 
 func (r ProjectIPAccessListApiDeleteProjectIpAccessListRequest) Execute() (*http.Response, error) {
@@ -401,9 +403,10 @@ type ProjectIPAccessListApiGetProjectIpAccessListStatusRequest struct {
 	groupId string
 	entryValue string
 }
+
 type ProjectIPAccessListApiGetProjectIpAccessListStatusQueryParams struct {
-		groupId string
-		entryValue string
+		GroupId string
+		EntryValue string
 }
 
 func (r ProjectIPAccessListApiGetProjectIpAccessListStatusRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
@@ -526,9 +529,10 @@ type ProjectIPAccessListApiGetProjectIpListRequest struct {
 	groupId string
 	entryValue string
 }
+
 type ProjectIPAccessListApiGetProjectIpListQueryParams struct {
-		groupId string
-		entryValue string
+		GroupId string
+		EntryValue string
 }
 
 func (r ProjectIPAccessListApiGetProjectIpListRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
@@ -653,11 +657,12 @@ type ProjectIPAccessListApiListProjectIpAccessListsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ProjectIPAccessListApiListProjectIpAccessListsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -113,7 +113,7 @@ type ProjectIPAccessListApiCreateProjectIpAccessListRequest struct {
 	pageNum *int32
 }
 
-type ProjectIPAccessListApiCreateProjectIpAccessListParams struct {
+type CreateProjectIpAccessListParams struct {
 		GroupId string
 		NetworkPermissionEntry *[]NetworkPermissionEntry
 		IncludeCount *bool
@@ -289,7 +289,7 @@ type ProjectIPAccessListApiDeleteProjectIpAccessListRequest struct {
 	entryValue string
 }
 
-type ProjectIPAccessListApiDeleteProjectIpAccessListParams struct {
+type DeleteProjectIpAccessListParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -404,7 +404,7 @@ type ProjectIPAccessListApiGetProjectIpAccessListStatusRequest struct {
 	entryValue string
 }
 
-type ProjectIPAccessListApiGetProjectIpAccessListStatusParams struct {
+type GetProjectIpAccessListStatusParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -530,7 +530,7 @@ type ProjectIPAccessListApiGetProjectIpListRequest struct {
 	entryValue string
 }
 
-type ProjectIPAccessListApiGetProjectIpListParams struct {
+type GetProjectIpListParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -658,7 +658,7 @@ type ProjectIPAccessListApiListProjectIpAccessListsRequest struct {
 	pageNum *int32
 }
 
-type ProjectIPAccessListApiListProjectIpAccessListsParams struct {
+type ListProjectIpAccessListsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -113,7 +113,7 @@ type CreateProjectIpAccessListApiRequest struct {
 	pageNum *int32
 }
 
-type CreateProjectIpAccessListParams struct {
+type CreateProjectIpAccessListApiParams struct {
 		GroupId string
 		NetworkPermissionEntry *[]NetworkPermissionEntry
 		IncludeCount *bool
@@ -289,7 +289,7 @@ type DeleteProjectIpAccessListApiRequest struct {
 	entryValue string
 }
 
-type DeleteProjectIpAccessListParams struct {
+type DeleteProjectIpAccessListApiParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -404,7 +404,7 @@ type GetProjectIpAccessListStatusApiRequest struct {
 	entryValue string
 }
 
-type GetProjectIpAccessListStatusParams struct {
+type GetProjectIpAccessListStatusApiParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -530,7 +530,7 @@ type GetProjectIpListApiRequest struct {
 	entryValue string
 }
 
-type GetProjectIpListParams struct {
+type GetProjectIpListApiParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -658,7 +658,7 @@ type ListProjectIpAccessListsApiRequest struct {
 	pageNum *int32
 }
 
-type ListProjectIpAccessListsParams struct {
+type ListProjectIpAccessListsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -29,13 +29,13 @@ type ProjectIPAccessListApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectIPAccessListApiCreateProjectIpAccessListRequest
+	@return CreateProjectIpAccessListApiRequest
 	*/
-	CreateProjectIpAccessList(ctx context.Context, groupId string) ProjectIPAccessListApiCreateProjectIpAccessListRequest
+	CreateProjectIpAccessList(ctx context.Context, groupId string) CreateProjectIpAccessListApiRequest
 
 	// CreateProjectIpAccessListExecute executes the request
 	//  @return PaginatedNetworkAccess
-	CreateProjectIpAccessListExecute(r ProjectIPAccessListApiCreateProjectIpAccessListRequest) (*PaginatedNetworkAccess, *http.Response, error)
+	CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 
 	/*
 	DeleteProjectIpAccessList Remove One Entry from One Project IP Access List
@@ -45,12 +45,12 @@ type ProjectIPAccessListApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param entryValue Access list entry that you want to remove from the project's IP access list. This value can use one of the following: one AWS security group ID, one IP address, or one CIDR block of addresses. For CIDR blocks that use a subnet mask, replace the forward slash (`/`) with its URL-encoded value (`%2F`). When you remove an entry from the IP access list, existing connections from the removed address or addresses may remain open for a variable amount of time. The amount of time it takes MongoDB Cloud to close the connection depends upon several factors, including:  - how your application established the connection, - how MongoDB Cloud or the driver using the address behaves, and - which protocol (like TCP or UDP) the connection uses.
-	@return ProjectIPAccessListApiDeleteProjectIpAccessListRequest
+	@return DeleteProjectIpAccessListApiRequest
 	*/
-	DeleteProjectIpAccessList(ctx context.Context, groupId string, entryValue string) ProjectIPAccessListApiDeleteProjectIpAccessListRequest
+	DeleteProjectIpAccessList(ctx context.Context, groupId string, entryValue string) DeleteProjectIpAccessListApiRequest
 
 	// DeleteProjectIpAccessListExecute executes the request
-	DeleteProjectIpAccessListExecute(r ProjectIPAccessListApiDeleteProjectIpAccessListRequest) (*http.Response, error)
+	DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (*http.Response, error)
 
 	/*
 	GetProjectIpAccessListStatus Return Status of One Project IP Access List Entry
@@ -60,13 +60,13 @@ type ProjectIPAccessListApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param entryValue Network address or cloud provider security construct that identifies which project access list entry to be verified.
-	@return ProjectIPAccessListApiGetProjectIpAccessListStatusRequest
+	@return GetProjectIpAccessListStatusApiRequest
 	*/
-	GetProjectIpAccessListStatus(ctx context.Context, groupId string, entryValue string) ProjectIPAccessListApiGetProjectIpAccessListStatusRequest
+	GetProjectIpAccessListStatus(ctx context.Context, groupId string, entryValue string) GetProjectIpAccessListStatusApiRequest
 
 	// GetProjectIpAccessListStatusExecute executes the request
 	//  @return NetworkPermissionEntryStatus
-	GetProjectIpAccessListStatusExecute(r ProjectIPAccessListApiGetProjectIpAccessListStatusRequest) (*NetworkPermissionEntryStatus, *http.Response, error)
+	GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error)
 
 	/*
 	GetProjectIpList Return One Project IP Access List Entry
@@ -76,13 +76,13 @@ type ProjectIPAccessListApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param entryValue Access list entry that you want to return from the project's IP access list. This value can use one of the following: one AWS security group ID, one IP address, or one CIDR block of addresses. For CIDR blocks that use a subnet mask, replace the forward slash (`/`) with its URL-encoded value (`%2F`).
-	@return ProjectIPAccessListApiGetProjectIpListRequest
+	@return GetProjectIpListApiRequest
 	*/
-	GetProjectIpList(ctx context.Context, groupId string, entryValue string) ProjectIPAccessListApiGetProjectIpListRequest
+	GetProjectIpList(ctx context.Context, groupId string, entryValue string) GetProjectIpListApiRequest
 
 	// GetProjectIpListExecute executes the request
 	//  @return NetworkPermissionEntry
-	GetProjectIpListExecute(r ProjectIPAccessListApiGetProjectIpListRequest) (*NetworkPermissionEntry, *http.Response, error)
+	GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error)
 
 	/*
 	ListProjectIpAccessLists Return Project IP Access List
@@ -91,19 +91,19 @@ type ProjectIPAccessListApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectIPAccessListApiListProjectIpAccessListsRequest
+	@return ListProjectIpAccessListsApiRequest
 	*/
-	ListProjectIpAccessLists(ctx context.Context, groupId string) ProjectIPAccessListApiListProjectIpAccessListsRequest
+	ListProjectIpAccessLists(ctx context.Context, groupId string) ListProjectIpAccessListsApiRequest
 
 	// ListProjectIpAccessListsExecute executes the request
 	//  @return PaginatedNetworkAccess
-	ListProjectIpAccessListsExecute(r ProjectIPAccessListApiListProjectIpAccessListsRequest) (*PaginatedNetworkAccess, *http.Response, error)
+	ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 }
 
 // ProjectIPAccessListApiService ProjectIPAccessListApi service
 type ProjectIPAccessListApiService service
 
-type ProjectIPAccessListApiCreateProjectIpAccessListRequest struct {
+type CreateProjectIpAccessListApiRequest struct {
 	ctx context.Context
 	ApiService ProjectIPAccessListApi
 	groupId string
@@ -122,30 +122,30 @@ type CreateProjectIpAccessListParams struct {
 }
 
 // One or more access list entries to add to the specified project.
-func (r ProjectIPAccessListApiCreateProjectIpAccessListRequest) NetworkPermissionEntry(networkPermissionEntry []NetworkPermissionEntry) ProjectIPAccessListApiCreateProjectIpAccessListRequest {
+func (r CreateProjectIpAccessListApiRequest) NetworkPermissionEntry(networkPermissionEntry []NetworkPermissionEntry) CreateProjectIpAccessListApiRequest {
 	r.networkPermissionEntry = &networkPermissionEntry
 	return r
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProjectIPAccessListApiCreateProjectIpAccessListRequest) IncludeCount(includeCount bool) ProjectIPAccessListApiCreateProjectIpAccessListRequest {
+func (r CreateProjectIpAccessListApiRequest) IncludeCount(includeCount bool) CreateProjectIpAccessListApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProjectIPAccessListApiCreateProjectIpAccessListRequest) ItemsPerPage(itemsPerPage int32) ProjectIPAccessListApiCreateProjectIpAccessListRequest {
+func (r CreateProjectIpAccessListApiRequest) ItemsPerPage(itemsPerPage int32) CreateProjectIpAccessListApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProjectIPAccessListApiCreateProjectIpAccessListRequest) PageNum(pageNum int32) ProjectIPAccessListApiCreateProjectIpAccessListRequest {
+func (r CreateProjectIpAccessListApiRequest) PageNum(pageNum int32) CreateProjectIpAccessListApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ProjectIPAccessListApiCreateProjectIpAccessListRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
+func (r CreateProjectIpAccessListApiRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
 	return r.ApiService.CreateProjectIpAccessListExecute(r)
 }
 
@@ -156,10 +156,10 @@ Adds one or more access list entries to the specified project. MongoDB Cloud onl
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectIPAccessListApiCreateProjectIpAccessListRequest
+ @return CreateProjectIpAccessListApiRequest
 */
-func (a *ProjectIPAccessListApiService) CreateProjectIpAccessList(ctx context.Context, groupId string) ProjectIPAccessListApiCreateProjectIpAccessListRequest {
-	return ProjectIPAccessListApiCreateProjectIpAccessListRequest{
+func (a *ProjectIPAccessListApiService) CreateProjectIpAccessList(ctx context.Context, groupId string) CreateProjectIpAccessListApiRequest {
+	return CreateProjectIpAccessListApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -168,7 +168,7 @@ func (a *ProjectIPAccessListApiService) CreateProjectIpAccessList(ctx context.Co
 
 // Execute executes the request
 //  @return PaginatedNetworkAccess
-func (a *ProjectIPAccessListApiService) CreateProjectIpAccessListExecute(r ProjectIPAccessListApiCreateProjectIpAccessListRequest) (*PaginatedNetworkAccess, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -282,7 +282,7 @@ func (a *ProjectIPAccessListApiService) CreateProjectIpAccessListExecute(r Proje
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectIPAccessListApiDeleteProjectIpAccessListRequest struct {
+type DeleteProjectIpAccessListApiRequest struct {
 	ctx context.Context
 	ApiService ProjectIPAccessListApi
 	groupId string
@@ -294,7 +294,7 @@ type DeleteProjectIpAccessListParams struct {
 		EntryValue string
 }
 
-func (r ProjectIPAccessListApiDeleteProjectIpAccessListRequest) Execute() (*http.Response, error) {
+func (r DeleteProjectIpAccessListApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectIpAccessListExecute(r)
 }
 
@@ -306,10 +306,10 @@ Removes one access list entry from the specified project's IP access list. Each 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param entryValue Access list entry that you want to remove from the project's IP access list. This value can use one of the following: one AWS security group ID, one IP address, or one CIDR block of addresses. For CIDR blocks that use a subnet mask, replace the forward slash (`/`) with its URL-encoded value (`%2F`). When you remove an entry from the IP access list, existing connections from the removed address or addresses may remain open for a variable amount of time. The amount of time it takes MongoDB Cloud to close the connection depends upon several factors, including:  - how your application established the connection, - how MongoDB Cloud or the driver using the address behaves, and - which protocol (like TCP or UDP) the connection uses.
- @return ProjectIPAccessListApiDeleteProjectIpAccessListRequest
+ @return DeleteProjectIpAccessListApiRequest
 */
-func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessList(ctx context.Context, groupId string, entryValue string) ProjectIPAccessListApiDeleteProjectIpAccessListRequest {
-	return ProjectIPAccessListApiDeleteProjectIpAccessListRequest{
+func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessList(ctx context.Context, groupId string, entryValue string) DeleteProjectIpAccessListApiRequest {
+	return DeleteProjectIpAccessListApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -318,7 +318,7 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessList(ctx context.Co
 }
 
 // Execute executes the request
-func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r ProjectIPAccessListApiDeleteProjectIpAccessListRequest) (*http.Response, error) {
+func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -397,7 +397,7 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r Proje
 	return localVarHTTPResponse, nil
 }
 
-type ProjectIPAccessListApiGetProjectIpAccessListStatusRequest struct {
+type GetProjectIpAccessListStatusApiRequest struct {
 	ctx context.Context
 	ApiService ProjectIPAccessListApi
 	groupId string
@@ -409,7 +409,7 @@ type GetProjectIpAccessListStatusParams struct {
 		EntryValue string
 }
 
-func (r ProjectIPAccessListApiGetProjectIpAccessListStatusRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
+func (r GetProjectIpAccessListStatusApiRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
 	return r.ApiService.GetProjectIpAccessListStatusExecute(r)
 }
 
@@ -421,10 +421,10 @@ Returns the status of one project IP access list entry. This resource checks if 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param entryValue Network address or cloud provider security construct that identifies which project access list entry to be verified.
- @return ProjectIPAccessListApiGetProjectIpAccessListStatusRequest
+ @return GetProjectIpAccessListStatusApiRequest
 */
-func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatus(ctx context.Context, groupId string, entryValue string) ProjectIPAccessListApiGetProjectIpAccessListStatusRequest {
-	return ProjectIPAccessListApiGetProjectIpAccessListStatusRequest{
+func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatus(ctx context.Context, groupId string, entryValue string) GetProjectIpAccessListStatusApiRequest {
+	return GetProjectIpAccessListStatusApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -434,7 +434,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatus(ctx context
 
 // Execute executes the request
 //  @return NetworkPermissionEntryStatus
-func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusExecute(r ProjectIPAccessListApiGetProjectIpAccessListStatusRequest) (*NetworkPermissionEntryStatus, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -523,7 +523,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusExecute(r Pr
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectIPAccessListApiGetProjectIpListRequest struct {
+type GetProjectIpListApiRequest struct {
 	ctx context.Context
 	ApiService ProjectIPAccessListApi
 	groupId string
@@ -535,7 +535,7 @@ type GetProjectIpListParams struct {
 		EntryValue string
 }
 
-func (r ProjectIPAccessListApiGetProjectIpListRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
+func (r GetProjectIpListApiRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
 	return r.ApiService.GetProjectIpListExecute(r)
 }
 
@@ -547,10 +547,10 @@ Returns one access list entry from the specified project's IP access list. Each 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param entryValue Access list entry that you want to return from the project's IP access list. This value can use one of the following: one AWS security group ID, one IP address, or one CIDR block of addresses. For CIDR blocks that use a subnet mask, replace the forward slash (`/`) with its URL-encoded value (`%2F`).
- @return ProjectIPAccessListApiGetProjectIpListRequest
+ @return GetProjectIpListApiRequest
 */
-func (a *ProjectIPAccessListApiService) GetProjectIpList(ctx context.Context, groupId string, entryValue string) ProjectIPAccessListApiGetProjectIpListRequest {
-	return ProjectIPAccessListApiGetProjectIpListRequest{
+func (a *ProjectIPAccessListApiService) GetProjectIpList(ctx context.Context, groupId string, entryValue string) GetProjectIpListApiRequest {
+	return GetProjectIpListApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -560,7 +560,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpList(ctx context.Context, gr
 
 // Execute executes the request
 //  @return NetworkPermissionEntry
-func (a *ProjectIPAccessListApiService) GetProjectIpListExecute(r ProjectIPAccessListApiGetProjectIpListRequest) (*NetworkPermissionEntry, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -649,7 +649,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpListExecute(r ProjectIPAcces
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectIPAccessListApiListProjectIpAccessListsRequest struct {
+type ListProjectIpAccessListsApiRequest struct {
 	ctx context.Context
 	ApiService ProjectIPAccessListApi
 	groupId string
@@ -666,24 +666,24 @@ type ListProjectIpAccessListsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProjectIPAccessListApiListProjectIpAccessListsRequest) IncludeCount(includeCount bool) ProjectIPAccessListApiListProjectIpAccessListsRequest {
+func (r ListProjectIpAccessListsApiRequest) IncludeCount(includeCount bool) ListProjectIpAccessListsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProjectIPAccessListApiListProjectIpAccessListsRequest) ItemsPerPage(itemsPerPage int32) ProjectIPAccessListApiListProjectIpAccessListsRequest {
+func (r ListProjectIpAccessListsApiRequest) ItemsPerPage(itemsPerPage int32) ListProjectIpAccessListsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProjectIPAccessListApiListProjectIpAccessListsRequest) PageNum(pageNum int32) ProjectIPAccessListApiListProjectIpAccessListsRequest {
+func (r ListProjectIpAccessListsApiRequest) PageNum(pageNum int32) ListProjectIpAccessListsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ProjectIPAccessListApiListProjectIpAccessListsRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
+func (r ListProjectIpAccessListsApiRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
 	return r.ApiService.ListProjectIpAccessListsExecute(r)
 }
 
@@ -694,10 +694,10 @@ Returns all access list entries from the specified project's IP access list. Eac
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectIPAccessListApiListProjectIpAccessListsRequest
+ @return ListProjectIpAccessListsApiRequest
 */
-func (a *ProjectIPAccessListApiService) ListProjectIpAccessLists(ctx context.Context, groupId string) ProjectIPAccessListApiListProjectIpAccessListsRequest {
-	return ProjectIPAccessListApiListProjectIpAccessListsRequest{
+func (a *ProjectIPAccessListApiService) ListProjectIpAccessLists(ctx context.Context, groupId string) ListProjectIpAccessListsApiRequest {
+	return ListProjectIpAccessListsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -706,7 +706,7 @@ func (a *ProjectIPAccessListApiService) ListProjectIpAccessLists(ctx context.Con
 
 // Execute executes the request
 //  @return PaginatedNetworkAccess
-func (a *ProjectIPAccessListApiService) ListProjectIpAccessListsExecute(r ProjectIPAccessListApiListProjectIpAccessListsRequest) (*PaginatedNetworkAccess, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -113,7 +113,7 @@ type ProjectIPAccessListApiCreateProjectIpAccessListRequest struct {
 	pageNum *int32
 }
 
-type ProjectIPAccessListApiCreateProjectIpAccessListQueryParams struct {
+type ProjectIPAccessListApiCreateProjectIpAccessListParams struct {
 		GroupId string
 		NetworkPermissionEntry *[]NetworkPermissionEntry
 		IncludeCount *bool
@@ -289,7 +289,7 @@ type ProjectIPAccessListApiDeleteProjectIpAccessListRequest struct {
 	entryValue string
 }
 
-type ProjectIPAccessListApiDeleteProjectIpAccessListQueryParams struct {
+type ProjectIPAccessListApiDeleteProjectIpAccessListParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -404,7 +404,7 @@ type ProjectIPAccessListApiGetProjectIpAccessListStatusRequest struct {
 	entryValue string
 }
 
-type ProjectIPAccessListApiGetProjectIpAccessListStatusQueryParams struct {
+type ProjectIPAccessListApiGetProjectIpAccessListStatusParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -530,7 +530,7 @@ type ProjectIPAccessListApiGetProjectIpListRequest struct {
 	entryValue string
 }
 
-type ProjectIPAccessListApiGetProjectIpListQueryParams struct {
+type ProjectIPAccessListApiGetProjectIpListParams struct {
 		GroupId string
 		EntryValue string
 }
@@ -658,7 +658,7 @@ type ProjectIPAccessListApiListProjectIpAccessListsRequest struct {
 	pageNum *int32
 }
 
-type ProjectIPAccessListApiListProjectIpAccessListsQueryParams struct {
+type ProjectIPAccessListApiListProjectIpAccessListsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -112,6 +112,13 @@ type ProjectIPAccessListApiCreateProjectIpAccessListRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type ProjectIPAccessListApiCreateProjectIpAccessListQueryParams struct {
+		groupId string
+		networkPermissionEntry *[]NetworkPermissionEntry
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // One or more access list entries to add to the specified project.
 func (r ProjectIPAccessListApiCreateProjectIpAccessListRequest) NetworkPermissionEntry(networkPermissionEntry []NetworkPermissionEntry) ProjectIPAccessListApiCreateProjectIpAccessListRequest {
@@ -280,6 +287,10 @@ type ProjectIPAccessListApiDeleteProjectIpAccessListRequest struct {
 	groupId string
 	entryValue string
 }
+type ProjectIPAccessListApiDeleteProjectIpAccessListQueryParams struct {
+		groupId string
+		entryValue string
+}
 
 func (r ProjectIPAccessListApiDeleteProjectIpAccessListRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectIpAccessListExecute(r)
@@ -389,6 +400,10 @@ type ProjectIPAccessListApiGetProjectIpAccessListStatusRequest struct {
 	ApiService ProjectIPAccessListApi
 	groupId string
 	entryValue string
+}
+type ProjectIPAccessListApiGetProjectIpAccessListStatusQueryParams struct {
+		groupId string
+		entryValue string
 }
 
 func (r ProjectIPAccessListApiGetProjectIpAccessListStatusRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
@@ -510,6 +525,10 @@ type ProjectIPAccessListApiGetProjectIpListRequest struct {
 	ApiService ProjectIPAccessListApi
 	groupId string
 	entryValue string
+}
+type ProjectIPAccessListApiGetProjectIpListQueryParams struct {
+		groupId string
+		entryValue string
 }
 
 func (r ProjectIPAccessListApiGetProjectIpListRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
@@ -633,6 +652,12 @@ type ProjectIPAccessListApiListProjectIpAccessListsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type ProjectIPAccessListApiListProjectIpAccessListsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -335,9 +335,10 @@ type ProjectsApiCreateProjectRequest struct {
 	group *Group
 	projectOwnerId *string
 }
+
 type ProjectsApiCreateProjectQueryParams struct {
-		group *Group
-		projectOwnerId *string
+		Group *Group
+		ProjectOwnerId *string
 }
 
 // Creates one project.
@@ -468,9 +469,10 @@ type ProjectsApiCreateProjectInvitationRequest struct {
 	groupId string
 	groupInvitationRequest *GroupInvitationRequest
 }
+
 type ProjectsApiCreateProjectInvitationQueryParams struct {
-		groupId string
-		groupInvitationRequest *GroupInvitationRequest
+		GroupId string
+		GroupInvitationRequest *GroupInvitationRequest
 }
 
 // Invites one MongoDB Cloud user to join the specified project.
@@ -600,8 +602,9 @@ type ProjectsApiDeleteProjectRequest struct {
 	ApiService ProjectsApi
 	groupId string
 }
+
 type ProjectsApiDeleteProjectQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r ProjectsApiDeleteProjectRequest) Execute() (*http.Response, error) {
@@ -710,9 +713,10 @@ type ProjectsApiDeleteProjectInvitationRequest struct {
 	groupId string
 	invitationId string
 }
+
 type ProjectsApiDeleteProjectInvitationQueryParams struct {
-		groupId string
-		invitationId string
+		GroupId string
+		InvitationId string
 }
 
 func (r ProjectsApiDeleteProjectInvitationRequest) Execute() (*http.Response, error) {
@@ -830,9 +834,10 @@ type ProjectsApiDeleteProjectLimitRequest struct {
 	limitName string
 	groupId string
 }
+
 type ProjectsApiDeleteProjectLimitQueryParams struct {
-		limitName string
-		groupId string
+		LimitName string
+		GroupId string
 }
 
 func (r ProjectsApiDeleteProjectLimitRequest) Execute() (*http.Response, error) {
@@ -943,8 +948,9 @@ type ProjectsApiGetProjectRequest struct {
 	ApiService ProjectsApi
 	groupId string
 }
+
 type ProjectsApiGetProjectQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r ProjectsApiGetProjectRequest) Execute() (*Group, *http.Response, error) {
@@ -1063,8 +1069,9 @@ type ProjectsApiGetProjectByNameRequest struct {
 	ApiService ProjectsApi
 	groupName string
 }
+
 type ProjectsApiGetProjectByNameQueryParams struct {
-		groupName string
+		GroupName string
 }
 
 func (r ProjectsApiGetProjectByNameRequest) Execute() (*Group, *http.Response, error) {
@@ -1184,9 +1191,10 @@ type ProjectsApiGetProjectInvitationRequest struct {
 	groupId string
 	invitationId string
 }
+
 type ProjectsApiGetProjectInvitationQueryParams struct {
-		groupId string
-		invitationId string
+		GroupId string
+		InvitationId string
 }
 
 func (r ProjectsApiGetProjectInvitationRequest) Execute() (*GroupInvitation, *http.Response, error) {
@@ -1315,9 +1323,10 @@ type ProjectsApiGetProjectLimitRequest struct {
 	limitName string
 	groupId string
 }
+
 type ProjectsApiGetProjectLimitQueryParams struct {
-		limitName string
-		groupId string
+		LimitName string
+		GroupId string
 }
 
 func (r ProjectsApiGetProjectLimitRequest) Execute() (*Limit, *http.Response, error) {
@@ -1439,8 +1448,9 @@ type ProjectsApiGetProjectSettingsRequest struct {
 	ApiService ProjectsApi
 	groupId string
 }
+
 type ProjectsApiGetProjectSettingsQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r ProjectsApiGetProjectSettingsRequest) Execute() (*GroupSettings, *http.Response, error) {
@@ -1560,9 +1570,10 @@ type ProjectsApiListProjectInvitationsRequest struct {
 	groupId string
 	username *string
 }
+
 type ProjectsApiListProjectInvitationsQueryParams struct {
-		groupId string
-		username *string
+		GroupId string
+		Username *string
 }
 
 // Email address of the user account invited to this project.
@@ -1690,8 +1701,9 @@ type ProjectsApiListProjectLimitsRequest struct {
 	ApiService ProjectsApi
 	groupId string
 }
+
 type ProjectsApiListProjectLimitsQueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r ProjectsApiListProjectLimitsRequest) Execute() (*Limit, *http.Response, error) {
@@ -1815,13 +1827,14 @@ type ProjectsApiListProjectUsersRequest struct {
 	flattenTeams *bool
 	includeOrgUsers *bool
 }
+
 type ProjectsApiListProjectUsersQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
-		flattenTeams *bool
-		includeOrgUsers *bool
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
+		FlattenTeams *bool
+		IncludeOrgUsers *bool
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -2007,10 +2020,11 @@ type ProjectsApiListProjectsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ProjectsApiListProjectsQueryParams struct {
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -2160,9 +2174,10 @@ type ProjectsApiRemoveProjectUserRequest struct {
 	groupId string
 	userId string
 }
+
 type ProjectsApiRemoveProjectUserQueryParams struct {
-		groupId string
-		userId string
+		GroupId string
+		UserId string
 }
 
 func (r ProjectsApiRemoveProjectUserRequest) Execute() (*http.Response, error) {
@@ -2281,10 +2296,11 @@ type ProjectsApiSetProjectLimitRequest struct {
 	groupId string
 	limit *Limit
 }
+
 type ProjectsApiSetProjectLimitQueryParams struct {
-		limitName string
-		groupId string
-		limit *Limit
+		LimitName string
+		GroupId string
+		Limit *Limit
 }
 
 func (r ProjectsApiSetProjectLimitRequest) Limit(limit Limit) ProjectsApiSetProjectLimitRequest {
@@ -2416,9 +2432,10 @@ type ProjectsApiUpdateProjectRequest struct {
 	groupId string
 	groupName *GroupName
 }
+
 type ProjectsApiUpdateProjectQueryParams struct {
-		groupId string
-		groupName *GroupName
+		GroupId string
+		GroupName *GroupName
 }
 
 func (r ProjectsApiUpdateProjectRequest) GroupName(groupName GroupName) ProjectsApiUpdateProjectRequest {
@@ -2545,9 +2562,10 @@ type ProjectsApiUpdateProjectInvitationRequest struct {
 	groupId string
 	groupInvitationRequest *GroupInvitationRequest
 }
+
 type ProjectsApiUpdateProjectInvitationQueryParams struct {
-		groupId string
-		groupInvitationRequest *GroupInvitationRequest
+		GroupId string
+		GroupInvitationRequest *GroupInvitationRequest
 }
 
 // Updates the details of one pending invitation to the specified project.
@@ -2679,10 +2697,11 @@ type ProjectsApiUpdateProjectInvitationByIdRequest struct {
 	invitationId string
 	groupInvitationUpdateRequest *GroupInvitationUpdateRequest
 }
+
 type ProjectsApiUpdateProjectInvitationByIdQueryParams struct {
-		groupId string
-		invitationId string
-		groupInvitationUpdateRequest *GroupInvitationUpdateRequest
+		GroupId string
+		InvitationId string
+		GroupInvitationUpdateRequest *GroupInvitationUpdateRequest
 }
 
 // Updates the details of one pending invitation to the specified project.
@@ -2822,9 +2841,10 @@ type ProjectsApiUpdateProjectSettingsRequest struct {
 	groupId string
 	groupSettings *GroupSettings
 }
+
 type ProjectsApiUpdateProjectSettingsQueryParams struct {
-		groupId string
-		groupSettings *GroupSettings
+		GroupId string
+		GroupSettings *GroupSettings
 }
 
 func (r ProjectsApiUpdateProjectSettingsRequest) GroupSettings(groupSettings GroupSettings) ProjectsApiUpdateProjectSettingsRequest {

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -28,13 +28,13 @@ type ProjectsApi interface {
 	Creates one project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings. To use this resource, the requesting API Key must have the Read Write role. This resource doesn't require the API Key to have an Access List.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ProjectsApiCreateProjectRequest
+	@return CreateProjectApiRequest
 	*/
-	CreateProject(ctx context.Context) ProjectsApiCreateProjectRequest
+	CreateProject(ctx context.Context) CreateProjectApiRequest
 
 	// CreateProjectExecute executes the request
 	//  @return Group
-	CreateProjectExecute(r ProjectsApiCreateProjectRequest) (*Group, *http.Response, error)
+	CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 	CreateProjectInvitation Invite One MongoDB Cloud User to Join One Project
@@ -43,13 +43,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiCreateProjectInvitationRequest
+	@return CreateProjectInvitationApiRequest
 	*/
-	CreateProjectInvitation(ctx context.Context, groupId string) ProjectsApiCreateProjectInvitationRequest
+	CreateProjectInvitation(ctx context.Context, groupId string) CreateProjectInvitationApiRequest
 
 	// CreateProjectInvitationExecute executes the request
 	//  @return GroupInvitation
-	CreateProjectInvitationExecute(r ProjectsApiCreateProjectInvitationRequest) (*GroupInvitation, *http.Response, error)
+	CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	DeleteProject Remove One Project
@@ -58,12 +58,12 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiDeleteProjectRequest
+	@return DeleteProjectApiRequest
 	*/
-	DeleteProject(ctx context.Context, groupId string) ProjectsApiDeleteProjectRequest
+	DeleteProject(ctx context.Context, groupId string) DeleteProjectApiRequest
 
 	// DeleteProjectExecute executes the request
-	DeleteProjectExecute(r ProjectsApiDeleteProjectRequest) (*http.Response, error)
+	DeleteProjectExecute(r DeleteProjectApiRequest) (*http.Response, error)
 
 	/*
 	DeleteProjectInvitation Cancel One Project Invitation
@@ -73,12 +73,12 @@ type ProjectsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
-	@return ProjectsApiDeleteProjectInvitationRequest
+	@return DeleteProjectInvitationApiRequest
 	*/
-	DeleteProjectInvitation(ctx context.Context, groupId string, invitationId string) ProjectsApiDeleteProjectInvitationRequest
+	DeleteProjectInvitation(ctx context.Context, groupId string, invitationId string) DeleteProjectInvitationApiRequest
 
 	// DeleteProjectInvitationExecute executes the request
-	DeleteProjectInvitationExecute(r ProjectsApiDeleteProjectInvitationRequest) (*http.Response, error)
+	DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (*http.Response, error)
 
 	/*
 	DeleteProjectLimit Remove One Project Limit
@@ -88,12 +88,12 @@ type ProjectsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param limitName Human-readable label that identifies this project limit.  | Limit Name | Description | Default | API Override Limit | | --- | --- | --- | --- | | atlas.project.deployment.clusters | Limit on the number of clusters in this project | 25 | 90 | | atlas.project.deployment.nodesPerPrivateLinkRegion | Limit on the number of nodes per Private Link region in this project | 50 | 90 | | atlas.project.security.databaseAccess.customRoles | Limit on the number of custom roles in this project | 100 | 1400 | | atlas.project.security.databaseAccess.users | Limit on the number of database users in this project | 100 | 900 | | atlas.project.security.networkAccess.crossRegionEntries | Limit on the number of cross-region network access entries in this project | 40 | 220 | | atlas.project.security.networkAccess.entries | Limit on the number of network access entries in this project | 200 | 20 | | dataFederation.bytesProcessed.query | Limit on the number of bytes processed during a single Data Federation query | N/A | N/A | | dataFederation.bytesProcessed.daily | Limit on the number of bytes processed across all Data Federation tenants for the current day | N/A | N/A | | dataFederation.bytesProcessed.weekly | Limit on the number of bytes processed across all Data Federation tenants for the current week | N/A | N/A | | dataFederation.bytesProcessed.monthly | Limit on the number of bytes processed across all Data Federation tenants for the current month | N/A | N/A | 
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiDeleteProjectLimitRequest
+	@return DeleteProjectLimitApiRequest
 	*/
-	DeleteProjectLimit(ctx context.Context, limitName string, groupId string) ProjectsApiDeleteProjectLimitRequest
+	DeleteProjectLimit(ctx context.Context, limitName string, groupId string) DeleteProjectLimitApiRequest
 
 	// DeleteProjectLimitExecute executes the request
-	DeleteProjectLimitExecute(r ProjectsApiDeleteProjectLimitRequest) (*http.Response, error)
+	DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (*http.Response, error)
 
 	/*
 	GetProject Return One Project
@@ -102,13 +102,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiGetProjectRequest
+	@return GetProjectApiRequest
 	*/
-	GetProject(ctx context.Context, groupId string) ProjectsApiGetProjectRequest
+	GetProject(ctx context.Context, groupId string) GetProjectApiRequest
 
 	// GetProjectExecute executes the request
 	//  @return Group
-	GetProjectExecute(r ProjectsApiGetProjectRequest) (*Group, *http.Response, error)
+	GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 	GetProjectByName Return One Project using Its Name
@@ -117,13 +117,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupName Human-readable label that identifies this project.
-	@return ProjectsApiGetProjectByNameRequest
+	@return GetProjectByNameApiRequest
 	*/
-	GetProjectByName(ctx context.Context, groupName string) ProjectsApiGetProjectByNameRequest
+	GetProjectByName(ctx context.Context, groupName string) GetProjectByNameApiRequest
 
 	// GetProjectByNameExecute executes the request
 	//  @return Group
-	GetProjectByNameExecute(r ProjectsApiGetProjectByNameRequest) (*Group, *http.Response, error)
+	GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error)
 
 	/*
 	GetProjectInvitation Return One Project Invitation
@@ -133,13 +133,13 @@ type ProjectsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
-	@return ProjectsApiGetProjectInvitationRequest
+	@return GetProjectInvitationApiRequest
 	*/
-	GetProjectInvitation(ctx context.Context, groupId string, invitationId string) ProjectsApiGetProjectInvitationRequest
+	GetProjectInvitation(ctx context.Context, groupId string, invitationId string) GetProjectInvitationApiRequest
 
 	// GetProjectInvitationExecute executes the request
 	//  @return GroupInvitation
-	GetProjectInvitationExecute(r ProjectsApiGetProjectInvitationRequest) (*GroupInvitation, *http.Response, error)
+	GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	GetProjectLimit Return One Limit for One Project
@@ -149,13 +149,13 @@ type ProjectsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param limitName Human-readable label that identifies this project limit.  | Limit Name | Description | Default | API Override Limit | | --- | --- | --- | --- | | atlas.project.deployment.clusters | Limit on the number of clusters in this project | 25 | 90 | | atlas.project.deployment.nodesPerPrivateLinkRegion | Limit on the number of nodes per Private Link region in this project | 50 | 90 | | atlas.project.security.databaseAccess.customRoles | Limit on the number of custom roles in this project | 100 | 1400 | | atlas.project.security.databaseAccess.users | Limit on the number of database users in this project | 100 | 900 | | atlas.project.security.networkAccess.crossRegionEntries | Limit on the number of cross-region network access entries in this project | 40 | 220 | | atlas.project.security.networkAccess.entries | Limit on the number of network access entries in this project | 200 | 20 | | dataFederation.bytesProcessed.query | Limit on the number of bytes processed during a single Data Federation query | N/A | N/A | | dataFederation.bytesProcessed.daily | Limit on the number of bytes processed across all Data Federation tenants for the current day | N/A | N/A | | dataFederation.bytesProcessed.weekly | Limit on the number of bytes processed across all Data Federation tenants for the current week | N/A | N/A | | dataFederation.bytesProcessed.monthly | Limit on the number of bytes processed across all Data Federation tenants for the current month | N/A | N/A | 
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiGetProjectLimitRequest
+	@return GetProjectLimitApiRequest
 	*/
-	GetProjectLimit(ctx context.Context, limitName string, groupId string) ProjectsApiGetProjectLimitRequest
+	GetProjectLimit(ctx context.Context, limitName string, groupId string) GetProjectLimitApiRequest
 
 	// GetProjectLimitExecute executes the request
 	//  @return Limit
-	GetProjectLimitExecute(r ProjectsApiGetProjectLimitRequest) (*Limit, *http.Response, error)
+	GetProjectLimitExecute(r GetProjectLimitApiRequest) (*Limit, *http.Response, error)
 
 	/*
 	GetProjectSettings Return One Project Settings
@@ -164,13 +164,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiGetProjectSettingsRequest
+	@return GetProjectSettingsApiRequest
 	*/
-	GetProjectSettings(ctx context.Context, groupId string) ProjectsApiGetProjectSettingsRequest
+	GetProjectSettings(ctx context.Context, groupId string) GetProjectSettingsApiRequest
 
 	// GetProjectSettingsExecute executes the request
 	//  @return GroupSettings
-	GetProjectSettingsExecute(r ProjectsApiGetProjectSettingsRequest) (*GroupSettings, *http.Response, error)
+	GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 
 	/*
 	ListProjectInvitations Return All Project Invitations
@@ -179,13 +179,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiListProjectInvitationsRequest
+	@return ListProjectInvitationsApiRequest
 	*/
-	ListProjectInvitations(ctx context.Context, groupId string) ProjectsApiListProjectInvitationsRequest
+	ListProjectInvitations(ctx context.Context, groupId string) ListProjectInvitationsApiRequest
 
 	// ListProjectInvitationsExecute executes the request
 	//  @return []GroupInvitation
-	ListProjectInvitationsExecute(r ProjectsApiListProjectInvitationsRequest) ([]GroupInvitation, *http.Response, error)
+	ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error)
 
 	/*
 	ListProjectLimits Return All Limits for One Project
@@ -194,13 +194,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiListProjectLimitsRequest
+	@return ListProjectLimitsApiRequest
 	*/
-	ListProjectLimits(ctx context.Context, groupId string) ProjectsApiListProjectLimitsRequest
+	ListProjectLimits(ctx context.Context, groupId string) ListProjectLimitsApiRequest
 
 	// ListProjectLimitsExecute executes the request
 	//  @return Limit
-	ListProjectLimitsExecute(r ProjectsApiListProjectLimitsRequest) (*Limit, *http.Response, error)
+	ListProjectLimitsExecute(r ListProjectLimitsApiRequest) (*Limit, *http.Response, error)
 
 	/*
 	ListProjectUsers Return All Users in One Project
@@ -209,13 +209,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiListProjectUsersRequest
+	@return ListProjectUsersApiRequest
 	*/
-	ListProjectUsers(ctx context.Context, groupId string) ProjectsApiListProjectUsersRequest
+	ListProjectUsers(ctx context.Context, groupId string) ListProjectUsersApiRequest
 
 	// ListProjectUsersExecute executes the request
 	//  @return PaginatedApiAppUser
-	ListProjectUsersExecute(r ProjectsApiListProjectUsersRequest) (*PaginatedApiAppUser, *http.Response, error)
+	ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 	ListProjects Return All Projects
@@ -223,13 +223,13 @@ type ProjectsApi interface {
 	Returns details about all projects. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings. To use this resource, the requesting API Key must have the Read Write role. This resource doesn't require the API Key to have an Access List.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ProjectsApiListProjectsRequest
+	@return ListProjectsApiRequest
 	*/
-	ListProjects(ctx context.Context) ProjectsApiListProjectsRequest
+	ListProjects(ctx context.Context) ListProjectsApiRequest
 
 	// ListProjectsExecute executes the request
 	//  @return PaginatedAtlasGroup
-	ListProjectsExecute(r ProjectsApiListProjectsRequest) (*PaginatedAtlasGroup, *http.Response, error)
+	ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
 	RemoveProjectUser Remove One User from One Project
@@ -239,12 +239,12 @@ type ProjectsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param userId Unique 24-hexadecimal string that identifies MongoDB Cloud user you want to remove from the specified project. To return a application user's ID using their application username, use the Get All application users in One Project endpoint.
-	@return ProjectsApiRemoveProjectUserRequest
+	@return RemoveProjectUserApiRequest
 	*/
-	RemoveProjectUser(ctx context.Context, groupId string, userId string) ProjectsApiRemoveProjectUserRequest
+	RemoveProjectUser(ctx context.Context, groupId string, userId string) RemoveProjectUserApiRequest
 
 	// RemoveProjectUserExecute executes the request
-	RemoveProjectUserExecute(r ProjectsApiRemoveProjectUserRequest) (*http.Response, error)
+	RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error)
 
 	/*
 	SetProjectLimit Set One Project Limit
@@ -256,13 +256,13 @@ type ProjectsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param limitName Human-readable label that identifies this project limit.  | Limit Name | Description | Default | API Override Limit | | --- | --- | --- | --- | | atlas.project.deployment.clusters | Limit on the number of clusters in this project | 25 | 90 | | atlas.project.deployment.nodesPerPrivateLinkRegion | Limit on the number of nodes per Private Link region in this project | 50 | 90 | | atlas.project.security.databaseAccess.customRoles | Limit on the number of custom roles in this project | 100 | 1400 | | atlas.project.security.databaseAccess.users | Limit on the number of database users in this project | 100 | 900 | | atlas.project.security.networkAccess.crossRegionEntries | Limit on the number of cross-region network access entries in this project | 40 | 220 | | atlas.project.security.networkAccess.entries | Limit on the number of network access entries in this project | 200 | 20 | | dataFederation.bytesProcessed.query | Limit on the number of bytes processed during a single Data Federation query | N/A | N/A | | dataFederation.bytesProcessed.daily | Limit on the number of bytes processed across all Data Federation tenants for the current day | N/A | N/A | | dataFederation.bytesProcessed.weekly | Limit on the number of bytes processed across all Data Federation tenants for the current week | N/A | N/A | | dataFederation.bytesProcessed.monthly | Limit on the number of bytes processed across all Data Federation tenants for the current month | N/A | N/A | 
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiSetProjectLimitRequest
+	@return SetProjectLimitApiRequest
 	*/
-	SetProjectLimit(ctx context.Context, limitName string, groupId string) ProjectsApiSetProjectLimitRequest
+	SetProjectLimit(ctx context.Context, limitName string, groupId string) SetProjectLimitApiRequest
 
 	// SetProjectLimitExecute executes the request
 	//  @return Limit
-	SetProjectLimitExecute(r ProjectsApiSetProjectLimitRequest) (*Limit, *http.Response, error)
+	SetProjectLimitExecute(r SetProjectLimitApiRequest) (*Limit, *http.Response, error)
 
 	/*
 	UpdateProject Update One Project Name
@@ -271,13 +271,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiUpdateProjectRequest
+	@return UpdateProjectApiRequest
 	*/
-	UpdateProject(ctx context.Context, groupId string) ProjectsApiUpdateProjectRequest
+	UpdateProject(ctx context.Context, groupId string) UpdateProjectApiRequest
 
 	// UpdateProjectExecute executes the request
 	//  @return Group
-	UpdateProjectExecute(r ProjectsApiUpdateProjectRequest) (*Group, *http.Response, error)
+	UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 	UpdateProjectInvitation Update One Project Invitation
@@ -286,13 +286,13 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiUpdateProjectInvitationRequest
+	@return UpdateProjectInvitationApiRequest
 	*/
-	UpdateProjectInvitation(ctx context.Context, groupId string) ProjectsApiUpdateProjectInvitationRequest
+	UpdateProjectInvitation(ctx context.Context, groupId string) UpdateProjectInvitationApiRequest
 
 	// UpdateProjectInvitationExecute executes the request
 	//  @return GroupInvitation
-	UpdateProjectInvitationExecute(r ProjectsApiUpdateProjectInvitationRequest) (*GroupInvitation, *http.Response, error)
+	UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	UpdateProjectInvitationById Update One Project Invitation by Invitation ID
@@ -302,13 +302,13 @@ type ProjectsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
-	@return ProjectsApiUpdateProjectInvitationByIdRequest
+	@return UpdateProjectInvitationByIdApiRequest
 	*/
-	UpdateProjectInvitationById(ctx context.Context, groupId string, invitationId string) ProjectsApiUpdateProjectInvitationByIdRequest
+	UpdateProjectInvitationById(ctx context.Context, groupId string, invitationId string) UpdateProjectInvitationByIdApiRequest
 
 	// UpdateProjectInvitationByIdExecute executes the request
 	//  @return GroupInvitation
-	UpdateProjectInvitationByIdExecute(r ProjectsApiUpdateProjectInvitationByIdRequest) (*GroupInvitation, *http.Response, error)
+	UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	UpdateProjectSettings Update One Project Settings
@@ -317,19 +317,19 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ProjectsApiUpdateProjectSettingsRequest
+	@return UpdateProjectSettingsApiRequest
 	*/
-	UpdateProjectSettings(ctx context.Context, groupId string) ProjectsApiUpdateProjectSettingsRequest
+	UpdateProjectSettings(ctx context.Context, groupId string) UpdateProjectSettingsApiRequest
 
 	// UpdateProjectSettingsExecute executes the request
 	//  @return GroupSettings
-	UpdateProjectSettingsExecute(r ProjectsApiUpdateProjectSettingsRequest) (*GroupSettings, *http.Response, error)
+	UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 }
 
 // ProjectsApiService ProjectsApi service
 type ProjectsApiService service
 
-type ProjectsApiCreateProjectRequest struct {
+type CreateProjectApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	group *Group
@@ -342,18 +342,18 @@ type CreateProjectParams struct {
 }
 
 // Creates one project.
-func (r ProjectsApiCreateProjectRequest) Group(group Group) ProjectsApiCreateProjectRequest {
+func (r CreateProjectApiRequest) Group(group Group) CreateProjectApiRequest {
 	r.group = &group
 	return r
 }
 
 // Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user to whom to grant the Project Owner role on the specified project. If you set this parameter, it overrides the default value of the oldest Organization Owner. 
-func (r ProjectsApiCreateProjectRequest) ProjectOwnerId(projectOwnerId string) ProjectsApiCreateProjectRequest {
+func (r CreateProjectApiRequest) ProjectOwnerId(projectOwnerId string) CreateProjectApiRequest {
 	r.projectOwnerId = &projectOwnerId
 	return r
 }
 
-func (r ProjectsApiCreateProjectRequest) Execute() (*Group, *http.Response, error) {
+func (r CreateProjectApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.CreateProjectExecute(r)
 }
 
@@ -363,10 +363,10 @@ CreateProject Create One Project
 Creates one project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings. To use this resource, the requesting API Key must have the Read Write role. This resource doesn't require the API Key to have an Access List.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ProjectsApiCreateProjectRequest
+ @return CreateProjectApiRequest
 */
-func (a *ProjectsApiService) CreateProject(ctx context.Context) ProjectsApiCreateProjectRequest {
-	return ProjectsApiCreateProjectRequest{
+func (a *ProjectsApiService) CreateProject(ctx context.Context) CreateProjectApiRequest {
+	return CreateProjectApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -374,7 +374,7 @@ func (a *ProjectsApiService) CreateProject(ctx context.Context) ProjectsApiCreat
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) CreateProjectExecute(r ProjectsApiCreateProjectRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -463,7 +463,7 @@ func (a *ProjectsApiService) CreateProjectExecute(r ProjectsApiCreateProjectRequ
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiCreateProjectInvitationRequest struct {
+type CreateProjectInvitationApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -476,12 +476,12 @@ type CreateProjectInvitationParams struct {
 }
 
 // Invites one MongoDB Cloud user to join the specified project.
-func (r ProjectsApiCreateProjectInvitationRequest) GroupInvitationRequest(groupInvitationRequest GroupInvitationRequest) ProjectsApiCreateProjectInvitationRequest {
+func (r CreateProjectInvitationApiRequest) GroupInvitationRequest(groupInvitationRequest GroupInvitationRequest) CreateProjectInvitationApiRequest {
 	r.groupInvitationRequest = &groupInvitationRequest
 	return r
 }
 
-func (r ProjectsApiCreateProjectInvitationRequest) Execute() (*GroupInvitation, *http.Response, error) {
+func (r CreateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
 	return r.ApiService.CreateProjectInvitationExecute(r)
 }
 
@@ -492,10 +492,10 @@ Invites one MongoDB Cloud user to join the specified project. The MongoDB Cloud 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiCreateProjectInvitationRequest
+ @return CreateProjectInvitationApiRequest
 */
-func (a *ProjectsApiService) CreateProjectInvitation(ctx context.Context, groupId string) ProjectsApiCreateProjectInvitationRequest {
-	return ProjectsApiCreateProjectInvitationRequest{
+func (a *ProjectsApiService) CreateProjectInvitation(ctx context.Context, groupId string) CreateProjectInvitationApiRequest {
+	return CreateProjectInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -504,7 +504,7 @@ func (a *ProjectsApiService) CreateProjectInvitation(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) CreateProjectInvitationExecute(r ProjectsApiCreateProjectInvitationRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -597,7 +597,7 @@ func (a *ProjectsApiService) CreateProjectInvitationExecute(r ProjectsApiCreateP
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiDeleteProjectRequest struct {
+type DeleteProjectApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -607,7 +607,7 @@ type DeleteProjectParams struct {
 		GroupId string
 }
 
-func (r ProjectsApiDeleteProjectRequest) Execute() (*http.Response, error) {
+func (r DeleteProjectApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectExecute(r)
 }
 
@@ -618,10 +618,10 @@ Removes the specified project. Projects group clusters into logical collections 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiDeleteProjectRequest
+ @return DeleteProjectApiRequest
 */
-func (a *ProjectsApiService) DeleteProject(ctx context.Context, groupId string) ProjectsApiDeleteProjectRequest {
-	return ProjectsApiDeleteProjectRequest{
+func (a *ProjectsApiService) DeleteProject(ctx context.Context, groupId string) DeleteProjectApiRequest {
+	return DeleteProjectApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -629,7 +629,7 @@ func (a *ProjectsApiService) DeleteProject(ctx context.Context, groupId string) 
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) DeleteProjectExecute(r ProjectsApiDeleteProjectRequest) (*http.Response, error) {
+func (a *ProjectsApiService) DeleteProjectExecute(r DeleteProjectApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -707,7 +707,7 @@ func (a *ProjectsApiService) DeleteProjectExecute(r ProjectsApiDeleteProjectRequ
 	return localVarHTTPResponse, nil
 }
 
-type ProjectsApiDeleteProjectInvitationRequest struct {
+type DeleteProjectInvitationApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -719,7 +719,7 @@ type DeleteProjectInvitationParams struct {
 		InvitationId string
 }
 
-func (r ProjectsApiDeleteProjectInvitationRequest) Execute() (*http.Response, error) {
+func (r DeleteProjectInvitationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectInvitationExecute(r)
 }
 
@@ -731,10 +731,10 @@ Cancels one pending invitation sent to the specified MongoDB Cloud user to join 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
- @return ProjectsApiDeleteProjectInvitationRequest
+ @return DeleteProjectInvitationApiRequest
 */
-func (a *ProjectsApiService) DeleteProjectInvitation(ctx context.Context, groupId string, invitationId string) ProjectsApiDeleteProjectInvitationRequest {
-	return ProjectsApiDeleteProjectInvitationRequest{
+func (a *ProjectsApiService) DeleteProjectInvitation(ctx context.Context, groupId string, invitationId string) DeleteProjectInvitationApiRequest {
+	return DeleteProjectInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -743,7 +743,7 @@ func (a *ProjectsApiService) DeleteProjectInvitation(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) DeleteProjectInvitationExecute(r ProjectsApiDeleteProjectInvitationRequest) (*http.Response, error) {
+func (a *ProjectsApiService) DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -828,7 +828,7 @@ func (a *ProjectsApiService) DeleteProjectInvitationExecute(r ProjectsApiDeleteP
 	return localVarHTTPResponse, nil
 }
 
-type ProjectsApiDeleteProjectLimitRequest struct {
+type DeleteProjectLimitApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	limitName string
@@ -840,7 +840,7 @@ type DeleteProjectLimitParams struct {
 		GroupId string
 }
 
-func (r ProjectsApiDeleteProjectLimitRequest) Execute() (*http.Response, error) {
+func (r DeleteProjectLimitApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectLimitExecute(r)
 }
 
@@ -852,10 +852,10 @@ Removes the specified project limit. Depending on the limit, Atlas either resets
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param limitName Human-readable label that identifies this project limit.  | Limit Name | Description | Default | API Override Limit | | --- | --- | --- | --- | | atlas.project.deployment.clusters | Limit on the number of clusters in this project | 25 | 90 | | atlas.project.deployment.nodesPerPrivateLinkRegion | Limit on the number of nodes per Private Link region in this project | 50 | 90 | | atlas.project.security.databaseAccess.customRoles | Limit on the number of custom roles in this project | 100 | 1400 | | atlas.project.security.databaseAccess.users | Limit on the number of database users in this project | 100 | 900 | | atlas.project.security.networkAccess.crossRegionEntries | Limit on the number of cross-region network access entries in this project | 40 | 220 | | atlas.project.security.networkAccess.entries | Limit on the number of network access entries in this project | 200 | 20 | | dataFederation.bytesProcessed.query | Limit on the number of bytes processed during a single Data Federation query | N/A | N/A | | dataFederation.bytesProcessed.daily | Limit on the number of bytes processed across all Data Federation tenants for the current day | N/A | N/A | | dataFederation.bytesProcessed.weekly | Limit on the number of bytes processed across all Data Federation tenants for the current week | N/A | N/A | | dataFederation.bytesProcessed.monthly | Limit on the number of bytes processed across all Data Federation tenants for the current month | N/A | N/A | 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiDeleteProjectLimitRequest
+ @return DeleteProjectLimitApiRequest
 */
-func (a *ProjectsApiService) DeleteProjectLimit(ctx context.Context, limitName string, groupId string) ProjectsApiDeleteProjectLimitRequest {
-	return ProjectsApiDeleteProjectLimitRequest{
+func (a *ProjectsApiService) DeleteProjectLimit(ctx context.Context, limitName string, groupId string) DeleteProjectLimitApiRequest {
+	return DeleteProjectLimitApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		limitName: limitName,
@@ -864,7 +864,7 @@ func (a *ProjectsApiService) DeleteProjectLimit(ctx context.Context, limitName s
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) DeleteProjectLimitExecute(r ProjectsApiDeleteProjectLimitRequest) (*http.Response, error) {
+func (a *ProjectsApiService) DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -943,7 +943,7 @@ func (a *ProjectsApiService) DeleteProjectLimitExecute(r ProjectsApiDeleteProjec
 	return localVarHTTPResponse, nil
 }
 
-type ProjectsApiGetProjectRequest struct {
+type GetProjectApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -953,7 +953,7 @@ type GetProjectParams struct {
 		GroupId string
 }
 
-func (r ProjectsApiGetProjectRequest) Execute() (*Group, *http.Response, error) {
+func (r GetProjectApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.GetProjectExecute(r)
 }
 
@@ -964,10 +964,10 @@ Returns details about the specified project. Projects group clusters into logica
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiGetProjectRequest
+ @return GetProjectApiRequest
 */
-func (a *ProjectsApiService) GetProject(ctx context.Context, groupId string) ProjectsApiGetProjectRequest {
-	return ProjectsApiGetProjectRequest{
+func (a *ProjectsApiService) GetProject(ctx context.Context, groupId string) GetProjectApiRequest {
+	return GetProjectApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -976,7 +976,7 @@ func (a *ProjectsApiService) GetProject(ctx context.Context, groupId string) Pro
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) GetProjectExecute(r ProjectsApiGetProjectRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1064,7 +1064,7 @@ func (a *ProjectsApiService) GetProjectExecute(r ProjectsApiGetProjectRequest) (
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiGetProjectByNameRequest struct {
+type GetProjectByNameApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupName string
@@ -1074,7 +1074,7 @@ type GetProjectByNameParams struct {
 		GroupName string
 }
 
-func (r ProjectsApiGetProjectByNameRequest) Execute() (*Group, *http.Response, error) {
+func (r GetProjectByNameApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.GetProjectByNameExecute(r)
 }
 
@@ -1085,10 +1085,10 @@ Returns details about the specified project. Projects group clusters into logica
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupName Human-readable label that identifies this project.
- @return ProjectsApiGetProjectByNameRequest
+ @return GetProjectByNameApiRequest
 */
-func (a *ProjectsApiService) GetProjectByName(ctx context.Context, groupName string) ProjectsApiGetProjectByNameRequest {
-	return ProjectsApiGetProjectByNameRequest{
+func (a *ProjectsApiService) GetProjectByName(ctx context.Context, groupName string) GetProjectByNameApiRequest {
+	return GetProjectByNameApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupName: groupName,
@@ -1097,7 +1097,7 @@ func (a *ProjectsApiService) GetProjectByName(ctx context.Context, groupName str
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) GetProjectByNameExecute(r ProjectsApiGetProjectByNameRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1185,7 +1185,7 @@ func (a *ProjectsApiService) GetProjectByNameExecute(r ProjectsApiGetProjectByNa
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiGetProjectInvitationRequest struct {
+type GetProjectInvitationApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -1197,7 +1197,7 @@ type GetProjectInvitationParams struct {
 		InvitationId string
 }
 
-func (r ProjectsApiGetProjectInvitationRequest) Execute() (*GroupInvitation, *http.Response, error) {
+func (r GetProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
 	return r.ApiService.GetProjectInvitationExecute(r)
 }
 
@@ -1209,10 +1209,10 @@ Returns the details of one pending invitation to the specified project. To use t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
- @return ProjectsApiGetProjectInvitationRequest
+ @return GetProjectInvitationApiRequest
 */
-func (a *ProjectsApiService) GetProjectInvitation(ctx context.Context, groupId string, invitationId string) ProjectsApiGetProjectInvitationRequest {
-	return ProjectsApiGetProjectInvitationRequest{
+func (a *ProjectsApiService) GetProjectInvitation(ctx context.Context, groupId string, invitationId string) GetProjectInvitationApiRequest {
+	return GetProjectInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1222,7 +1222,7 @@ func (a *ProjectsApiService) GetProjectInvitation(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) GetProjectInvitationExecute(r ProjectsApiGetProjectInvitationRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1317,7 +1317,7 @@ func (a *ProjectsApiService) GetProjectInvitationExecute(r ProjectsApiGetProject
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiGetProjectLimitRequest struct {
+type GetProjectLimitApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	limitName string
@@ -1329,7 +1329,7 @@ type GetProjectLimitParams struct {
 		GroupId string
 }
 
-func (r ProjectsApiGetProjectLimitRequest) Execute() (*Limit, *http.Response, error) {
+func (r GetProjectLimitApiRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.GetProjectLimitExecute(r)
 }
 
@@ -1341,10 +1341,10 @@ Returns the specified limit for the specified project. To use this resource, the
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param limitName Human-readable label that identifies this project limit.  | Limit Name | Description | Default | API Override Limit | | --- | --- | --- | --- | | atlas.project.deployment.clusters | Limit on the number of clusters in this project | 25 | 90 | | atlas.project.deployment.nodesPerPrivateLinkRegion | Limit on the number of nodes per Private Link region in this project | 50 | 90 | | atlas.project.security.databaseAccess.customRoles | Limit on the number of custom roles in this project | 100 | 1400 | | atlas.project.security.databaseAccess.users | Limit on the number of database users in this project | 100 | 900 | | atlas.project.security.networkAccess.crossRegionEntries | Limit on the number of cross-region network access entries in this project | 40 | 220 | | atlas.project.security.networkAccess.entries | Limit on the number of network access entries in this project | 200 | 20 | | dataFederation.bytesProcessed.query | Limit on the number of bytes processed during a single Data Federation query | N/A | N/A | | dataFederation.bytesProcessed.daily | Limit on the number of bytes processed across all Data Federation tenants for the current day | N/A | N/A | | dataFederation.bytesProcessed.weekly | Limit on the number of bytes processed across all Data Federation tenants for the current week | N/A | N/A | | dataFederation.bytesProcessed.monthly | Limit on the number of bytes processed across all Data Federation tenants for the current month | N/A | N/A | 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiGetProjectLimitRequest
+ @return GetProjectLimitApiRequest
 */
-func (a *ProjectsApiService) GetProjectLimit(ctx context.Context, limitName string, groupId string) ProjectsApiGetProjectLimitRequest {
-	return ProjectsApiGetProjectLimitRequest{
+func (a *ProjectsApiService) GetProjectLimit(ctx context.Context, limitName string, groupId string) GetProjectLimitApiRequest {
+	return GetProjectLimitApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		limitName: limitName,
@@ -1354,7 +1354,7 @@ func (a *ProjectsApiService) GetProjectLimit(ctx context.Context, limitName stri
 
 // Execute executes the request
 //  @return Limit
-func (a *ProjectsApiService) GetProjectLimitExecute(r ProjectsApiGetProjectLimitRequest) (*Limit, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectLimitExecute(r GetProjectLimitApiRequest) (*Limit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1443,7 +1443,7 @@ func (a *ProjectsApiService) GetProjectLimitExecute(r ProjectsApiGetProjectLimit
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiGetProjectSettingsRequest struct {
+type GetProjectSettingsApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -1453,7 +1453,7 @@ type GetProjectSettingsParams struct {
 		GroupId string
 }
 
-func (r ProjectsApiGetProjectSettingsRequest) Execute() (*GroupSettings, *http.Response, error) {
+func (r GetProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
 	return r.ApiService.GetProjectSettingsExecute(r)
 }
 
@@ -1464,10 +1464,10 @@ Returns details about the specified project's settings. To use this resource, th
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiGetProjectSettingsRequest
+ @return GetProjectSettingsApiRequest
 */
-func (a *ProjectsApiService) GetProjectSettings(ctx context.Context, groupId string) ProjectsApiGetProjectSettingsRequest {
-	return ProjectsApiGetProjectSettingsRequest{
+func (a *ProjectsApiService) GetProjectSettings(ctx context.Context, groupId string) GetProjectSettingsApiRequest {
+	return GetProjectSettingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1476,7 +1476,7 @@ func (a *ProjectsApiService) GetProjectSettings(ctx context.Context, groupId str
 
 // Execute executes the request
 //  @return GroupSettings
-func (a *ProjectsApiService) GetProjectSettingsExecute(r ProjectsApiGetProjectSettingsRequest) (*GroupSettings, *http.Response, error) {
+func (a *ProjectsApiService) GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1564,7 +1564,7 @@ func (a *ProjectsApiService) GetProjectSettingsExecute(r ProjectsApiGetProjectSe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiListProjectInvitationsRequest struct {
+type ListProjectInvitationsApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -1577,12 +1577,12 @@ type ListProjectInvitationsParams struct {
 }
 
 // Email address of the user account invited to this project.
-func (r ProjectsApiListProjectInvitationsRequest) Username(username string) ProjectsApiListProjectInvitationsRequest {
+func (r ListProjectInvitationsApiRequest) Username(username string) ListProjectInvitationsApiRequest {
 	r.username = &username
 	return r
 }
 
-func (r ProjectsApiListProjectInvitationsRequest) Execute() ([]GroupInvitation, *http.Response, error) {
+func (r ListProjectInvitationsApiRequest) Execute() ([]GroupInvitation, *http.Response, error) {
 	return r.ApiService.ListProjectInvitationsExecute(r)
 }
 
@@ -1593,10 +1593,10 @@ Returns all pending invitations to the specified project. To use this resource, 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiListProjectInvitationsRequest
+ @return ListProjectInvitationsApiRequest
 */
-func (a *ProjectsApiService) ListProjectInvitations(ctx context.Context, groupId string) ProjectsApiListProjectInvitationsRequest {
-	return ProjectsApiListProjectInvitationsRequest{
+func (a *ProjectsApiService) ListProjectInvitations(ctx context.Context, groupId string) ListProjectInvitationsApiRequest {
+	return ListProjectInvitationsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1605,7 +1605,7 @@ func (a *ProjectsApiService) ListProjectInvitations(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return []GroupInvitation
-func (a *ProjectsApiService) ListProjectInvitationsExecute(r ProjectsApiListProjectInvitationsRequest) ([]GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1696,7 +1696,7 @@ func (a *ProjectsApiService) ListProjectInvitationsExecute(r ProjectsApiListProj
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiListProjectLimitsRequest struct {
+type ListProjectLimitsApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -1706,7 +1706,7 @@ type ListProjectLimitsParams struct {
 		GroupId string
 }
 
-func (r ProjectsApiListProjectLimitsRequest) Execute() (*Limit, *http.Response, error) {
+func (r ListProjectLimitsApiRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.ListProjectLimitsExecute(r)
 }
 
@@ -1717,10 +1717,10 @@ Returns all the limits for the specified project. To use this resource, the requ
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiListProjectLimitsRequest
+ @return ListProjectLimitsApiRequest
 */
-func (a *ProjectsApiService) ListProjectLimits(ctx context.Context, groupId string) ProjectsApiListProjectLimitsRequest {
-	return ProjectsApiListProjectLimitsRequest{
+func (a *ProjectsApiService) ListProjectLimits(ctx context.Context, groupId string) ListProjectLimitsApiRequest {
+	return ListProjectLimitsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1729,7 +1729,7 @@ func (a *ProjectsApiService) ListProjectLimits(ctx context.Context, groupId stri
 
 // Execute executes the request
 //  @return Limit
-func (a *ProjectsApiService) ListProjectLimitsExecute(r ProjectsApiListProjectLimitsRequest) (*Limit, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectLimitsExecute(r ListProjectLimitsApiRequest) (*Limit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1817,7 +1817,7 @@ func (a *ProjectsApiService) ListProjectLimitsExecute(r ProjectsApiListProjectLi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiListProjectUsersRequest struct {
+type ListProjectUsersApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -1838,36 +1838,36 @@ type ListProjectUsersParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProjectsApiListProjectUsersRequest) IncludeCount(includeCount bool) ProjectsApiListProjectUsersRequest {
+func (r ListProjectUsersApiRequest) IncludeCount(includeCount bool) ListProjectUsersApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProjectsApiListProjectUsersRequest) ItemsPerPage(itemsPerPage int32) ProjectsApiListProjectUsersRequest {
+func (r ListProjectUsersApiRequest) ItemsPerPage(itemsPerPage int32) ListProjectUsersApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProjectsApiListProjectUsersRequest) PageNum(pageNum int32) ProjectsApiListProjectUsersRequest {
+func (r ListProjectUsersApiRequest) PageNum(pageNum int32) ListProjectUsersApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
 // Flag that indicates whether the returned list should include users who belong to a team with a role in this project. You might not have assigned the individual users a role in this project. If &#x60;\&quot;flattenTeams\&quot; : false&#x60;, this resource returns only users with a role in the project.  If &#x60;\&quot;flattenTeams\&quot; : true&#x60;, this resource returns both users with roles in the project and users who belong to teams with roles in the project.
-func (r ProjectsApiListProjectUsersRequest) FlattenTeams(flattenTeams bool) ProjectsApiListProjectUsersRequest {
+func (r ListProjectUsersApiRequest) FlattenTeams(flattenTeams bool) ListProjectUsersApiRequest {
 	r.flattenTeams = &flattenTeams
 	return r
 }
 
 // Flag that indicates whether the returned list should include users with implicit access to the project, the Organization Owner or Organization Read Only role. You might not have assigned the individual users a role in this project. If &#x60;\&quot;includeOrgUsers\&quot;: false&#x60;, this resource returns only users with a role in the project. If &#x60;\&quot;includeOrgUsers\&quot;: true&#x60;, this resource returns both users with roles in the project and users who have implicit access to the project through their organization role.
-func (r ProjectsApiListProjectUsersRequest) IncludeOrgUsers(includeOrgUsers bool) ProjectsApiListProjectUsersRequest {
+func (r ListProjectUsersApiRequest) IncludeOrgUsers(includeOrgUsers bool) ListProjectUsersApiRequest {
 	r.includeOrgUsers = &includeOrgUsers
 	return r
 }
 
-func (r ProjectsApiListProjectUsersRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
+func (r ListProjectUsersApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
 	return r.ApiService.ListProjectUsersExecute(r)
 }
 
@@ -1878,10 +1878,10 @@ Returns details about all users in the specified project. Users belong to an org
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiListProjectUsersRequest
+ @return ListProjectUsersApiRequest
 */
-func (a *ProjectsApiService) ListProjectUsers(ctx context.Context, groupId string) ProjectsApiListProjectUsersRequest {
-	return ProjectsApiListProjectUsersRequest{
+func (a *ProjectsApiService) ListProjectUsers(ctx context.Context, groupId string) ListProjectUsersApiRequest {
+	return ListProjectUsersApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1890,7 +1890,7 @@ func (a *ProjectsApiService) ListProjectUsers(ctx context.Context, groupId strin
 
 // Execute executes the request
 //  @return PaginatedApiAppUser
-func (a *ProjectsApiService) ListProjectUsersExecute(r ProjectsApiListProjectUsersRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2013,7 +2013,7 @@ func (a *ProjectsApiService) ListProjectUsersExecute(r ProjectsApiListProjectUse
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiListProjectsRequest struct {
+type ListProjectsApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	includeCount *bool
@@ -2028,24 +2028,24 @@ type ListProjectsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ProjectsApiListProjectsRequest) IncludeCount(includeCount bool) ProjectsApiListProjectsRequest {
+func (r ListProjectsApiRequest) IncludeCount(includeCount bool) ListProjectsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ProjectsApiListProjectsRequest) ItemsPerPage(itemsPerPage int32) ProjectsApiListProjectsRequest {
+func (r ListProjectsApiRequest) ItemsPerPage(itemsPerPage int32) ListProjectsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ProjectsApiListProjectsRequest) PageNum(pageNum int32) ProjectsApiListProjectsRequest {
+func (r ListProjectsApiRequest) PageNum(pageNum int32) ListProjectsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ProjectsApiListProjectsRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
+func (r ListProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
 	return r.ApiService.ListProjectsExecute(r)
 }
 
@@ -2055,10 +2055,10 @@ ListProjects Return All Projects
 Returns details about all projects. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings. To use this resource, the requesting API Key must have the Read Write role. This resource doesn't require the API Key to have an Access List.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ProjectsApiListProjectsRequest
+ @return ListProjectsApiRequest
 */
-func (a *ProjectsApiService) ListProjects(ctx context.Context) ProjectsApiListProjectsRequest {
-	return ProjectsApiListProjectsRequest{
+func (a *ProjectsApiService) ListProjects(ctx context.Context) ListProjectsApiRequest {
+	return ListProjectsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -2066,7 +2066,7 @@ func (a *ProjectsApiService) ListProjects(ctx context.Context) ProjectsApiListPr
 
 // Execute executes the request
 //  @return PaginatedAtlasGroup
-func (a *ProjectsApiService) ListProjectsExecute(r ProjectsApiListProjectsRequest) (*PaginatedAtlasGroup, *http.Response, error) {
+func (a *ProjectsApiService) ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2168,7 +2168,7 @@ func (a *ProjectsApiService) ListProjectsExecute(r ProjectsApiListProjectsReques
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiRemoveProjectUserRequest struct {
+type RemoveProjectUserApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -2180,7 +2180,7 @@ type RemoveProjectUserParams struct {
 		UserId string
 }
 
-func (r ProjectsApiRemoveProjectUserRequest) Execute() (*http.Response, error) {
+func (r RemoveProjectUserApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectUserExecute(r)
 }
 
@@ -2192,10 +2192,10 @@ Removes the specified user from the specified project. To use this resource, the
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param userId Unique 24-hexadecimal string that identifies MongoDB Cloud user you want to remove from the specified project. To return a application user's ID using their application username, use the Get All application users in One Project endpoint.
- @return ProjectsApiRemoveProjectUserRequest
+ @return RemoveProjectUserApiRequest
 */
-func (a *ProjectsApiService) RemoveProjectUser(ctx context.Context, groupId string, userId string) ProjectsApiRemoveProjectUserRequest {
-	return ProjectsApiRemoveProjectUserRequest{
+func (a *ProjectsApiService) RemoveProjectUser(ctx context.Context, groupId string, userId string) RemoveProjectUserApiRequest {
+	return RemoveProjectUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2204,7 +2204,7 @@ func (a *ProjectsApiService) RemoveProjectUser(ctx context.Context, groupId stri
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) RemoveProjectUserExecute(r ProjectsApiRemoveProjectUserRequest) (*http.Response, error) {
+func (a *ProjectsApiService) RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -2289,7 +2289,7 @@ func (a *ProjectsApiService) RemoveProjectUserExecute(r ProjectsApiRemoveProject
 	return localVarHTTPResponse, nil
 }
 
-type ProjectsApiSetProjectLimitRequest struct {
+type SetProjectLimitApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	limitName string
@@ -2303,12 +2303,12 @@ type SetProjectLimitParams struct {
 		Limit *Limit
 }
 
-func (r ProjectsApiSetProjectLimitRequest) Limit(limit Limit) ProjectsApiSetProjectLimitRequest {
+func (r SetProjectLimitApiRequest) Limit(limit Limit) SetProjectLimitApiRequest {
 	r.limit = &limit
 	return r
 }
 
-func (r ProjectsApiSetProjectLimitRequest) Execute() (*Limit, *http.Response, error) {
+func (r SetProjectLimitApiRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.SetProjectLimitExecute(r)
 }
 
@@ -2322,10 +2322,10 @@ Sets the specified project limit. To use this resource, the requesting API Key m
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param limitName Human-readable label that identifies this project limit.  | Limit Name | Description | Default | API Override Limit | | --- | --- | --- | --- | | atlas.project.deployment.clusters | Limit on the number of clusters in this project | 25 | 90 | | atlas.project.deployment.nodesPerPrivateLinkRegion | Limit on the number of nodes per Private Link region in this project | 50 | 90 | | atlas.project.security.databaseAccess.customRoles | Limit on the number of custom roles in this project | 100 | 1400 | | atlas.project.security.databaseAccess.users | Limit on the number of database users in this project | 100 | 900 | | atlas.project.security.networkAccess.crossRegionEntries | Limit on the number of cross-region network access entries in this project | 40 | 220 | | atlas.project.security.networkAccess.entries | Limit on the number of network access entries in this project | 200 | 20 | | dataFederation.bytesProcessed.query | Limit on the number of bytes processed during a single Data Federation query | N/A | N/A | | dataFederation.bytesProcessed.daily | Limit on the number of bytes processed across all Data Federation tenants for the current day | N/A | N/A | | dataFederation.bytesProcessed.weekly | Limit on the number of bytes processed across all Data Federation tenants for the current week | N/A | N/A | | dataFederation.bytesProcessed.monthly | Limit on the number of bytes processed across all Data Federation tenants for the current month | N/A | N/A | 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiSetProjectLimitRequest
+ @return SetProjectLimitApiRequest
 */
-func (a *ProjectsApiService) SetProjectLimit(ctx context.Context, limitName string, groupId string) ProjectsApiSetProjectLimitRequest {
-	return ProjectsApiSetProjectLimitRequest{
+func (a *ProjectsApiService) SetProjectLimit(ctx context.Context, limitName string, groupId string) SetProjectLimitApiRequest {
+	return SetProjectLimitApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		limitName: limitName,
@@ -2335,7 +2335,7 @@ func (a *ProjectsApiService) SetProjectLimit(ctx context.Context, limitName stri
 
 // Execute executes the request
 //  @return Limit
-func (a *ProjectsApiService) SetProjectLimitExecute(r ProjectsApiSetProjectLimitRequest) (*Limit, *http.Response, error) {
+func (a *ProjectsApiService) SetProjectLimitExecute(r SetProjectLimitApiRequest) (*Limit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2426,7 +2426,7 @@ func (a *ProjectsApiService) SetProjectLimitExecute(r ProjectsApiSetProjectLimit
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiUpdateProjectRequest struct {
+type UpdateProjectApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -2438,12 +2438,12 @@ type UpdateProjectParams struct {
 		GroupName *GroupName
 }
 
-func (r ProjectsApiUpdateProjectRequest) GroupName(groupName GroupName) ProjectsApiUpdateProjectRequest {
+func (r UpdateProjectApiRequest) GroupName(groupName GroupName) UpdateProjectApiRequest {
 	r.groupName = &groupName
 	return r
 }
 
-func (r ProjectsApiUpdateProjectRequest) Execute() (*Group, *http.Response, error) {
+func (r UpdateProjectApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.UpdateProjectExecute(r)
 }
 
@@ -2454,10 +2454,10 @@ Updates the human-readable label that identifies the specified project. To use t
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiUpdateProjectRequest
+ @return UpdateProjectApiRequest
 */
-func (a *ProjectsApiService) UpdateProject(ctx context.Context, groupId string) ProjectsApiUpdateProjectRequest {
-	return ProjectsApiUpdateProjectRequest{
+func (a *ProjectsApiService) UpdateProject(ctx context.Context, groupId string) UpdateProjectApiRequest {
+	return UpdateProjectApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2466,7 +2466,7 @@ func (a *ProjectsApiService) UpdateProject(ctx context.Context, groupId string) 
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) UpdateProjectExecute(r ProjectsApiUpdateProjectRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2556,7 +2556,7 @@ func (a *ProjectsApiService) UpdateProjectExecute(r ProjectsApiUpdateProjectRequ
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiUpdateProjectInvitationRequest struct {
+type UpdateProjectInvitationApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -2569,12 +2569,12 @@ type UpdateProjectInvitationParams struct {
 }
 
 // Updates the details of one pending invitation to the specified project.
-func (r ProjectsApiUpdateProjectInvitationRequest) GroupInvitationRequest(groupInvitationRequest GroupInvitationRequest) ProjectsApiUpdateProjectInvitationRequest {
+func (r UpdateProjectInvitationApiRequest) GroupInvitationRequest(groupInvitationRequest GroupInvitationRequest) UpdateProjectInvitationApiRequest {
 	r.groupInvitationRequest = &groupInvitationRequest
 	return r
 }
 
-func (r ProjectsApiUpdateProjectInvitationRequest) Execute() (*GroupInvitation, *http.Response, error) {
+func (r UpdateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
 	return r.ApiService.UpdateProjectInvitationExecute(r)
 }
 
@@ -2585,10 +2585,10 @@ Updates the details of one pending invitation to the specified project. To speci
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiUpdateProjectInvitationRequest
+ @return UpdateProjectInvitationApiRequest
 */
-func (a *ProjectsApiService) UpdateProjectInvitation(ctx context.Context, groupId string) ProjectsApiUpdateProjectInvitationRequest {
-	return ProjectsApiUpdateProjectInvitationRequest{
+func (a *ProjectsApiService) UpdateProjectInvitation(ctx context.Context, groupId string) UpdateProjectInvitationApiRequest {
+	return UpdateProjectInvitationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2597,7 +2597,7 @@ func (a *ProjectsApiService) UpdateProjectInvitation(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) UpdateProjectInvitationExecute(r ProjectsApiUpdateProjectInvitationRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2690,7 +2690,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationExecute(r ProjectsApiUpdateP
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiUpdateProjectInvitationByIdRequest struct {
+type UpdateProjectInvitationByIdApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -2705,12 +2705,12 @@ type UpdateProjectInvitationByIdParams struct {
 }
 
 // Updates the details of one pending invitation to the specified project.
-func (r ProjectsApiUpdateProjectInvitationByIdRequest) GroupInvitationUpdateRequest(groupInvitationUpdateRequest GroupInvitationUpdateRequest) ProjectsApiUpdateProjectInvitationByIdRequest {
+func (r UpdateProjectInvitationByIdApiRequest) GroupInvitationUpdateRequest(groupInvitationUpdateRequest GroupInvitationUpdateRequest) UpdateProjectInvitationByIdApiRequest {
 	r.groupInvitationUpdateRequest = &groupInvitationUpdateRequest
 	return r
 }
 
-func (r ProjectsApiUpdateProjectInvitationByIdRequest) Execute() (*GroupInvitation, *http.Response, error) {
+func (r UpdateProjectInvitationByIdApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
 	return r.ApiService.UpdateProjectInvitationByIdExecute(r)
 }
 
@@ -2722,10 +2722,10 @@ Updates the details of one pending invitation to the specified project. To speci
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param invitationId Unique 24-hexadecimal digit string that identifies the invitation.
- @return ProjectsApiUpdateProjectInvitationByIdRequest
+ @return UpdateProjectInvitationByIdApiRequest
 */
-func (a *ProjectsApiService) UpdateProjectInvitationById(ctx context.Context, groupId string, invitationId string) ProjectsApiUpdateProjectInvitationByIdRequest {
-	return ProjectsApiUpdateProjectInvitationByIdRequest{
+func (a *ProjectsApiService) UpdateProjectInvitationById(ctx context.Context, groupId string, invitationId string) UpdateProjectInvitationByIdApiRequest {
+	return UpdateProjectInvitationByIdApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2735,7 +2735,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationById(ctx context.Context, gr
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) UpdateProjectInvitationByIdExecute(r ProjectsApiUpdateProjectInvitationByIdRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2835,7 +2835,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationByIdExecute(r ProjectsApiUpd
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ProjectsApiUpdateProjectSettingsRequest struct {
+type UpdateProjectSettingsApiRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
@@ -2847,12 +2847,12 @@ type UpdateProjectSettingsParams struct {
 		GroupSettings *GroupSettings
 }
 
-func (r ProjectsApiUpdateProjectSettingsRequest) GroupSettings(groupSettings GroupSettings) ProjectsApiUpdateProjectSettingsRequest {
+func (r UpdateProjectSettingsApiRequest) GroupSettings(groupSettings GroupSettings) UpdateProjectSettingsApiRequest {
 	r.groupSettings = &groupSettings
 	return r
 }
 
-func (r ProjectsApiUpdateProjectSettingsRequest) Execute() (*GroupSettings, *http.Response, error) {
+func (r UpdateProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
 	return r.ApiService.UpdateProjectSettingsExecute(r)
 }
 
@@ -2863,10 +2863,10 @@ Updates the settings of the specified project. You can update any of the options
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ProjectsApiUpdateProjectSettingsRequest
+ @return UpdateProjectSettingsApiRequest
 */
-func (a *ProjectsApiService) UpdateProjectSettings(ctx context.Context, groupId string) ProjectsApiUpdateProjectSettingsRequest {
-	return ProjectsApiUpdateProjectSettingsRequest{
+func (a *ProjectsApiService) UpdateProjectSettings(ctx context.Context, groupId string) UpdateProjectSettingsApiRequest {
+	return UpdateProjectSettingsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -2875,7 +2875,7 @@ func (a *ProjectsApiService) UpdateProjectSettings(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return GroupSettings
-func (a *ProjectsApiService) UpdateProjectSettingsExecute(r ProjectsApiUpdateProjectSettingsRequest) (*GroupSettings, *http.Response, error) {
+func (a *ProjectsApiService) UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -336,7 +336,7 @@ type ProjectsApiCreateProjectRequest struct {
 	projectOwnerId *string
 }
 
-type ProjectsApiCreateProjectParams struct {
+type CreateProjectParams struct {
 		Group *Group
 		ProjectOwnerId *string
 }
@@ -470,7 +470,7 @@ type ProjectsApiCreateProjectInvitationRequest struct {
 	groupInvitationRequest *GroupInvitationRequest
 }
 
-type ProjectsApiCreateProjectInvitationParams struct {
+type CreateProjectInvitationParams struct {
 		GroupId string
 		GroupInvitationRequest *GroupInvitationRequest
 }
@@ -603,7 +603,7 @@ type ProjectsApiDeleteProjectRequest struct {
 	groupId string
 }
 
-type ProjectsApiDeleteProjectParams struct {
+type DeleteProjectParams struct {
 		GroupId string
 }
 
@@ -714,7 +714,7 @@ type ProjectsApiDeleteProjectInvitationRequest struct {
 	invitationId string
 }
 
-type ProjectsApiDeleteProjectInvitationParams struct {
+type DeleteProjectInvitationParams struct {
 		GroupId string
 		InvitationId string
 }
@@ -835,7 +835,7 @@ type ProjectsApiDeleteProjectLimitRequest struct {
 	groupId string
 }
 
-type ProjectsApiDeleteProjectLimitParams struct {
+type DeleteProjectLimitParams struct {
 		LimitName string
 		GroupId string
 }
@@ -949,7 +949,7 @@ type ProjectsApiGetProjectRequest struct {
 	groupId string
 }
 
-type ProjectsApiGetProjectParams struct {
+type GetProjectParams struct {
 		GroupId string
 }
 
@@ -1070,7 +1070,7 @@ type ProjectsApiGetProjectByNameRequest struct {
 	groupName string
 }
 
-type ProjectsApiGetProjectByNameParams struct {
+type GetProjectByNameParams struct {
 		GroupName string
 }
 
@@ -1192,7 +1192,7 @@ type ProjectsApiGetProjectInvitationRequest struct {
 	invitationId string
 }
 
-type ProjectsApiGetProjectInvitationParams struct {
+type GetProjectInvitationParams struct {
 		GroupId string
 		InvitationId string
 }
@@ -1324,7 +1324,7 @@ type ProjectsApiGetProjectLimitRequest struct {
 	groupId string
 }
 
-type ProjectsApiGetProjectLimitParams struct {
+type GetProjectLimitParams struct {
 		LimitName string
 		GroupId string
 }
@@ -1449,7 +1449,7 @@ type ProjectsApiGetProjectSettingsRequest struct {
 	groupId string
 }
 
-type ProjectsApiGetProjectSettingsParams struct {
+type GetProjectSettingsParams struct {
 		GroupId string
 }
 
@@ -1571,7 +1571,7 @@ type ProjectsApiListProjectInvitationsRequest struct {
 	username *string
 }
 
-type ProjectsApiListProjectInvitationsParams struct {
+type ListProjectInvitationsParams struct {
 		GroupId string
 		Username *string
 }
@@ -1702,7 +1702,7 @@ type ProjectsApiListProjectLimitsRequest struct {
 	groupId string
 }
 
-type ProjectsApiListProjectLimitsParams struct {
+type ListProjectLimitsParams struct {
 		GroupId string
 }
 
@@ -1828,7 +1828,7 @@ type ProjectsApiListProjectUsersRequest struct {
 	includeOrgUsers *bool
 }
 
-type ProjectsApiListProjectUsersParams struct {
+type ListProjectUsersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -2021,7 +2021,7 @@ type ProjectsApiListProjectsRequest struct {
 	pageNum *int32
 }
 
-type ProjectsApiListProjectsParams struct {
+type ListProjectsParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -2175,7 +2175,7 @@ type ProjectsApiRemoveProjectUserRequest struct {
 	userId string
 }
 
-type ProjectsApiRemoveProjectUserParams struct {
+type RemoveProjectUserParams struct {
 		GroupId string
 		UserId string
 }
@@ -2297,7 +2297,7 @@ type ProjectsApiSetProjectLimitRequest struct {
 	limit *Limit
 }
 
-type ProjectsApiSetProjectLimitParams struct {
+type SetProjectLimitParams struct {
 		LimitName string
 		GroupId string
 		Limit *Limit
@@ -2433,7 +2433,7 @@ type ProjectsApiUpdateProjectRequest struct {
 	groupName *GroupName
 }
 
-type ProjectsApiUpdateProjectParams struct {
+type UpdateProjectParams struct {
 		GroupId string
 		GroupName *GroupName
 }
@@ -2563,7 +2563,7 @@ type ProjectsApiUpdateProjectInvitationRequest struct {
 	groupInvitationRequest *GroupInvitationRequest
 }
 
-type ProjectsApiUpdateProjectInvitationParams struct {
+type UpdateProjectInvitationParams struct {
 		GroupId string
 		GroupInvitationRequest *GroupInvitationRequest
 }
@@ -2698,7 +2698,7 @@ type ProjectsApiUpdateProjectInvitationByIdRequest struct {
 	groupInvitationUpdateRequest *GroupInvitationUpdateRequest
 }
 
-type ProjectsApiUpdateProjectInvitationByIdParams struct {
+type UpdateProjectInvitationByIdParams struct {
 		GroupId string
 		InvitationId string
 		GroupInvitationUpdateRequest *GroupInvitationUpdateRequest
@@ -2842,7 +2842,7 @@ type ProjectsApiUpdateProjectSettingsRequest struct {
 	groupSettings *GroupSettings
 }
 
-type ProjectsApiUpdateProjectSettingsParams struct {
+type UpdateProjectSettingsParams struct {
 		GroupId string
 		GroupSettings *GroupSettings
 }

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -335,6 +335,10 @@ type ProjectsApiCreateProjectRequest struct {
 	group *Group
 	projectOwnerId *string
 }
+type ProjectsApiCreateProjectQueryParams struct {
+		group *Group
+		projectOwnerId *string
+}
 
 // Creates one project.
 func (r ProjectsApiCreateProjectRequest) Group(group Group) ProjectsApiCreateProjectRequest {
@@ -464,6 +468,10 @@ type ProjectsApiCreateProjectInvitationRequest struct {
 	groupId string
 	groupInvitationRequest *GroupInvitationRequest
 }
+type ProjectsApiCreateProjectInvitationQueryParams struct {
+		groupId string
+		groupInvitationRequest *GroupInvitationRequest
+}
 
 // Invites one MongoDB Cloud user to join the specified project.
 func (r ProjectsApiCreateProjectInvitationRequest) GroupInvitationRequest(groupInvitationRequest GroupInvitationRequest) ProjectsApiCreateProjectInvitationRequest {
@@ -592,6 +600,9 @@ type ProjectsApiDeleteProjectRequest struct {
 	ApiService ProjectsApi
 	groupId string
 }
+type ProjectsApiDeleteProjectQueryParams struct {
+		groupId string
+}
 
 func (r ProjectsApiDeleteProjectRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectExecute(r)
@@ -698,6 +709,10 @@ type ProjectsApiDeleteProjectInvitationRequest struct {
 	ApiService ProjectsApi
 	groupId string
 	invitationId string
+}
+type ProjectsApiDeleteProjectInvitationQueryParams struct {
+		groupId string
+		invitationId string
 }
 
 func (r ProjectsApiDeleteProjectInvitationRequest) Execute() (*http.Response, error) {
@@ -815,6 +830,10 @@ type ProjectsApiDeleteProjectLimitRequest struct {
 	limitName string
 	groupId string
 }
+type ProjectsApiDeleteProjectLimitQueryParams struct {
+		limitName string
+		groupId string
+}
 
 func (r ProjectsApiDeleteProjectLimitRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectLimitExecute(r)
@@ -923,6 +942,9 @@ type ProjectsApiGetProjectRequest struct {
 	ctx context.Context
 	ApiService ProjectsApi
 	groupId string
+}
+type ProjectsApiGetProjectQueryParams struct {
+		groupId string
 }
 
 func (r ProjectsApiGetProjectRequest) Execute() (*Group, *http.Response, error) {
@@ -1041,6 +1063,9 @@ type ProjectsApiGetProjectByNameRequest struct {
 	ApiService ProjectsApi
 	groupName string
 }
+type ProjectsApiGetProjectByNameQueryParams struct {
+		groupName string
+}
 
 func (r ProjectsApiGetProjectByNameRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.GetProjectByNameExecute(r)
@@ -1158,6 +1183,10 @@ type ProjectsApiGetProjectInvitationRequest struct {
 	ApiService ProjectsApi
 	groupId string
 	invitationId string
+}
+type ProjectsApiGetProjectInvitationQueryParams struct {
+		groupId string
+		invitationId string
 }
 
 func (r ProjectsApiGetProjectInvitationRequest) Execute() (*GroupInvitation, *http.Response, error) {
@@ -1286,6 +1315,10 @@ type ProjectsApiGetProjectLimitRequest struct {
 	limitName string
 	groupId string
 }
+type ProjectsApiGetProjectLimitQueryParams struct {
+		limitName string
+		groupId string
+}
 
 func (r ProjectsApiGetProjectLimitRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.GetProjectLimitExecute(r)
@@ -1406,6 +1439,9 @@ type ProjectsApiGetProjectSettingsRequest struct {
 	ApiService ProjectsApi
 	groupId string
 }
+type ProjectsApiGetProjectSettingsQueryParams struct {
+		groupId string
+}
 
 func (r ProjectsApiGetProjectSettingsRequest) Execute() (*GroupSettings, *http.Response, error) {
 	return r.ApiService.GetProjectSettingsExecute(r)
@@ -1523,6 +1559,10 @@ type ProjectsApiListProjectInvitationsRequest struct {
 	ApiService ProjectsApi
 	groupId string
 	username *string
+}
+type ProjectsApiListProjectInvitationsQueryParams struct {
+		groupId string
+		username *string
 }
 
 // Email address of the user account invited to this project.
@@ -1650,6 +1690,9 @@ type ProjectsApiListProjectLimitsRequest struct {
 	ApiService ProjectsApi
 	groupId string
 }
+type ProjectsApiListProjectLimitsQueryParams struct {
+		groupId string
+}
 
 func (r ProjectsApiListProjectLimitsRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.ListProjectLimitsExecute(r)
@@ -1771,6 +1814,14 @@ type ProjectsApiListProjectUsersRequest struct {
 	pageNum *int32
 	flattenTeams *bool
 	includeOrgUsers *bool
+}
+type ProjectsApiListProjectUsersQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+		flattenTeams *bool
+		includeOrgUsers *bool
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1956,6 +2007,11 @@ type ProjectsApiListProjectsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type ProjectsApiListProjectsQueryParams struct {
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ProjectsApiListProjectsRequest) IncludeCount(includeCount bool) ProjectsApiListProjectsRequest {
@@ -2104,6 +2160,10 @@ type ProjectsApiRemoveProjectUserRequest struct {
 	groupId string
 	userId string
 }
+type ProjectsApiRemoveProjectUserQueryParams struct {
+		groupId string
+		userId string
+}
 
 func (r ProjectsApiRemoveProjectUserRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectUserExecute(r)
@@ -2220,6 +2280,11 @@ type ProjectsApiSetProjectLimitRequest struct {
 	limitName string
 	groupId string
 	limit *Limit
+}
+type ProjectsApiSetProjectLimitQueryParams struct {
+		limitName string
+		groupId string
+		limit *Limit
 }
 
 func (r ProjectsApiSetProjectLimitRequest) Limit(limit Limit) ProjectsApiSetProjectLimitRequest {
@@ -2351,6 +2416,10 @@ type ProjectsApiUpdateProjectRequest struct {
 	groupId string
 	groupName *GroupName
 }
+type ProjectsApiUpdateProjectQueryParams struct {
+		groupId string
+		groupName *GroupName
+}
 
 func (r ProjectsApiUpdateProjectRequest) GroupName(groupName GroupName) ProjectsApiUpdateProjectRequest {
 	r.groupName = &groupName
@@ -2475,6 +2544,10 @@ type ProjectsApiUpdateProjectInvitationRequest struct {
 	ApiService ProjectsApi
 	groupId string
 	groupInvitationRequest *GroupInvitationRequest
+}
+type ProjectsApiUpdateProjectInvitationQueryParams struct {
+		groupId string
+		groupInvitationRequest *GroupInvitationRequest
 }
 
 // Updates the details of one pending invitation to the specified project.
@@ -2605,6 +2678,11 @@ type ProjectsApiUpdateProjectInvitationByIdRequest struct {
 	groupId string
 	invitationId string
 	groupInvitationUpdateRequest *GroupInvitationUpdateRequest
+}
+type ProjectsApiUpdateProjectInvitationByIdQueryParams struct {
+		groupId string
+		invitationId string
+		groupInvitationUpdateRequest *GroupInvitationUpdateRequest
 }
 
 // Updates the details of one pending invitation to the specified project.
@@ -2743,6 +2821,10 @@ type ProjectsApiUpdateProjectSettingsRequest struct {
 	ApiService ProjectsApi
 	groupId string
 	groupSettings *GroupSettings
+}
+type ProjectsApiUpdateProjectSettingsQueryParams struct {
+		groupId string
+		groupSettings *GroupSettings
 }
 
 func (r ProjectsApiUpdateProjectSettingsRequest) GroupSettings(groupSettings GroupSettings) ProjectsApiUpdateProjectSettingsRequest {

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -336,7 +336,7 @@ type CreateProjectApiRequest struct {
 	projectOwnerId *string
 }
 
-type CreateProjectParams struct {
+type CreateProjectApiParams struct {
 		Group *Group
 		ProjectOwnerId *string
 }
@@ -470,7 +470,7 @@ type CreateProjectInvitationApiRequest struct {
 	groupInvitationRequest *GroupInvitationRequest
 }
 
-type CreateProjectInvitationParams struct {
+type CreateProjectInvitationApiParams struct {
 		GroupId string
 		GroupInvitationRequest *GroupInvitationRequest
 }
@@ -603,7 +603,7 @@ type DeleteProjectApiRequest struct {
 	groupId string
 }
 
-type DeleteProjectParams struct {
+type DeleteProjectApiParams struct {
 		GroupId string
 }
 
@@ -714,7 +714,7 @@ type DeleteProjectInvitationApiRequest struct {
 	invitationId string
 }
 
-type DeleteProjectInvitationParams struct {
+type DeleteProjectInvitationApiParams struct {
 		GroupId string
 		InvitationId string
 }
@@ -835,7 +835,7 @@ type DeleteProjectLimitApiRequest struct {
 	groupId string
 }
 
-type DeleteProjectLimitParams struct {
+type DeleteProjectLimitApiParams struct {
 		LimitName string
 		GroupId string
 }
@@ -949,7 +949,7 @@ type GetProjectApiRequest struct {
 	groupId string
 }
 
-type GetProjectParams struct {
+type GetProjectApiParams struct {
 		GroupId string
 }
 
@@ -1070,7 +1070,7 @@ type GetProjectByNameApiRequest struct {
 	groupName string
 }
 
-type GetProjectByNameParams struct {
+type GetProjectByNameApiParams struct {
 		GroupName string
 }
 
@@ -1192,7 +1192,7 @@ type GetProjectInvitationApiRequest struct {
 	invitationId string
 }
 
-type GetProjectInvitationParams struct {
+type GetProjectInvitationApiParams struct {
 		GroupId string
 		InvitationId string
 }
@@ -1324,7 +1324,7 @@ type GetProjectLimitApiRequest struct {
 	groupId string
 }
 
-type GetProjectLimitParams struct {
+type GetProjectLimitApiParams struct {
 		LimitName string
 		GroupId string
 }
@@ -1449,7 +1449,7 @@ type GetProjectSettingsApiRequest struct {
 	groupId string
 }
 
-type GetProjectSettingsParams struct {
+type GetProjectSettingsApiParams struct {
 		GroupId string
 }
 
@@ -1571,7 +1571,7 @@ type ListProjectInvitationsApiRequest struct {
 	username *string
 }
 
-type ListProjectInvitationsParams struct {
+type ListProjectInvitationsApiParams struct {
 		GroupId string
 		Username *string
 }
@@ -1702,7 +1702,7 @@ type ListProjectLimitsApiRequest struct {
 	groupId string
 }
 
-type ListProjectLimitsParams struct {
+type ListProjectLimitsApiParams struct {
 		GroupId string
 }
 
@@ -1828,7 +1828,7 @@ type ListProjectUsersApiRequest struct {
 	includeOrgUsers *bool
 }
 
-type ListProjectUsersParams struct {
+type ListProjectUsersApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -2021,7 +2021,7 @@ type ListProjectsApiRequest struct {
 	pageNum *int32
 }
 
-type ListProjectsParams struct {
+type ListProjectsApiParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -2175,7 +2175,7 @@ type RemoveProjectUserApiRequest struct {
 	userId string
 }
 
-type RemoveProjectUserParams struct {
+type RemoveProjectUserApiParams struct {
 		GroupId string
 		UserId string
 }
@@ -2297,7 +2297,7 @@ type SetProjectLimitApiRequest struct {
 	limit *Limit
 }
 
-type SetProjectLimitParams struct {
+type SetProjectLimitApiParams struct {
 		LimitName string
 		GroupId string
 		Limit *Limit
@@ -2433,7 +2433,7 @@ type UpdateProjectApiRequest struct {
 	groupName *GroupName
 }
 
-type UpdateProjectParams struct {
+type UpdateProjectApiParams struct {
 		GroupId string
 		GroupName *GroupName
 }
@@ -2563,7 +2563,7 @@ type UpdateProjectInvitationApiRequest struct {
 	groupInvitationRequest *GroupInvitationRequest
 }
 
-type UpdateProjectInvitationParams struct {
+type UpdateProjectInvitationApiParams struct {
 		GroupId string
 		GroupInvitationRequest *GroupInvitationRequest
 }
@@ -2698,7 +2698,7 @@ type UpdateProjectInvitationByIdApiRequest struct {
 	groupInvitationUpdateRequest *GroupInvitationUpdateRequest
 }
 
-type UpdateProjectInvitationByIdParams struct {
+type UpdateProjectInvitationByIdApiParams struct {
 		GroupId string
 		InvitationId string
 		GroupInvitationUpdateRequest *GroupInvitationUpdateRequest
@@ -2842,7 +2842,7 @@ type UpdateProjectSettingsApiRequest struct {
 	groupSettings *GroupSettings
 }
 
-type UpdateProjectSettingsParams struct {
+type UpdateProjectSettingsApiParams struct {
 		GroupId string
 		GroupSettings *GroupSettings
 }

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -336,7 +336,7 @@ type ProjectsApiCreateProjectRequest struct {
 	projectOwnerId *string
 }
 
-type ProjectsApiCreateProjectQueryParams struct {
+type ProjectsApiCreateProjectParams struct {
 		Group *Group
 		ProjectOwnerId *string
 }
@@ -470,7 +470,7 @@ type ProjectsApiCreateProjectInvitationRequest struct {
 	groupInvitationRequest *GroupInvitationRequest
 }
 
-type ProjectsApiCreateProjectInvitationQueryParams struct {
+type ProjectsApiCreateProjectInvitationParams struct {
 		GroupId string
 		GroupInvitationRequest *GroupInvitationRequest
 }
@@ -603,7 +603,7 @@ type ProjectsApiDeleteProjectRequest struct {
 	groupId string
 }
 
-type ProjectsApiDeleteProjectQueryParams struct {
+type ProjectsApiDeleteProjectParams struct {
 		GroupId string
 }
 
@@ -714,7 +714,7 @@ type ProjectsApiDeleteProjectInvitationRequest struct {
 	invitationId string
 }
 
-type ProjectsApiDeleteProjectInvitationQueryParams struct {
+type ProjectsApiDeleteProjectInvitationParams struct {
 		GroupId string
 		InvitationId string
 }
@@ -835,7 +835,7 @@ type ProjectsApiDeleteProjectLimitRequest struct {
 	groupId string
 }
 
-type ProjectsApiDeleteProjectLimitQueryParams struct {
+type ProjectsApiDeleteProjectLimitParams struct {
 		LimitName string
 		GroupId string
 }
@@ -949,7 +949,7 @@ type ProjectsApiGetProjectRequest struct {
 	groupId string
 }
 
-type ProjectsApiGetProjectQueryParams struct {
+type ProjectsApiGetProjectParams struct {
 		GroupId string
 }
 
@@ -1070,7 +1070,7 @@ type ProjectsApiGetProjectByNameRequest struct {
 	groupName string
 }
 
-type ProjectsApiGetProjectByNameQueryParams struct {
+type ProjectsApiGetProjectByNameParams struct {
 		GroupName string
 }
 
@@ -1192,7 +1192,7 @@ type ProjectsApiGetProjectInvitationRequest struct {
 	invitationId string
 }
 
-type ProjectsApiGetProjectInvitationQueryParams struct {
+type ProjectsApiGetProjectInvitationParams struct {
 		GroupId string
 		InvitationId string
 }
@@ -1324,7 +1324,7 @@ type ProjectsApiGetProjectLimitRequest struct {
 	groupId string
 }
 
-type ProjectsApiGetProjectLimitQueryParams struct {
+type ProjectsApiGetProjectLimitParams struct {
 		LimitName string
 		GroupId string
 }
@@ -1449,7 +1449,7 @@ type ProjectsApiGetProjectSettingsRequest struct {
 	groupId string
 }
 
-type ProjectsApiGetProjectSettingsQueryParams struct {
+type ProjectsApiGetProjectSettingsParams struct {
 		GroupId string
 }
 
@@ -1571,7 +1571,7 @@ type ProjectsApiListProjectInvitationsRequest struct {
 	username *string
 }
 
-type ProjectsApiListProjectInvitationsQueryParams struct {
+type ProjectsApiListProjectInvitationsParams struct {
 		GroupId string
 		Username *string
 }
@@ -1702,7 +1702,7 @@ type ProjectsApiListProjectLimitsRequest struct {
 	groupId string
 }
 
-type ProjectsApiListProjectLimitsQueryParams struct {
+type ProjectsApiListProjectLimitsParams struct {
 		GroupId string
 }
 
@@ -1828,7 +1828,7 @@ type ProjectsApiListProjectUsersRequest struct {
 	includeOrgUsers *bool
 }
 
-type ProjectsApiListProjectUsersQueryParams struct {
+type ProjectsApiListProjectUsersParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -2021,7 +2021,7 @@ type ProjectsApiListProjectsRequest struct {
 	pageNum *int32
 }
 
-type ProjectsApiListProjectsQueryParams struct {
+type ProjectsApiListProjectsParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
@@ -2175,7 +2175,7 @@ type ProjectsApiRemoveProjectUserRequest struct {
 	userId string
 }
 
-type ProjectsApiRemoveProjectUserQueryParams struct {
+type ProjectsApiRemoveProjectUserParams struct {
 		GroupId string
 		UserId string
 }
@@ -2297,7 +2297,7 @@ type ProjectsApiSetProjectLimitRequest struct {
 	limit *Limit
 }
 
-type ProjectsApiSetProjectLimitQueryParams struct {
+type ProjectsApiSetProjectLimitParams struct {
 		LimitName string
 		GroupId string
 		Limit *Limit
@@ -2433,7 +2433,7 @@ type ProjectsApiUpdateProjectRequest struct {
 	groupName *GroupName
 }
 
-type ProjectsApiUpdateProjectQueryParams struct {
+type ProjectsApiUpdateProjectParams struct {
 		GroupId string
 		GroupName *GroupName
 }
@@ -2563,7 +2563,7 @@ type ProjectsApiUpdateProjectInvitationRequest struct {
 	groupInvitationRequest *GroupInvitationRequest
 }
 
-type ProjectsApiUpdateProjectInvitationQueryParams struct {
+type ProjectsApiUpdateProjectInvitationParams struct {
 		GroupId string
 		GroupInvitationRequest *GroupInvitationRequest
 }
@@ -2698,7 +2698,7 @@ type ProjectsApiUpdateProjectInvitationByIdRequest struct {
 	groupInvitationUpdateRequest *GroupInvitationUpdateRequest
 }
 
-type ProjectsApiUpdateProjectInvitationByIdQueryParams struct {
+type ProjectsApiUpdateProjectInvitationByIdParams struct {
 		GroupId string
 		InvitationId string
 		GroupInvitationUpdateRequest *GroupInvitationUpdateRequest
@@ -2842,7 +2842,7 @@ type ProjectsApiUpdateProjectSettingsRequest struct {
 	groupSettings *GroupSettings
 }
 
-type ProjectsApiUpdateProjectSettingsQueryParams struct {
+type ProjectsApiUpdateProjectSettingsParams struct {
 		GroupId string
 		GroupSettings *GroupSettings
 }

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -30,18 +30,18 @@ type RollingIndexApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster on which MongoDB Cloud creates an index.
-	@return RollingIndexApiCreateRollingIndexRequest
+	@return CreateRollingIndexApiRequest
 	*/
-	CreateRollingIndex(ctx context.Context, groupId string, clusterName string) RollingIndexApiCreateRollingIndexRequest
+	CreateRollingIndex(ctx context.Context, groupId string, clusterName string) CreateRollingIndexApiRequest
 
 	// CreateRollingIndexExecute executes the request
-	CreateRollingIndexExecute(r RollingIndexApiCreateRollingIndexRequest) (*http.Response, error)
+	CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error)
 }
 
 // RollingIndexApiService RollingIndexApi service
 type RollingIndexApiService service
 
-type RollingIndexApiCreateRollingIndexRequest struct {
+type CreateRollingIndexApiRequest struct {
 	ctx context.Context
 	ApiService RollingIndexApi
 	groupId string
@@ -56,12 +56,12 @@ type CreateRollingIndexParams struct {
 }
 
 // Rolling index to create on the specified cluster.
-func (r RollingIndexApiCreateRollingIndexRequest) IndexRequest(indexRequest IndexRequest) RollingIndexApiCreateRollingIndexRequest {
+func (r CreateRollingIndexApiRequest) IndexRequest(indexRequest IndexRequest) CreateRollingIndexApiRequest {
 	r.indexRequest = &indexRequest
 	return r
 }
 
-func (r RollingIndexApiCreateRollingIndexRequest) Execute() (*http.Response, error) {
+func (r CreateRollingIndexApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CreateRollingIndexExecute(r)
 }
 
@@ -73,10 +73,10 @@ Creates an index on the cluster identified by its name in a rolling manner. Crea
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster on which MongoDB Cloud creates an index.
- @return RollingIndexApiCreateRollingIndexRequest
+ @return CreateRollingIndexApiRequest
 */
-func (a *RollingIndexApiService) CreateRollingIndex(ctx context.Context, groupId string, clusterName string) RollingIndexApiCreateRollingIndexRequest {
-	return RollingIndexApiCreateRollingIndexRequest{
+func (a *RollingIndexApiService) CreateRollingIndex(ctx context.Context, groupId string, clusterName string) CreateRollingIndexApiRequest {
+	return CreateRollingIndexApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -85,7 +85,7 @@ func (a *RollingIndexApiService) CreateRollingIndex(ctx context.Context, groupId
 }
 
 // Execute executes the request
-func (a *RollingIndexApiService) CreateRollingIndexExecute(r RollingIndexApiCreateRollingIndexRequest) (*http.Response, error) {
+func (a *RollingIndexApiService) CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -48,10 +48,11 @@ type RollingIndexApiCreateRollingIndexRequest struct {
 	clusterName string
 	indexRequest *IndexRequest
 }
+
 type RollingIndexApiCreateRollingIndexQueryParams struct {
-		groupId string
-		clusterName string
-		indexRequest *IndexRequest
+		GroupId string
+		ClusterName string
+		IndexRequest *IndexRequest
 }
 
 // Rolling index to create on the specified cluster.

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -49,7 +49,7 @@ type CreateRollingIndexApiRequest struct {
 	indexRequest *IndexRequest
 }
 
-type CreateRollingIndexParams struct {
+type CreateRollingIndexApiParams struct {
 		GroupId string
 		ClusterName string
 		IndexRequest *IndexRequest

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -49,7 +49,7 @@ type RollingIndexApiCreateRollingIndexRequest struct {
 	indexRequest *IndexRequest
 }
 
-type RollingIndexApiCreateRollingIndexQueryParams struct {
+type RollingIndexApiCreateRollingIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexRequest *IndexRequest

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -49,7 +49,7 @@ type RollingIndexApiCreateRollingIndexRequest struct {
 	indexRequest *IndexRequest
 }
 
-type RollingIndexApiCreateRollingIndexParams struct {
+type CreateRollingIndexParams struct {
 		GroupId string
 		ClusterName string
 		IndexRequest *IndexRequest

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -48,6 +48,11 @@ type RollingIndexApiCreateRollingIndexRequest struct {
 	clusterName string
 	indexRequest *IndexRequest
 }
+type RollingIndexApiCreateRollingIndexQueryParams struct {
+		groupId string
+		clusterName string
+		indexRequest *IndexRequest
+}
 
 // Rolling index to create on the specified cluster.
 func (r RollingIndexApiCreateRollingIndexRequest) IndexRequest(indexRequest IndexRequest) RollingIndexApiCreateRollingIndexRequest {

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -43,6 +43,7 @@ type RootApiGetSystemStatusRequest struct {
 	ctx context.Context
 	ApiService RootApi
 }
+
 type RootApiGetSystemStatusQueryParams struct {
 }
 

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -27,19 +27,19 @@ type RootApi interface {
 	This resource returns information about the MongoDB application along with API key meta data.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return RootApiGetSystemStatusRequest
+	@return GetSystemStatusApiRequest
 	*/
-	GetSystemStatus(ctx context.Context) RootApiGetSystemStatusRequest
+	GetSystemStatus(ctx context.Context) GetSystemStatusApiRequest
 
 	// GetSystemStatusExecute executes the request
 	//  @return SystemStatus
-	GetSystemStatusExecute(r RootApiGetSystemStatusRequest) (*SystemStatus, *http.Response, error)
+	GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error)
 }
 
 // RootApiService RootApi service
 type RootApiService service
 
-type RootApiGetSystemStatusRequest struct {
+type GetSystemStatusApiRequest struct {
 	ctx context.Context
 	ApiService RootApi
 }
@@ -47,7 +47,7 @@ type RootApiGetSystemStatusRequest struct {
 type GetSystemStatusParams struct {
 }
 
-func (r RootApiGetSystemStatusRequest) Execute() (*SystemStatus, *http.Response, error) {
+func (r GetSystemStatusApiRequest) Execute() (*SystemStatus, *http.Response, error) {
 	return r.ApiService.GetSystemStatusExecute(r)
 }
 
@@ -57,10 +57,10 @@ GetSystemStatus Return the status of this MongoDB application
 This resource returns information about the MongoDB application along with API key meta data.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return RootApiGetSystemStatusRequest
+ @return GetSystemStatusApiRequest
 */
-func (a *RootApiService) GetSystemStatus(ctx context.Context) RootApiGetSystemStatusRequest {
-	return RootApiGetSystemStatusRequest{
+func (a *RootApiService) GetSystemStatus(ctx context.Context) GetSystemStatusApiRequest {
+	return GetSystemStatusApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -68,7 +68,7 @@ func (a *RootApiService) GetSystemStatus(ctx context.Context) RootApiGetSystemSt
 
 // Execute executes the request
 //  @return SystemStatus
-func (a *RootApiService) GetSystemStatusExecute(r RootApiGetSystemStatusRequest) (*SystemStatus, *http.Response, error) {
+func (a *RootApiService) GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -44,7 +44,7 @@ type RootApiGetSystemStatusRequest struct {
 	ApiService RootApi
 }
 
-type RootApiGetSystemStatusParams struct {
+type GetSystemStatusParams struct {
 }
 
 func (r RootApiGetSystemStatusRequest) Execute() (*SystemStatus, *http.Response, error) {

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -43,6 +43,8 @@ type RootApiGetSystemStatusRequest struct {
 	ctx context.Context
 	ApiService RootApi
 }
+type RootApiGetSystemStatusQueryParams struct {
+}
 
 func (r RootApiGetSystemStatusRequest) Execute() (*SystemStatus, *http.Response, error) {
 	return r.ApiService.GetSystemStatusExecute(r)

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -44,7 +44,7 @@ type GetSystemStatusApiRequest struct {
 	ApiService RootApi
 }
 
-type GetSystemStatusParams struct {
+type GetSystemStatusApiParams struct {
 }
 
 func (r GetSystemStatusApiRequest) Execute() (*SystemStatus, *http.Response, error) {

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -44,7 +44,7 @@ type RootApiGetSystemStatusRequest struct {
 	ApiService RootApi
 }
 
-type RootApiGetSystemStatusQueryParams struct {
+type RootApiGetSystemStatusParams struct {
 }
 
 func (r RootApiGetSystemStatusRequest) Execute() (*SystemStatus, *http.Response, error) {

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -110,7 +110,7 @@ type CreateServerlessInstanceApiRequest struct {
 	serverlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
 
-type CreateServerlessInstanceParams struct {
+type CreateServerlessInstanceApiParams struct {
 		GroupId string
 		ServerlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
@@ -244,7 +244,7 @@ type DeleteServerlessInstanceApiRequest struct {
 	name string
 }
 
-type DeleteServerlessInstanceParams struct {
+type DeleteServerlessInstanceApiParams struct {
 		GroupId string
 		Name string
 }
@@ -365,7 +365,7 @@ type GetServerlessInstanceApiRequest struct {
 	name string
 }
 
-type GetServerlessInstanceParams struct {
+type GetServerlessInstanceApiParams struct {
 		GroupId string
 		Name string
 }
@@ -499,7 +499,7 @@ type ListServerlessInstancesApiRequest struct {
 	pageNum *int32
 }
 
-type ListServerlessInstancesParams struct {
+type ListServerlessInstancesApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -664,7 +664,7 @@ type UpdateServerlessInstanceApiRequest struct {
 	serverlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
 }
 
-type UpdateServerlessInstanceParams struct {
+type UpdateServerlessInstanceApiParams struct {
 		GroupId string
 		Name string
 		ServerlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -109,9 +109,10 @@ type ServerlessInstancesApiCreateServerlessInstanceRequest struct {
 	groupId string
 	serverlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
+
 type ServerlessInstancesApiCreateServerlessInstanceQueryParams struct {
-		groupId string
-		serverlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
+		GroupId string
+		ServerlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
 
 // Create One Serverless Instance in One Project.
@@ -242,9 +243,10 @@ type ServerlessInstancesApiDeleteServerlessInstanceRequest struct {
 	groupId string
 	name string
 }
+
 type ServerlessInstancesApiDeleteServerlessInstanceQueryParams struct {
-		groupId string
-		name string
+		GroupId string
+		Name string
 }
 
 func (r ServerlessInstancesApiDeleteServerlessInstanceRequest) Execute() (*http.Response, error) {
@@ -362,9 +364,10 @@ type ServerlessInstancesApiGetServerlessInstanceRequest struct {
 	groupId string
 	name string
 }
+
 type ServerlessInstancesApiGetServerlessInstanceQueryParams struct {
-		groupId string
-		name string
+		GroupId string
+		Name string
 }
 
 func (r ServerlessInstancesApiGetServerlessInstanceRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
@@ -495,11 +498,12 @@ type ServerlessInstancesApiListServerlessInstancesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ServerlessInstancesApiListServerlessInstancesQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -659,10 +663,11 @@ type ServerlessInstancesApiUpdateServerlessInstanceRequest struct {
 	name string
 	serverlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
 }
+
 type ServerlessInstancesApiUpdateServerlessInstanceQueryParams struct {
-		groupId string
-		name string
-		serverlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
+		GroupId string
+		Name string
+		ServerlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
 }
 
 // Update One Serverless Instance in One Project.

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -110,7 +110,7 @@ type ServerlessInstancesApiCreateServerlessInstanceRequest struct {
 	serverlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
 
-type ServerlessInstancesApiCreateServerlessInstanceParams struct {
+type CreateServerlessInstanceParams struct {
 		GroupId string
 		ServerlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
@@ -244,7 +244,7 @@ type ServerlessInstancesApiDeleteServerlessInstanceRequest struct {
 	name string
 }
 
-type ServerlessInstancesApiDeleteServerlessInstanceParams struct {
+type DeleteServerlessInstanceParams struct {
 		GroupId string
 		Name string
 }
@@ -365,7 +365,7 @@ type ServerlessInstancesApiGetServerlessInstanceRequest struct {
 	name string
 }
 
-type ServerlessInstancesApiGetServerlessInstanceParams struct {
+type GetServerlessInstanceParams struct {
 		GroupId string
 		Name string
 }
@@ -499,7 +499,7 @@ type ServerlessInstancesApiListServerlessInstancesRequest struct {
 	pageNum *int32
 }
 
-type ServerlessInstancesApiListServerlessInstancesParams struct {
+type ListServerlessInstancesParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -664,7 +664,7 @@ type ServerlessInstancesApiUpdateServerlessInstanceRequest struct {
 	serverlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
 }
 
-type ServerlessInstancesApiUpdateServerlessInstanceParams struct {
+type UpdateServerlessInstanceParams struct {
 		GroupId string
 		Name string
 		ServerlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -29,13 +29,13 @@ type ServerlessInstancesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ServerlessInstancesApiCreateServerlessInstanceRequest
+	@return CreateServerlessInstanceApiRequest
 	*/
-	CreateServerlessInstance(ctx context.Context, groupId string) ServerlessInstancesApiCreateServerlessInstanceRequest
+	CreateServerlessInstance(ctx context.Context, groupId string) CreateServerlessInstanceApiRequest
 
 	// CreateServerlessInstanceExecute executes the request
 	//  @return ServerlessInstanceDescription
-	CreateServerlessInstanceExecute(r ServerlessInstancesApiCreateServerlessInstanceRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
 	DeleteServerlessInstance Remove One Serverless Instance from One Project
@@ -45,12 +45,12 @@ type ServerlessInstancesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param name Human-readable label that identifies the serverless instance.
-	@return ServerlessInstancesApiDeleteServerlessInstanceRequest
+	@return DeleteServerlessInstanceApiRequest
 	*/
-	DeleteServerlessInstance(ctx context.Context, groupId string, name string) ServerlessInstancesApiDeleteServerlessInstanceRequest
+	DeleteServerlessInstance(ctx context.Context, groupId string, name string) DeleteServerlessInstanceApiRequest
 
 	// DeleteServerlessInstanceExecute executes the request
-	DeleteServerlessInstanceExecute(r ServerlessInstancesApiDeleteServerlessInstanceRequest) (*http.Response, error)
+	DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (*http.Response, error)
 
 	/*
 	GetServerlessInstance Return One Serverless Instance from One Project
@@ -60,13 +60,13 @@ type ServerlessInstancesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param name Human-readable label that identifies the serverless instance.
-	@return ServerlessInstancesApiGetServerlessInstanceRequest
+	@return GetServerlessInstanceApiRequest
 	*/
-	GetServerlessInstance(ctx context.Context, groupId string, name string) ServerlessInstancesApiGetServerlessInstanceRequest
+	GetServerlessInstance(ctx context.Context, groupId string, name string) GetServerlessInstanceApiRequest
 
 	// GetServerlessInstanceExecute executes the request
 	//  @return ServerlessInstanceDescription
-	GetServerlessInstanceExecute(r ServerlessInstancesApiGetServerlessInstanceRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
 	ListServerlessInstances Return All Serverless Instances from One Project
@@ -75,13 +75,13 @@ type ServerlessInstancesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ServerlessInstancesApiListServerlessInstancesRequest
+	@return ListServerlessInstancesApiRequest
 	*/
-	ListServerlessInstances(ctx context.Context, groupId string) ServerlessInstancesApiListServerlessInstancesRequest
+	ListServerlessInstances(ctx context.Context, groupId string) ListServerlessInstancesApiRequest
 
 	// ListServerlessInstancesExecute executes the request
 	//  @return PaginatedServerlessInstanceDescription
-	ListServerlessInstancesExecute(r ServerlessInstancesApiListServerlessInstancesRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error)
+	ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error)
 
 	/*
 	UpdateServerlessInstance Update One Serverless Instance in One Project
@@ -91,19 +91,19 @@ type ServerlessInstancesApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param name Human-readable label that identifies the serverless instance.
-	@return ServerlessInstancesApiUpdateServerlessInstanceRequest
+	@return UpdateServerlessInstanceApiRequest
 	*/
-	UpdateServerlessInstance(ctx context.Context, groupId string, name string) ServerlessInstancesApiUpdateServerlessInstanceRequest
+	UpdateServerlessInstance(ctx context.Context, groupId string, name string) UpdateServerlessInstanceApiRequest
 
 	// UpdateServerlessInstanceExecute executes the request
 	//  @return ServerlessInstanceDescription
-	UpdateServerlessInstanceExecute(r ServerlessInstancesApiUpdateServerlessInstanceRequest) (*ServerlessInstanceDescription, *http.Response, error)
+	UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 
 // ServerlessInstancesApiService ServerlessInstancesApi service
 type ServerlessInstancesApiService service
 
-type ServerlessInstancesApiCreateServerlessInstanceRequest struct {
+type CreateServerlessInstanceApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessInstancesApi
 	groupId string
@@ -116,12 +116,12 @@ type CreateServerlessInstanceParams struct {
 }
 
 // Create One Serverless Instance in One Project.
-func (r ServerlessInstancesApiCreateServerlessInstanceRequest) ServerlessInstanceDescriptionCreate(serverlessInstanceDescriptionCreate ServerlessInstanceDescriptionCreate) ServerlessInstancesApiCreateServerlessInstanceRequest {
+func (r CreateServerlessInstanceApiRequest) ServerlessInstanceDescriptionCreate(serverlessInstanceDescriptionCreate ServerlessInstanceDescriptionCreate) CreateServerlessInstanceApiRequest {
 	r.serverlessInstanceDescriptionCreate = &serverlessInstanceDescriptionCreate
 	return r
 }
 
-func (r ServerlessInstancesApiCreateServerlessInstanceRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
+func (r CreateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.CreateServerlessInstanceExecute(r)
 }
 
@@ -132,10 +132,10 @@ Creates one serverless instance in the specified project. To use this resource, 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ServerlessInstancesApiCreateServerlessInstanceRequest
+ @return CreateServerlessInstanceApiRequest
 */
-func (a *ServerlessInstancesApiService) CreateServerlessInstance(ctx context.Context, groupId string) ServerlessInstancesApiCreateServerlessInstanceRequest {
-	return ServerlessInstancesApiCreateServerlessInstanceRequest{
+func (a *ServerlessInstancesApiService) CreateServerlessInstance(ctx context.Context, groupId string) CreateServerlessInstanceApiRequest {
+	return CreateServerlessInstanceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -144,7 +144,7 @@ func (a *ServerlessInstancesApiService) CreateServerlessInstance(ctx context.Con
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) CreateServerlessInstanceExecute(r ServerlessInstancesApiCreateServerlessInstanceRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -237,7 +237,7 @@ func (a *ServerlessInstancesApiService) CreateServerlessInstanceExecute(r Server
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ServerlessInstancesApiDeleteServerlessInstanceRequest struct {
+type DeleteServerlessInstanceApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessInstancesApi
 	groupId string
@@ -249,7 +249,7 @@ type DeleteServerlessInstanceParams struct {
 		Name string
 }
 
-func (r ServerlessInstancesApiDeleteServerlessInstanceRequest) Execute() (*http.Response, error) {
+func (r DeleteServerlessInstanceApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteServerlessInstanceExecute(r)
 }
 
@@ -261,10 +261,10 @@ Removes one serverless instance from the specified project. The serverless insta
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param name Human-readable label that identifies the serverless instance.
- @return ServerlessInstancesApiDeleteServerlessInstanceRequest
+ @return DeleteServerlessInstanceApiRequest
 */
-func (a *ServerlessInstancesApiService) DeleteServerlessInstance(ctx context.Context, groupId string, name string) ServerlessInstancesApiDeleteServerlessInstanceRequest {
-	return ServerlessInstancesApiDeleteServerlessInstanceRequest{
+func (a *ServerlessInstancesApiService) DeleteServerlessInstance(ctx context.Context, groupId string, name string) DeleteServerlessInstanceApiRequest {
+	return DeleteServerlessInstanceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -273,7 +273,7 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstance(ctx context.Con
 }
 
 // Execute executes the request
-func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r ServerlessInstancesApiDeleteServerlessInstanceRequest) (*http.Response, error) {
+func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -358,7 +358,7 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r Server
 	return localVarHTTPResponse, nil
 }
 
-type ServerlessInstancesApiGetServerlessInstanceRequest struct {
+type GetServerlessInstanceApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessInstancesApi
 	groupId string
@@ -370,7 +370,7 @@ type GetServerlessInstanceParams struct {
 		Name string
 }
 
-func (r ServerlessInstancesApiGetServerlessInstanceRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
+func (r GetServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.GetServerlessInstanceExecute(r)
 }
 
@@ -382,10 +382,10 @@ Returns details for one serverless instance in the specified project. To use thi
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param name Human-readable label that identifies the serverless instance.
- @return ServerlessInstancesApiGetServerlessInstanceRequest
+ @return GetServerlessInstanceApiRequest
 */
-func (a *ServerlessInstancesApiService) GetServerlessInstance(ctx context.Context, groupId string, name string) ServerlessInstancesApiGetServerlessInstanceRequest {
-	return ServerlessInstancesApiGetServerlessInstanceRequest{
+func (a *ServerlessInstancesApiService) GetServerlessInstance(ctx context.Context, groupId string, name string) GetServerlessInstanceApiRequest {
+	return GetServerlessInstanceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -395,7 +395,7 @@ func (a *ServerlessInstancesApiService) GetServerlessInstance(ctx context.Contex
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) GetServerlessInstanceExecute(r ServerlessInstancesApiGetServerlessInstanceRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -490,7 +490,7 @@ func (a *ServerlessInstancesApiService) GetServerlessInstanceExecute(r Serverles
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ServerlessInstancesApiListServerlessInstancesRequest struct {
+type ListServerlessInstancesApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessInstancesApi
 	groupId string
@@ -507,24 +507,24 @@ type ListServerlessInstancesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ServerlessInstancesApiListServerlessInstancesRequest) IncludeCount(includeCount bool) ServerlessInstancesApiListServerlessInstancesRequest {
+func (r ListServerlessInstancesApiRequest) IncludeCount(includeCount bool) ListServerlessInstancesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ServerlessInstancesApiListServerlessInstancesRequest) ItemsPerPage(itemsPerPage int32) ServerlessInstancesApiListServerlessInstancesRequest {
+func (r ListServerlessInstancesApiRequest) ItemsPerPage(itemsPerPage int32) ListServerlessInstancesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ServerlessInstancesApiListServerlessInstancesRequest) PageNum(pageNum int32) ServerlessInstancesApiListServerlessInstancesRequest {
+func (r ListServerlessInstancesApiRequest) PageNum(pageNum int32) ListServerlessInstancesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ServerlessInstancesApiListServerlessInstancesRequest) Execute() (*PaginatedServerlessInstanceDescription, *http.Response, error) {
+func (r ListServerlessInstancesApiRequest) Execute() (*PaginatedServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.ListServerlessInstancesExecute(r)
 }
 
@@ -535,10 +535,10 @@ Returns details for all serverless instances in the specified project. To use th
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ServerlessInstancesApiListServerlessInstancesRequest
+ @return ListServerlessInstancesApiRequest
 */
-func (a *ServerlessInstancesApiService) ListServerlessInstances(ctx context.Context, groupId string) ServerlessInstancesApiListServerlessInstancesRequest {
-	return ServerlessInstancesApiListServerlessInstancesRequest{
+func (a *ServerlessInstancesApiService) ListServerlessInstances(ctx context.Context, groupId string) ListServerlessInstancesApiRequest {
+	return ListServerlessInstancesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -547,7 +547,7 @@ func (a *ServerlessInstancesApiService) ListServerlessInstances(ctx context.Cont
 
 // Execute executes the request
 //  @return PaginatedServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) ListServerlessInstancesExecute(r ServerlessInstancesApiListServerlessInstancesRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -656,7 +656,7 @@ func (a *ServerlessInstancesApiService) ListServerlessInstancesExecute(r Serverl
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ServerlessInstancesApiUpdateServerlessInstanceRequest struct {
+type UpdateServerlessInstanceApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessInstancesApi
 	groupId string
@@ -671,12 +671,12 @@ type UpdateServerlessInstanceParams struct {
 }
 
 // Update One Serverless Instance in One Project.
-func (r ServerlessInstancesApiUpdateServerlessInstanceRequest) ServerlessInstanceDescriptionUpdate(serverlessInstanceDescriptionUpdate ServerlessInstanceDescriptionUpdate) ServerlessInstancesApiUpdateServerlessInstanceRequest {
+func (r UpdateServerlessInstanceApiRequest) ServerlessInstanceDescriptionUpdate(serverlessInstanceDescriptionUpdate ServerlessInstanceDescriptionUpdate) UpdateServerlessInstanceApiRequest {
 	r.serverlessInstanceDescriptionUpdate = &serverlessInstanceDescriptionUpdate
 	return r
 }
 
-func (r ServerlessInstancesApiUpdateServerlessInstanceRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
+func (r UpdateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.UpdateServerlessInstanceExecute(r)
 }
 
@@ -688,10 +688,10 @@ Updates one serverless instance in the specified project. To use this resource, 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param name Human-readable label that identifies the serverless instance.
- @return ServerlessInstancesApiUpdateServerlessInstanceRequest
+ @return UpdateServerlessInstanceApiRequest
 */
-func (a *ServerlessInstancesApiService) UpdateServerlessInstance(ctx context.Context, groupId string, name string) ServerlessInstancesApiUpdateServerlessInstanceRequest {
-	return ServerlessInstancesApiUpdateServerlessInstanceRequest{
+func (a *ServerlessInstancesApiService) UpdateServerlessInstance(ctx context.Context, groupId string, name string) UpdateServerlessInstanceApiRequest {
+	return UpdateServerlessInstanceApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -701,7 +701,7 @@ func (a *ServerlessInstancesApiService) UpdateServerlessInstance(ctx context.Con
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) UpdateServerlessInstanceExecute(r ServerlessInstancesApiUpdateServerlessInstanceRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -109,6 +109,10 @@ type ServerlessInstancesApiCreateServerlessInstanceRequest struct {
 	groupId string
 	serverlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
+type ServerlessInstancesApiCreateServerlessInstanceQueryParams struct {
+		groupId string
+		serverlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
+}
 
 // Create One Serverless Instance in One Project.
 func (r ServerlessInstancesApiCreateServerlessInstanceRequest) ServerlessInstanceDescriptionCreate(serverlessInstanceDescriptionCreate ServerlessInstanceDescriptionCreate) ServerlessInstancesApiCreateServerlessInstanceRequest {
@@ -238,6 +242,10 @@ type ServerlessInstancesApiDeleteServerlessInstanceRequest struct {
 	groupId string
 	name string
 }
+type ServerlessInstancesApiDeleteServerlessInstanceQueryParams struct {
+		groupId string
+		name string
+}
 
 func (r ServerlessInstancesApiDeleteServerlessInstanceRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteServerlessInstanceExecute(r)
@@ -353,6 +361,10 @@ type ServerlessInstancesApiGetServerlessInstanceRequest struct {
 	ApiService ServerlessInstancesApi
 	groupId string
 	name string
+}
+type ServerlessInstancesApiGetServerlessInstanceQueryParams struct {
+		groupId string
+		name string
 }
 
 func (r ServerlessInstancesApiGetServerlessInstanceRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
@@ -482,6 +494,12 @@ type ServerlessInstancesApiListServerlessInstancesRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type ServerlessInstancesApiListServerlessInstancesQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -640,6 +658,11 @@ type ServerlessInstancesApiUpdateServerlessInstanceRequest struct {
 	groupId string
 	name string
 	serverlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
+}
+type ServerlessInstancesApiUpdateServerlessInstanceQueryParams struct {
+		groupId string
+		name string
+		serverlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
 }
 
 // Update One Serverless Instance in One Project.

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -110,7 +110,7 @@ type ServerlessInstancesApiCreateServerlessInstanceRequest struct {
 	serverlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
 
-type ServerlessInstancesApiCreateServerlessInstanceQueryParams struct {
+type ServerlessInstancesApiCreateServerlessInstanceParams struct {
 		GroupId string
 		ServerlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
@@ -244,7 +244,7 @@ type ServerlessInstancesApiDeleteServerlessInstanceRequest struct {
 	name string
 }
 
-type ServerlessInstancesApiDeleteServerlessInstanceQueryParams struct {
+type ServerlessInstancesApiDeleteServerlessInstanceParams struct {
 		GroupId string
 		Name string
 }
@@ -365,7 +365,7 @@ type ServerlessInstancesApiGetServerlessInstanceRequest struct {
 	name string
 }
 
-type ServerlessInstancesApiGetServerlessInstanceQueryParams struct {
+type ServerlessInstancesApiGetServerlessInstanceParams struct {
 		GroupId string
 		Name string
 }
@@ -499,7 +499,7 @@ type ServerlessInstancesApiListServerlessInstancesRequest struct {
 	pageNum *int32
 }
 
-type ServerlessInstancesApiListServerlessInstancesQueryParams struct {
+type ServerlessInstancesApiListServerlessInstancesParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -664,7 +664,7 @@ type ServerlessInstancesApiUpdateServerlessInstanceRequest struct {
 	serverlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
 }
 
-type ServerlessInstancesApiUpdateServerlessInstanceQueryParams struct {
+type ServerlessInstancesApiUpdateServerlessInstanceParams struct {
 		GroupId string
 		Name string
 		ServerlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -32,13 +32,13 @@ type ServerlessPrivateEndpointsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param instanceName Human-readable label that identifies the serverless instance for which the tenant endpoint will be created.
-	@return ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest
+	@return CreateServerlessPrivateEndpointApiRequest
 	*/
-	CreateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string) ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest
+	CreateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string) CreateServerlessPrivateEndpointApiRequest
 
 	// CreateServerlessPrivateEndpointExecute executes the request
 	//  @return ServerlessTenantEndpoint
-	CreateServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+	CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 	DeleteServerlessPrivateEndpoint Remove One Private Endpoint for One Serverless Instance
@@ -49,12 +49,12 @@ type ServerlessPrivateEndpointsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param instanceName Human-readable label that identifies the serverless instance from which the tenant endpoint will be removed.
 	@param endpointId Unique 24-hexadecimal digit string that identifies the tenant endpoint which will be removed.
-	@return ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest
+	@return DeleteServerlessPrivateEndpointApiRequest
 	*/
-	DeleteServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest
+	DeleteServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) DeleteServerlessPrivateEndpointApiRequest
 
 	// DeleteServerlessPrivateEndpointExecute executes the request
-	DeleteServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest) (*http.Response, error)
+	DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (*http.Response, error)
 
 	/*
 	GetServerlessPrivateEndpoint Return One Private Endpoint for One Serverless Instance
@@ -65,13 +65,13 @@ type ServerlessPrivateEndpointsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param instanceName Human-readable label that identifies the serverless instance associated with the tenant endpoint.
 	@param endpointId Unique 24-hexadecimal digit string that identifies the tenant endpoint.
-	@return ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest
+	@return GetServerlessPrivateEndpointApiRequest
 	*/
-	GetServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest
+	GetServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) GetServerlessPrivateEndpointApiRequest
 
 	// GetServerlessPrivateEndpointExecute executes the request
 	//  @return ServerlessTenantEndpoint
-	GetServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+	GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 	ListServerlessPrivateEndpoints Return All Private Endpoints for One Serverless Instance
@@ -81,13 +81,13 @@ type ServerlessPrivateEndpointsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param instanceName Human-readable label that identifies the serverless instance associated with the tenant endpoint.
-	@return ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest
+	@return ListServerlessPrivateEndpointsApiRequest
 	*/
-	ListServerlessPrivateEndpoints(ctx context.Context, groupId string, instanceName string) ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest
+	ListServerlessPrivateEndpoints(ctx context.Context, groupId string, instanceName string) ListServerlessPrivateEndpointsApiRequest
 
 	// ListServerlessPrivateEndpointsExecute executes the request
 	//  @return []ServerlessTenantEndpoint
-	ListServerlessPrivateEndpointsExecute(r ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest) ([]ServerlessTenantEndpoint, *http.Response, error)
+	ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 	UpdateServerlessPrivateEndpoint Update One Private Endpoint for One Serverless Instance
@@ -98,19 +98,19 @@ type ServerlessPrivateEndpointsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param instanceName Human-readable label that identifies the serverless instance associated with the tenant endpoint that will be updated.
 	@param endpointId Unique 24-hexadecimal digit string that identifies the tenant endpoint which will be updated.
-	@return ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest
+	@return UpdateServerlessPrivateEndpointApiRequest
 	*/
-	UpdateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest
+	UpdateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) UpdateServerlessPrivateEndpointApiRequest
 
 	// UpdateServerlessPrivateEndpointExecute executes the request
 	//  @return ServerlessTenantEndpoint
-	UpdateServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+	UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 }
 
 // ServerlessPrivateEndpointsApiService ServerlessPrivateEndpointsApi service
 type ServerlessPrivateEndpointsApiService service
 
-type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest struct {
+type CreateServerlessPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessPrivateEndpointsApi
 	groupId string
@@ -125,12 +125,12 @@ type CreateServerlessPrivateEndpointParams struct {
 }
 
 // Information about the Private Endpoint to create for the Serverless Instance.
-func (r ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest) ServerlessTenantEndpointCreate(serverlessTenantEndpointCreate ServerlessTenantEndpointCreate) ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest {
+func (r CreateServerlessPrivateEndpointApiRequest) ServerlessTenantEndpointCreate(serverlessTenantEndpointCreate ServerlessTenantEndpointCreate) CreateServerlessPrivateEndpointApiRequest {
 	r.serverlessTenantEndpointCreate = &serverlessTenantEndpointCreate
 	return r
 }
 
-func (r ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
+func (r CreateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
 	return r.ApiService.CreateServerlessPrivateEndpointExecute(r)
 }
 
@@ -144,10 +144,10 @@ Creates one private endpoint for one serverless instance. To use this resource, 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param instanceName Human-readable label that identifies the serverless instance for which the tenant endpoint will be created.
- @return ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest
+ @return CreateServerlessPrivateEndpointApiRequest
 */
-func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string) ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest {
-	return ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest{
+func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string) CreateServerlessPrivateEndpointApiRequest {
+	return CreateServerlessPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -157,7 +157,7 @@ func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpoint(c
 
 // Execute executes the request
 //  @return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -254,7 +254,7 @@ func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointEx
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest struct {
+type DeleteServerlessPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessPrivateEndpointsApi
 	groupId string
@@ -268,7 +268,7 @@ type DeleteServerlessPrivateEndpointParams struct {
 		EndpointId string
 }
 
-func (r ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest) Execute() (*http.Response, error) {
+func (r DeleteServerlessPrivateEndpointApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteServerlessPrivateEndpointExecute(r)
 }
 
@@ -281,10 +281,10 @@ Remove one private endpoint from one serverless instance. To use this resource, 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param instanceName Human-readable label that identifies the serverless instance from which the tenant endpoint will be removed.
  @param endpointId Unique 24-hexadecimal digit string that identifies the tenant endpoint which will be removed.
- @return ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest
+ @return DeleteServerlessPrivateEndpointApiRequest
 */
-func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest {
-	return ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest{
+func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) DeleteServerlessPrivateEndpointApiRequest {
+	return DeleteServerlessPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -294,7 +294,7 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpoint(c
 }
 
 // Execute executes the request
-func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest) (*http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -383,7 +383,7 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointEx
 	return localVarHTTPResponse, nil
 }
 
-type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest struct {
+type GetServerlessPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessPrivateEndpointsApi
 	groupId string
@@ -397,7 +397,7 @@ type GetServerlessPrivateEndpointParams struct {
 		EndpointId string
 }
 
-func (r ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
+func (r GetServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
 	return r.ApiService.GetServerlessPrivateEndpointExecute(r)
 }
 
@@ -410,10 +410,10 @@ Return one private endpoint for one serverless instance. Identify this endpoint 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param instanceName Human-readable label that identifies the serverless instance associated with the tenant endpoint.
  @param endpointId Unique 24-hexadecimal digit string that identifies the tenant endpoint.
- @return ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest
+ @return GetServerlessPrivateEndpointApiRequest
 */
-func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest {
-	return ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest{
+func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) GetServerlessPrivateEndpointApiRequest {
+	return GetServerlessPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -424,7 +424,7 @@ func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpoint(ctx 
 
 // Execute executes the request
 //  @return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -523,7 +523,7 @@ func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointExecu
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest struct {
+type ListServerlessPrivateEndpointsApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessPrivateEndpointsApi
 	groupId string
@@ -535,7 +535,7 @@ type ListServerlessPrivateEndpointsParams struct {
 		InstanceName string
 }
 
-func (r ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest) Execute() ([]ServerlessTenantEndpoint, *http.Response, error) {
+func (r ListServerlessPrivateEndpointsApiRequest) Execute() ([]ServerlessTenantEndpoint, *http.Response, error) {
 	return r.ApiService.ListServerlessPrivateEndpointsExecute(r)
 }
 
@@ -547,10 +547,10 @@ Returns all private endpoints for one serverless instance. You must have at leas
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param instanceName Human-readable label that identifies the serverless instance associated with the tenant endpoint.
- @return ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest
+ @return ListServerlessPrivateEndpointsApiRequest
 */
-func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpoints(ctx context.Context, groupId string, instanceName string) ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest {
-	return ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest{
+func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpoints(ctx context.Context, groupId string, instanceName string) ListServerlessPrivateEndpointsApiRequest {
+	return ListServerlessPrivateEndpointsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -560,7 +560,7 @@ func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpoints(ct
 
 // Execute executes the request
 //  @return []ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsExecute(r ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest) ([]ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -652,7 +652,7 @@ func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsExe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest struct {
+type UpdateServerlessPrivateEndpointApiRequest struct {
 	ctx context.Context
 	ApiService ServerlessPrivateEndpointsApi
 	groupId string
@@ -668,12 +668,12 @@ type UpdateServerlessPrivateEndpointParams struct {
 		ServerlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
 
-func (r ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest) ServerlessTenantEndpointUpdate(serverlessTenantEndpointUpdate ServerlessTenantEndpointUpdate) ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest {
+func (r UpdateServerlessPrivateEndpointApiRequest) ServerlessTenantEndpointUpdate(serverlessTenantEndpointUpdate ServerlessTenantEndpointUpdate) UpdateServerlessPrivateEndpointApiRequest {
 	r.serverlessTenantEndpointUpdate = &serverlessTenantEndpointUpdate
 	return r
 }
 
-func (r ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
+func (r UpdateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
 	return r.ApiService.UpdateServerlessPrivateEndpointExecute(r)
 }
 
@@ -686,10 +686,10 @@ Updates one private endpoint for one serverless instance. To use this resource, 
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param instanceName Human-readable label that identifies the serverless instance associated with the tenant endpoint that will be updated.
  @param endpointId Unique 24-hexadecimal digit string that identifies the tenant endpoint which will be updated.
- @return ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest
+ @return UpdateServerlessPrivateEndpointApiRequest
 */
-func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest {
-	return ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest{
+func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) UpdateServerlessPrivateEndpointApiRequest {
+	return UpdateServerlessPrivateEndpointApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -700,7 +700,7 @@ func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpoint(c
 
 // Execute executes the request
 //  @return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpointExecute(r ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -117,10 +117,11 @@ type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest struct 
 	instanceName string
 	serverlessTenantEndpointCreate *ServerlessTenantEndpointCreate
 }
+
 type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointQueryParams struct {
-		groupId string
-		instanceName string
-		serverlessTenantEndpointCreate *ServerlessTenantEndpointCreate
+		GroupId string
+		InstanceName string
+		ServerlessTenantEndpointCreate *ServerlessTenantEndpointCreate
 }
 
 // Information about the Private Endpoint to create for the Serverless Instance.
@@ -260,10 +261,11 @@ type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest struct 
 	instanceName string
 	endpointId string
 }
+
 type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointQueryParams struct {
-		groupId string
-		instanceName string
-		endpointId string
+		GroupId string
+		InstanceName string
+		EndpointId string
 }
 
 func (r ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest) Execute() (*http.Response, error) {
@@ -388,10 +390,11 @@ type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest struct {
 	instanceName string
 	endpointId string
 }
+
 type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointQueryParams struct {
-		groupId string
-		instanceName string
-		endpointId string
+		GroupId string
+		InstanceName string
+		EndpointId string
 }
 
 func (r ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
@@ -526,9 +529,10 @@ type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest struct {
 	groupId string
 	instanceName string
 }
+
 type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsQueryParams struct {
-		groupId string
-		instanceName string
+		GroupId string
+		InstanceName string
 }
 
 func (r ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest) Execute() ([]ServerlessTenantEndpoint, *http.Response, error) {
@@ -656,11 +660,12 @@ type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest struct 
 	endpointId string
 	serverlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
+
 type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointQueryParams struct {
-		groupId string
-		instanceName string
-		endpointId string
-		serverlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
+		GroupId string
+		InstanceName string
+		EndpointId string
+		ServerlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
 
 func (r ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest) ServerlessTenantEndpointUpdate(serverlessTenantEndpointUpdate ServerlessTenantEndpointUpdate) ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest {

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -118,7 +118,7 @@ type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest struct 
 	serverlessTenantEndpointCreate *ServerlessTenantEndpointCreate
 }
 
-type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointQueryParams struct {
+type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		ServerlessTenantEndpointCreate *ServerlessTenantEndpointCreate
@@ -262,7 +262,7 @@ type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest struct 
 	endpointId string
 }
 
-type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointQueryParams struct {
+type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string
@@ -391,7 +391,7 @@ type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest struct {
 	endpointId string
 }
 
-type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointQueryParams struct {
+type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string
@@ -530,7 +530,7 @@ type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest struct {
 	instanceName string
 }
 
-type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsQueryParams struct {
+type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsParams struct {
 		GroupId string
 		InstanceName string
 }
@@ -661,7 +661,7 @@ type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest struct 
 	serverlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
 
-type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointQueryParams struct {
+type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -118,7 +118,7 @@ type CreateServerlessPrivateEndpointApiRequest struct {
 	serverlessTenantEndpointCreate *ServerlessTenantEndpointCreate
 }
 
-type CreateServerlessPrivateEndpointParams struct {
+type CreateServerlessPrivateEndpointApiParams struct {
 		GroupId string
 		InstanceName string
 		ServerlessTenantEndpointCreate *ServerlessTenantEndpointCreate
@@ -262,7 +262,7 @@ type DeleteServerlessPrivateEndpointApiRequest struct {
 	endpointId string
 }
 
-type DeleteServerlessPrivateEndpointParams struct {
+type DeleteServerlessPrivateEndpointApiParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string
@@ -391,7 +391,7 @@ type GetServerlessPrivateEndpointApiRequest struct {
 	endpointId string
 }
 
-type GetServerlessPrivateEndpointParams struct {
+type GetServerlessPrivateEndpointApiParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string
@@ -530,7 +530,7 @@ type ListServerlessPrivateEndpointsApiRequest struct {
 	instanceName string
 }
 
-type ListServerlessPrivateEndpointsParams struct {
+type ListServerlessPrivateEndpointsApiParams struct {
 		GroupId string
 		InstanceName string
 }
@@ -661,7 +661,7 @@ type UpdateServerlessPrivateEndpointApiRequest struct {
 	serverlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
 
-type UpdateServerlessPrivateEndpointParams struct {
+type UpdateServerlessPrivateEndpointApiParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -118,7 +118,7 @@ type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest struct 
 	serverlessTenantEndpointCreate *ServerlessTenantEndpointCreate
 }
 
-type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointParams struct {
+type CreateServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		ServerlessTenantEndpointCreate *ServerlessTenantEndpointCreate
@@ -262,7 +262,7 @@ type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest struct 
 	endpointId string
 }
 
-type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointParams struct {
+type DeleteServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string
@@ -391,7 +391,7 @@ type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest struct {
 	endpointId string
 }
 
-type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointParams struct {
+type GetServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string
@@ -530,7 +530,7 @@ type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest struct {
 	instanceName string
 }
 
-type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsParams struct {
+type ListServerlessPrivateEndpointsParams struct {
 		GroupId string
 		InstanceName string
 }
@@ -661,7 +661,7 @@ type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest struct 
 	serverlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
 
-type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointParams struct {
+type UpdateServerlessPrivateEndpointParams struct {
 		GroupId string
 		InstanceName string
 		EndpointId string

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -117,6 +117,11 @@ type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest struct 
 	instanceName string
 	serverlessTenantEndpointCreate *ServerlessTenantEndpointCreate
 }
+type ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointQueryParams struct {
+		groupId string
+		instanceName string
+		serverlessTenantEndpointCreate *ServerlessTenantEndpointCreate
+}
 
 // Information about the Private Endpoint to create for the Serverless Instance.
 func (r ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest) ServerlessTenantEndpointCreate(serverlessTenantEndpointCreate ServerlessTenantEndpointCreate) ServerlessPrivateEndpointsApiCreateServerlessPrivateEndpointRequest {
@@ -255,6 +260,11 @@ type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest struct 
 	instanceName string
 	endpointId string
 }
+type ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointQueryParams struct {
+		groupId string
+		instanceName string
+		endpointId string
+}
 
 func (r ServerlessPrivateEndpointsApiDeleteServerlessPrivateEndpointRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteServerlessPrivateEndpointExecute(r)
@@ -377,6 +387,11 @@ type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest struct {
 	groupId string
 	instanceName string
 	endpointId string
+}
+type ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointQueryParams struct {
+		groupId string
+		instanceName string
+		endpointId string
 }
 
 func (r ServerlessPrivateEndpointsApiGetServerlessPrivateEndpointRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
@@ -511,6 +526,10 @@ type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest struct {
 	groupId string
 	instanceName string
 }
+type ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsQueryParams struct {
+		groupId string
+		instanceName string
+}
 
 func (r ServerlessPrivateEndpointsApiListServerlessPrivateEndpointsRequest) Execute() ([]ServerlessTenantEndpoint, *http.Response, error) {
 	return r.ApiService.ListServerlessPrivateEndpointsExecute(r)
@@ -636,6 +655,12 @@ type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest struct 
 	instanceName string
 	endpointId string
 	serverlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
+}
+type ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointQueryParams struct {
+		groupId string
+		instanceName string
+		endpointId string
+		serverlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
 
 func (r ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest) ServerlessTenantEndpointUpdate(serverlessTenantEndpointUpdate ServerlessTenantEndpointUpdate) ServerlessPrivateEndpointsApiUpdateServerlessPrivateEndpointRequest {

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -82,6 +82,11 @@ type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest struct {
 	groupId string
 	tenantRestore *TenantRestore
 }
+type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobQueryParams struct {
+		clusterName string
+		groupId string
+		tenantRestore *TenantRestore
+}
 
 // The restore job details.
 func (r SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest) TenantRestore(tenantRestore TenantRestore) SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest {
@@ -221,6 +226,11 @@ type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest struct {
 	groupId string
 	restoreId string
 }
+type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobQueryParams struct {
+		clusterName string
+		groupId string
+		restoreId string
+}
 
 func (r SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest) Execute() (*TenantRestore, *http.Response, error) {
 	return r.ApiService.GetSharedClusterBackupRestoreJobExecute(r)
@@ -356,6 +366,10 @@ type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest struct {
 	ApiService SharedTierRestoreJobsApi
 	clusterName string
 	groupId string
+}
+type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsQueryParams struct {
+		clusterName string
+		groupId string
 }
 
 func (r SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -83,7 +83,7 @@ type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest struct {
 	tenantRestore *TenantRestore
 }
 
-type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobQueryParams struct {
+type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobParams struct {
 		ClusterName string
 		GroupId string
 		TenantRestore *TenantRestore
@@ -228,7 +228,7 @@ type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest struct {
 	restoreId string
 }
 
-type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobQueryParams struct {
+type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobParams struct {
 		ClusterName string
 		GroupId string
 		RestoreId string
@@ -370,7 +370,7 @@ type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest struct {
 	groupId string
 }
 
-type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsQueryParams struct {
+type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsParams struct {
 		ClusterName string
 		GroupId string
 }

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -83,7 +83,7 @@ type CreateSharedClusterBackupRestoreJobApiRequest struct {
 	tenantRestore *TenantRestore
 }
 
-type CreateSharedClusterBackupRestoreJobParams struct {
+type CreateSharedClusterBackupRestoreJobApiParams struct {
 		ClusterName string
 		GroupId string
 		TenantRestore *TenantRestore
@@ -228,7 +228,7 @@ type GetSharedClusterBackupRestoreJobApiRequest struct {
 	restoreId string
 }
 
-type GetSharedClusterBackupRestoreJobParams struct {
+type GetSharedClusterBackupRestoreJobApiParams struct {
 		ClusterName string
 		GroupId string
 		RestoreId string
@@ -370,7 +370,7 @@ type ListSharedClusterBackupRestoreJobsApiRequest struct {
 	groupId string
 }
 
-type ListSharedClusterBackupRestoreJobsParams struct {
+type ListSharedClusterBackupRestoreJobsApiParams struct {
 		ClusterName string
 		GroupId string
 }

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -30,13 +30,13 @@ type SharedTierRestoreJobsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param clusterName Human-readable label that identifies the cluster.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest
+	@return CreateSharedClusterBackupRestoreJobApiRequest
 	*/
-	CreateSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string) SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest
+	CreateSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string) CreateSharedClusterBackupRestoreJobApiRequest
 
 	// CreateSharedClusterBackupRestoreJobExecute executes the request
 	//  @return TenantRestore
-	CreateSharedClusterBackupRestoreJobExecute(r SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest) (*TenantRestore, *http.Response, error)
+	CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 	GetSharedClusterBackupRestoreJob Return One Restore Job for One M2 or M5 Cluster
@@ -47,13 +47,13 @@ type SharedTierRestoreJobsApi interface {
 	@param clusterName Human-readable label that identifies the cluster.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param restoreId Unique 24-hexadecimal digit string that identifies the restore job to return.
-	@return SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest
+	@return GetSharedClusterBackupRestoreJobApiRequest
 	*/
-	GetSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string, restoreId string) SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest
+	GetSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string, restoreId string) GetSharedClusterBackupRestoreJobApiRequest
 
 	// GetSharedClusterBackupRestoreJobExecute executes the request
 	//  @return TenantRestore
-	GetSharedClusterBackupRestoreJobExecute(r SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest) (*TenantRestore, *http.Response, error)
+	GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 	ListSharedClusterBackupRestoreJobs Return All Restore Jobs for One M2 or M5 Cluster
@@ -63,19 +63,19 @@ type SharedTierRestoreJobsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param clusterName Human-readable label that identifies the cluster.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest
+	@return ListSharedClusterBackupRestoreJobsApiRequest
 	*/
-	ListSharedClusterBackupRestoreJobs(ctx context.Context, clusterName string, groupId string) SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest
+	ListSharedClusterBackupRestoreJobs(ctx context.Context, clusterName string, groupId string) ListSharedClusterBackupRestoreJobsApiRequest
 
 	// ListSharedClusterBackupRestoreJobsExecute executes the request
 	//  @return PaginatedTenantRestore
-	ListSharedClusterBackupRestoreJobsExecute(r SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest) (*PaginatedTenantRestore, *http.Response, error)
+	ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error)
 }
 
 // SharedTierRestoreJobsApiService SharedTierRestoreJobsApi service
 type SharedTierRestoreJobsApiService service
 
-type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest struct {
+type CreateSharedClusterBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService SharedTierRestoreJobsApi
 	clusterName string
@@ -90,12 +90,12 @@ type CreateSharedClusterBackupRestoreJobParams struct {
 }
 
 // The restore job details.
-func (r SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest) TenantRestore(tenantRestore TenantRestore) SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest {
+func (r CreateSharedClusterBackupRestoreJobApiRequest) TenantRestore(tenantRestore TenantRestore) CreateSharedClusterBackupRestoreJobApiRequest {
 	r.tenantRestore = &tenantRestore
 	return r
 }
 
-func (r SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest) Execute() (*TenantRestore, *http.Response, error) {
+func (r CreateSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
 	return r.ApiService.CreateSharedClusterBackupRestoreJobExecute(r)
 }
 
@@ -107,10 +107,10 @@ Restores the specified cluster. MongoDB Cloud limits which clusters can be the t
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param clusterName Human-readable label that identifies the cluster.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest
+ @return CreateSharedClusterBackupRestoreJobApiRequest
 */
-func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string) SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest {
-	return SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest{
+func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string) CreateSharedClusterBackupRestoreJobApiRequest {
+	return CreateSharedClusterBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		clusterName: clusterName,
@@ -120,7 +120,7 @@ func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJob(ct
 
 // Execute executes the request
 //  @return TenantRestore
-func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobExecute(r SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -220,7 +220,7 @@ func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobExe
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest struct {
+type GetSharedClusterBackupRestoreJobApiRequest struct {
 	ctx context.Context
 	ApiService SharedTierRestoreJobsApi
 	clusterName string
@@ -234,7 +234,7 @@ type GetSharedClusterBackupRestoreJobParams struct {
 		RestoreId string
 }
 
-func (r SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest) Execute() (*TenantRestore, *http.Response, error) {
+func (r GetSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
 	return r.ApiService.GetSharedClusterBackupRestoreJobExecute(r)
 }
 
@@ -247,10 +247,10 @@ Returns the specified restore job. To use this resource, the requesting API Key 
  @param clusterName Human-readable label that identifies the cluster.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param restoreId Unique 24-hexadecimal digit string that identifies the restore job to return.
- @return SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest
+ @return GetSharedClusterBackupRestoreJobApiRequest
 */
-func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string, restoreId string) SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest {
-	return SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest{
+func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string, restoreId string) GetSharedClusterBackupRestoreJobApiRequest {
+	return GetSharedClusterBackupRestoreJobApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		clusterName: clusterName,
@@ -261,7 +261,7 @@ func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJob(ctx c
 
 // Execute executes the request
 //  @return TenantRestore
-func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobExecute(r SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -363,7 +363,7 @@ func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobExecut
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest struct {
+type ListSharedClusterBackupRestoreJobsApiRequest struct {
 	ctx context.Context
 	ApiService SharedTierRestoreJobsApi
 	clusterName string
@@ -375,7 +375,7 @@ type ListSharedClusterBackupRestoreJobsParams struct {
 		GroupId string
 }
 
-func (r SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {
+func (r ListSharedClusterBackupRestoreJobsApiRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {
 	return r.ApiService.ListSharedClusterBackupRestoreJobsExecute(r)
 }
 
@@ -387,10 +387,10 @@ Returns all restore jobs for the specified M2 or M5 cluster. Restore jobs restor
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param clusterName Human-readable label that identifies the cluster.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest
+ @return ListSharedClusterBackupRestoreJobsApiRequest
 */
-func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobs(ctx context.Context, clusterName string, groupId string) SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest {
-	return SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest{
+func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobs(ctx context.Context, clusterName string, groupId string) ListSharedClusterBackupRestoreJobsApiRequest {
+	return ListSharedClusterBackupRestoreJobsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		clusterName: clusterName,
@@ -400,7 +400,7 @@ func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobs(ctx
 
 // Execute executes the request
 //  @return PaginatedTenantRestore
-func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobsExecute(r SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest) (*PaginatedTenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -82,10 +82,11 @@ type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest struct {
 	groupId string
 	tenantRestore *TenantRestore
 }
+
 type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobQueryParams struct {
-		clusterName string
-		groupId string
-		tenantRestore *TenantRestore
+		ClusterName string
+		GroupId string
+		TenantRestore *TenantRestore
 }
 
 // The restore job details.
@@ -226,10 +227,11 @@ type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest struct {
 	groupId string
 	restoreId string
 }
+
 type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobQueryParams struct {
-		clusterName string
-		groupId string
-		restoreId string
+		ClusterName string
+		GroupId string
+		RestoreId string
 }
 
 func (r SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest) Execute() (*TenantRestore, *http.Response, error) {
@@ -367,9 +369,10 @@ type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest struct {
 	clusterName string
 	groupId string
 }
+
 type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsQueryParams struct {
-		clusterName string
-		groupId string
+		ClusterName string
+		GroupId string
 }
 
 func (r SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -83,7 +83,7 @@ type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobRequest struct {
 	tenantRestore *TenantRestore
 }
 
-type SharedTierRestoreJobsApiCreateSharedClusterBackupRestoreJobParams struct {
+type CreateSharedClusterBackupRestoreJobParams struct {
 		ClusterName string
 		GroupId string
 		TenantRestore *TenantRestore
@@ -228,7 +228,7 @@ type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobRequest struct {
 	restoreId string
 }
 
-type SharedTierRestoreJobsApiGetSharedClusterBackupRestoreJobParams struct {
+type GetSharedClusterBackupRestoreJobParams struct {
 		ClusterName string
 		GroupId string
 		RestoreId string
@@ -370,7 +370,7 @@ type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsRequest struct {
 	groupId string
 }
 
-type SharedTierRestoreJobsApiListSharedClusterBackupRestoreJobsParams struct {
+type ListSharedClusterBackupRestoreJobsParams struct {
 		ClusterName string
 		GroupId string
 }

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -83,7 +83,7 @@ type SharedTierSnapshotsApiDownloadSharedClusterBackupRequest struct {
 	tenantRestore *TenantRestore
 }
 
-type SharedTierSnapshotsApiDownloadSharedClusterBackupParams struct {
+type DownloadSharedClusterBackupParams struct {
 		ClusterName string
 		GroupId string
 		TenantRestore *TenantRestore
@@ -228,7 +228,7 @@ type SharedTierSnapshotsApiGetSharedClusterBackupRequest struct {
 	snapshotId string
 }
 
-type SharedTierSnapshotsApiGetSharedClusterBackupParams struct {
+type GetSharedClusterBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -370,7 +370,7 @@ type SharedTierSnapshotsApiListSharedClusterBackupsRequest struct {
 	clusterName string
 }
 
-type SharedTierSnapshotsApiListSharedClusterBackupsParams struct {
+type ListSharedClusterBackupsParams struct {
 		GroupId string
 		ClusterName string
 }

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -83,7 +83,7 @@ type DownloadSharedClusterBackupApiRequest struct {
 	tenantRestore *TenantRestore
 }
 
-type DownloadSharedClusterBackupParams struct {
+type DownloadSharedClusterBackupApiParams struct {
 		ClusterName string
 		GroupId string
 		TenantRestore *TenantRestore
@@ -228,7 +228,7 @@ type GetSharedClusterBackupApiRequest struct {
 	snapshotId string
 }
 
-type GetSharedClusterBackupParams struct {
+type GetSharedClusterBackupApiParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -370,7 +370,7 @@ type ListSharedClusterBackupsApiRequest struct {
 	clusterName string
 }
 
-type ListSharedClusterBackupsParams struct {
+type ListSharedClusterBackupsApiParams struct {
 		GroupId string
 		ClusterName string
 }

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -82,6 +82,11 @@ type SharedTierSnapshotsApiDownloadSharedClusterBackupRequest struct {
 	groupId string
 	tenantRestore *TenantRestore
 }
+type SharedTierSnapshotsApiDownloadSharedClusterBackupQueryParams struct {
+		clusterName string
+		groupId string
+		tenantRestore *TenantRestore
+}
 
 // Snapshot to be downloaded.
 func (r SharedTierSnapshotsApiDownloadSharedClusterBackupRequest) TenantRestore(tenantRestore TenantRestore) SharedTierSnapshotsApiDownloadSharedClusterBackupRequest {
@@ -221,6 +226,11 @@ type SharedTierSnapshotsApiGetSharedClusterBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+type SharedTierSnapshotsApiGetSharedClusterBackupQueryParams struct {
+		groupId string
+		clusterName string
+		snapshotId string
+}
 
 func (r SharedTierSnapshotsApiGetSharedClusterBackupRequest) Execute() (*TenantSnapshot, *http.Response, error) {
 	return r.ApiService.GetSharedClusterBackupExecute(r)
@@ -356,6 +366,10 @@ type SharedTierSnapshotsApiListSharedClusterBackupsRequest struct {
 	ApiService SharedTierSnapshotsApi
 	groupId string
 	clusterName string
+}
+type SharedTierSnapshotsApiListSharedClusterBackupsQueryParams struct {
+		groupId string
+		clusterName string
 }
 
 func (r SharedTierSnapshotsApiListSharedClusterBackupsRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -83,7 +83,7 @@ type SharedTierSnapshotsApiDownloadSharedClusterBackupRequest struct {
 	tenantRestore *TenantRestore
 }
 
-type SharedTierSnapshotsApiDownloadSharedClusterBackupQueryParams struct {
+type SharedTierSnapshotsApiDownloadSharedClusterBackupParams struct {
 		ClusterName string
 		GroupId string
 		TenantRestore *TenantRestore
@@ -228,7 +228,7 @@ type SharedTierSnapshotsApiGetSharedClusterBackupRequest struct {
 	snapshotId string
 }
 
-type SharedTierSnapshotsApiGetSharedClusterBackupQueryParams struct {
+type SharedTierSnapshotsApiGetSharedClusterBackupParams struct {
 		GroupId string
 		ClusterName string
 		SnapshotId string
@@ -370,7 +370,7 @@ type SharedTierSnapshotsApiListSharedClusterBackupsRequest struct {
 	clusterName string
 }
 
-type SharedTierSnapshotsApiListSharedClusterBackupsQueryParams struct {
+type SharedTierSnapshotsApiListSharedClusterBackupsParams struct {
 		GroupId string
 		ClusterName string
 }

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -30,13 +30,13 @@ type SharedTierSnapshotsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param clusterName Human-readable label that identifies the cluster.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return SharedTierSnapshotsApiDownloadSharedClusterBackupRequest
+	@return DownloadSharedClusterBackupApiRequest
 	*/
-	DownloadSharedClusterBackup(ctx context.Context, clusterName string, groupId string) SharedTierSnapshotsApiDownloadSharedClusterBackupRequest
+	DownloadSharedClusterBackup(ctx context.Context, clusterName string, groupId string) DownloadSharedClusterBackupApiRequest
 
 	// DownloadSharedClusterBackupExecute executes the request
 	//  @return TenantRestore
-	DownloadSharedClusterBackupExecute(r SharedTierSnapshotsApiDownloadSharedClusterBackupRequest) (*TenantRestore, *http.Response, error)
+	DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 	GetSharedClusterBackup Return One Snapshot for One M2 or M5 Cluster
@@ -47,13 +47,13 @@ type SharedTierSnapshotsApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
-	@return SharedTierSnapshotsApiGetSharedClusterBackupRequest
+	@return GetSharedClusterBackupApiRequest
 	*/
-	GetSharedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) SharedTierSnapshotsApiGetSharedClusterBackupRequest
+	GetSharedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetSharedClusterBackupApiRequest
 
 	// GetSharedClusterBackupExecute executes the request
 	//  @return TenantSnapshot
-	GetSharedClusterBackupExecute(r SharedTierSnapshotsApiGetSharedClusterBackupRequest) (*TenantSnapshot, *http.Response, error)
+	GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*TenantSnapshot, *http.Response, error)
 
 	/*
 	ListSharedClusterBackups Return All Snapshots for One M2 or M5 Cluster
@@ -63,19 +63,19 @@ type SharedTierSnapshotsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param clusterName Human-readable label that identifies the cluster.
-	@return SharedTierSnapshotsApiListSharedClusterBackupsRequest
+	@return ListSharedClusterBackupsApiRequest
 	*/
-	ListSharedClusterBackups(ctx context.Context, groupId string, clusterName string) SharedTierSnapshotsApiListSharedClusterBackupsRequest
+	ListSharedClusterBackups(ctx context.Context, groupId string, clusterName string) ListSharedClusterBackupsApiRequest
 
 	// ListSharedClusterBackupsExecute executes the request
 	//  @return PaginatedTenantSnapshot
-	ListSharedClusterBackupsExecute(r SharedTierSnapshotsApiListSharedClusterBackupsRequest) (*PaginatedTenantSnapshot, *http.Response, error)
+	ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error)
 }
 
 // SharedTierSnapshotsApiService SharedTierSnapshotsApi service
 type SharedTierSnapshotsApiService service
 
-type SharedTierSnapshotsApiDownloadSharedClusterBackupRequest struct {
+type DownloadSharedClusterBackupApiRequest struct {
 	ctx context.Context
 	ApiService SharedTierSnapshotsApi
 	clusterName string
@@ -90,12 +90,12 @@ type DownloadSharedClusterBackupParams struct {
 }
 
 // Snapshot to be downloaded.
-func (r SharedTierSnapshotsApiDownloadSharedClusterBackupRequest) TenantRestore(tenantRestore TenantRestore) SharedTierSnapshotsApiDownloadSharedClusterBackupRequest {
+func (r DownloadSharedClusterBackupApiRequest) TenantRestore(tenantRestore TenantRestore) DownloadSharedClusterBackupApiRequest {
 	r.tenantRestore = &tenantRestore
 	return r
 }
 
-func (r SharedTierSnapshotsApiDownloadSharedClusterBackupRequest) Execute() (*TenantRestore, *http.Response, error) {
+func (r DownloadSharedClusterBackupApiRequest) Execute() (*TenantRestore, *http.Response, error) {
 	return r.ApiService.DownloadSharedClusterBackupExecute(r)
 }
 
@@ -107,10 +107,10 @@ Requests one snapshot for the specified shared cluster. This resource returns a 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param clusterName Human-readable label that identifies the cluster.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return SharedTierSnapshotsApiDownloadSharedClusterBackupRequest
+ @return DownloadSharedClusterBackupApiRequest
 */
-func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackup(ctx context.Context, clusterName string, groupId string) SharedTierSnapshotsApiDownloadSharedClusterBackupRequest {
-	return SharedTierSnapshotsApiDownloadSharedClusterBackupRequest{
+func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackup(ctx context.Context, clusterName string, groupId string) DownloadSharedClusterBackupApiRequest {
+	return DownloadSharedClusterBackupApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		clusterName: clusterName,
@@ -120,7 +120,7 @@ func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackup(ctx context.
 
 // Execute executes the request
 //  @return TenantRestore
-func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupExecute(r SharedTierSnapshotsApiDownloadSharedClusterBackupRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -220,7 +220,7 @@ func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupExecute(r Sha
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type SharedTierSnapshotsApiGetSharedClusterBackupRequest struct {
+type GetSharedClusterBackupApiRequest struct {
 	ctx context.Context
 	ApiService SharedTierSnapshotsApi
 	groupId string
@@ -234,7 +234,7 @@ type GetSharedClusterBackupParams struct {
 		SnapshotId string
 }
 
-func (r SharedTierSnapshotsApiGetSharedClusterBackupRequest) Execute() (*TenantSnapshot, *http.Response, error) {
+func (r GetSharedClusterBackupApiRequest) Execute() (*TenantSnapshot, *http.Response, error) {
 	return r.ApiService.GetSharedClusterBackupExecute(r)
 }
 
@@ -247,10 +247,10 @@ Returns details for one snapshot for the specified shared cluster. To use this r
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
  @param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
- @return SharedTierSnapshotsApiGetSharedClusterBackupRequest
+ @return GetSharedClusterBackupApiRequest
 */
-func (a *SharedTierSnapshotsApiService) GetSharedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) SharedTierSnapshotsApiGetSharedClusterBackupRequest {
-	return SharedTierSnapshotsApiGetSharedClusterBackupRequest{
+func (a *SharedTierSnapshotsApiService) GetSharedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetSharedClusterBackupApiRequest {
+	return GetSharedClusterBackupApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -261,7 +261,7 @@ func (a *SharedTierSnapshotsApiService) GetSharedClusterBackup(ctx context.Conte
 
 // Execute executes the request
 //  @return TenantSnapshot
-func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupExecute(r SharedTierSnapshotsApiGetSharedClusterBackupRequest) (*TenantSnapshot, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*TenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -363,7 +363,7 @@ func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupExecute(r SharedTi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type SharedTierSnapshotsApiListSharedClusterBackupsRequest struct {
+type ListSharedClusterBackupsApiRequest struct {
 	ctx context.Context
 	ApiService SharedTierSnapshotsApi
 	groupId string
@@ -375,7 +375,7 @@ type ListSharedClusterBackupsParams struct {
 		ClusterName string
 }
 
-func (r SharedTierSnapshotsApiListSharedClusterBackupsRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {
+func (r ListSharedClusterBackupsApiRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {
 	return r.ApiService.ListSharedClusterBackupsExecute(r)
 }
 
@@ -387,10 +387,10 @@ Returns details for all snapshots for the specified shared cluster. To use this 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param clusterName Human-readable label that identifies the cluster.
- @return SharedTierSnapshotsApiListSharedClusterBackupsRequest
+ @return ListSharedClusterBackupsApiRequest
 */
-func (a *SharedTierSnapshotsApiService) ListSharedClusterBackups(ctx context.Context, groupId string, clusterName string) SharedTierSnapshotsApiListSharedClusterBackupsRequest {
-	return SharedTierSnapshotsApiListSharedClusterBackupsRequest{
+func (a *SharedTierSnapshotsApiService) ListSharedClusterBackups(ctx context.Context, groupId string, clusterName string) ListSharedClusterBackupsApiRequest {
+	return ListSharedClusterBackupsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -400,7 +400,7 @@ func (a *SharedTierSnapshotsApiService) ListSharedClusterBackups(ctx context.Con
 
 // Execute executes the request
 //  @return PaginatedTenantSnapshot
-func (a *SharedTierSnapshotsApiService) ListSharedClusterBackupsExecute(r SharedTierSnapshotsApiListSharedClusterBackupsRequest) (*PaginatedTenantSnapshot, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -82,10 +82,11 @@ type SharedTierSnapshotsApiDownloadSharedClusterBackupRequest struct {
 	groupId string
 	tenantRestore *TenantRestore
 }
+
 type SharedTierSnapshotsApiDownloadSharedClusterBackupQueryParams struct {
-		clusterName string
-		groupId string
-		tenantRestore *TenantRestore
+		ClusterName string
+		GroupId string
+		TenantRestore *TenantRestore
 }
 
 // Snapshot to be downloaded.
@@ -226,10 +227,11 @@ type SharedTierSnapshotsApiGetSharedClusterBackupRequest struct {
 	clusterName string
 	snapshotId string
 }
+
 type SharedTierSnapshotsApiGetSharedClusterBackupQueryParams struct {
-		groupId string
-		clusterName string
-		snapshotId string
+		GroupId string
+		ClusterName string
+		SnapshotId string
 }
 
 func (r SharedTierSnapshotsApiGetSharedClusterBackupRequest) Execute() (*TenantSnapshot, *http.Response, error) {
@@ -367,9 +369,10 @@ type SharedTierSnapshotsApiListSharedClusterBackupsRequest struct {
 	groupId string
 	clusterName string
 }
+
 type SharedTierSnapshotsApiListSharedClusterBackupsQueryParams struct {
-		groupId string
-		clusterName string
+		GroupId string
+		ClusterName string
 }
 
 func (r SharedTierSnapshotsApiListSharedClusterBackupsRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -234,6 +234,10 @@ type TeamsApiAddAllTeamsToProjectRequest struct {
 	groupId string
 	teamRole *[]TeamRole
 }
+type TeamsApiAddAllTeamsToProjectQueryParams struct {
+		groupId string
+		teamRole *[]TeamRole
+}
 
 // Team to add to the specified project.
 func (r TeamsApiAddAllTeamsToProjectRequest) TeamRole(teamRole []TeamRole) TeamsApiAddAllTeamsToProjectRequest {
@@ -363,6 +367,11 @@ type TeamsApiAddTeamUserRequest struct {
 	orgId string
 	teamId string
 	addUserToTeam *[]AddUserToTeam
+}
+type TeamsApiAddTeamUserQueryParams struct {
+		orgId string
+		teamId string
+		addUserToTeam *[]AddUserToTeam
 }
 
 // One or more MongoDB Cloud users that you want to add to the specified team.
@@ -502,6 +511,10 @@ type TeamsApiCreateTeamRequest struct {
 	orgId string
 	team *Team
 }
+type TeamsApiCreateTeamQueryParams struct {
+		orgId string
+		team *Team
+}
 
 // Team that you want to create in the specified organization.
 func (r TeamsApiCreateTeamRequest) Team(team Team) TeamsApiCreateTeamRequest {
@@ -631,6 +644,10 @@ type TeamsApiDeleteTeamRequest struct {
 	orgId string
 	teamId string
 }
+type TeamsApiDeleteTeamQueryParams struct {
+		orgId string
+		teamId string
+}
 
 func (r TeamsApiDeleteTeamRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteTeamExecute(r)
@@ -746,6 +763,10 @@ type TeamsApiGetTeamByIdRequest struct {
 	ApiService TeamsApi
 	orgId string
 	teamId string
+}
+type TeamsApiGetTeamByIdQueryParams struct {
+		orgId string
+		teamId string
 }
 
 func (r TeamsApiGetTeamByIdRequest) Execute() (*TeamResponse, *http.Response, error) {
@@ -874,6 +895,10 @@ type TeamsApiGetTeamByNameRequest struct {
 	orgId string
 	teamName string
 }
+type TeamsApiGetTeamByNameQueryParams struct {
+		orgId string
+		teamName string
+}
 
 func (r TeamsApiGetTeamByNameRequest) Execute() (*TeamResponse, *http.Response, error) {
 	return r.ApiService.GetTeamByNameExecute(r)
@@ -996,6 +1021,12 @@ type TeamsApiListOrganizationTeamsRequest struct {
 	itemsPerPage *int32
 	includeCount *bool
 	pageNum *int32
+}
+type TeamsApiListOrganizationTeamsQueryParams struct {
+		orgId string
+		itemsPerPage *int32
+		includeCount *bool
+		pageNum *int32
 }
 
 // Number of items that the response returns per page.
@@ -1156,6 +1187,12 @@ type TeamsApiListProjectTeamsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type TeamsApiListProjectTeamsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r TeamsApiListProjectTeamsRequest) IncludeCount(includeCount bool) TeamsApiListProjectTeamsRequest {
@@ -1315,6 +1352,12 @@ type TeamsApiListTeamUsersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type TeamsApiListTeamUsersQueryParams struct {
+		orgId string
+		teamId string
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Number of items that the response returns per page.
 func (r TeamsApiListTeamUsersRequest) ItemsPerPage(itemsPerPage int32) TeamsApiListTeamUsersRequest {
@@ -1468,6 +1511,10 @@ type TeamsApiRemoveProjectTeamRequest struct {
 	groupId string
 	teamId string
 }
+type TeamsApiRemoveProjectTeamQueryParams struct {
+		groupId string
+		teamId string
+}
 
 func (r TeamsApiRemoveProjectTeamRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectTeamExecute(r)
@@ -1584,6 +1631,11 @@ type TeamsApiRemoveTeamUserRequest struct {
 	orgId string
 	teamId string
 	userId string
+}
+type TeamsApiRemoveTeamUserQueryParams struct {
+		orgId string
+		teamId string
+		userId string
 }
 
 func (r TeamsApiRemoveTeamUserRequest) Execute() (*http.Response, error) {
@@ -1710,6 +1762,11 @@ type TeamsApiRenameTeamRequest struct {
 	orgId string
 	teamId string
 	team *Team
+}
+type TeamsApiRenameTeamQueryParams struct {
+		orgId string
+		teamId string
+		team *Team
 }
 
 // Details to update on the specified team.
@@ -1849,6 +1906,11 @@ type TeamsApiUpdateTeamRolesRequest struct {
 	groupId string
 	teamId string
 	teamRole *TeamRole
+}
+type TeamsApiUpdateTeamRolesQueryParams struct {
+		groupId string
+		teamId string
+		teamRole *TeamRole
 }
 
 // The project roles assigned to the specified team.

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -234,9 +234,10 @@ type TeamsApiAddAllTeamsToProjectRequest struct {
 	groupId string
 	teamRole *[]TeamRole
 }
+
 type TeamsApiAddAllTeamsToProjectQueryParams struct {
-		groupId string
-		teamRole *[]TeamRole
+		GroupId string
+		TeamRole *[]TeamRole
 }
 
 // Team to add to the specified project.
@@ -368,10 +369,11 @@ type TeamsApiAddTeamUserRequest struct {
 	teamId string
 	addUserToTeam *[]AddUserToTeam
 }
+
 type TeamsApiAddTeamUserQueryParams struct {
-		orgId string
-		teamId string
-		addUserToTeam *[]AddUserToTeam
+		OrgId string
+		TeamId string
+		AddUserToTeam *[]AddUserToTeam
 }
 
 // One or more MongoDB Cloud users that you want to add to the specified team.
@@ -511,9 +513,10 @@ type TeamsApiCreateTeamRequest struct {
 	orgId string
 	team *Team
 }
+
 type TeamsApiCreateTeamQueryParams struct {
-		orgId string
-		team *Team
+		OrgId string
+		Team *Team
 }
 
 // Team that you want to create in the specified organization.
@@ -644,9 +647,10 @@ type TeamsApiDeleteTeamRequest struct {
 	orgId string
 	teamId string
 }
+
 type TeamsApiDeleteTeamQueryParams struct {
-		orgId string
-		teamId string
+		OrgId string
+		TeamId string
 }
 
 func (r TeamsApiDeleteTeamRequest) Execute() (*http.Response, error) {
@@ -764,9 +768,10 @@ type TeamsApiGetTeamByIdRequest struct {
 	orgId string
 	teamId string
 }
+
 type TeamsApiGetTeamByIdQueryParams struct {
-		orgId string
-		teamId string
+		OrgId string
+		TeamId string
 }
 
 func (r TeamsApiGetTeamByIdRequest) Execute() (*TeamResponse, *http.Response, error) {
@@ -895,9 +900,10 @@ type TeamsApiGetTeamByNameRequest struct {
 	orgId string
 	teamName string
 }
+
 type TeamsApiGetTeamByNameQueryParams struct {
-		orgId string
-		teamName string
+		OrgId string
+		TeamName string
 }
 
 func (r TeamsApiGetTeamByNameRequest) Execute() (*TeamResponse, *http.Response, error) {
@@ -1022,11 +1028,12 @@ type TeamsApiListOrganizationTeamsRequest struct {
 	includeCount *bool
 	pageNum *int32
 }
+
 type TeamsApiListOrganizationTeamsQueryParams struct {
-		orgId string
-		itemsPerPage *int32
-		includeCount *bool
-		pageNum *int32
+		OrgId string
+		ItemsPerPage *int32
+		IncludeCount *bool
+		PageNum *int32
 }
 
 // Number of items that the response returns per page.
@@ -1187,11 +1194,12 @@ type TeamsApiListProjectTeamsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type TeamsApiListProjectTeamsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -1352,11 +1360,12 @@ type TeamsApiListTeamUsersRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type TeamsApiListTeamUsersQueryParams struct {
-		orgId string
-		teamId string
-		itemsPerPage *int32
-		pageNum *int32
+		OrgId string
+		TeamId string
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Number of items that the response returns per page.
@@ -1511,9 +1520,10 @@ type TeamsApiRemoveProjectTeamRequest struct {
 	groupId string
 	teamId string
 }
+
 type TeamsApiRemoveProjectTeamQueryParams struct {
-		groupId string
-		teamId string
+		GroupId string
+		TeamId string
 }
 
 func (r TeamsApiRemoveProjectTeamRequest) Execute() (*http.Response, error) {
@@ -1632,10 +1642,11 @@ type TeamsApiRemoveTeamUserRequest struct {
 	teamId string
 	userId string
 }
+
 type TeamsApiRemoveTeamUserQueryParams struct {
-		orgId string
-		teamId string
-		userId string
+		OrgId string
+		TeamId string
+		UserId string
 }
 
 func (r TeamsApiRemoveTeamUserRequest) Execute() (*http.Response, error) {
@@ -1763,10 +1774,11 @@ type TeamsApiRenameTeamRequest struct {
 	teamId string
 	team *Team
 }
+
 type TeamsApiRenameTeamQueryParams struct {
-		orgId string
-		teamId string
-		team *Team
+		OrgId string
+		TeamId string
+		Team *Team
 }
 
 // Details to update on the specified team.
@@ -1907,10 +1919,11 @@ type TeamsApiUpdateTeamRolesRequest struct {
 	teamId string
 	teamRole *TeamRole
 }
+
 type TeamsApiUpdateTeamRolesQueryParams struct {
-		groupId string
-		teamId string
-		teamRole *TeamRole
+		GroupId string
+		TeamId string
+		TeamRole *TeamRole
 }
 
 // The project roles assigned to the specified team.

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -235,7 +235,7 @@ type AddAllTeamsToProjectApiRequest struct {
 	teamRole *[]TeamRole
 }
 
-type AddAllTeamsToProjectParams struct {
+type AddAllTeamsToProjectApiParams struct {
 		GroupId string
 		TeamRole *[]TeamRole
 }
@@ -370,7 +370,7 @@ type AddTeamUserApiRequest struct {
 	addUserToTeam *[]AddUserToTeam
 }
 
-type AddTeamUserParams struct {
+type AddTeamUserApiParams struct {
 		OrgId string
 		TeamId string
 		AddUserToTeam *[]AddUserToTeam
@@ -514,7 +514,7 @@ type CreateTeamApiRequest struct {
 	team *Team
 }
 
-type CreateTeamParams struct {
+type CreateTeamApiParams struct {
 		OrgId string
 		Team *Team
 }
@@ -648,7 +648,7 @@ type DeleteTeamApiRequest struct {
 	teamId string
 }
 
-type DeleteTeamParams struct {
+type DeleteTeamApiParams struct {
 		OrgId string
 		TeamId string
 }
@@ -769,7 +769,7 @@ type GetTeamByIdApiRequest struct {
 	teamId string
 }
 
-type GetTeamByIdParams struct {
+type GetTeamByIdApiParams struct {
 		OrgId string
 		TeamId string
 }
@@ -901,7 +901,7 @@ type GetTeamByNameApiRequest struct {
 	teamName string
 }
 
-type GetTeamByNameParams struct {
+type GetTeamByNameApiParams struct {
 		OrgId string
 		TeamName string
 }
@@ -1029,7 +1029,7 @@ type ListOrganizationTeamsApiRequest struct {
 	pageNum *int32
 }
 
-type ListOrganizationTeamsParams struct {
+type ListOrganizationTeamsApiParams struct {
 		OrgId string
 		ItemsPerPage *int32
 		IncludeCount *bool
@@ -1195,7 +1195,7 @@ type ListProjectTeamsApiRequest struct {
 	pageNum *int32
 }
 
-type ListProjectTeamsParams struct {
+type ListProjectTeamsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1361,7 +1361,7 @@ type ListTeamUsersApiRequest struct {
 	pageNum *int32
 }
 
-type ListTeamUsersParams struct {
+type ListTeamUsersApiParams struct {
 		OrgId string
 		TeamId string
 		ItemsPerPage *int32
@@ -1521,7 +1521,7 @@ type RemoveProjectTeamApiRequest struct {
 	teamId string
 }
 
-type RemoveProjectTeamParams struct {
+type RemoveProjectTeamApiParams struct {
 		GroupId string
 		TeamId string
 }
@@ -1643,7 +1643,7 @@ type RemoveTeamUserApiRequest struct {
 	userId string
 }
 
-type RemoveTeamUserParams struct {
+type RemoveTeamUserApiParams struct {
 		OrgId string
 		TeamId string
 		UserId string
@@ -1775,7 +1775,7 @@ type RenameTeamApiRequest struct {
 	team *Team
 }
 
-type RenameTeamParams struct {
+type RenameTeamApiParams struct {
 		OrgId string
 		TeamId string
 		Team *Team
@@ -1920,7 +1920,7 @@ type UpdateTeamRolesApiRequest struct {
 	teamRole *TeamRole
 }
 
-type UpdateTeamRolesParams struct {
+type UpdateTeamRolesApiParams struct {
 		GroupId string
 		TeamId string
 		TeamRole *TeamRole

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -235,7 +235,7 @@ type TeamsApiAddAllTeamsToProjectRequest struct {
 	teamRole *[]TeamRole
 }
 
-type TeamsApiAddAllTeamsToProjectQueryParams struct {
+type TeamsApiAddAllTeamsToProjectParams struct {
 		GroupId string
 		TeamRole *[]TeamRole
 }
@@ -370,7 +370,7 @@ type TeamsApiAddTeamUserRequest struct {
 	addUserToTeam *[]AddUserToTeam
 }
 
-type TeamsApiAddTeamUserQueryParams struct {
+type TeamsApiAddTeamUserParams struct {
 		OrgId string
 		TeamId string
 		AddUserToTeam *[]AddUserToTeam
@@ -514,7 +514,7 @@ type TeamsApiCreateTeamRequest struct {
 	team *Team
 }
 
-type TeamsApiCreateTeamQueryParams struct {
+type TeamsApiCreateTeamParams struct {
 		OrgId string
 		Team *Team
 }
@@ -648,7 +648,7 @@ type TeamsApiDeleteTeamRequest struct {
 	teamId string
 }
 
-type TeamsApiDeleteTeamQueryParams struct {
+type TeamsApiDeleteTeamParams struct {
 		OrgId string
 		TeamId string
 }
@@ -769,7 +769,7 @@ type TeamsApiGetTeamByIdRequest struct {
 	teamId string
 }
 
-type TeamsApiGetTeamByIdQueryParams struct {
+type TeamsApiGetTeamByIdParams struct {
 		OrgId string
 		TeamId string
 }
@@ -901,7 +901,7 @@ type TeamsApiGetTeamByNameRequest struct {
 	teamName string
 }
 
-type TeamsApiGetTeamByNameQueryParams struct {
+type TeamsApiGetTeamByNameParams struct {
 		OrgId string
 		TeamName string
 }
@@ -1029,7 +1029,7 @@ type TeamsApiListOrganizationTeamsRequest struct {
 	pageNum *int32
 }
 
-type TeamsApiListOrganizationTeamsQueryParams struct {
+type TeamsApiListOrganizationTeamsParams struct {
 		OrgId string
 		ItemsPerPage *int32
 		IncludeCount *bool
@@ -1195,7 +1195,7 @@ type TeamsApiListProjectTeamsRequest struct {
 	pageNum *int32
 }
 
-type TeamsApiListProjectTeamsQueryParams struct {
+type TeamsApiListProjectTeamsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1361,7 +1361,7 @@ type TeamsApiListTeamUsersRequest struct {
 	pageNum *int32
 }
 
-type TeamsApiListTeamUsersQueryParams struct {
+type TeamsApiListTeamUsersParams struct {
 		OrgId string
 		TeamId string
 		ItemsPerPage *int32
@@ -1521,7 +1521,7 @@ type TeamsApiRemoveProjectTeamRequest struct {
 	teamId string
 }
 
-type TeamsApiRemoveProjectTeamQueryParams struct {
+type TeamsApiRemoveProjectTeamParams struct {
 		GroupId string
 		TeamId string
 }
@@ -1643,7 +1643,7 @@ type TeamsApiRemoveTeamUserRequest struct {
 	userId string
 }
 
-type TeamsApiRemoveTeamUserQueryParams struct {
+type TeamsApiRemoveTeamUserParams struct {
 		OrgId string
 		TeamId string
 		UserId string
@@ -1775,7 +1775,7 @@ type TeamsApiRenameTeamRequest struct {
 	team *Team
 }
 
-type TeamsApiRenameTeamQueryParams struct {
+type TeamsApiRenameTeamParams struct {
 		OrgId string
 		TeamId string
 		Team *Team
@@ -1920,7 +1920,7 @@ type TeamsApiUpdateTeamRolesRequest struct {
 	teamRole *TeamRole
 }
 
-type TeamsApiUpdateTeamRolesQueryParams struct {
+type TeamsApiUpdateTeamRolesParams struct {
 		GroupId string
 		TeamId string
 		TeamRole *TeamRole

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -235,7 +235,7 @@ type TeamsApiAddAllTeamsToProjectRequest struct {
 	teamRole *[]TeamRole
 }
 
-type TeamsApiAddAllTeamsToProjectParams struct {
+type AddAllTeamsToProjectParams struct {
 		GroupId string
 		TeamRole *[]TeamRole
 }
@@ -370,7 +370,7 @@ type TeamsApiAddTeamUserRequest struct {
 	addUserToTeam *[]AddUserToTeam
 }
 
-type TeamsApiAddTeamUserParams struct {
+type AddTeamUserParams struct {
 		OrgId string
 		TeamId string
 		AddUserToTeam *[]AddUserToTeam
@@ -514,7 +514,7 @@ type TeamsApiCreateTeamRequest struct {
 	team *Team
 }
 
-type TeamsApiCreateTeamParams struct {
+type CreateTeamParams struct {
 		OrgId string
 		Team *Team
 }
@@ -648,7 +648,7 @@ type TeamsApiDeleteTeamRequest struct {
 	teamId string
 }
 
-type TeamsApiDeleteTeamParams struct {
+type DeleteTeamParams struct {
 		OrgId string
 		TeamId string
 }
@@ -769,7 +769,7 @@ type TeamsApiGetTeamByIdRequest struct {
 	teamId string
 }
 
-type TeamsApiGetTeamByIdParams struct {
+type GetTeamByIdParams struct {
 		OrgId string
 		TeamId string
 }
@@ -901,7 +901,7 @@ type TeamsApiGetTeamByNameRequest struct {
 	teamName string
 }
 
-type TeamsApiGetTeamByNameParams struct {
+type GetTeamByNameParams struct {
 		OrgId string
 		TeamName string
 }
@@ -1029,7 +1029,7 @@ type TeamsApiListOrganizationTeamsRequest struct {
 	pageNum *int32
 }
 
-type TeamsApiListOrganizationTeamsParams struct {
+type ListOrganizationTeamsParams struct {
 		OrgId string
 		ItemsPerPage *int32
 		IncludeCount *bool
@@ -1195,7 +1195,7 @@ type TeamsApiListProjectTeamsRequest struct {
 	pageNum *int32
 }
 
-type TeamsApiListProjectTeamsParams struct {
+type ListProjectTeamsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -1361,7 +1361,7 @@ type TeamsApiListTeamUsersRequest struct {
 	pageNum *int32
 }
 
-type TeamsApiListTeamUsersParams struct {
+type ListTeamUsersParams struct {
 		OrgId string
 		TeamId string
 		ItemsPerPage *int32
@@ -1521,7 +1521,7 @@ type TeamsApiRemoveProjectTeamRequest struct {
 	teamId string
 }
 
-type TeamsApiRemoveProjectTeamParams struct {
+type RemoveProjectTeamParams struct {
 		GroupId string
 		TeamId string
 }
@@ -1643,7 +1643,7 @@ type TeamsApiRemoveTeamUserRequest struct {
 	userId string
 }
 
-type TeamsApiRemoveTeamUserParams struct {
+type RemoveTeamUserParams struct {
 		OrgId string
 		TeamId string
 		UserId string
@@ -1775,7 +1775,7 @@ type TeamsApiRenameTeamRequest struct {
 	team *Team
 }
 
-type TeamsApiRenameTeamParams struct {
+type RenameTeamParams struct {
 		OrgId string
 		TeamId string
 		Team *Team
@@ -1920,7 +1920,7 @@ type TeamsApiUpdateTeamRolesRequest struct {
 	teamRole *TeamRole
 }
 
-type TeamsApiUpdateTeamRolesParams struct {
+type UpdateTeamRolesParams struct {
 		GroupId string
 		TeamId string
 		TeamRole *TeamRole

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -29,13 +29,13 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return TeamsApiAddAllTeamsToProjectRequest
+	@return AddAllTeamsToProjectApiRequest
 	*/
-	AddAllTeamsToProject(ctx context.Context, groupId string) TeamsApiAddAllTeamsToProjectRequest
+	AddAllTeamsToProject(ctx context.Context, groupId string) AddAllTeamsToProjectApiRequest
 
 	// AddAllTeamsToProjectExecute executes the request
 	//  @return PaginatedTeamRole
-	AddAllTeamsToProjectExecute(r TeamsApiAddAllTeamsToProjectRequest) (*PaginatedTeamRole, *http.Response, error)
+	AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
 	AddTeamUser Assign MongoDB Cloud Users from One Organization to One Team
@@ -45,13 +45,13 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param teamId Unique 24-hexadecimal character string that identifies the team to which you want to add MongoDB Cloud users.
-	@return TeamsApiAddTeamUserRequest
+	@return AddTeamUserApiRequest
 	*/
-	AddTeamUser(ctx context.Context, orgId string, teamId string) TeamsApiAddTeamUserRequest
+	AddTeamUser(ctx context.Context, orgId string, teamId string) AddTeamUserApiRequest
 
 	// AddTeamUserExecute executes the request
 	//  @return PaginatedApiAppUser
-	AddTeamUserExecute(r TeamsApiAddTeamUserRequest) (*PaginatedApiAppUser, *http.Response, error)
+	AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 	CreateTeam Create One Team in One Organization
@@ -60,13 +60,13 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return TeamsApiCreateTeamRequest
+	@return CreateTeamApiRequest
 	*/
-	CreateTeam(ctx context.Context, orgId string) TeamsApiCreateTeamRequest
+	CreateTeam(ctx context.Context, orgId string) CreateTeamApiRequest
 
 	// CreateTeamExecute executes the request
 	//  @return Team
-	CreateTeamExecute(r TeamsApiCreateTeamRequest) (*Team, *http.Response, error)
+	CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error)
 
 	/*
 	DeleteTeam Remove One Team from One Organization
@@ -76,12 +76,12 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param teamId Unique 24-hexadecimal digit string that identifies the team that you want to delete.
-	@return TeamsApiDeleteTeamRequest
+	@return DeleteTeamApiRequest
 	*/
-	DeleteTeam(ctx context.Context, orgId string, teamId string) TeamsApiDeleteTeamRequest
+	DeleteTeam(ctx context.Context, orgId string, teamId string) DeleteTeamApiRequest
 
 	// DeleteTeamExecute executes the request
-	DeleteTeamExecute(r TeamsApiDeleteTeamRequest) (*http.Response, error)
+	DeleteTeamExecute(r DeleteTeamApiRequest) (*http.Response, error)
 
 	/*
 	GetTeamById Return One Team using its ID
@@ -91,13 +91,13 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param teamId Unique 24-hexadecimal digit string that identifies the team whose information you want to return.
-	@return TeamsApiGetTeamByIdRequest
+	@return GetTeamByIdApiRequest
 	*/
-	GetTeamById(ctx context.Context, orgId string, teamId string) TeamsApiGetTeamByIdRequest
+	GetTeamById(ctx context.Context, orgId string, teamId string) GetTeamByIdApiRequest
 
 	// GetTeamByIdExecute executes the request
 	//  @return TeamResponse
-	GetTeamByIdExecute(r TeamsApiGetTeamByIdRequest) (*TeamResponse, *http.Response, error)
+	GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 	GetTeamByName Return One Team using its Name
@@ -107,13 +107,13 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param teamName Name of the team whose information you want to return.
-	@return TeamsApiGetTeamByNameRequest
+	@return GetTeamByNameApiRequest
 	*/
-	GetTeamByName(ctx context.Context, orgId string, teamName string) TeamsApiGetTeamByNameRequest
+	GetTeamByName(ctx context.Context, orgId string, teamName string) GetTeamByNameApiRequest
 
 	// GetTeamByNameExecute executes the request
 	//  @return TeamResponse
-	GetTeamByNameExecute(r TeamsApiGetTeamByNameRequest) (*TeamResponse, *http.Response, error)
+	GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 	ListOrganizationTeams Return All Teams in One Organization
@@ -122,13 +122,13 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-	@return TeamsApiListOrganizationTeamsRequest
+	@return ListOrganizationTeamsApiRequest
 	*/
-	ListOrganizationTeams(ctx context.Context, orgId string) TeamsApiListOrganizationTeamsRequest
+	ListOrganizationTeams(ctx context.Context, orgId string) ListOrganizationTeamsApiRequest
 
 	// ListOrganizationTeamsExecute executes the request
 	//  @return PaginatedTeam
-	ListOrganizationTeamsExecute(r TeamsApiListOrganizationTeamsRequest) (*PaginatedTeam, *http.Response, error)
+	ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error)
 
 	/*
 	ListProjectTeams Return All Teams in One Project
@@ -137,13 +137,13 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return TeamsApiListProjectTeamsRequest
+	@return ListProjectTeamsApiRequest
 	*/
-	ListProjectTeams(ctx context.Context, groupId string) TeamsApiListProjectTeamsRequest
+	ListProjectTeams(ctx context.Context, groupId string) ListProjectTeamsApiRequest
 
 	// ListProjectTeamsExecute executes the request
 	//  @return PaginatedTeamRole
-	ListProjectTeamsExecute(r TeamsApiListProjectTeamsRequest) (*PaginatedTeamRole, *http.Response, error)
+	ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
 	ListTeamUsers Return All MongoDB Cloud Users Assigned to One Team
@@ -153,13 +153,13 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param teamId Unique 24-hexadecimal digit string that identifies the team whose application users you want to return.
-	@return TeamsApiListTeamUsersRequest
+	@return ListTeamUsersApiRequest
 	*/
-	ListTeamUsers(ctx context.Context, orgId string, teamId string) TeamsApiListTeamUsersRequest
+	ListTeamUsers(ctx context.Context, orgId string, teamId string) ListTeamUsersApiRequest
 
 	// ListTeamUsersExecute executes the request
 	//  @return PaginatedApiAppUser
-	ListTeamUsersExecute(r TeamsApiListTeamUsersRequest) (*PaginatedApiAppUser, *http.Response, error)
+	ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 	RemoveProjectTeam Remove One Team from One Project
@@ -169,12 +169,12 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param teamId Unique 24-hexadecimal digit string that identifies the team that you want to remove from the specified project.
-	@return TeamsApiRemoveProjectTeamRequest
+	@return RemoveProjectTeamApiRequest
 	*/
-	RemoveProjectTeam(ctx context.Context, groupId string, teamId string) TeamsApiRemoveProjectTeamRequest
+	RemoveProjectTeam(ctx context.Context, groupId string, teamId string) RemoveProjectTeamApiRequest
 
 	// RemoveProjectTeamExecute executes the request
-	RemoveProjectTeamExecute(r TeamsApiRemoveProjectTeamRequest) (*http.Response, error)
+	RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error)
 
 	/*
 	RemoveTeamUser Remove One MongoDB Cloud User from One Team
@@ -185,12 +185,12 @@ type TeamsApi interface {
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param teamId Unique 24-hexadecimal digit string that identifies the team from which you want to remove one database application user.
 	@param userId Unique 24-hexadecimal digit string that identifies MongoDB Cloud user that you want to remove from the specified team.
-	@return TeamsApiRemoveTeamUserRequest
+	@return RemoveTeamUserApiRequest
 	*/
-	RemoveTeamUser(ctx context.Context, orgId string, teamId string, userId string) TeamsApiRemoveTeamUserRequest
+	RemoveTeamUser(ctx context.Context, orgId string, teamId string, userId string) RemoveTeamUserApiRequest
 
 	// RemoveTeamUserExecute executes the request
-	RemoveTeamUserExecute(r TeamsApiRemoveTeamUserRequest) (*http.Response, error)
+	RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error)
 
 	/*
 	RenameTeam Rename One Team
@@ -200,13 +200,13 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 	@param teamId Unique 24-hexadecimal digit string that identifies the team that you want to rename.
-	@return TeamsApiRenameTeamRequest
+	@return RenameTeamApiRequest
 	*/
-	RenameTeam(ctx context.Context, orgId string, teamId string) TeamsApiRenameTeamRequest
+	RenameTeam(ctx context.Context, orgId string, teamId string) RenameTeamApiRequest
 
 	// RenameTeamExecute executes the request
 	//  @return TeamResponse
-	RenameTeamExecute(r TeamsApiRenameTeamRequest) (*TeamResponse, *http.Response, error)
+	RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 	UpdateTeamRoles Update Team Roles in One Project
@@ -216,19 +216,19 @@ type TeamsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param teamId Unique 24-hexadecimal digit string that identifies the team for which you want to update roles.
-	@return TeamsApiUpdateTeamRolesRequest
+	@return UpdateTeamRolesApiRequest
 	*/
-	UpdateTeamRoles(ctx context.Context, groupId string, teamId string) TeamsApiUpdateTeamRolesRequest
+	UpdateTeamRoles(ctx context.Context, groupId string, teamId string) UpdateTeamRolesApiRequest
 
 	// UpdateTeamRolesExecute executes the request
 	//  @return PaginatedTeamRole
-	UpdateTeamRolesExecute(r TeamsApiUpdateTeamRolesRequest) (*PaginatedTeamRole, *http.Response, error)
+	UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error)
 }
 
 // TeamsApiService TeamsApi service
 type TeamsApiService service
 
-type TeamsApiAddAllTeamsToProjectRequest struct {
+type AddAllTeamsToProjectApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	groupId string
@@ -241,12 +241,12 @@ type AddAllTeamsToProjectParams struct {
 }
 
 // Team to add to the specified project.
-func (r TeamsApiAddAllTeamsToProjectRequest) TeamRole(teamRole []TeamRole) TeamsApiAddAllTeamsToProjectRequest {
+func (r AddAllTeamsToProjectApiRequest) TeamRole(teamRole []TeamRole) AddAllTeamsToProjectApiRequest {
 	r.teamRole = &teamRole
 	return r
 }
 
-func (r TeamsApiAddAllTeamsToProjectRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
+func (r AddAllTeamsToProjectApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
 	return r.ApiService.AddAllTeamsToProjectExecute(r)
 }
 
@@ -257,10 +257,10 @@ Adds one team to the specified project. All members of the team share the same p
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return TeamsApiAddAllTeamsToProjectRequest
+ @return AddAllTeamsToProjectApiRequest
 */
-func (a *TeamsApiService) AddAllTeamsToProject(ctx context.Context, groupId string) TeamsApiAddAllTeamsToProjectRequest {
-	return TeamsApiAddAllTeamsToProjectRequest{
+func (a *TeamsApiService) AddAllTeamsToProject(ctx context.Context, groupId string) AddAllTeamsToProjectApiRequest {
+	return AddAllTeamsToProjectApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -269,7 +269,7 @@ func (a *TeamsApiService) AddAllTeamsToProject(ctx context.Context, groupId stri
 
 // Execute executes the request
 //  @return PaginatedTeamRole
-func (a *TeamsApiService) AddAllTeamsToProjectExecute(r TeamsApiAddAllTeamsToProjectRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -362,7 +362,7 @@ func (a *TeamsApiService) AddAllTeamsToProjectExecute(r TeamsApiAddAllTeamsToPro
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiAddTeamUserRequest struct {
+type AddTeamUserApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -377,12 +377,12 @@ type AddTeamUserParams struct {
 }
 
 // One or more MongoDB Cloud users that you want to add to the specified team.
-func (r TeamsApiAddTeamUserRequest) AddUserToTeam(addUserToTeam []AddUserToTeam) TeamsApiAddTeamUserRequest {
+func (r AddTeamUserApiRequest) AddUserToTeam(addUserToTeam []AddUserToTeam) AddTeamUserApiRequest {
 	r.addUserToTeam = &addUserToTeam
 	return r
 }
 
-func (r TeamsApiAddTeamUserRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
+func (r AddTeamUserApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
 	return r.ApiService.AddTeamUserExecute(r)
 }
 
@@ -394,10 +394,10 @@ Adds one or more MongoDB Cloud users from the specified organization to the spec
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param teamId Unique 24-hexadecimal character string that identifies the team to which you want to add MongoDB Cloud users.
- @return TeamsApiAddTeamUserRequest
+ @return AddTeamUserApiRequest
 */
-func (a *TeamsApiService) AddTeamUser(ctx context.Context, orgId string, teamId string) TeamsApiAddTeamUserRequest {
-	return TeamsApiAddTeamUserRequest{
+func (a *TeamsApiService) AddTeamUser(ctx context.Context, orgId string, teamId string) AddTeamUserApiRequest {
+	return AddTeamUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -407,7 +407,7 @@ func (a *TeamsApiService) AddTeamUser(ctx context.Context, orgId string, teamId 
 
 // Execute executes the request
 //  @return PaginatedApiAppUser
-func (a *TeamsApiService) AddTeamUserExecute(r TeamsApiAddTeamUserRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *TeamsApiService) AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -507,7 +507,7 @@ func (a *TeamsApiService) AddTeamUserExecute(r TeamsApiAddTeamUserRequest) (*Pag
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiCreateTeamRequest struct {
+type CreateTeamApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -520,12 +520,12 @@ type CreateTeamParams struct {
 }
 
 // Team that you want to create in the specified organization.
-func (r TeamsApiCreateTeamRequest) Team(team Team) TeamsApiCreateTeamRequest {
+func (r CreateTeamApiRequest) Team(team Team) CreateTeamApiRequest {
 	r.team = &team
 	return r
 }
 
-func (r TeamsApiCreateTeamRequest) Execute() (*Team, *http.Response, error) {
+func (r CreateTeamApiRequest) Execute() (*Team, *http.Response, error) {
 	return r.ApiService.CreateTeamExecute(r)
 }
 
@@ -536,10 +536,10 @@ Creates one team in the specified organization. Teams enable you to grant projec
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return TeamsApiCreateTeamRequest
+ @return CreateTeamApiRequest
 */
-func (a *TeamsApiService) CreateTeam(ctx context.Context, orgId string) TeamsApiCreateTeamRequest {
-	return TeamsApiCreateTeamRequest{
+func (a *TeamsApiService) CreateTeam(ctx context.Context, orgId string) CreateTeamApiRequest {
+	return CreateTeamApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -548,7 +548,7 @@ func (a *TeamsApiService) CreateTeam(ctx context.Context, orgId string) TeamsApi
 
 // Execute executes the request
 //  @return Team
-func (a *TeamsApiService) CreateTeamExecute(r TeamsApiCreateTeamRequest) (*Team, *http.Response, error) {
+func (a *TeamsApiService) CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -641,7 +641,7 @@ func (a *TeamsApiService) CreateTeamExecute(r TeamsApiCreateTeamRequest) (*Team,
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiDeleteTeamRequest struct {
+type DeleteTeamApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -653,7 +653,7 @@ type DeleteTeamParams struct {
 		TeamId string
 }
 
-func (r TeamsApiDeleteTeamRequest) Execute() (*http.Response, error) {
+func (r DeleteTeamApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteTeamExecute(r)
 }
 
@@ -665,10 +665,10 @@ Removes one team specified using its unique 24-hexadecimal digit identifier from
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param teamId Unique 24-hexadecimal digit string that identifies the team that you want to delete.
- @return TeamsApiDeleteTeamRequest
+ @return DeleteTeamApiRequest
 */
-func (a *TeamsApiService) DeleteTeam(ctx context.Context, orgId string, teamId string) TeamsApiDeleteTeamRequest {
-	return TeamsApiDeleteTeamRequest{
+func (a *TeamsApiService) DeleteTeam(ctx context.Context, orgId string, teamId string) DeleteTeamApiRequest {
+	return DeleteTeamApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -677,7 +677,7 @@ func (a *TeamsApiService) DeleteTeam(ctx context.Context, orgId string, teamId s
 }
 
 // Execute executes the request
-func (a *TeamsApiService) DeleteTeamExecute(r TeamsApiDeleteTeamRequest) (*http.Response, error) {
+func (a *TeamsApiService) DeleteTeamExecute(r DeleteTeamApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -762,7 +762,7 @@ func (a *TeamsApiService) DeleteTeamExecute(r TeamsApiDeleteTeamRequest) (*http.
 	return localVarHTTPResponse, nil
 }
 
-type TeamsApiGetTeamByIdRequest struct {
+type GetTeamByIdApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -774,7 +774,7 @@ type GetTeamByIdParams struct {
 		TeamId string
 }
 
-func (r TeamsApiGetTeamByIdRequest) Execute() (*TeamResponse, *http.Response, error) {
+func (r GetTeamByIdApiRequest) Execute() (*TeamResponse, *http.Response, error) {
 	return r.ApiService.GetTeamByIdExecute(r)
 }
 
@@ -786,10 +786,10 @@ Returns one team that you identified using its unique 24-hexadecimal digit ID. T
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param teamId Unique 24-hexadecimal digit string that identifies the team whose information you want to return.
- @return TeamsApiGetTeamByIdRequest
+ @return GetTeamByIdApiRequest
 */
-func (a *TeamsApiService) GetTeamById(ctx context.Context, orgId string, teamId string) TeamsApiGetTeamByIdRequest {
-	return TeamsApiGetTeamByIdRequest{
+func (a *TeamsApiService) GetTeamById(ctx context.Context, orgId string, teamId string) GetTeamByIdApiRequest {
+	return GetTeamByIdApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -799,7 +799,7 @@ func (a *TeamsApiService) GetTeamById(ctx context.Context, orgId string, teamId 
 
 // Execute executes the request
 //  @return TeamResponse
-func (a *TeamsApiService) GetTeamByIdExecute(r TeamsApiGetTeamByIdRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -894,7 +894,7 @@ func (a *TeamsApiService) GetTeamByIdExecute(r TeamsApiGetTeamByIdRequest) (*Tea
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiGetTeamByNameRequest struct {
+type GetTeamByNameApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -906,7 +906,7 @@ type GetTeamByNameParams struct {
 		TeamName string
 }
 
-func (r TeamsApiGetTeamByNameRequest) Execute() (*TeamResponse, *http.Response, error) {
+func (r GetTeamByNameApiRequest) Execute() (*TeamResponse, *http.Response, error) {
 	return r.ApiService.GetTeamByNameExecute(r)
 }
 
@@ -918,10 +918,10 @@ Returns one team that you identified using its human-readable name. This team be
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param teamName Name of the team whose information you want to return.
- @return TeamsApiGetTeamByNameRequest
+ @return GetTeamByNameApiRequest
 */
-func (a *TeamsApiService) GetTeamByName(ctx context.Context, orgId string, teamName string) TeamsApiGetTeamByNameRequest {
-	return TeamsApiGetTeamByNameRequest{
+func (a *TeamsApiService) GetTeamByName(ctx context.Context, orgId string, teamName string) GetTeamByNameApiRequest {
+	return GetTeamByNameApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -931,7 +931,7 @@ func (a *TeamsApiService) GetTeamByName(ctx context.Context, orgId string, teamN
 
 // Execute executes the request
 //  @return TeamResponse
-func (a *TeamsApiService) GetTeamByNameExecute(r TeamsApiGetTeamByNameRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1020,7 +1020,7 @@ func (a *TeamsApiService) GetTeamByNameExecute(r TeamsApiGetTeamByNameRequest) (
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiListOrganizationTeamsRequest struct {
+type ListOrganizationTeamsApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -1037,24 +1037,24 @@ type ListOrganizationTeamsParams struct {
 }
 
 // Number of items that the response returns per page.
-func (r TeamsApiListOrganizationTeamsRequest) ItemsPerPage(itemsPerPage int32) TeamsApiListOrganizationTeamsRequest {
+func (r ListOrganizationTeamsApiRequest) ItemsPerPage(itemsPerPage int32) ListOrganizationTeamsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r TeamsApiListOrganizationTeamsRequest) IncludeCount(includeCount bool) TeamsApiListOrganizationTeamsRequest {
+func (r ListOrganizationTeamsApiRequest) IncludeCount(includeCount bool) ListOrganizationTeamsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r TeamsApiListOrganizationTeamsRequest) PageNum(pageNum int32) TeamsApiListOrganizationTeamsRequest {
+func (r ListOrganizationTeamsApiRequest) PageNum(pageNum int32) ListOrganizationTeamsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r TeamsApiListOrganizationTeamsRequest) Execute() (*PaginatedTeam, *http.Response, error) {
+func (r ListOrganizationTeamsApiRequest) Execute() (*PaginatedTeam, *http.Response, error) {
 	return r.ApiService.ListOrganizationTeamsExecute(r)
 }
 
@@ -1065,10 +1065,10 @@ Returns all teams that belong to the specified organization. Teams enable you to
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
- @return TeamsApiListOrganizationTeamsRequest
+ @return ListOrganizationTeamsApiRequest
 */
-func (a *TeamsApiService) ListOrganizationTeams(ctx context.Context, orgId string) TeamsApiListOrganizationTeamsRequest {
-	return TeamsApiListOrganizationTeamsRequest{
+func (a *TeamsApiService) ListOrganizationTeams(ctx context.Context, orgId string) ListOrganizationTeamsApiRequest {
+	return ListOrganizationTeamsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1077,7 +1077,7 @@ func (a *TeamsApiService) ListOrganizationTeams(ctx context.Context, orgId strin
 
 // Execute executes the request
 //  @return PaginatedTeam
-func (a *TeamsApiService) ListOrganizationTeamsExecute(r TeamsApiListOrganizationTeamsRequest) (*PaginatedTeam, *http.Response, error) {
+func (a *TeamsApiService) ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1186,7 +1186,7 @@ func (a *TeamsApiService) ListOrganizationTeamsExecute(r TeamsApiListOrganizatio
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiListProjectTeamsRequest struct {
+type ListProjectTeamsApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	groupId string
@@ -1203,24 +1203,24 @@ type ListProjectTeamsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r TeamsApiListProjectTeamsRequest) IncludeCount(includeCount bool) TeamsApiListProjectTeamsRequest {
+func (r ListProjectTeamsApiRequest) IncludeCount(includeCount bool) ListProjectTeamsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r TeamsApiListProjectTeamsRequest) ItemsPerPage(itemsPerPage int32) TeamsApiListProjectTeamsRequest {
+func (r ListProjectTeamsApiRequest) ItemsPerPage(itemsPerPage int32) ListProjectTeamsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r TeamsApiListProjectTeamsRequest) PageNum(pageNum int32) TeamsApiListProjectTeamsRequest {
+func (r ListProjectTeamsApiRequest) PageNum(pageNum int32) ListProjectTeamsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r TeamsApiListProjectTeamsRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
+func (r ListProjectTeamsApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
 	return r.ApiService.ListProjectTeamsExecute(r)
 }
 
@@ -1231,10 +1231,10 @@ Returns all teams to which the authenticated user has access in the project spec
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return TeamsApiListProjectTeamsRequest
+ @return ListProjectTeamsApiRequest
 */
-func (a *TeamsApiService) ListProjectTeams(ctx context.Context, groupId string) TeamsApiListProjectTeamsRequest {
-	return TeamsApiListProjectTeamsRequest{
+func (a *TeamsApiService) ListProjectTeams(ctx context.Context, groupId string) ListProjectTeamsApiRequest {
+	return ListProjectTeamsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1243,7 +1243,7 @@ func (a *TeamsApiService) ListProjectTeams(ctx context.Context, groupId string) 
 
 // Execute executes the request
 //  @return PaginatedTeamRole
-func (a *TeamsApiService) ListProjectTeamsExecute(r TeamsApiListProjectTeamsRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1352,7 +1352,7 @@ func (a *TeamsApiService) ListProjectTeamsExecute(r TeamsApiListProjectTeamsRequ
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiListTeamUsersRequest struct {
+type ListTeamUsersApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -1369,18 +1369,18 @@ type ListTeamUsersParams struct {
 }
 
 // Number of items that the response returns per page.
-func (r TeamsApiListTeamUsersRequest) ItemsPerPage(itemsPerPage int32) TeamsApiListTeamUsersRequest {
+func (r ListTeamUsersApiRequest) ItemsPerPage(itemsPerPage int32) ListTeamUsersApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r TeamsApiListTeamUsersRequest) PageNum(pageNum int32) TeamsApiListTeamUsersRequest {
+func (r ListTeamUsersApiRequest) PageNum(pageNum int32) ListTeamUsersApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r TeamsApiListTeamUsersRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
+func (r ListTeamUsersApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
 	return r.ApiService.ListTeamUsersExecute(r)
 }
 
@@ -1392,10 +1392,10 @@ Returns all MongoDB Cloud users assigned to the team specified using its unique 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param teamId Unique 24-hexadecimal digit string that identifies the team whose application users you want to return.
- @return TeamsApiListTeamUsersRequest
+ @return ListTeamUsersApiRequest
 */
-func (a *TeamsApiService) ListTeamUsers(ctx context.Context, orgId string, teamId string) TeamsApiListTeamUsersRequest {
-	return TeamsApiListTeamUsersRequest{
+func (a *TeamsApiService) ListTeamUsers(ctx context.Context, orgId string, teamId string) ListTeamUsersApiRequest {
+	return ListTeamUsersApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1405,7 +1405,7 @@ func (a *TeamsApiService) ListTeamUsers(ctx context.Context, orgId string, teamI
 
 // Execute executes the request
 //  @return PaginatedApiAppUser
-func (a *TeamsApiService) ListTeamUsersExecute(r TeamsApiListTeamUsersRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *TeamsApiService) ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1514,7 +1514,7 @@ func (a *TeamsApiService) ListTeamUsersExecute(r TeamsApiListTeamUsersRequest) (
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiRemoveProjectTeamRequest struct {
+type RemoveProjectTeamApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	groupId string
@@ -1526,7 +1526,7 @@ type RemoveProjectTeamParams struct {
 		TeamId string
 }
 
-func (r TeamsApiRemoveProjectTeamRequest) Execute() (*http.Response, error) {
+func (r RemoveProjectTeamApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectTeamExecute(r)
 }
 
@@ -1538,10 +1538,10 @@ Removes one team specified using its unique 24-hexadecimal digit identifier from
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param teamId Unique 24-hexadecimal digit string that identifies the team that you want to remove from the specified project.
- @return TeamsApiRemoveProjectTeamRequest
+ @return RemoveProjectTeamApiRequest
 */
-func (a *TeamsApiService) RemoveProjectTeam(ctx context.Context, groupId string, teamId string) TeamsApiRemoveProjectTeamRequest {
-	return TeamsApiRemoveProjectTeamRequest{
+func (a *TeamsApiService) RemoveProjectTeam(ctx context.Context, groupId string, teamId string) RemoveProjectTeamApiRequest {
+	return RemoveProjectTeamApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1550,7 +1550,7 @@ func (a *TeamsApiService) RemoveProjectTeam(ctx context.Context, groupId string,
 }
 
 // Execute executes the request
-func (a *TeamsApiService) RemoveProjectTeamExecute(r TeamsApiRemoveProjectTeamRequest) (*http.Response, error) {
+func (a *TeamsApiService) RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1635,7 +1635,7 @@ func (a *TeamsApiService) RemoveProjectTeamExecute(r TeamsApiRemoveProjectTeamRe
 	return localVarHTTPResponse, nil
 }
 
-type TeamsApiRemoveTeamUserRequest struct {
+type RemoveTeamUserApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -1649,7 +1649,7 @@ type RemoveTeamUserParams struct {
 		UserId string
 }
 
-func (r TeamsApiRemoveTeamUserRequest) Execute() (*http.Response, error) {
+func (r RemoveTeamUserApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveTeamUserExecute(r)
 }
 
@@ -1662,10 +1662,10 @@ Removes one MongoDB Cloud user from the specified team. This team belongs to one
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param teamId Unique 24-hexadecimal digit string that identifies the team from which you want to remove one database application user.
  @param userId Unique 24-hexadecimal digit string that identifies MongoDB Cloud user that you want to remove from the specified team.
- @return TeamsApiRemoveTeamUserRequest
+ @return RemoveTeamUserApiRequest
 */
-func (a *TeamsApiService) RemoveTeamUser(ctx context.Context, orgId string, teamId string, userId string) TeamsApiRemoveTeamUserRequest {
-	return TeamsApiRemoveTeamUserRequest{
+func (a *TeamsApiService) RemoveTeamUser(ctx context.Context, orgId string, teamId string, userId string) RemoveTeamUserApiRequest {
+	return RemoveTeamUserApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1675,7 +1675,7 @@ func (a *TeamsApiService) RemoveTeamUser(ctx context.Context, orgId string, team
 }
 
 // Execute executes the request
-func (a *TeamsApiService) RemoveTeamUserExecute(r TeamsApiRemoveTeamUserRequest) (*http.Response, error) {
+func (a *TeamsApiService) RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1767,7 +1767,7 @@ func (a *TeamsApiService) RemoveTeamUserExecute(r TeamsApiRemoveTeamUserRequest)
 	return localVarHTTPResponse, nil
 }
 
-type TeamsApiRenameTeamRequest struct {
+type RenameTeamApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	orgId string
@@ -1782,12 +1782,12 @@ type RenameTeamParams struct {
 }
 
 // Details to update on the specified team.
-func (r TeamsApiRenameTeamRequest) Team(team Team) TeamsApiRenameTeamRequest {
+func (r RenameTeamApiRequest) Team(team Team) RenameTeamApiRequest {
 	r.team = &team
 	return r
 }
 
-func (r TeamsApiRenameTeamRequest) Execute() (*TeamResponse, *http.Response, error) {
+func (r RenameTeamApiRequest) Execute() (*TeamResponse, *http.Response, error) {
 	return r.ApiService.RenameTeamExecute(r)
 }
 
@@ -1799,10 +1799,10 @@ Renames one team in the specified organization. Teams enable you to grant projec
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param orgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
  @param teamId Unique 24-hexadecimal digit string that identifies the team that you want to rename.
- @return TeamsApiRenameTeamRequest
+ @return RenameTeamApiRequest
 */
-func (a *TeamsApiService) RenameTeam(ctx context.Context, orgId string, teamId string) TeamsApiRenameTeamRequest {
-	return TeamsApiRenameTeamRequest{
+func (a *TeamsApiService) RenameTeam(ctx context.Context, orgId string, teamId string) RenameTeamApiRequest {
+	return RenameTeamApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		orgId: orgId,
@@ -1812,7 +1812,7 @@ func (a *TeamsApiService) RenameTeam(ctx context.Context, orgId string, teamId s
 
 // Execute executes the request
 //  @return TeamResponse
-func (a *TeamsApiService) RenameTeamExecute(r TeamsApiRenameTeamRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1912,7 +1912,7 @@ func (a *TeamsApiService) RenameTeamExecute(r TeamsApiRenameTeamRequest) (*TeamR
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type TeamsApiUpdateTeamRolesRequest struct {
+type UpdateTeamRolesApiRequest struct {
 	ctx context.Context
 	ApiService TeamsApi
 	groupId string
@@ -1927,12 +1927,12 @@ type UpdateTeamRolesParams struct {
 }
 
 // The project roles assigned to the specified team.
-func (r TeamsApiUpdateTeamRolesRequest) TeamRole(teamRole TeamRole) TeamsApiUpdateTeamRolesRequest {
+func (r UpdateTeamRolesApiRequest) TeamRole(teamRole TeamRole) UpdateTeamRolesApiRequest {
 	r.teamRole = &teamRole
 	return r
 }
 
-func (r TeamsApiUpdateTeamRolesRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
+func (r UpdateTeamRolesApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
 	return r.ApiService.UpdateTeamRolesExecute(r)
 }
 
@@ -1944,10 +1944,10 @@ Updates the project roles assigned to the specified team. You can grant team rol
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param teamId Unique 24-hexadecimal digit string that identifies the team for which you want to update roles.
- @return TeamsApiUpdateTeamRolesRequest
+ @return UpdateTeamRolesApiRequest
 */
-func (a *TeamsApiService) UpdateTeamRoles(ctx context.Context, groupId string, teamId string) TeamsApiUpdateTeamRolesRequest {
-	return TeamsApiUpdateTeamRolesRequest{
+func (a *TeamsApiService) UpdateTeamRoles(ctx context.Context, groupId string, teamId string) UpdateTeamRolesApiRequest {
+	return UpdateTeamRolesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -1957,7 +1957,7 @@ func (a *TeamsApiService) UpdateTeamRoles(ctx context.Context, groupId string, t
 
 // Execute executes the request
 //  @return PaginatedTeamRole
-func (a *TeamsApiService) UpdateTeamRolesExecute(r TeamsApiUpdateTeamRolesRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -45,7 +45,7 @@ type TestApiVersionedExampleRequest struct {
 	additionalInfo *bool
 }
 
-type TestApiVersionedExampleParams struct {
+type VersionedExampleParams struct {
 		AdditionalInfo *bool
 }
 

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -45,7 +45,7 @@ type VersionedExampleApiRequest struct {
 	additionalInfo *bool
 }
 
-type VersionedExampleParams struct {
+type VersionedExampleApiParams struct {
 		AdditionalInfo *bool
 }
 

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -27,19 +27,19 @@ type TestApi interface {
 	Returns some text dummy data for test purposes. Deprecated versions: v2-{2023-01-01}
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return TestApiVersionedExampleRequest
+	@return VersionedExampleApiRequest
 	*/
-	VersionedExample(ctx context.Context) TestApiVersionedExampleRequest
+	VersionedExample(ctx context.Context) VersionedExampleApiRequest
 
 	// VersionedExampleExecute executes the request
 	//  @return ExampleResourceResponseView20230201
-	VersionedExampleExecute(r TestApiVersionedExampleRequest) (*ExampleResourceResponseView20230201, *http.Response, error)
+	VersionedExampleExecute(r VersionedExampleApiRequest) (*ExampleResourceResponseView20230201, *http.Response, error)
 }
 
 // TestApiService TestApi service
 type TestApiService service
 
-type TestApiVersionedExampleRequest struct {
+type VersionedExampleApiRequest struct {
 	ctx context.Context
 	ApiService TestApi
 	additionalInfo *bool
@@ -49,12 +49,12 @@ type VersionedExampleParams struct {
 		AdditionalInfo *bool
 }
 
-func (r TestApiVersionedExampleRequest) AdditionalInfo(additionalInfo bool) TestApiVersionedExampleRequest {
+func (r VersionedExampleApiRequest) AdditionalInfo(additionalInfo bool) VersionedExampleApiRequest {
 	r.additionalInfo = &additionalInfo
 	return r
 }
 
-func (r TestApiVersionedExampleRequest) Execute() (*ExampleResourceResponseView20230201, *http.Response, error) {
+func (r VersionedExampleApiRequest) Execute() (*ExampleResourceResponseView20230201, *http.Response, error) {
 	return r.ApiService.VersionedExampleExecute(r)
 }
 
@@ -64,10 +64,10 @@ VersionedExample Example resource info for versioning of the Atlas API
 Returns some text dummy data for test purposes. Deprecated versions: v2-{2023-01-01}
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return TestApiVersionedExampleRequest
+ @return VersionedExampleApiRequest
 */
-func (a *TestApiService) VersionedExample(ctx context.Context) TestApiVersionedExampleRequest {
-	return TestApiVersionedExampleRequest{
+func (a *TestApiService) VersionedExample(ctx context.Context) VersionedExampleApiRequest {
+	return VersionedExampleApiRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -75,7 +75,7 @@ func (a *TestApiService) VersionedExample(ctx context.Context) TestApiVersionedE
 
 // Execute executes the request
 //  @return ExampleResourceResponseView20230201
-func (a *TestApiService) VersionedExampleExecute(r TestApiVersionedExampleRequest) (*ExampleResourceResponseView20230201, *http.Response, error) {
+func (a *TestApiService) VersionedExampleExecute(r VersionedExampleApiRequest) (*ExampleResourceResponseView20230201, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -45,7 +45,7 @@ type TestApiVersionedExampleRequest struct {
 	additionalInfo *bool
 }
 
-type TestApiVersionedExampleQueryParams struct {
+type TestApiVersionedExampleParams struct {
 		AdditionalInfo *bool
 }
 

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -44,6 +44,9 @@ type TestApiVersionedExampleRequest struct {
 	ApiService TestApi
 	additionalInfo *bool
 }
+type TestApiVersionedExampleQueryParams struct {
+		additionalInfo *bool
+}
 
 func (r TestApiVersionedExampleRequest) AdditionalInfo(additionalInfo bool) TestApiVersionedExampleRequest {
 	r.additionalInfo = &additionalInfo

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -44,8 +44,9 @@ type TestApiVersionedExampleRequest struct {
 	ApiService TestApi
 	additionalInfo *bool
 }
+
 type TestApiVersionedExampleQueryParams struct {
-		additionalInfo *bool
+		AdditionalInfo *bool
 }
 
 func (r TestApiVersionedExampleRequest) AdditionalInfo(additionalInfo bool) TestApiVersionedExampleRequest {

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -115,7 +115,7 @@ type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest struct {
 	pageNum *int32
 }
 
-type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationParams struct {
+type CreateThirdPartyIntegrationParams struct {
 		IntegrationType string
 		GroupId string
 		Integration *Integration
@@ -295,7 +295,7 @@ type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest struct {
 	groupId string
 }
 
-type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationParams struct {
+type DeleteThirdPartyIntegrationParams struct {
 		IntegrationType string
 		GroupId string
 }
@@ -410,7 +410,7 @@ type ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest struct {
 	integrationType string
 }
 
-type ThirdPartyIntegrationsApiGetThirdPartyIntegrationParams struct {
+type GetThirdPartyIntegrationParams struct {
 		GroupId string
 		IntegrationType string
 }
@@ -538,7 +538,7 @@ type ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest struct {
 	pageNum *int32
 }
 
-type ThirdPartyIntegrationsApiListThirdPartyIntegrationsParams struct {
+type ListThirdPartyIntegrationsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -706,7 +706,7 @@ type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest struct {
 	pageNum *int32
 }
 
-type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationParams struct {
+type UpdateThirdPartyIntegrationParams struct {
 		IntegrationType string
 		GroupId string
 		Integration *Integration

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -30,13 +30,13 @@ type ThirdPartyIntegrationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest
+	@return CreateThirdPartyIntegrationApiRequest
 	*/
-	CreateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest
+	CreateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) CreateThirdPartyIntegrationApiRequest
 
 	// CreateThirdPartyIntegrationExecute executes the request
 	//  @return PaginatedIntegration
-	CreateThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) (*PaginatedIntegration, *http.Response, error)
+	CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
 	DeleteThirdPartyIntegration Remove One Third-Party Service Integration
@@ -46,12 +46,12 @@ type ThirdPartyIntegrationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest
+	@return DeleteThirdPartyIntegrationApiRequest
 	*/
-	DeleteThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest
+	DeleteThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) DeleteThirdPartyIntegrationApiRequest
 
 	// DeleteThirdPartyIntegrationExecute executes the request
-	DeleteThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest) (*http.Response, error)
+	DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (*http.Response, error)
 
 	/*
 	GetThirdPartyIntegration Return One Third-Party Service Integration
@@ -61,13 +61,13 @@ type ThirdPartyIntegrationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
-	@return ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest
+	@return GetThirdPartyIntegrationApiRequest
 	*/
-	GetThirdPartyIntegration(ctx context.Context, groupId string, integrationType string) ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest
+	GetThirdPartyIntegration(ctx context.Context, groupId string, integrationType string) GetThirdPartyIntegrationApiRequest
 
 	// GetThirdPartyIntegrationExecute executes the request
 	//  @return Integration
-	GetThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest) (*Integration, *http.Response, error)
+	GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*Integration, *http.Response, error)
 
 	/*
 	ListThirdPartyIntegrations Return All Active Third-Party Service Integrations
@@ -76,13 +76,13 @@ type ThirdPartyIntegrationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest
+	@return ListThirdPartyIntegrationsApiRequest
 	*/
-	ListThirdPartyIntegrations(ctx context.Context, groupId string) ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest
+	ListThirdPartyIntegrations(ctx context.Context, groupId string) ListThirdPartyIntegrationsApiRequest
 
 	// ListThirdPartyIntegrationsExecute executes the request
 	//  @return PaginatedIntegration
-	ListThirdPartyIntegrationsExecute(r ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest) (*PaginatedIntegration, *http.Response, error)
+	ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
 	UpdateThirdPartyIntegration Update One Third-Party Service Integration
@@ -92,19 +92,19 @@ type ThirdPartyIntegrationsApi interface {
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest
+	@return UpdateThirdPartyIntegrationApiRequest
 	*/
-	UpdateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest
+	UpdateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) UpdateThirdPartyIntegrationApiRequest
 
 	// UpdateThirdPartyIntegrationExecute executes the request
 	//  @return PaginatedIntegration
-	UpdateThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest) (*PaginatedIntegration, *http.Response, error)
+	UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 }
 
 // ThirdPartyIntegrationsApiService ThirdPartyIntegrationsApi service
 type ThirdPartyIntegrationsApiService service
 
-type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest struct {
+type CreateThirdPartyIntegrationApiRequest struct {
 	ctx context.Context
 	ApiService ThirdPartyIntegrationsApi
 	integrationType string
@@ -125,30 +125,30 @@ type CreateThirdPartyIntegrationParams struct {
 }
 
 // Third-party integration that you want to configure for your project.
-func (r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) Integration(integration Integration) ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest {
+func (r CreateThirdPartyIntegrationApiRequest) Integration(integration Integration) CreateThirdPartyIntegrationApiRequest {
 	r.integration = &integration
 	return r
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) IncludeCount(includeCount bool) ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest {
+func (r CreateThirdPartyIntegrationApiRequest) IncludeCount(includeCount bool) CreateThirdPartyIntegrationApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) ItemsPerPage(itemsPerPage int32) ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest {
+func (r CreateThirdPartyIntegrationApiRequest) ItemsPerPage(itemsPerPage int32) CreateThirdPartyIntegrationApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) PageNum(pageNum int32) ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest {
+func (r CreateThirdPartyIntegrationApiRequest) PageNum(pageNum int32) CreateThirdPartyIntegrationApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
+func (r CreateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
 	return r.ApiService.CreateThirdPartyIntegrationExecute(r)
 }
 
@@ -160,10 +160,10 @@ Adds the settings for configuring one third-party service integration. These set
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest
+ @return CreateThirdPartyIntegrationApiRequest
 */
-func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest {
-	return ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest{
+func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) CreateThirdPartyIntegrationApiRequest {
+	return CreateThirdPartyIntegrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		integrationType: integrationType,
@@ -173,7 +173,7 @@ func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegration(ctx conte
 
 // Execute executes the request
 //  @return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -288,7 +288,7 @@ func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegrationExecute(r 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest struct {
+type DeleteThirdPartyIntegrationApiRequest struct {
 	ctx context.Context
 	ApiService ThirdPartyIntegrationsApi
 	integrationType string
@@ -300,7 +300,7 @@ type DeleteThirdPartyIntegrationParams struct {
 		GroupId string
 }
 
-func (r ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest) Execute() (*http.Response, error) {
+func (r DeleteThirdPartyIntegrationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteThirdPartyIntegrationExecute(r)
 }
 
@@ -312,10 +312,10 @@ Removes the settings that permit configuring one third-party service integration
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest
+ @return DeleteThirdPartyIntegrationApiRequest
 */
-func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest {
-	return ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest{
+func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) DeleteThirdPartyIntegrationApiRequest {
+	return DeleteThirdPartyIntegrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		integrationType: integrationType,
@@ -324,7 +324,7 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegration(ctx conte
 }
 
 // Execute executes the request
-func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest) (*http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -403,7 +403,7 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r 
 	return localVarHTTPResponse, nil
 }
 
-type ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest struct {
+type GetThirdPartyIntegrationApiRequest struct {
 	ctx context.Context
 	ApiService ThirdPartyIntegrationsApi
 	groupId string
@@ -415,7 +415,7 @@ type GetThirdPartyIntegrationParams struct {
 		IntegrationType string
 }
 
-func (r ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest) Execute() (*Integration, *http.Response, error) {
+func (r GetThirdPartyIntegrationApiRequest) Execute() (*Integration, *http.Response, error) {
 	return r.ApiService.GetThirdPartyIntegrationExecute(r)
 }
 
@@ -427,10 +427,10 @@ Returns the settings for configuring integration with one third-party service. T
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
- @return ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest
+ @return GetThirdPartyIntegrationApiRequest
 */
-func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegration(ctx context.Context, groupId string, integrationType string) ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest {
-	return ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest{
+func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegration(ctx context.Context, groupId string, integrationType string) GetThirdPartyIntegrationApiRequest {
+	return GetThirdPartyIntegrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -440,7 +440,7 @@ func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegration(ctx context.
 
 // Execute executes the request
 //  @return Integration
-func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest) (*Integration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*Integration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -529,7 +529,7 @@ func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationExecute(r Thi
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest struct {
+type ListThirdPartyIntegrationsApiRequest struct {
 	ctx context.Context
 	ApiService ThirdPartyIntegrationsApi
 	groupId string
@@ -546,24 +546,24 @@ type ListThirdPartyIntegrationsParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest) IncludeCount(includeCount bool) ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest {
+func (r ListThirdPartyIntegrationsApiRequest) IncludeCount(includeCount bool) ListThirdPartyIntegrationsApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest) ItemsPerPage(itemsPerPage int32) ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest {
+func (r ListThirdPartyIntegrationsApiRequest) ItemsPerPage(itemsPerPage int32) ListThirdPartyIntegrationsApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest) PageNum(pageNum int32) ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest {
+func (r ListThirdPartyIntegrationsApiRequest) PageNum(pageNum int32) ListThirdPartyIntegrationsApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
+func (r ListThirdPartyIntegrationsApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
 	return r.ApiService.ListThirdPartyIntegrationsExecute(r)
 }
 
@@ -574,10 +574,10 @@ Returns the settings that permit integrations with all configured third-party se
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest
+ @return ListThirdPartyIntegrationsApiRequest
 */
-func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrations(ctx context.Context, groupId string) ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest {
-	return ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest{
+func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrations(ctx context.Context, groupId string) ListThirdPartyIntegrationsApiRequest {
+	return ListThirdPartyIntegrationsApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -586,7 +586,7 @@ func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrations(ctx contex
 
 // Execute executes the request
 //  @return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrationsExecute(r ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -695,7 +695,7 @@ func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrationsExecute(r T
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest struct {
+type UpdateThirdPartyIntegrationApiRequest struct {
 	ctx context.Context
 	ApiService ThirdPartyIntegrationsApi
 	integrationType string
@@ -716,30 +716,30 @@ type UpdateThirdPartyIntegrationParams struct {
 }
 
 // Third-party integration that you want to configure for your project.
-func (r ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest) Integration(integration Integration) ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest {
+func (r UpdateThirdPartyIntegrationApiRequest) Integration(integration Integration) UpdateThirdPartyIntegrationApiRequest {
 	r.integration = &integration
 	return r
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest) IncludeCount(includeCount bool) ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest {
+func (r UpdateThirdPartyIntegrationApiRequest) IncludeCount(includeCount bool) UpdateThirdPartyIntegrationApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest) ItemsPerPage(itemsPerPage int32) ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest {
+func (r UpdateThirdPartyIntegrationApiRequest) ItemsPerPage(itemsPerPage int32) UpdateThirdPartyIntegrationApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest) PageNum(pageNum int32) ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest {
+func (r UpdateThirdPartyIntegrationApiRequest) PageNum(pageNum int32) UpdateThirdPartyIntegrationApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
+func (r UpdateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
 	return r.ApiService.UpdateThirdPartyIntegrationExecute(r)
 }
 
@@ -751,10 +751,10 @@ Updates the settings for configuring integration with one third-party service. T
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param integrationType Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest
+ @return UpdateThirdPartyIntegrationApiRequest
 */
-func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest {
-	return ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest{
+func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) UpdateThirdPartyIntegrationApiRequest {
+	return UpdateThirdPartyIntegrationApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		integrationType: integrationType,
@@ -764,7 +764,7 @@ func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegration(ctx conte
 
 // Execute executes the request
 //  @return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegrationExecute(r ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -115,7 +115,7 @@ type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest struct {
 	pageNum *int32
 }
 
-type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationQueryParams struct {
+type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationParams struct {
 		IntegrationType string
 		GroupId string
 		Integration *Integration
@@ -295,7 +295,7 @@ type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest struct {
 	groupId string
 }
 
-type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationQueryParams struct {
+type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationParams struct {
 		IntegrationType string
 		GroupId string
 }
@@ -410,7 +410,7 @@ type ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest struct {
 	integrationType string
 }
 
-type ThirdPartyIntegrationsApiGetThirdPartyIntegrationQueryParams struct {
+type ThirdPartyIntegrationsApiGetThirdPartyIntegrationParams struct {
 		GroupId string
 		IntegrationType string
 }
@@ -538,7 +538,7 @@ type ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest struct {
 	pageNum *int32
 }
 
-type ThirdPartyIntegrationsApiListThirdPartyIntegrationsQueryParams struct {
+type ThirdPartyIntegrationsApiListThirdPartyIntegrationsParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -706,7 +706,7 @@ type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest struct {
 	pageNum *int32
 }
 
-type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationQueryParams struct {
+type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationParams struct {
 		IntegrationType string
 		GroupId string
 		Integration *Integration

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -115,7 +115,7 @@ type CreateThirdPartyIntegrationApiRequest struct {
 	pageNum *int32
 }
 
-type CreateThirdPartyIntegrationParams struct {
+type CreateThirdPartyIntegrationApiParams struct {
 		IntegrationType string
 		GroupId string
 		Integration *Integration
@@ -295,7 +295,7 @@ type DeleteThirdPartyIntegrationApiRequest struct {
 	groupId string
 }
 
-type DeleteThirdPartyIntegrationParams struct {
+type DeleteThirdPartyIntegrationApiParams struct {
 		IntegrationType string
 		GroupId string
 }
@@ -410,7 +410,7 @@ type GetThirdPartyIntegrationApiRequest struct {
 	integrationType string
 }
 
-type GetThirdPartyIntegrationParams struct {
+type GetThirdPartyIntegrationApiParams struct {
 		GroupId string
 		IntegrationType string
 }
@@ -538,7 +538,7 @@ type ListThirdPartyIntegrationsApiRequest struct {
 	pageNum *int32
 }
 
-type ListThirdPartyIntegrationsParams struct {
+type ListThirdPartyIntegrationsApiParams struct {
 		GroupId string
 		IncludeCount *bool
 		ItemsPerPage *int32
@@ -706,7 +706,7 @@ type UpdateThirdPartyIntegrationApiRequest struct {
 	pageNum *int32
 }
 
-type UpdateThirdPartyIntegrationParams struct {
+type UpdateThirdPartyIntegrationApiParams struct {
 		IntegrationType string
 		GroupId string
 		Integration *Integration

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -114,6 +114,14 @@ type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationQueryParams struct {
+		integrationType string
+		groupId string
+		integration *Integration
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
+}
 
 // Third-party integration that you want to configure for your project.
 func (r ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest) Integration(integration Integration) ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest {
@@ -285,6 +293,10 @@ type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest struct {
 	integrationType string
 	groupId string
 }
+type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationQueryParams struct {
+		integrationType string
+		groupId string
+}
 
 func (r ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteThirdPartyIntegrationExecute(r)
@@ -394,6 +406,10 @@ type ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest struct {
 	ApiService ThirdPartyIntegrationsApi
 	groupId string
 	integrationType string
+}
+type ThirdPartyIntegrationsApiGetThirdPartyIntegrationQueryParams struct {
+		groupId string
+		integrationType string
 }
 
 func (r ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest) Execute() (*Integration, *http.Response, error) {
@@ -517,6 +533,12 @@ type ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type ThirdPartyIntegrationsApiListThirdPartyIntegrationsQueryParams struct {
+		groupId string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -678,6 +700,14 @@ type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationQueryParams struct {
+		integrationType string
+		groupId string
+		integration *Integration
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Third-party integration that you want to configure for your project.

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -114,13 +114,14 @@ type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ThirdPartyIntegrationsApiCreateThirdPartyIntegrationQueryParams struct {
-		integrationType string
-		groupId string
-		integration *Integration
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		IntegrationType string
+		GroupId string
+		Integration *Integration
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Third-party integration that you want to configure for your project.
@@ -293,9 +294,10 @@ type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest struct {
 	integrationType string
 	groupId string
 }
+
 type ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationQueryParams struct {
-		integrationType string
-		groupId string
+		IntegrationType string
+		GroupId string
 }
 
 func (r ThirdPartyIntegrationsApiDeleteThirdPartyIntegrationRequest) Execute() (*http.Response, error) {
@@ -407,9 +409,10 @@ type ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest struct {
 	groupId string
 	integrationType string
 }
+
 type ThirdPartyIntegrationsApiGetThirdPartyIntegrationQueryParams struct {
-		groupId string
-		integrationType string
+		GroupId string
+		IntegrationType string
 }
 
 func (r ThirdPartyIntegrationsApiGetThirdPartyIntegrationRequest) Execute() (*Integration, *http.Response, error) {
@@ -534,11 +537,12 @@ type ThirdPartyIntegrationsApiListThirdPartyIntegrationsRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ThirdPartyIntegrationsApiListThirdPartyIntegrationsQueryParams struct {
-		groupId string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
@@ -701,13 +705,14 @@ type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type ThirdPartyIntegrationsApiUpdateThirdPartyIntegrationQueryParams struct {
-		integrationType string
-		groupId string
-		integration *Integration
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		IntegrationType string
+		GroupId string
+		Integration *Integration
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Third-party integration that you want to configure for your project.

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -34,12 +34,12 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param username Human-readable label that represents the MongoDB database user account for whom to create a certificate.
-	@return X509AuthenticationApiCreateDatabaseUserCertificateRequest
+	@return CreateDatabaseUserCertificateApiRequest
 	*/
-	CreateDatabaseUserCertificate(ctx context.Context, groupId string, username string) X509AuthenticationApiCreateDatabaseUserCertificateRequest
+	CreateDatabaseUserCertificate(ctx context.Context, groupId string, username string) CreateDatabaseUserCertificateApiRequest
 
 	// CreateDatabaseUserCertificateExecute executes the request
-	CreateDatabaseUserCertificateExecute(r X509AuthenticationApiCreateDatabaseUserCertificateRequest) (*http.Response, error)
+	CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (*http.Response, error)
 
 	/*
 	DisableCustomerManagedX509 Disable Customer-Managed X.509
@@ -50,13 +50,13 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
-	@return X509AuthenticationApiDisableCustomerManagedX509Request
+	@return DisableCustomerManagedX509ApiRequest
 	*/
-	DisableCustomerManagedX509(ctx context.Context, groupId string) X509AuthenticationApiDisableCustomerManagedX509Request
+	DisableCustomerManagedX509(ctx context.Context, groupId string) DisableCustomerManagedX509ApiRequest
 
 	// DisableCustomerManagedX509Execute executes the request
 	//  @return UserSecurity
-	DisableCustomerManagedX509Execute(r X509AuthenticationApiDisableCustomerManagedX509Request) (*UserSecurity, *http.Response, error)
+	DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 	ListDatabaseUserCertificates Return All X.509 Certificates Assigned to One MongoDB User
@@ -66,19 +66,19 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@param username Human-readable label that represents the MongoDB database user account whose certificates you want to return.
-	@return X509AuthenticationApiListDatabaseUserCertificatesRequest
+	@return ListDatabaseUserCertificatesApiRequest
 	*/
-	ListDatabaseUserCertificates(ctx context.Context, groupId string, username string) X509AuthenticationApiListDatabaseUserCertificatesRequest
+	ListDatabaseUserCertificates(ctx context.Context, groupId string, username string) ListDatabaseUserCertificatesApiRequest
 
 	// ListDatabaseUserCertificatesExecute executes the request
 	//  @return PaginatedUserCert
-	ListDatabaseUserCertificatesExecute(r X509AuthenticationApiListDatabaseUserCertificatesRequest) (*PaginatedUserCert, *http.Response, error)
+	ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error)
 }
 
 // X509AuthenticationApiService X509AuthenticationApi service
 type X509AuthenticationApiService service
 
-type X509AuthenticationApiCreateDatabaseUserCertificateRequest struct {
+type CreateDatabaseUserCertificateApiRequest struct {
 	ctx context.Context
 	ApiService X509AuthenticationApi
 	groupId string
@@ -93,12 +93,12 @@ type CreateDatabaseUserCertificateParams struct {
 }
 
 // Generates one X.509 certificate for the specified MongoDB user.
-func (r X509AuthenticationApiCreateDatabaseUserCertificateRequest) UserCert(userCert UserCert) X509AuthenticationApiCreateDatabaseUserCertificateRequest {
+func (r CreateDatabaseUserCertificateApiRequest) UserCert(userCert UserCert) CreateDatabaseUserCertificateApiRequest {
 	r.userCert = &userCert
 	return r
 }
 
-func (r X509AuthenticationApiCreateDatabaseUserCertificateRequest) Execute() (*http.Response, error) {
+func (r CreateDatabaseUserCertificateApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CreateDatabaseUserCertificateExecute(r)
 }
 
@@ -114,10 +114,10 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param username Human-readable label that represents the MongoDB database user account for whom to create a certificate.
- @return X509AuthenticationApiCreateDatabaseUserCertificateRequest
+ @return CreateDatabaseUserCertificateApiRequest
 */
-func (a *X509AuthenticationApiService) CreateDatabaseUserCertificate(ctx context.Context, groupId string, username string) X509AuthenticationApiCreateDatabaseUserCertificateRequest {
-	return X509AuthenticationApiCreateDatabaseUserCertificateRequest{
+func (a *X509AuthenticationApiService) CreateDatabaseUserCertificate(ctx context.Context, groupId string, username string) CreateDatabaseUserCertificateApiRequest {
+	return CreateDatabaseUserCertificateApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -126,7 +126,7 @@ func (a *X509AuthenticationApiService) CreateDatabaseUserCertificate(ctx context
 }
 
 // Execute executes the request
-func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateExecute(r X509AuthenticationApiCreateDatabaseUserCertificateRequest) (*http.Response, error) {
+func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -210,7 +210,7 @@ func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateExecute(r X5
 	return localVarHTTPResponse, nil
 }
 
-type X509AuthenticationApiDisableCustomerManagedX509Request struct {
+type DisableCustomerManagedX509ApiRequest struct {
 	ctx context.Context
 	ApiService X509AuthenticationApi
 	groupId string
@@ -220,7 +220,7 @@ type DisableCustomerManagedX509Params struct {
 		GroupId string
 }
 
-func (r X509AuthenticationApiDisableCustomerManagedX509Request) Execute() (*UserSecurity, *http.Response, error) {
+func (r DisableCustomerManagedX509ApiRequest) Execute() (*UserSecurity, *http.Response, error) {
 	return r.ApiService.DisableCustomerManagedX509Execute(r)
 }
 
@@ -233,10 +233,10 @@ Clears the customer-managed X.509 settings on a project, including the uploaded 
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
- @return X509AuthenticationApiDisableCustomerManagedX509Request
+ @return DisableCustomerManagedX509ApiRequest
 */
-func (a *X509AuthenticationApiService) DisableCustomerManagedX509(ctx context.Context, groupId string) X509AuthenticationApiDisableCustomerManagedX509Request {
-	return X509AuthenticationApiDisableCustomerManagedX509Request{
+func (a *X509AuthenticationApiService) DisableCustomerManagedX509(ctx context.Context, groupId string) DisableCustomerManagedX509ApiRequest {
+	return DisableCustomerManagedX509ApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -245,7 +245,7 @@ func (a *X509AuthenticationApiService) DisableCustomerManagedX509(ctx context.Co
 
 // Execute executes the request
 //  @return UserSecurity
-func (a *X509AuthenticationApiService) DisableCustomerManagedX509Execute(r X509AuthenticationApiDisableCustomerManagedX509Request) (*UserSecurity, *http.Response, error) {
+func (a *X509AuthenticationApiService) DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -333,7 +333,7 @@ func (a *X509AuthenticationApiService) DisableCustomerManagedX509Execute(r X509A
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type X509AuthenticationApiListDatabaseUserCertificatesRequest struct {
+type ListDatabaseUserCertificatesApiRequest struct {
 	ctx context.Context
 	ApiService X509AuthenticationApi
 	groupId string
@@ -352,24 +352,24 @@ type ListDatabaseUserCertificatesParams struct {
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
-func (r X509AuthenticationApiListDatabaseUserCertificatesRequest) IncludeCount(includeCount bool) X509AuthenticationApiListDatabaseUserCertificatesRequest {
+func (r ListDatabaseUserCertificatesApiRequest) IncludeCount(includeCount bool) ListDatabaseUserCertificatesApiRequest {
 	r.includeCount = &includeCount
 	return r
 }
 
 // Number of items that the response returns per page.
-func (r X509AuthenticationApiListDatabaseUserCertificatesRequest) ItemsPerPage(itemsPerPage int32) X509AuthenticationApiListDatabaseUserCertificatesRequest {
+func (r ListDatabaseUserCertificatesApiRequest) ItemsPerPage(itemsPerPage int32) ListDatabaseUserCertificatesApiRequest {
 	r.itemsPerPage = &itemsPerPage
 	return r
 }
 
 // Number of the page that displays the current set of the total objects that the response returns.
-func (r X509AuthenticationApiListDatabaseUserCertificatesRequest) PageNum(pageNum int32) X509AuthenticationApiListDatabaseUserCertificatesRequest {
+func (r ListDatabaseUserCertificatesApiRequest) PageNum(pageNum int32) ListDatabaseUserCertificatesApiRequest {
 	r.pageNum = &pageNum
 	return r
 }
 
-func (r X509AuthenticationApiListDatabaseUserCertificatesRequest) Execute() (*PaginatedUserCert, *http.Response, error) {
+func (r ListDatabaseUserCertificatesApiRequest) Execute() (*PaginatedUserCert, *http.Response, error) {
 	return r.ApiService.ListDatabaseUserCertificatesExecute(r)
 }
 
@@ -381,10 +381,10 @@ Returns all unexpired X.509 certificates for the specified MongoDB user. This Mo
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
  @param username Human-readable label that represents the MongoDB database user account whose certificates you want to return.
- @return X509AuthenticationApiListDatabaseUserCertificatesRequest
+ @return ListDatabaseUserCertificatesApiRequest
 */
-func (a *X509AuthenticationApiService) ListDatabaseUserCertificates(ctx context.Context, groupId string, username string) X509AuthenticationApiListDatabaseUserCertificatesRequest {
-	return X509AuthenticationApiListDatabaseUserCertificatesRequest{
+func (a *X509AuthenticationApiService) ListDatabaseUserCertificates(ctx context.Context, groupId string, username string) ListDatabaseUserCertificatesApiRequest {
+	return ListDatabaseUserCertificatesApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		groupId: groupId,
@@ -394,7 +394,7 @@ func (a *X509AuthenticationApiService) ListDatabaseUserCertificates(ctx context.
 
 // Execute executes the request
 //  @return PaginatedUserCert
-func (a *X509AuthenticationApiService) ListDatabaseUserCertificatesExecute(r X509AuthenticationApiListDatabaseUserCertificatesRequest) (*PaginatedUserCert, *http.Response, error) {
+func (a *X509AuthenticationApiService) ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -86,7 +86,7 @@ type CreateDatabaseUserCertificateApiRequest struct {
 	userCert *UserCert
 }
 
-type CreateDatabaseUserCertificateParams struct {
+type CreateDatabaseUserCertificateApiParams struct {
 		GroupId string
 		Username string
 		UserCert *UserCert
@@ -216,7 +216,7 @@ type DisableCustomerManagedX509ApiRequest struct {
 	groupId string
 }
 
-type DisableCustomerManagedX509Params struct {
+type DisableCustomerManagedX509ApiParams struct {
 		GroupId string
 }
 
@@ -343,7 +343,7 @@ type ListDatabaseUserCertificatesApiRequest struct {
 	pageNum *int32
 }
 
-type ListDatabaseUserCertificatesParams struct {
+type ListDatabaseUserCertificatesApiParams struct {
 		GroupId string
 		Username string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -85,6 +85,11 @@ type X509AuthenticationApiCreateDatabaseUserCertificateRequest struct {
 	username string
 	userCert *UserCert
 }
+type X509AuthenticationApiCreateDatabaseUserCertificateQueryParams struct {
+		groupId string
+		username string
+		userCert *UserCert
+}
 
 // Generates one X.509 certificate for the specified MongoDB user.
 func (r X509AuthenticationApiCreateDatabaseUserCertificateRequest) UserCert(userCert UserCert) X509AuthenticationApiCreateDatabaseUserCertificateRequest {
@@ -209,6 +214,9 @@ type X509AuthenticationApiDisableCustomerManagedX509Request struct {
 	ApiService X509AuthenticationApi
 	groupId string
 }
+type X509AuthenticationApiDisableCustomerManagedX509QueryParams struct {
+		groupId string
+}
 
 func (r X509AuthenticationApiDisableCustomerManagedX509Request) Execute() (*UserSecurity, *http.Response, error) {
 	return r.ApiService.DisableCustomerManagedX509Execute(r)
@@ -331,6 +339,13 @@ type X509AuthenticationApiListDatabaseUserCertificatesRequest struct {
 	includeCount *bool
 	itemsPerPage *int32
 	pageNum *int32
+}
+type X509AuthenticationApiListDatabaseUserCertificatesQueryParams struct {
+		groupId string
+		username string
+		includeCount *bool
+		itemsPerPage *int32
+		pageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -86,7 +86,7 @@ type X509AuthenticationApiCreateDatabaseUserCertificateRequest struct {
 	userCert *UserCert
 }
 
-type X509AuthenticationApiCreateDatabaseUserCertificateParams struct {
+type CreateDatabaseUserCertificateParams struct {
 		GroupId string
 		Username string
 		UserCert *UserCert
@@ -216,7 +216,7 @@ type X509AuthenticationApiDisableCustomerManagedX509Request struct {
 	groupId string
 }
 
-type X509AuthenticationApiDisableCustomerManagedX509Params struct {
+type DisableCustomerManagedX509Params struct {
 		GroupId string
 }
 
@@ -343,7 +343,7 @@ type X509AuthenticationApiListDatabaseUserCertificatesRequest struct {
 	pageNum *int32
 }
 
-type X509AuthenticationApiListDatabaseUserCertificatesParams struct {
+type ListDatabaseUserCertificatesParams struct {
 		GroupId string
 		Username string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -86,7 +86,7 @@ type X509AuthenticationApiCreateDatabaseUserCertificateRequest struct {
 	userCert *UserCert
 }
 
-type X509AuthenticationApiCreateDatabaseUserCertificateQueryParams struct {
+type X509AuthenticationApiCreateDatabaseUserCertificateParams struct {
 		GroupId string
 		Username string
 		UserCert *UserCert
@@ -216,7 +216,7 @@ type X509AuthenticationApiDisableCustomerManagedX509Request struct {
 	groupId string
 }
 
-type X509AuthenticationApiDisableCustomerManagedX509QueryParams struct {
+type X509AuthenticationApiDisableCustomerManagedX509Params struct {
 		GroupId string
 }
 
@@ -343,7 +343,7 @@ type X509AuthenticationApiListDatabaseUserCertificatesRequest struct {
 	pageNum *int32
 }
 
-type X509AuthenticationApiListDatabaseUserCertificatesQueryParams struct {
+type X509AuthenticationApiListDatabaseUserCertificatesParams struct {
 		GroupId string
 		Username string
 		IncludeCount *bool

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -85,10 +85,11 @@ type X509AuthenticationApiCreateDatabaseUserCertificateRequest struct {
 	username string
 	userCert *UserCert
 }
+
 type X509AuthenticationApiCreateDatabaseUserCertificateQueryParams struct {
-		groupId string
-		username string
-		userCert *UserCert
+		GroupId string
+		Username string
+		UserCert *UserCert
 }
 
 // Generates one X.509 certificate for the specified MongoDB user.
@@ -214,8 +215,9 @@ type X509AuthenticationApiDisableCustomerManagedX509Request struct {
 	ApiService X509AuthenticationApi
 	groupId string
 }
+
 type X509AuthenticationApiDisableCustomerManagedX509QueryParams struct {
-		groupId string
+		GroupId string
 }
 
 func (r X509AuthenticationApiDisableCustomerManagedX509Request) Execute() (*UserSecurity, *http.Response, error) {
@@ -340,12 +342,13 @@ type X509AuthenticationApiListDatabaseUserCertificatesRequest struct {
 	itemsPerPage *int32
 	pageNum *int32
 }
+
 type X509AuthenticationApiListDatabaseUserCertificatesQueryParams struct {
-		groupId string
-		username string
-		includeCount *bool
-		itemsPerPage *int32
-		pageNum *int32
+		GroupId string
+		Username string
+		IncludeCount *bool
+		ItemsPerPage *int32
+		PageNum *int32
 }
 
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -26,20 +26,20 @@ type {{classname}} interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().{{#pathParams}}
 	@param {{paramName}}{{#description}} {{{.}}}{{/description}}{{/pathParams}}
-	@return {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request
+	@return {{operationId}}ApiRequest
 	{{#isDeprecated}}
 
 	Deprecated
 	{{/isDeprecated}}
 	*/
-	{{{nickname}}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request
+	{{{nickname}}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{operationId}}ApiRequest
 
 	// {{nickname}}Execute executes the request{{#returnType}}
 	//  @return {{{.}}}{{/returnType}}
 	{{#isDeprecated}}
 	// Deprecated
 	{{/isDeprecated}}
-	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
+	{{nickname}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -48,7 +48,7 @@ type {{classname}} interface {
 type {{classname}}Service service
 {{#operation}}
 
-type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request struct {
+type {{operationId}}ApiRequest struct {
 	ctx context.Context{{#generateInterfaces}}
 	ApiService {{classname}}
 {{/generateInterfaces}}{{^generateInterfaces}}
@@ -74,14 +74,14 @@ type {{operationId}}Params struct {
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request {
+func (r {{operationId}}ApiRequest) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{operationId}}ApiRequest {
 	r.{{paramName}} = {{^isFile}}&{{/isFile}}{{paramName}}
 	return r
 }
 
 {{/isPathParam}}
 {{/allParams}}
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) Execute() ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+func (r {{operationId}}ApiRequest) Execute() ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
@@ -94,14 +94,14 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/s
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().{{#pathParams}}
  @param {{paramName}}{{#description}} {{{.}}}{{/description}}{{/pathParams}}
- @return {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request
+ @return {{operationId}}ApiRequest
 {{#isDeprecated}}
 
 Deprecated
 {{/isDeprecated}}
 */
-func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request {
-	return {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request{
+func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{operationId}}ApiRequest {
+	return {{operationId}}ApiRequest{
 		ApiService: a,
 		ctx: ctx,
 		{{#pathParams}}
@@ -115,7 +115,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#pathParams
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.Method{{httpMethod}}
 		localVarPostBody     interface{}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -58,6 +58,12 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/stru
 	{{paramName}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
 {{/allParams}}
 }
+{{!X-GEN-CUSTOM}}
+type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}QueryParams struct {
+	{{#allParams}}
+		{{paramName}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
+	{{/allParams}}
+}
 
 {{#allParams}}
 {{^isPathParam}}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -60,7 +60,7 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/stru
 }
 
 {{!X-GEN-CUSTOM}}
-type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Params struct {
+type {{operationId}}Params struct {
 	{{#allParams}}
 		{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
 	{{/allParams}}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -60,7 +60,7 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/stru
 }
 
 {{!X-GEN-CUSTOM}}
-type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}QueryParams struct {
+type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Params struct {
 	{{#allParams}}
 		{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
 	{{/allParams}}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -58,10 +58,11 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/stru
 	{{paramName}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
 {{/allParams}}
 }
+
 {{!X-GEN-CUSTOM}}
 type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}QueryParams struct {
 	{{#allParams}}
-		{{paramName}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
+		{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
 	{{/allParams}}
 }
 

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -60,7 +60,7 @@ type {{operationId}}ApiRequest struct {
 }
 
 {{!X-GEN-CUSTOM}}
-type {{operationId}}Params struct {
+type {{operationId}}ApiParams struct {
 	{{#allParams}}
 		{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
 	{{/allParams}}


### PR DESCRIPTION
## Description

Create separate structure for query params

## Long

As part of the migration, I see recurrent theme where GET url arguments are returned as part of the Fluent API. E.g
 ```
 s.clientv2.PerformanceAdvisorApi.
		ListSuggestedIndexes(s.ctx, projectID, processName).
		NExamples(1) // This is query param
		Execute()		
```	
Due to the architecture in the CLI (stores) we see need to pass those arguments to functions
This usually means:
- Passing from 3 to 10 arguments to methods
- Create some intermediate objects in the CLI

Manual SDKs have been supporting this by GET arguments being represented as struct:
https://github.com/mongodb/go-client-mongodb-atlas/blob/437d9b43222e10c0fd565d979eafd85f80c199e2/mongodbatlas/performance_advisor.go#L105-L130

This PR brings parity (with level of backwards compatibility between both SDKs.