### PR TITLE
Enable fluent and struct API for go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ Generated client support different use cases:
 - Suppling request arguments as single structure
 
 ### Fluent API example
+
 ```go
     projects, response, err := sdk.ProjectsApi.ListProjects(ctx).
 	    ItemsPerPage(1).Execute()
 ```  
 
 ### Struct based API example
+
 ```go
 	listParams := &mongodbatlas.ListProjectsApiParams{ItemsPerPage: mongodbatlas.PtrInt32(1)}
-	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).ExecuteWithParams(listParams)
+	projects, response, err := sdk.ProjectsApi.ListProjectsWithParams(ctx, listParams).Execute()
 ```    
-
-
 
 ## Usage for v1 client
 
@@ -155,8 +155,6 @@ if errors.IsErrorCode(err, "code"){
  // Do something
 }
 ```
-
-
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -51,25 +51,32 @@ Example for creating an dedicated MongoDB cluster on AWS infrastructure
 go run ./examples/example_cluster_aws.go
 ```
 
-## Fluent and Struct Based API
+## Advanced usage
 
-Generated client support different use cases:
-- Supplying arguments using chain of functions (Fluent API)
-- Suppling request arguments as single structure
+###  Fluent and Struct Based API
 
-### Fluent API example
+Generated client support two different ways to execute API requests.
+1. Fluent API: where users are supplying arguments using chain of functions (default)
+2. Struct API: Suppling request data using an single go structure containing request body and arguments
+
+#### Fluent API example
+
+Fluent API should be used by default to handle all requests.
 
 ```go
     projects, response, err := sdk.ProjectsApi.ListProjects(ctx).
 	    ItemsPerPage(1).Execute()
 ```  
 
-### Struct based API example
+#### Struct based API example
 
+Struct based API is particularly useful for HTTP GET requests where we need to pass number of arguments to the function without checking 
 ```go
 	listParams := &mongodbatlas.ListProjectsApiParams{ItemsPerPage: mongodbatlas.PtrInt32(1)}
 	projects, response, err := sdk.ProjectsApi.ListProjectsWithParams(ctx, listParams).Execute()
 ```    
+
+> NOTE: Struct based API is an still experimental feature.
 
 ## Usage for v1 client
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ Example for creating an dedicated MongoDB cluster on AWS infrastructure
 go run ./examples/example_cluster_aws.go
 ```
 
+## Fluent and Struct Based API
+
+Generated client support different use cases:
+- Supplying arguments using chain of functions (Fluent API)
+- Suppling request arguments as single structure
+
+### Fluent API example
+```go
+    projects, response, err := sdk.ProjectsApi.ListProjects(ctx).
+	    ItemsPerPage(1).Execute()
+```  
+
+### Struct based API example
+```go
+	listParams := &mongodbatlas.ListProjectsApiParams{ItemsPerPage: mongodbatlas.PtrInt32(1)}
+	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).ExecuteWithParams(listParams)
+```    
+
+
+
 ## Usage for v1 client
 
 ```go

--- a/examples/example_cluster_aws.go
+++ b/examples/example_cluster_aws.go
@@ -37,7 +37,7 @@ func main() {
 
 	// -- 1. Get first project
 	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).
-		IncludeCount(false).ItemsPerPage(1).Execute()
+		IncludeCount(false).Execute()
 	handleErr(err, response)
 
 	if projects.GetTotalCount() == 0 {

--- a/examples/example_cluster_aws.go
+++ b/examples/example_cluster_aws.go
@@ -35,9 +35,14 @@ func main() {
 		mongodbatlas.UseDebug(false))
 	handleErr(err, nil)
 
-	// -- 1. Get first project
-	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).
-		IncludeCount(false).Execute()
+	// -- 1. Get first project using fluent API
+	_, response, err := sdk.ProjectsApi.ListProjects(ctx).
+		IncludeCount(false).ItemsPerPage(1).Execute()
+	handleErr(err, response)
+
+	// -- 1.1 Get first project using struct based API
+	listParams := &mongodbatlas.ListProjectsApiParams{ItemsPerPage: mongodbatlas.PtrInt32(1)}
+	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).ExecuteWithParams(listParams)
 	handleErr(err, response)
 
 	if projects.GetTotalCount() == 0 {

--- a/examples/example_cluster_aws.go
+++ b/examples/example_cluster_aws.go
@@ -42,7 +42,7 @@ func main() {
 
 	// -- 1.1 Get first project using struct based API
 	listParams := &mongodbatlas.ListProjectsApiParams{ItemsPerPage: mongodbatlas.PtrInt32(1)}
-	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).ExecuteWithParams(listParams)
+	projects, response, err := sdk.ProjectsApi.ListProjectsWithParams(ctx, listParams).Execute()
 	handleErr(err, response)
 
 	if projects.GetTotalCount() == 0 {

--- a/examples/example_cluster_aws.go
+++ b/examples/example_cluster_aws.go
@@ -35,14 +35,9 @@ func main() {
 		mongodbatlas.UseDebug(false))
 	handleErr(err, nil)
 
-	// -- 1. Get first project using fluent API
-	_, response, err := sdk.ProjectsApi.ListProjects(ctx).
+	// -- 1. Get first project
+	projects, response, err := sdk.ProjectsApi.ListProjects(ctx).
 		IncludeCount(false).ItemsPerPage(1).Execute()
-	handleErr(err, response)
-
-	// -- 1.1 Get first project using struct based API
-	listParams := &mongodbatlas.ListProjectsApiParams{ItemsPerPage: mongodbatlas.PtrInt32(1)}
-	projects, response, err := sdk.ProjectsApi.ListProjectsWithParams(ctx, listParams).Execute()
 	handleErr(err, response)
 
 	if projects.GetTotalCount() == 0 {

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -36,7 +36,7 @@ type AccessTrackingApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAccessLogsByClusterNameApiParams - Parameters for the request
-	@return ListAccessLogsByClusterNameApiRequest}}
+	@return ListAccessLogsByClusterNameApiRequest
 	*/
 	ListAccessLogsByClusterNameWithParams(ctx context.Context, args *ListAccessLogsByClusterNameApiParams) ListAccessLogsByClusterNameApiRequest
 
@@ -60,7 +60,7 @@ type AccessTrackingApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAccessLogsByHostnameApiParams - Parameters for the request
-	@return ListAccessLogsByHostnameApiRequest}}
+	@return ListAccessLogsByHostnameApiRequest
 	*/
 	ListAccessLogsByHostnameWithParams(ctx context.Context, args *ListAccessLogsByHostnameApiParams) ListAccessLogsByHostnameApiRequest
 

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -30,10 +30,18 @@ type AccessTrackingApi interface {
 	@return ListAccessLogsByClusterNameApiRequest
 	*/
 	ListAccessLogsByClusterName(ctx context.Context, groupId string, clusterName string) ListAccessLogsByClusterNameApiRequest
+	/*
+	ListAccessLogsByClusterName Return Database Access History for One Cluster using Its Cluster Name
 
-	// ListAccessLogsByClusterNameExecute executes the request
-	//  @return MongoDBAccessLogsList
-	ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAccessLogsByClusterNameApiParams - Parameters for the request
+	@return ListAccessLogsByClusterNameApiRequest}}
+	*/
+	ListAccessLogsByClusterNameWithParams(ctx context.Context, args *ListAccessLogsByClusterNameApiParams) ListAccessLogsByClusterNameApiRequest
+
+	// Interface only available internally
+	listAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 
 	/*
 	ListAccessLogsByHostname Return Database Access History for One Cluster using Its Hostname
@@ -46,10 +54,18 @@ type AccessTrackingApi interface {
 	@return ListAccessLogsByHostnameApiRequest
 	*/
 	ListAccessLogsByHostname(ctx context.Context, groupId string, hostname string) ListAccessLogsByHostnameApiRequest
+	/*
+	ListAccessLogsByHostname Return Database Access History for One Cluster using Its Hostname
 
-	// ListAccessLogsByHostnameExecute executes the request
-	//  @return MongoDBAccessLogsList
-	ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAccessLogsByHostnameApiParams - Parameters for the request
+	@return ListAccessLogsByHostnameApiRequest}}
+	*/
+	ListAccessLogsByHostnameWithParams(ctx context.Context, args *ListAccessLogsByHostnameApiParams) ListAccessLogsByHostnameApiRequest
+
+	// Interface only available internally
+	listAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error)
 }
 
 // AccessTrackingApiService AccessTrackingApi service
@@ -75,6 +91,20 @@ type ListAccessLogsByClusterNameApiParams struct {
 		IpAddress *string
 		NLogs *int64
 		Start *time.Time
+}
+
+func (a *AccessTrackingApiService) ListAccessLogsByClusterNameWithParams(ctx context.Context, args *ListAccessLogsByClusterNameApiParams) ListAccessLogsByClusterNameApiRequest {
+	return ListAccessLogsByClusterNameApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		authResult: args.AuthResult,
+		end: args.End,
+		ipAddress: args.IpAddress,
+		nLogs: args.NLogs,
+		start: args.Start,
+	}
 }
 
 // Flag that indicates whether the response returns the successful authentication attempts only.
@@ -108,18 +138,7 @@ func (r ListAccessLogsByClusterNameApiRequest) Start(start time.Time) ListAccess
 }
 
 func (r ListAccessLogsByClusterNameApiRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
-	return r.ApiService.ListAccessLogsByClusterNameExecute(r)
-}
-
-func (r ListAccessLogsByClusterNameApiRequest) ExecuteWithParams(params *ListAccessLogsByClusterNameApiParams) (*MongoDBAccessLogsList, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.authResult = params.AuthResult 
-	r.end = params.End 
-	r.ipAddress = params.IpAddress 
-	r.nLogs = params.NLogs 
-	r.start = params.Start 
-	return r.Execute()
+	return r.ApiService.listAccessLogsByClusterNameExecute(r)
 }
 
 /*
@@ -143,7 +162,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByClusterName(ctx context.Conte
 
 // Execute executes the request
 //  @return MongoDBAccessLogsList
-func (a *AccessTrackingApiService) ListAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
+func (a *AccessTrackingApiService) listAccessLogsByClusterNameExecute(r ListAccessLogsByClusterNameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -279,6 +298,20 @@ type ListAccessLogsByHostnameApiParams struct {
 		Start *time.Time
 }
 
+func (a *AccessTrackingApiService) ListAccessLogsByHostnameWithParams(ctx context.Context, args *ListAccessLogsByHostnameApiParams) ListAccessLogsByHostnameApiRequest {
+	return ListAccessLogsByHostnameApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		hostname: args.Hostname,
+		authResult: args.AuthResult,
+		end: args.End,
+		ipAddress: args.IpAddress,
+		nLogs: args.NLogs,
+		start: args.Start,
+	}
+}
+
 // Flag that indicates whether the response returns the successful authentication attempts only.
 func (r ListAccessLogsByHostnameApiRequest) AuthResult(authResult bool) ListAccessLogsByHostnameApiRequest {
 	r.authResult = &authResult
@@ -310,18 +343,7 @@ func (r ListAccessLogsByHostnameApiRequest) Start(start time.Time) ListAccessLog
 }
 
 func (r ListAccessLogsByHostnameApiRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
-	return r.ApiService.ListAccessLogsByHostnameExecute(r)
-}
-
-func (r ListAccessLogsByHostnameApiRequest) ExecuteWithParams(params *ListAccessLogsByHostnameApiParams) (*MongoDBAccessLogsList, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.hostname = params.Hostname 
-	r.authResult = params.AuthResult 
-	r.end = params.End 
-	r.ipAddress = params.IpAddress 
-	r.nLogs = params.NLogs 
-	r.start = params.Start 
-	return r.Execute()
+	return r.ApiService.listAccessLogsByHostnameExecute(r)
 }
 
 /*
@@ -345,7 +367,7 @@ func (a *AccessTrackingApiService) ListAccessLogsByHostname(ctx context.Context,
 
 // Execute executes the request
 //  @return MongoDBAccessLogsList
-func (a *AccessTrackingApiService) ListAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
+func (a *AccessTrackingApiService) listAccessLogsByHostnameExecute(r ListAccessLogsByHostnameApiRequest) (*MongoDBAccessLogsList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_access_tracking.go
+++ b/mongodbatlasv2/api_access_tracking.go
@@ -111,6 +111,17 @@ func (r ListAccessLogsByClusterNameApiRequest) Execute() (*MongoDBAccessLogsList
 	return r.ApiService.ListAccessLogsByClusterNameExecute(r)
 }
 
+func (r ListAccessLogsByClusterNameApiRequest) ExecuteWithParams(params *ListAccessLogsByClusterNameApiParams) (*MongoDBAccessLogsList, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.authResult = params.AuthResult 
+	r.end = params.End 
+	r.ipAddress = params.IpAddress 
+	r.nLogs = params.NLogs 
+	r.start = params.Start 
+	return r.Execute()
+}
+
 /*
 ListAccessLogsByClusterName Return Database Access History for One Cluster using Its Cluster Name
 
@@ -300,6 +311,17 @@ func (r ListAccessLogsByHostnameApiRequest) Start(start time.Time) ListAccessLog
 
 func (r ListAccessLogsByHostnameApiRequest) Execute() (*MongoDBAccessLogsList, *http.Response, error) {
 	return r.ApiService.ListAccessLogsByHostnameExecute(r)
+}
+
+func (r ListAccessLogsByHostnameApiRequest) ExecuteWithParams(params *ListAccessLogsByHostnameApiParams) (*MongoDBAccessLogsList, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.hostname = params.Hostname 
+	r.authResult = params.AuthResult 
+	r.end = params.End 
+	r.ipAddress = params.IpAddress 
+	r.nLogs = params.NLogs 
+	r.start = params.Start 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -185,6 +185,12 @@ func (r CreateAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGro
 	return r.ApiService.CreateAlertConfigurationExecute(r)
 }
 
+func (r CreateAlertConfigurationApiRequest) ExecuteWithParams(params *CreateAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertConfigViewForNdsGroup = params.AlertConfigViewForNdsGroup 
+	return r.Execute()
+}
+
 /*
 CreateAlertConfiguration Create One Alert Configuration in One Project
 
@@ -315,6 +321,12 @@ func (r DeleteAlertConfigurationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteAlertConfigurationExecute(r)
 }
 
+func (r DeleteAlertConfigurationApiRequest) ExecuteWithParams(params *DeleteAlertConfigurationApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertConfigId = params.AlertConfigId 
+	return r.Execute()
+}
+
 /*
 DeleteAlertConfiguration Remove One Alert Configuration from One Project
 
@@ -436,6 +448,12 @@ type GetAlertConfigurationApiParams struct {
 
 func (r GetAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.GetAlertConfigurationExecute(r)
+}
+
+func (r GetAlertConfigurationApiRequest) ExecuteWithParams(params *GetAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertConfigId = params.AlertConfigId 
+	return r.Execute()
 }
 
 /*
@@ -566,6 +584,10 @@ type ListAlertConfigurationMatchersFieldNamesApiParams struct {
 
 func (r ListAlertConfigurationMatchersFieldNamesApiRequest) Execute() ([]MatcherField, *http.Response, error) {
 	return r.ApiService.ListAlertConfigurationMatchersFieldNamesExecute(r)
+}
+
+func (r ListAlertConfigurationMatchersFieldNamesApiRequest) ExecuteWithParams(params *ListAlertConfigurationMatchersFieldNamesApiParams) ([]MatcherField, *http.Response, error) {
+	return r.Execute()
 }
 
 /*
@@ -702,6 +724,14 @@ func (r ListAlertConfigurationsApiRequest) PageNum(pageNum int32) ListAlertConfi
 
 func (r ListAlertConfigurationsApiRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
 	return r.ApiService.ListAlertConfigurationsExecute(r)
+}
+
+func (r ListAlertConfigurationsApiRequest) ExecuteWithParams(params *ListAlertConfigurationsApiParams) (*PaginatedAlertConfig, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -874,6 +904,15 @@ func (r ListAlertConfigurationsByAlertIdApiRequest) Execute() (*PaginatedAlertCo
 	return r.ApiService.ListAlertConfigurationsByAlertIdExecute(r)
 }
 
+func (r ListAlertConfigurationsByAlertIdApiRequest) ExecuteWithParams(params *ListAlertConfigurationsByAlertIdApiParams) (*PaginatedAlertConfig, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertId = params.AlertId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListAlertConfigurationsByAlertId Return All Alert Configurations Set for One Alert
 
@@ -1037,6 +1076,13 @@ func (r ToggleAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGro
 	return r.ApiService.ToggleAlertConfigurationExecute(r)
 }
 
+func (r ToggleAlertConfigurationApiRequest) ExecuteWithParams(params *ToggleAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertConfigId = params.AlertConfigId 
+	r.toggle = params.Toggle 
+	return r.Execute()
+}
+
 /*
 ToggleAlertConfiguration Toggle One State of One Alert Configuration in One Project
 
@@ -1184,6 +1230,13 @@ func (r UpdateAlertConfigurationApiRequest) AlertConfigViewForNdsGroup(alertConf
 
 func (r UpdateAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.UpdateAlertConfigurationExecute(r)
+}
+
+func (r UpdateAlertConfigurationApiRequest) ExecuteWithParams(params *UpdateAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertConfigId = params.AlertConfigId 
+	r.alertConfigViewForNdsGroup = params.AlertConfigViewForNdsGroup 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -36,7 +36,7 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateAlertConfigurationApiParams - Parameters for the request
-	@return CreateAlertConfigurationApiRequest}}
+	@return CreateAlertConfigurationApiRequest
 	*/
 	CreateAlertConfigurationWithParams(ctx context.Context, args *CreateAlertConfigurationApiParams) CreateAlertConfigurationApiRequest
 
@@ -62,7 +62,7 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteAlertConfigurationApiParams - Parameters for the request
-	@return DeleteAlertConfigurationApiRequest}}
+	@return DeleteAlertConfigurationApiRequest
 	*/
 	DeleteAlertConfigurationWithParams(ctx context.Context, args *DeleteAlertConfigurationApiParams) DeleteAlertConfigurationApiRequest
 
@@ -88,7 +88,7 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetAlertConfigurationApiParams - Parameters for the request
-	@return GetAlertConfigurationApiRequest}}
+	@return GetAlertConfigurationApiRequest
 	*/
 	GetAlertConfigurationWithParams(ctx context.Context, args *GetAlertConfigurationApiParams) GetAlertConfigurationApiRequest
 
@@ -110,7 +110,7 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAlertConfigurationMatchersFieldNamesApiParams - Parameters for the request
-	@return ListAlertConfigurationMatchersFieldNamesApiRequest}}
+	@return ListAlertConfigurationMatchersFieldNamesApiRequest
 	*/
 	ListAlertConfigurationMatchersFieldNamesWithParams(ctx context.Context, args *ListAlertConfigurationMatchersFieldNamesApiParams) ListAlertConfigurationMatchersFieldNamesApiRequest
 
@@ -135,7 +135,7 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAlertConfigurationsApiParams - Parameters for the request
-	@return ListAlertConfigurationsApiRequest}}
+	@return ListAlertConfigurationsApiRequest
 	*/
 	ListAlertConfigurationsWithParams(ctx context.Context, args *ListAlertConfigurationsApiParams) ListAlertConfigurationsApiRequest
 
@@ -161,7 +161,7 @@ type AlertConfigurationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAlertConfigurationsByAlertIdApiParams - Parameters for the request
-	@return ListAlertConfigurationsByAlertIdApiRequest}}
+	@return ListAlertConfigurationsByAlertIdApiRequest
 	*/
 	ListAlertConfigurationsByAlertIdWithParams(ctx context.Context, args *ListAlertConfigurationsByAlertIdApiParams) ListAlertConfigurationsByAlertIdApiRequest
 
@@ -189,7 +189,7 @@ This resource remains under revision and may change. Refer to the [legacy docume
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ToggleAlertConfigurationApiParams - Parameters for the request
-	@return ToggleAlertConfigurationApiRequest}}
+	@return ToggleAlertConfigurationApiRequest
 	*/
 	ToggleAlertConfigurationWithParams(ctx context.Context, args *ToggleAlertConfigurationApiParams) ToggleAlertConfigurationApiRequest
 
@@ -217,7 +217,7 @@ This resource remains under revision and may change. Refer to the [legacy docume
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateAlertConfigurationApiParams - Parameters for the request
-	@return UpdateAlertConfigurationApiRequest}}
+	@return UpdateAlertConfigurationApiRequest
 	*/
 	UpdateAlertConfigurationWithParams(ctx context.Context, args *UpdateAlertConfigurationApiParams) UpdateAlertConfigurationApiRequest
 

--- a/mongodbatlasv2/api_alert_configurations.go
+++ b/mongodbatlasv2/api_alert_configurations.go
@@ -30,10 +30,18 @@ type AlertConfigurationsApi interface {
 	@return CreateAlertConfigurationApiRequest
 	*/
 	CreateAlertConfiguration(ctx context.Context, groupId string) CreateAlertConfigurationApiRequest
+	/*
+	CreateAlertConfiguration Create One Alert Configuration in One Project
 
-	// CreateAlertConfigurationExecute executes the request
-	//  @return AlertConfigViewForNdsGroup
-	CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateAlertConfigurationApiParams - Parameters for the request
+	@return CreateAlertConfigurationApiRequest}}
+	*/
+	CreateAlertConfigurationWithParams(ctx context.Context, args *CreateAlertConfigurationApiParams) CreateAlertConfigurationApiRequest
+
+	// Interface only available internally
+	createAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 
 	/*
 	DeleteAlertConfiguration Remove One Alert Configuration from One Project
@@ -48,9 +56,18 @@ type AlertConfigurationsApi interface {
 	@return DeleteAlertConfigurationApiRequest
 	*/
 	DeleteAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) DeleteAlertConfigurationApiRequest
+	/*
+	DeleteAlertConfiguration Remove One Alert Configuration from One Project
 
-	// DeleteAlertConfigurationExecute executes the request
-	DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteAlertConfigurationApiParams - Parameters for the request
+	@return DeleteAlertConfigurationApiRequest}}
+	*/
+	DeleteAlertConfigurationWithParams(ctx context.Context, args *DeleteAlertConfigurationApiParams) DeleteAlertConfigurationApiRequest
+
+	// Interface only available internally
+	deleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error)
 
 	/*
 	GetAlertConfiguration Return One Alert Configuration from One Project
@@ -65,10 +82,18 @@ type AlertConfigurationsApi interface {
 	@return GetAlertConfigurationApiRequest
 	*/
 	GetAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) GetAlertConfigurationApiRequest
+	/*
+	GetAlertConfiguration Return One Alert Configuration from One Project
 
-	// GetAlertConfigurationExecute executes the request
-	//  @return AlertConfigViewForNdsGroup
-	GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetAlertConfigurationApiParams - Parameters for the request
+	@return GetAlertConfigurationApiRequest}}
+	*/
+	GetAlertConfigurationWithParams(ctx context.Context, args *GetAlertConfigurationApiParams) GetAlertConfigurationApiRequest
+
+	// Interface only available internally
+	getAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 
 	/*
 	ListAlertConfigurationMatchersFieldNames Get All Alert Configuration Matchers Field Names
@@ -79,10 +104,18 @@ type AlertConfigurationsApi interface {
 	@return ListAlertConfigurationMatchersFieldNamesApiRequest
 	*/
 	ListAlertConfigurationMatchersFieldNames(ctx context.Context) ListAlertConfigurationMatchersFieldNamesApiRequest
+	/*
+	ListAlertConfigurationMatchersFieldNames Get All Alert Configuration Matchers Field Names
 
-	// ListAlertConfigurationMatchersFieldNamesExecute executes the request
-	//  @return []MatcherField
-	ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]MatcherField, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAlertConfigurationMatchersFieldNamesApiParams - Parameters for the request
+	@return ListAlertConfigurationMatchersFieldNamesApiRequest}}
+	*/
+	ListAlertConfigurationMatchersFieldNamesWithParams(ctx context.Context, args *ListAlertConfigurationMatchersFieldNamesApiParams) ListAlertConfigurationMatchersFieldNamesApiRequest
+
+	// Interface only available internally
+	listAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]MatcherField, *http.Response, error)
 
 	/*
 	ListAlertConfigurations Return All Alert Configurations for One Project
@@ -96,10 +129,18 @@ type AlertConfigurationsApi interface {
 	@return ListAlertConfigurationsApiRequest
 	*/
 	ListAlertConfigurations(ctx context.Context, groupId string) ListAlertConfigurationsApiRequest
+	/*
+	ListAlertConfigurations Return All Alert Configurations for One Project
 
-	// ListAlertConfigurationsExecute executes the request
-	//  @return PaginatedAlertConfig
-	ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAlertConfigurationsApiParams - Parameters for the request
+	@return ListAlertConfigurationsApiRequest}}
+	*/
+	ListAlertConfigurationsWithParams(ctx context.Context, args *ListAlertConfigurationsApiParams) ListAlertConfigurationsApiRequest
+
+	// Interface only available internally
+	listAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
 	ListAlertConfigurationsByAlertId Return All Alert Configurations Set for One Alert
@@ -114,10 +155,18 @@ type AlertConfigurationsApi interface {
 	@return ListAlertConfigurationsByAlertIdApiRequest
 	*/
 	ListAlertConfigurationsByAlertId(ctx context.Context, groupId string, alertId string) ListAlertConfigurationsByAlertIdApiRequest
+	/*
+	ListAlertConfigurationsByAlertId Return All Alert Configurations Set for One Alert
 
-	// ListAlertConfigurationsByAlertIdExecute executes the request
-	//  @return PaginatedAlertConfig
-	ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAlertConfigurationsByAlertIdApiParams - Parameters for the request
+	@return ListAlertConfigurationsByAlertIdApiRequest}}
+	*/
+	ListAlertConfigurationsByAlertIdWithParams(ctx context.Context, args *ListAlertConfigurationsByAlertIdApiParams) ListAlertConfigurationsByAlertIdApiRequest
+
+	// Interface only available internally
+	listAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error)
 
 	/*
 	ToggleAlertConfiguration Toggle One State of One Alert Configuration in One Project
@@ -134,10 +183,18 @@ This resource remains under revision and may change. Refer to the [legacy docume
 	@return ToggleAlertConfigurationApiRequest
 	*/
 	ToggleAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) ToggleAlertConfigurationApiRequest
+	/*
+	ToggleAlertConfiguration Toggle One State of One Alert Configuration in One Project
 
-	// ToggleAlertConfigurationExecute executes the request
-	//  @return AlertConfigViewForNdsGroup
-	ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ToggleAlertConfigurationApiParams - Parameters for the request
+	@return ToggleAlertConfigurationApiRequest}}
+	*/
+	ToggleAlertConfigurationWithParams(ctx context.Context, args *ToggleAlertConfigurationApiParams) ToggleAlertConfigurationApiRequest
+
+	// Interface only available internally
+	toggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 
 	/*
 	UpdateAlertConfiguration Update One Alert Configuration for One Project
@@ -154,10 +211,18 @@ This resource remains under revision and may change. Refer to the [legacy docume
 	@return UpdateAlertConfigurationApiRequest
 	*/
 	UpdateAlertConfiguration(ctx context.Context, groupId string, alertConfigId string) UpdateAlertConfigurationApiRequest
+	/*
+	UpdateAlertConfiguration Update One Alert Configuration for One Project
 
-	// UpdateAlertConfigurationExecute executes the request
-	//  @return AlertConfigViewForNdsGroup
-	UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateAlertConfigurationApiParams - Parameters for the request
+	@return UpdateAlertConfigurationApiRequest}}
+	*/
+	UpdateAlertConfigurationWithParams(ctx context.Context, args *UpdateAlertConfigurationApiParams) UpdateAlertConfigurationApiRequest
+
+	// Interface only available internally
+	updateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error)
 }
 
 // AlertConfigurationsApiService AlertConfigurationsApi service
@@ -175,6 +240,15 @@ type CreateAlertConfigurationApiParams struct {
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
+func (a *AlertConfigurationsApiService) CreateAlertConfigurationWithParams(ctx context.Context, args *CreateAlertConfigurationApiParams) CreateAlertConfigurationApiRequest {
+	return CreateAlertConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertConfigViewForNdsGroup: args.AlertConfigViewForNdsGroup,
+	}
+}
+
 // Creates one alert configuration for the specified project.
 func (r CreateAlertConfigurationApiRequest) AlertConfigViewForNdsGroup(alertConfigViewForNdsGroup AlertConfigViewForNdsGroup) CreateAlertConfigurationApiRequest {
 	r.alertConfigViewForNdsGroup = &alertConfigViewForNdsGroup
@@ -182,13 +256,7 @@ func (r CreateAlertConfigurationApiRequest) AlertConfigViewForNdsGroup(alertConf
 }
 
 func (r CreateAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.CreateAlertConfigurationExecute(r)
-}
-
-func (r CreateAlertConfigurationApiRequest) ExecuteWithParams(params *CreateAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertConfigViewForNdsGroup = params.AlertConfigViewForNdsGroup 
-	return r.Execute()
+	return r.ApiService.createAlertConfigurationExecute(r)
 }
 
 /*
@@ -212,7 +280,7 @@ func (a *AlertConfigurationsApiService) CreateAlertConfiguration(ctx context.Con
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) CreateAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) createAlertConfigurationExecute(r CreateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -317,14 +385,17 @@ type DeleteAlertConfigurationApiParams struct {
 		AlertConfigId string
 }
 
-func (r DeleteAlertConfigurationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteAlertConfigurationExecute(r)
+func (a *AlertConfigurationsApiService) DeleteAlertConfigurationWithParams(ctx context.Context, args *DeleteAlertConfigurationApiParams) DeleteAlertConfigurationApiRequest {
+	return DeleteAlertConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertConfigId: args.AlertConfigId,
+	}
 }
 
-func (r DeleteAlertConfigurationApiRequest) ExecuteWithParams(params *DeleteAlertConfigurationApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertConfigId = params.AlertConfigId 
-	return r.Execute()
+func (r DeleteAlertConfigurationApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteAlertConfigurationExecute(r)
 }
 
 /*
@@ -349,7 +420,7 @@ func (a *AlertConfigurationsApiService) DeleteAlertConfiguration(ctx context.Con
 }
 
 // Execute executes the request
-func (a *AlertConfigurationsApiService) DeleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error) {
+func (a *AlertConfigurationsApiService) deleteAlertConfigurationExecute(r DeleteAlertConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -446,14 +517,17 @@ type GetAlertConfigurationApiParams struct {
 		AlertConfigId string
 }
 
-func (r GetAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.GetAlertConfigurationExecute(r)
+func (a *AlertConfigurationsApiService) GetAlertConfigurationWithParams(ctx context.Context, args *GetAlertConfigurationApiParams) GetAlertConfigurationApiRequest {
+	return GetAlertConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertConfigId: args.AlertConfigId,
+	}
 }
 
-func (r GetAlertConfigurationApiRequest) ExecuteWithParams(params *GetAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertConfigId = params.AlertConfigId 
-	return r.Execute()
+func (r GetAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
+	return r.ApiService.getAlertConfigurationExecute(r)
 }
 
 /*
@@ -479,7 +553,7 @@ func (a *AlertConfigurationsApiService) GetAlertConfiguration(ctx context.Contex
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) GetAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) getAlertConfigurationExecute(r GetAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -582,12 +656,15 @@ type ListAlertConfigurationMatchersFieldNamesApiRequest struct {
 type ListAlertConfigurationMatchersFieldNamesApiParams struct {
 }
 
-func (r ListAlertConfigurationMatchersFieldNamesApiRequest) Execute() ([]MatcherField, *http.Response, error) {
-	return r.ApiService.ListAlertConfigurationMatchersFieldNamesExecute(r)
+func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNamesWithParams(ctx context.Context, args *ListAlertConfigurationMatchersFieldNamesApiParams) ListAlertConfigurationMatchersFieldNamesApiRequest {
+	return ListAlertConfigurationMatchersFieldNamesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+	}
 }
 
-func (r ListAlertConfigurationMatchersFieldNamesApiRequest) ExecuteWithParams(params *ListAlertConfigurationMatchersFieldNamesApiParams) ([]MatcherField, *http.Response, error) {
-	return r.Execute()
+func (r ListAlertConfigurationMatchersFieldNamesApiRequest) Execute() ([]MatcherField, *http.Response, error) {
+	return r.ApiService.listAlertConfigurationMatchersFieldNamesExecute(r)
 }
 
 /*
@@ -607,7 +684,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNames
 
 // Execute executes the request
 //  @return []MatcherField
-func (a *AlertConfigurationsApiService) ListAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]MatcherField, *http.Response, error) {
+func (a *AlertConfigurationsApiService) listAlertConfigurationMatchersFieldNamesExecute(r ListAlertConfigurationMatchersFieldNamesApiRequest) ([]MatcherField, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -704,6 +781,17 @@ type ListAlertConfigurationsApiParams struct {
 		PageNum *int32
 }
 
+func (a *AlertConfigurationsApiService) ListAlertConfigurationsWithParams(ctx context.Context, args *ListAlertConfigurationsApiParams) ListAlertConfigurationsApiRequest {
+	return ListAlertConfigurationsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListAlertConfigurationsApiRequest) IncludeCount(includeCount bool) ListAlertConfigurationsApiRequest {
 	r.includeCount = &includeCount
@@ -723,15 +811,7 @@ func (r ListAlertConfigurationsApiRequest) PageNum(pageNum int32) ListAlertConfi
 }
 
 func (r ListAlertConfigurationsApiRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
-	return r.ApiService.ListAlertConfigurationsExecute(r)
-}
-
-func (r ListAlertConfigurationsApiRequest) ExecuteWithParams(params *ListAlertConfigurationsApiParams) (*PaginatedAlertConfig, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listAlertConfigurationsExecute(r)
 }
 
 /*
@@ -755,7 +835,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurations(ctx context.Cont
 
 // Execute executes the request
 //  @return PaginatedAlertConfig
-func (a *AlertConfigurationsApiService) ListAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) listAlertConfigurationsExecute(r ListAlertConfigurationsApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -882,6 +962,18 @@ type ListAlertConfigurationsByAlertIdApiParams struct {
 		PageNum *int32
 }
 
+func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertIdWithParams(ctx context.Context, args *ListAlertConfigurationsByAlertIdApiParams) ListAlertConfigurationsByAlertIdApiRequest {
+	return ListAlertConfigurationsByAlertIdApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertId: args.AlertId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListAlertConfigurationsByAlertIdApiRequest) IncludeCount(includeCount bool) ListAlertConfigurationsByAlertIdApiRequest {
 	r.includeCount = &includeCount
@@ -901,16 +993,7 @@ func (r ListAlertConfigurationsByAlertIdApiRequest) PageNum(pageNum int32) ListA
 }
 
 func (r ListAlertConfigurationsByAlertIdApiRequest) Execute() (*PaginatedAlertConfig, *http.Response, error) {
-	return r.ApiService.ListAlertConfigurationsByAlertIdExecute(r)
-}
-
-func (r ListAlertConfigurationsByAlertIdApiRequest) ExecuteWithParams(params *ListAlertConfigurationsByAlertIdApiParams) (*PaginatedAlertConfig, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertId = params.AlertId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listAlertConfigurationsByAlertIdExecute(r)
 }
 
 /*
@@ -936,7 +1019,7 @@ func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertId(ctx con
 
 // Execute executes the request
 //  @return PaginatedAlertConfig
-func (a *AlertConfigurationsApiService) ListAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
+func (a *AlertConfigurationsApiService) listAlertConfigurationsByAlertIdExecute(r ListAlertConfigurationsByAlertIdApiRequest) (*PaginatedAlertConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1066,6 +1149,16 @@ type ToggleAlertConfigurationApiParams struct {
 		Toggle *Toggle
 }
 
+func (a *AlertConfigurationsApiService) ToggleAlertConfigurationWithParams(ctx context.Context, args *ToggleAlertConfigurationApiParams) ToggleAlertConfigurationApiRequest {
+	return ToggleAlertConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertConfigId: args.AlertConfigId,
+		toggle: args.Toggle,
+	}
+}
+
 // Enables or disables the specified alert configuration in the specified project.
 func (r ToggleAlertConfigurationApiRequest) Toggle(toggle Toggle) ToggleAlertConfigurationApiRequest {
 	r.toggle = &toggle
@@ -1073,14 +1166,7 @@ func (r ToggleAlertConfigurationApiRequest) Toggle(toggle Toggle) ToggleAlertCon
 }
 
 func (r ToggleAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.ToggleAlertConfigurationExecute(r)
-}
-
-func (r ToggleAlertConfigurationApiRequest) ExecuteWithParams(params *ToggleAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertConfigId = params.AlertConfigId 
-	r.toggle = params.Toggle 
-	return r.Execute()
+	return r.ApiService.toggleAlertConfigurationExecute(r)
 }
 
 /*
@@ -1108,7 +1194,7 @@ func (a *AlertConfigurationsApiService) ToggleAlertConfiguration(ctx context.Con
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) ToggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) toggleAlertConfigurationExecute(r ToggleAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1222,6 +1308,16 @@ type UpdateAlertConfigurationApiParams struct {
 		AlertConfigViewForNdsGroup *AlertConfigViewForNdsGroup
 }
 
+func (a *AlertConfigurationsApiService) UpdateAlertConfigurationWithParams(ctx context.Context, args *UpdateAlertConfigurationApiParams) UpdateAlertConfigurationApiRequest {
+	return UpdateAlertConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertConfigId: args.AlertConfigId,
+		alertConfigViewForNdsGroup: args.AlertConfigViewForNdsGroup,
+	}
+}
+
 // Updates one alert configuration in the specified project.
 func (r UpdateAlertConfigurationApiRequest) AlertConfigViewForNdsGroup(alertConfigViewForNdsGroup AlertConfigViewForNdsGroup) UpdateAlertConfigurationApiRequest {
 	r.alertConfigViewForNdsGroup = &alertConfigViewForNdsGroup
@@ -1229,14 +1325,7 @@ func (r UpdateAlertConfigurationApiRequest) AlertConfigViewForNdsGroup(alertConf
 }
 
 func (r UpdateAlertConfigurationApiRequest) Execute() (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.UpdateAlertConfigurationExecute(r)
-}
-
-func (r UpdateAlertConfigurationApiRequest) ExecuteWithParams(params *UpdateAlertConfigurationApiParams) (*AlertConfigViewForNdsGroup, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertConfigId = params.AlertConfigId 
-	r.alertConfigViewForNdsGroup = params.AlertConfigViewForNdsGroup 
-	return r.Execute()
+	return r.ApiService.updateAlertConfigurationExecute(r)
 }
 
 /*
@@ -1264,7 +1353,7 @@ func (a *AlertConfigurationsApiService) UpdateAlertConfiguration(ctx context.Con
 
 // Execute executes the request
 //  @return AlertConfigViewForNdsGroup
-func (a *AlertConfigurationsApiService) UpdateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
+func (a *AlertConfigurationsApiService) updateAlertConfigurationExecute(r UpdateAlertConfigurationApiRequest) (*AlertConfigViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -117,6 +117,13 @@ func (r AcknowledgeAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Resp
 	return r.ApiService.AcknowledgeAlertExecute(r)
 }
 
+func (r AcknowledgeAlertApiRequest) ExecuteWithParams(params *AcknowledgeAlertApiParams) (*AlertViewForNdsGroup, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertId = params.AlertId 
+	r.alertViewForNdsGroup = params.AlertViewForNdsGroup 
+	return r.Execute()
+}
+
 /*
 AcknowledgeAlert Acknowledge One Alert from One Project
 
@@ -254,6 +261,12 @@ type GetAlertApiParams struct {
 
 func (r GetAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.GetAlertExecute(r)
+}
+
+func (r GetAlertApiRequest) ExecuteWithParams(params *GetAlertApiParams) (*AlertViewForNdsGroup, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertId = params.AlertId 
+	return r.Execute()
 }
 
 /*
@@ -418,6 +431,15 @@ func (r ListAlertsApiRequest) Status(status string) ListAlertsApiRequest {
 
 func (r ListAlertsApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
 	return r.ApiService.ListAlertsExecute(r)
+}
+
+func (r ListAlertsApiRequest) ExecuteWithParams(params *ListAlertsApiParams) (*PaginatedAlert, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.status = params.Status 
+	return r.Execute()
 }
 
 /*
@@ -591,6 +613,15 @@ func (r ListAlertsByAlertConfigurationIdApiRequest) PageNum(pageNum int32) ListA
 
 func (r ListAlertsByAlertConfigurationIdApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
 	return r.ApiService.ListAlertsByAlertConfigurationIdExecute(r)
+}
+
+func (r ListAlertsByAlertConfigurationIdApiRequest) ExecuteWithParams(params *ListAlertsByAlertConfigurationIdApiParams) (*PaginatedAlert, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.alertConfigId = params.AlertConfigId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -31,10 +31,18 @@ type AlertsApi interface {
 	@return AcknowledgeAlertApiRequest
 	*/
 	AcknowledgeAlert(ctx context.Context, groupId string, alertId string) AcknowledgeAlertApiRequest
+	/*
+	AcknowledgeAlert Acknowledge One Alert from One Project
 
-	// AcknowledgeAlertExecute executes the request
-	//  @return AlertViewForNdsGroup
-	AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param AcknowledgeAlertApiParams - Parameters for the request
+	@return AcknowledgeAlertApiRequest}}
+	*/
+	AcknowledgeAlertWithParams(ctx context.Context, args *AcknowledgeAlertApiParams) AcknowledgeAlertApiRequest
+
+	// Interface only available internally
+	acknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
 	GetAlert Return One Alert from One Project
@@ -49,10 +57,18 @@ type AlertsApi interface {
 	@return GetAlertApiRequest
 	*/
 	GetAlert(ctx context.Context, groupId string, alertId string) GetAlertApiRequest
+	/*
+	GetAlert Return One Alert from One Project
 
-	// GetAlertExecute executes the request
-	//  @return AlertViewForNdsGroup
-	GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetAlertApiParams - Parameters for the request
+	@return GetAlertApiRequest}}
+	*/
+	GetAlertWithParams(ctx context.Context, args *GetAlertApiParams) GetAlertApiRequest
+
+	// Interface only available internally
+	getAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error)
 
 	/*
 	ListAlerts Return All Alerts from One Project
@@ -66,10 +82,18 @@ type AlertsApi interface {
 	@return ListAlertsApiRequest
 	*/
 	ListAlerts(ctx context.Context, groupId string) ListAlertsApiRequest
+	/*
+	ListAlerts Return All Alerts from One Project
 
-	// ListAlertsExecute executes the request
-	//  @return PaginatedAlert
-	ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAlertsApiParams - Parameters for the request
+	@return ListAlertsApiRequest}}
+	*/
+	ListAlertsWithParams(ctx context.Context, args *ListAlertsApiParams) ListAlertsApiRequest
+
+	// Interface only available internally
+	listAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error)
 
 	/*
 	ListAlertsByAlertConfigurationId Return All Open Alerts for Alert Configuration
@@ -84,10 +108,18 @@ type AlertsApi interface {
 	@return ListAlertsByAlertConfigurationIdApiRequest
 	*/
 	ListAlertsByAlertConfigurationId(ctx context.Context, groupId string, alertConfigId string) ListAlertsByAlertConfigurationIdApiRequest
+	/*
+	ListAlertsByAlertConfigurationId Return All Open Alerts for Alert Configuration
 
-	// ListAlertsByAlertConfigurationIdExecute executes the request
-	//  @return PaginatedAlert
-	ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAlertsByAlertConfigurationIdApiParams - Parameters for the request
+	@return ListAlertsByAlertConfigurationIdApiRequest}}
+	*/
+	ListAlertsByAlertConfigurationIdWithParams(ctx context.Context, args *ListAlertsByAlertConfigurationIdApiParams) ListAlertsByAlertConfigurationIdApiRequest
+
+	// Interface only available internally
+	listAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error)
 }
 
 // AlertsApiService AlertsApi service
@@ -107,6 +139,16 @@ type AcknowledgeAlertApiParams struct {
 		AlertViewForNdsGroup *AlertViewForNdsGroup
 }
 
+func (a *AlertsApiService) AcknowledgeAlertWithParams(ctx context.Context, args *AcknowledgeAlertApiParams) AcknowledgeAlertApiRequest {
+	return AcknowledgeAlertApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertId: args.AlertId,
+		alertViewForNdsGroup: args.AlertViewForNdsGroup,
+	}
+}
+
 // Confirm one alert.
 func (r AcknowledgeAlertApiRequest) AlertViewForNdsGroup(alertViewForNdsGroup AlertViewForNdsGroup) AcknowledgeAlertApiRequest {
 	r.alertViewForNdsGroup = &alertViewForNdsGroup
@@ -114,14 +156,7 @@ func (r AcknowledgeAlertApiRequest) AlertViewForNdsGroup(alertViewForNdsGroup Al
 }
 
 func (r AcknowledgeAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.AcknowledgeAlertExecute(r)
-}
-
-func (r AcknowledgeAlertApiRequest) ExecuteWithParams(params *AcknowledgeAlertApiParams) (*AlertViewForNdsGroup, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertId = params.AlertId 
-	r.alertViewForNdsGroup = params.AlertViewForNdsGroup 
-	return r.Execute()
+	return r.ApiService.acknowledgeAlertExecute(r)
 }
 
 /*
@@ -147,7 +182,7 @@ func (a *AlertsApiService) AcknowledgeAlert(ctx context.Context, groupId string,
 
 // Execute executes the request
 //  @return AlertViewForNdsGroup
-func (a *AlertsApiService) AcknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
+func (a *AlertsApiService) acknowledgeAlertExecute(r AcknowledgeAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -259,14 +294,17 @@ type GetAlertApiParams struct {
 		AlertId string
 }
 
-func (r GetAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.GetAlertExecute(r)
+func (a *AlertsApiService) GetAlertWithParams(ctx context.Context, args *GetAlertApiParams) GetAlertApiRequest {
+	return GetAlertApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertId: args.AlertId,
+	}
 }
 
-func (r GetAlertApiRequest) ExecuteWithParams(params *GetAlertApiParams) (*AlertViewForNdsGroup, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertId = params.AlertId 
-	return r.Execute()
+func (r GetAlertApiRequest) Execute() (*AlertViewForNdsGroup, *http.Response, error) {
+	return r.ApiService.getAlertExecute(r)
 }
 
 /*
@@ -292,7 +330,7 @@ func (a *AlertsApiService) GetAlert(ctx context.Context, groupId string, alertId
 
 // Execute executes the request
 //  @return AlertViewForNdsGroup
-func (a *AlertsApiService) GetAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
+func (a *AlertsApiService) getAlertExecute(r GetAlertApiRequest) (*AlertViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -405,6 +443,18 @@ type ListAlertsApiParams struct {
 		Status *string
 }
 
+func (a *AlertsApiService) ListAlertsWithParams(ctx context.Context, args *ListAlertsApiParams) ListAlertsApiRequest {
+	return ListAlertsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		status: args.Status,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListAlertsApiRequest) IncludeCount(includeCount bool) ListAlertsApiRequest {
 	r.includeCount = &includeCount
@@ -430,16 +480,7 @@ func (r ListAlertsApiRequest) Status(status string) ListAlertsApiRequest {
 }
 
 func (r ListAlertsApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
-	return r.ApiService.ListAlertsExecute(r)
-}
-
-func (r ListAlertsApiRequest) ExecuteWithParams(params *ListAlertsApiParams) (*PaginatedAlert, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.status = params.Status 
-	return r.Execute()
+	return r.ApiService.listAlertsExecute(r)
 }
 
 /*
@@ -463,7 +504,7 @@ func (a *AlertsApiService) ListAlerts(ctx context.Context, groupId string) ListA
 
 // Execute executes the request
 //  @return PaginatedAlert
-func (a *AlertsApiService) ListAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error) {
+func (a *AlertsApiService) listAlertsExecute(r ListAlertsApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -593,6 +634,18 @@ type ListAlertsByAlertConfigurationIdApiParams struct {
 		PageNum *int32
 }
 
+func (a *AlertsApiService) ListAlertsByAlertConfigurationIdWithParams(ctx context.Context, args *ListAlertsByAlertConfigurationIdApiParams) ListAlertsByAlertConfigurationIdApiRequest {
+	return ListAlertsByAlertConfigurationIdApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		alertConfigId: args.AlertConfigId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListAlertsByAlertConfigurationIdApiRequest) IncludeCount(includeCount bool) ListAlertsByAlertConfigurationIdApiRequest {
 	r.includeCount = &includeCount
@@ -612,16 +665,7 @@ func (r ListAlertsByAlertConfigurationIdApiRequest) PageNum(pageNum int32) ListA
 }
 
 func (r ListAlertsByAlertConfigurationIdApiRequest) Execute() (*PaginatedAlert, *http.Response, error) {
-	return r.ApiService.ListAlertsByAlertConfigurationIdExecute(r)
-}
-
-func (r ListAlertsByAlertConfigurationIdApiRequest) ExecuteWithParams(params *ListAlertsByAlertConfigurationIdApiParams) (*PaginatedAlert, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.alertConfigId = params.AlertConfigId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listAlertsByAlertConfigurationIdExecute(r)
 }
 
 /*
@@ -647,7 +691,7 @@ func (a *AlertsApiService) ListAlertsByAlertConfigurationId(ctx context.Context,
 
 // Execute executes the request
 //  @return PaginatedAlert
-func (a *AlertsApiService) ListAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error) {
+func (a *AlertsApiService) listAlertsByAlertConfigurationIdExecute(r ListAlertsByAlertConfigurationIdApiRequest) (*PaginatedAlert, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_alerts.go
+++ b/mongodbatlasv2/api_alerts.go
@@ -37,7 +37,7 @@ type AlertsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param AcknowledgeAlertApiParams - Parameters for the request
-	@return AcknowledgeAlertApiRequest}}
+	@return AcknowledgeAlertApiRequest
 	*/
 	AcknowledgeAlertWithParams(ctx context.Context, args *AcknowledgeAlertApiParams) AcknowledgeAlertApiRequest
 
@@ -63,7 +63,7 @@ type AlertsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetAlertApiParams - Parameters for the request
-	@return GetAlertApiRequest}}
+	@return GetAlertApiRequest
 	*/
 	GetAlertWithParams(ctx context.Context, args *GetAlertApiParams) GetAlertApiRequest
 
@@ -88,7 +88,7 @@ type AlertsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAlertsApiParams - Parameters for the request
-	@return ListAlertsApiRequest}}
+	@return ListAlertsApiRequest
 	*/
 	ListAlertsWithParams(ctx context.Context, args *ListAlertsApiParams) ListAlertsApiRequest
 
@@ -114,7 +114,7 @@ type AlertsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAlertsByAlertConfigurationIdApiParams - Parameters for the request
-	@return ListAlertsByAlertConfigurationIdApiRequest}}
+	@return ListAlertsByAlertConfigurationIdApiRequest
 	*/
 	ListAlertsByAlertConfigurationIdWithParams(ctx context.Context, args *ListAlertsByAlertConfigurationIdApiParams) ListAlertsByAlertConfigurationIdApiRequest
 

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -29,10 +29,18 @@ type AtlasSearchApi interface {
 	@return CreateAtlasSearchIndexApiRequest
 	*/
 	CreateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string) CreateAtlasSearchIndexApiRequest
+	/*
+	CreateAtlasSearchIndex Create One Atlas Search Index
 
-	// CreateAtlasSearchIndexExecute executes the request
-	//  @return FTSIndex
-	CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateAtlasSearchIndexApiParams - Parameters for the request
+	@return CreateAtlasSearchIndexApiRequest}}
+	*/
+	CreateAtlasSearchIndexWithParams(ctx context.Context, args *CreateAtlasSearchIndexApiParams) CreateAtlasSearchIndexApiRequest
+
+	// Interface only available internally
+	createAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
 
 	/*
 	DeleteAtlasSearchIndex Remove One Atlas Search Index
@@ -46,9 +54,18 @@ type AtlasSearchApi interface {
 	@return DeleteAtlasSearchIndexApiRequest
 	*/
 	DeleteAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) DeleteAtlasSearchIndexApiRequest
+	/*
+	DeleteAtlasSearchIndex Remove One Atlas Search Index
 
-	// DeleteAtlasSearchIndexExecute executes the request
-	DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteAtlasSearchIndexApiParams - Parameters for the request
+	@return DeleteAtlasSearchIndexApiRequest}}
+	*/
+	DeleteAtlasSearchIndexWithParams(ctx context.Context, args *DeleteAtlasSearchIndexApiParams) DeleteAtlasSearchIndexApiRequest
+
+	// Interface only available internally
+	deleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (*http.Response, error)
 
 	/*
 	GetAtlasSearchIndex Return One Atlas Search Index
@@ -62,10 +79,18 @@ type AtlasSearchApi interface {
 	@return GetAtlasSearchIndexApiRequest
 	*/
 	GetAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) GetAtlasSearchIndexApiRequest
+	/*
+	GetAtlasSearchIndex Return One Atlas Search Index
 
-	// GetAtlasSearchIndexExecute executes the request
-	//  @return FTSIndex
-	GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetAtlasSearchIndexApiParams - Parameters for the request
+	@return GetAtlasSearchIndexApiRequest}}
+	*/
+	GetAtlasSearchIndexWithParams(ctx context.Context, args *GetAtlasSearchIndexApiParams) GetAtlasSearchIndexApiRequest
+
+	// Interface only available internally
+	getAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
 
 	/*
 	ListAtlasSearchIndexes Return All Atlas Search Indexes for One Collection
@@ -80,10 +105,18 @@ type AtlasSearchApi interface {
 	@return ListAtlasSearchIndexesApiRequest
 	*/
 	ListAtlasSearchIndexes(ctx context.Context, groupId string, clusterName string, collectionName string, databaseName string) ListAtlasSearchIndexesApiRequest
+	/*
+	ListAtlasSearchIndexes Return All Atlas Search Indexes for One Collection
 
-	// ListAtlasSearchIndexesExecute executes the request
-	//  @return []FTSIndex
-	ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]FTSIndex, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAtlasSearchIndexesApiParams - Parameters for the request
+	@return ListAtlasSearchIndexesApiRequest}}
+	*/
+	ListAtlasSearchIndexesWithParams(ctx context.Context, args *ListAtlasSearchIndexesApiParams) ListAtlasSearchIndexesApiRequest
+
+	// Interface only available internally
+	listAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]FTSIndex, *http.Response, error)
 
 	/*
 	UpdateAtlasSearchIndex Update One Atlas Search Index
@@ -97,10 +130,18 @@ type AtlasSearchApi interface {
 	@return UpdateAtlasSearchIndexApiRequest
 	*/
 	UpdateAtlasSearchIndex(ctx context.Context, groupId string, clusterName string, indexId string) UpdateAtlasSearchIndexApiRequest
+	/*
+	UpdateAtlasSearchIndex Update One Atlas Search Index
 
-	// UpdateAtlasSearchIndexExecute executes the request
-	//  @return FTSIndex
-	UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateAtlasSearchIndexApiParams - Parameters for the request
+	@return UpdateAtlasSearchIndexApiRequest}}
+	*/
+	UpdateAtlasSearchIndexWithParams(ctx context.Context, args *UpdateAtlasSearchIndexApiParams) UpdateAtlasSearchIndexApiRequest
+
+	// Interface only available internally
+	updateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error)
 }
 
 // AtlasSearchApiService AtlasSearchApi service
@@ -120,6 +161,16 @@ type CreateAtlasSearchIndexApiParams struct {
 		FTSIndex *FTSIndex
 }
 
+func (a *AtlasSearchApiService) CreateAtlasSearchIndexWithParams(ctx context.Context, args *CreateAtlasSearchIndexApiParams) CreateAtlasSearchIndexApiRequest {
+	return CreateAtlasSearchIndexApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		fTSIndex: args.FTSIndex,
+	}
+}
+
 // Creates one Atlas Search index on the specified collection.
 func (r CreateAtlasSearchIndexApiRequest) FTSIndex(fTSIndex FTSIndex) CreateAtlasSearchIndexApiRequest {
 	r.fTSIndex = &fTSIndex
@@ -127,14 +178,7 @@ func (r CreateAtlasSearchIndexApiRequest) FTSIndex(fTSIndex FTSIndex) CreateAtla
 }
 
 func (r CreateAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
-	return r.ApiService.CreateAtlasSearchIndexExecute(r)
-}
-
-func (r CreateAtlasSearchIndexApiRequest) ExecuteWithParams(params *CreateAtlasSearchIndexApiParams) (*FTSIndex, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.fTSIndex = params.FTSIndex 
-	return r.Execute()
+	return r.ApiService.createAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -158,7 +202,7 @@ func (a *AtlasSearchApiService) CreateAtlasSearchIndex(ctx context.Context, grou
 
 // Execute executes the request
 //  @return FTSIndex
-func (a *AtlasSearchApiService) CreateAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) createAtlasSearchIndexExecute(r CreateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -272,15 +316,18 @@ type DeleteAtlasSearchIndexApiParams struct {
 		IndexId string
 }
 
-func (r DeleteAtlasSearchIndexApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteAtlasSearchIndexExecute(r)
+func (a *AtlasSearchApiService) DeleteAtlasSearchIndexWithParams(ctx context.Context, args *DeleteAtlasSearchIndexApiParams) DeleteAtlasSearchIndexApiRequest {
+	return DeleteAtlasSearchIndexApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		indexId: args.IndexId,
+	}
 }
 
-func (r DeleteAtlasSearchIndexApiRequest) ExecuteWithParams(params *DeleteAtlasSearchIndexApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.indexId = params.IndexId 
-	return r.Execute()
+func (r DeleteAtlasSearchIndexApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -305,7 +352,7 @@ func (a *AtlasSearchApiService) DeleteAtlasSearchIndex(ctx context.Context, grou
 }
 
 // Execute executes the request
-func (a *AtlasSearchApiService) DeleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (*http.Response, error) {
+func (a *AtlasSearchApiService) deleteAtlasSearchIndexExecute(r DeleteAtlasSearchIndexApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -411,15 +458,18 @@ type GetAtlasSearchIndexApiParams struct {
 		IndexId string
 }
 
-func (r GetAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
-	return r.ApiService.GetAtlasSearchIndexExecute(r)
+func (a *AtlasSearchApiService) GetAtlasSearchIndexWithParams(ctx context.Context, args *GetAtlasSearchIndexApiParams) GetAtlasSearchIndexApiRequest {
+	return GetAtlasSearchIndexApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		indexId: args.IndexId,
+	}
 }
 
-func (r GetAtlasSearchIndexApiRequest) ExecuteWithParams(params *GetAtlasSearchIndexApiParams) (*FTSIndex, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.indexId = params.IndexId 
-	return r.Execute()
+func (r GetAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
+	return r.ApiService.getAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -445,7 +495,7 @@ func (a *AtlasSearchApiService) GetAtlasSearchIndex(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return FTSIndex
-func (a *AtlasSearchApiService) GetAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) getAtlasSearchIndexExecute(r GetAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -563,16 +613,19 @@ type ListAtlasSearchIndexesApiParams struct {
 		DatabaseName string
 }
 
-func (r ListAtlasSearchIndexesApiRequest) Execute() ([]FTSIndex, *http.Response, error) {
-	return r.ApiService.ListAtlasSearchIndexesExecute(r)
+func (a *AtlasSearchApiService) ListAtlasSearchIndexesWithParams(ctx context.Context, args *ListAtlasSearchIndexesApiParams) ListAtlasSearchIndexesApiRequest {
+	return ListAtlasSearchIndexesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		collectionName: args.CollectionName,
+		databaseName: args.DatabaseName,
+	}
 }
 
-func (r ListAtlasSearchIndexesApiRequest) ExecuteWithParams(params *ListAtlasSearchIndexesApiParams) ([]FTSIndex, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.collectionName = params.CollectionName 
-	r.databaseName = params.DatabaseName 
-	return r.Execute()
+func (r ListAtlasSearchIndexesApiRequest) Execute() ([]FTSIndex, *http.Response, error) {
+	return r.ApiService.listAtlasSearchIndexesExecute(r)
 }
 
 /*
@@ -600,7 +653,7 @@ func (a *AtlasSearchApiService) ListAtlasSearchIndexes(ctx context.Context, grou
 
 // Execute executes the request
 //  @return []FTSIndex
-func (a *AtlasSearchApiService) ListAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) listAtlasSearchIndexesExecute(r ListAtlasSearchIndexesApiRequest) ([]FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -713,6 +766,17 @@ type UpdateAtlasSearchIndexApiParams struct {
 		FTSIndex *FTSIndex
 }
 
+func (a *AtlasSearchApiService) UpdateAtlasSearchIndexWithParams(ctx context.Context, args *UpdateAtlasSearchIndexApiParams) UpdateAtlasSearchIndexApiRequest {
+	return UpdateAtlasSearchIndexApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		indexId: args.IndexId,
+		fTSIndex: args.FTSIndex,
+	}
+}
+
 // Details to update on the Atlas Search index.
 func (r UpdateAtlasSearchIndexApiRequest) FTSIndex(fTSIndex FTSIndex) UpdateAtlasSearchIndexApiRequest {
 	r.fTSIndex = &fTSIndex
@@ -720,15 +784,7 @@ func (r UpdateAtlasSearchIndexApiRequest) FTSIndex(fTSIndex FTSIndex) UpdateAtla
 }
 
 func (r UpdateAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
-	return r.ApiService.UpdateAtlasSearchIndexExecute(r)
-}
-
-func (r UpdateAtlasSearchIndexApiRequest) ExecuteWithParams(params *UpdateAtlasSearchIndexApiParams) (*FTSIndex, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.indexId = params.IndexId 
-	r.fTSIndex = params.FTSIndex 
-	return r.Execute()
+	return r.ApiService.updateAtlasSearchIndexExecute(r)
 }
 
 /*
@@ -754,7 +810,7 @@ func (a *AtlasSearchApiService) UpdateAtlasSearchIndex(ctx context.Context, grou
 
 // Execute executes the request
 //  @return FTSIndex
-func (a *AtlasSearchApiService) UpdateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
+func (a *AtlasSearchApiService) updateAtlasSearchIndexExecute(r UpdateAtlasSearchIndexApiRequest) (*FTSIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -35,7 +35,7 @@ type AtlasSearchApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateAtlasSearchIndexApiParams - Parameters for the request
-	@return CreateAtlasSearchIndexApiRequest}}
+	@return CreateAtlasSearchIndexApiRequest
 	*/
 	CreateAtlasSearchIndexWithParams(ctx context.Context, args *CreateAtlasSearchIndexApiParams) CreateAtlasSearchIndexApiRequest
 
@@ -60,7 +60,7 @@ type AtlasSearchApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteAtlasSearchIndexApiParams - Parameters for the request
-	@return DeleteAtlasSearchIndexApiRequest}}
+	@return DeleteAtlasSearchIndexApiRequest
 	*/
 	DeleteAtlasSearchIndexWithParams(ctx context.Context, args *DeleteAtlasSearchIndexApiParams) DeleteAtlasSearchIndexApiRequest
 
@@ -85,7 +85,7 @@ type AtlasSearchApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetAtlasSearchIndexApiParams - Parameters for the request
-	@return GetAtlasSearchIndexApiRequest}}
+	@return GetAtlasSearchIndexApiRequest
 	*/
 	GetAtlasSearchIndexWithParams(ctx context.Context, args *GetAtlasSearchIndexApiParams) GetAtlasSearchIndexApiRequest
 
@@ -111,7 +111,7 @@ type AtlasSearchApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAtlasSearchIndexesApiParams - Parameters for the request
-	@return ListAtlasSearchIndexesApiRequest}}
+	@return ListAtlasSearchIndexesApiRequest
 	*/
 	ListAtlasSearchIndexesWithParams(ctx context.Context, args *ListAtlasSearchIndexesApiParams) ListAtlasSearchIndexesApiRequest
 
@@ -136,7 +136,7 @@ type AtlasSearchApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateAtlasSearchIndexApiParams - Parameters for the request
-	@return UpdateAtlasSearchIndexApiRequest}}
+	@return UpdateAtlasSearchIndexApiRequest
 	*/
 	UpdateAtlasSearchIndexWithParams(ctx context.Context, args *UpdateAtlasSearchIndexApiParams) UpdateAtlasSearchIndexApiRequest
 

--- a/mongodbatlasv2/api_atlas_search.go
+++ b/mongodbatlasv2/api_atlas_search.go
@@ -130,6 +130,13 @@ func (r CreateAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, 
 	return r.ApiService.CreateAtlasSearchIndexExecute(r)
 }
 
+func (r CreateAtlasSearchIndexApiRequest) ExecuteWithParams(params *CreateAtlasSearchIndexApiParams) (*FTSIndex, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.fTSIndex = params.FTSIndex 
+	return r.Execute()
+}
+
 /*
 CreateAtlasSearchIndex Create One Atlas Search Index
 
@@ -269,6 +276,13 @@ func (r DeleteAtlasSearchIndexApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteAtlasSearchIndexExecute(r)
 }
 
+func (r DeleteAtlasSearchIndexApiRequest) ExecuteWithParams(params *DeleteAtlasSearchIndexApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.indexId = params.IndexId 
+	return r.Execute()
+}
+
 /*
 DeleteAtlasSearchIndex Remove One Atlas Search Index
 
@@ -399,6 +413,13 @@ type GetAtlasSearchIndexApiParams struct {
 
 func (r GetAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
 	return r.ApiService.GetAtlasSearchIndexExecute(r)
+}
+
+func (r GetAtlasSearchIndexApiRequest) ExecuteWithParams(params *GetAtlasSearchIndexApiParams) (*FTSIndex, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.indexId = params.IndexId 
+	return r.Execute()
 }
 
 /*
@@ -544,6 +565,14 @@ type ListAtlasSearchIndexesApiParams struct {
 
 func (r ListAtlasSearchIndexesApiRequest) Execute() ([]FTSIndex, *http.Response, error) {
 	return r.ApiService.ListAtlasSearchIndexesExecute(r)
+}
+
+func (r ListAtlasSearchIndexesApiRequest) ExecuteWithParams(params *ListAtlasSearchIndexesApiParams) ([]FTSIndex, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.collectionName = params.CollectionName 
+	r.databaseName = params.DatabaseName 
+	return r.Execute()
 }
 
 /*
@@ -692,6 +721,14 @@ func (r UpdateAtlasSearchIndexApiRequest) FTSIndex(fTSIndex FTSIndex) UpdateAtla
 
 func (r UpdateAtlasSearchIndexApiRequest) Execute() (*FTSIndex, *http.Response, error) {
 	return r.ApiService.UpdateAtlasSearchIndexExecute(r)
+}
+
+func (r UpdateAtlasSearchIndexApiRequest) ExecuteWithParams(params *UpdateAtlasSearchIndexApiParams) (*FTSIndex, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.indexId = params.IndexId 
+	r.fTSIndex = params.FTSIndex 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -34,7 +34,7 @@ type AuditingApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetAuditingConfigurationApiParams - Parameters for the request
-	@return GetAuditingConfigurationApiRequest}}
+	@return GetAuditingConfigurationApiRequest
 	*/
 	GetAuditingConfigurationWithParams(ctx context.Context, args *GetAuditingConfigurationApiParams) GetAuditingConfigurationApiRequest
 
@@ -57,7 +57,7 @@ type AuditingApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateAuditingConfigurationApiParams - Parameters for the request
-	@return UpdateAuditingConfigurationApiRequest}}
+	@return UpdateAuditingConfigurationApiRequest
 	*/
 	UpdateAuditingConfigurationWithParams(ctx context.Context, args *UpdateAuditingConfigurationApiParams) UpdateAuditingConfigurationApiRequest
 

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -66,6 +66,11 @@ func (r GetAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response
 	return r.ApiService.GetAuditingConfigurationExecute(r)
 }
 
+func (r GetAuditingConfigurationApiRequest) ExecuteWithParams(params *GetAuditingConfigurationApiParams) (*AuditLog, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 GetAuditingConfiguration Return the Auditing Configuration for One Project
 
@@ -193,6 +198,12 @@ func (r UpdateAuditingConfigurationApiRequest) AuditLog(auditLog AuditLog) Updat
 
 func (r UpdateAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
 	return r.ApiService.UpdateAuditingConfigurationExecute(r)
+}
+
+func (r UpdateAuditingConfigurationApiRequest) ExecuteWithParams(params *UpdateAuditingConfigurationApiParams) (*AuditLog, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.auditLog = params.AuditLog 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_auditing.go
+++ b/mongodbatlasv2/api_auditing.go
@@ -28,10 +28,18 @@ type AuditingApi interface {
 	@return GetAuditingConfigurationApiRequest
 	*/
 	GetAuditingConfiguration(ctx context.Context, groupId string) GetAuditingConfigurationApiRequest
+	/*
+	GetAuditingConfiguration Return the Auditing Configuration for One Project
 
-	// GetAuditingConfigurationExecute executes the request
-	//  @return AuditLog
-	GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetAuditingConfigurationApiParams - Parameters for the request
+	@return GetAuditingConfigurationApiRequest}}
+	*/
+	GetAuditingConfigurationWithParams(ctx context.Context, args *GetAuditingConfigurationApiParams) GetAuditingConfigurationApiRequest
+
+	// Interface only available internally
+	getAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 
 	/*
 	UpdateAuditingConfiguration Update Auditing Configuration for One Project
@@ -43,10 +51,18 @@ type AuditingApi interface {
 	@return UpdateAuditingConfigurationApiRequest
 	*/
 	UpdateAuditingConfiguration(ctx context.Context, groupId string) UpdateAuditingConfigurationApiRequest
+	/*
+	UpdateAuditingConfiguration Update Auditing Configuration for One Project
 
-	// UpdateAuditingConfigurationExecute executes the request
-	//  @return AuditLog
-	UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateAuditingConfigurationApiParams - Parameters for the request
+	@return UpdateAuditingConfigurationApiRequest}}
+	*/
+	UpdateAuditingConfigurationWithParams(ctx context.Context, args *UpdateAuditingConfigurationApiParams) UpdateAuditingConfigurationApiRequest
+
+	// Interface only available internally
+	updateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error)
 }
 
 // AuditingApiService AuditingApi service
@@ -62,13 +78,16 @@ type GetAuditingConfigurationApiParams struct {
 		GroupId string
 }
 
-func (r GetAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
-	return r.ApiService.GetAuditingConfigurationExecute(r)
+func (a *AuditingApiService) GetAuditingConfigurationWithParams(ctx context.Context, args *GetAuditingConfigurationApiParams) GetAuditingConfigurationApiRequest {
+	return GetAuditingConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetAuditingConfigurationApiRequest) ExecuteWithParams(params *GetAuditingConfigurationApiParams) (*AuditLog, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
+	return r.ApiService.getAuditingConfigurationExecute(r)
 }
 
 /*
@@ -90,7 +109,7 @@ func (a *AuditingApiService) GetAuditingConfiguration(ctx context.Context, group
 
 // Execute executes the request
 //  @return AuditLog
-func (a *AuditingApiService) GetAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
+func (a *AuditingApiService) getAuditingConfigurationExecute(r GetAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -190,6 +209,15 @@ type UpdateAuditingConfigurationApiParams struct {
 		AuditLog *AuditLog
 }
 
+func (a *AuditingApiService) UpdateAuditingConfigurationWithParams(ctx context.Context, args *UpdateAuditingConfigurationApiParams) UpdateAuditingConfigurationApiRequest {
+	return UpdateAuditingConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		auditLog: args.AuditLog,
+	}
+}
+
 // Updated auditing configuration for the specified project.
 func (r UpdateAuditingConfigurationApiRequest) AuditLog(auditLog AuditLog) UpdateAuditingConfigurationApiRequest {
 	r.auditLog = &auditLog
@@ -197,13 +225,7 @@ func (r UpdateAuditingConfigurationApiRequest) AuditLog(auditLog AuditLog) Updat
 }
 
 func (r UpdateAuditingConfigurationApiRequest) Execute() (*AuditLog, *http.Response, error) {
-	return r.ApiService.UpdateAuditingConfigurationExecute(r)
-}
-
-func (r UpdateAuditingConfigurationApiRequest) ExecuteWithParams(params *UpdateAuditingConfigurationApiParams) (*AuditLog, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.auditLog = params.AuditLog 
-	return r.Execute()
+	return r.ApiService.updateAuditingConfigurationExecute(r)
 }
 
 /*
@@ -225,7 +247,7 @@ func (a *AuditingApiService) UpdateAuditingConfiguration(ctx context.Context, gr
 
 // Execute executes the request
 //  @return AuditLog
-func (a *AuditingApiService) UpdateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
+func (a *AuditingApiService) updateAuditingConfigurationExecute(r UpdateAuditingConfigurationApiRequest) (*AuditLog, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -34,7 +34,7 @@ type AWSClustersDNSApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetAWSCustomDNSApiParams - Parameters for the request
-	@return GetAWSCustomDNSApiRequest}}
+	@return GetAWSCustomDNSApiRequest
 	*/
 	GetAWSCustomDNSWithParams(ctx context.Context, args *GetAWSCustomDNSApiParams) GetAWSCustomDNSApiRequest
 
@@ -57,7 +57,7 @@ type AWSClustersDNSApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ToggleAWSCustomDNSApiParams - Parameters for the request
-	@return ToggleAWSCustomDNSApiRequest}}
+	@return ToggleAWSCustomDNSApiRequest
 	*/
 	ToggleAWSCustomDNSWithParams(ctx context.Context, args *ToggleAWSCustomDNSApiParams) ToggleAWSCustomDNSApiRequest
 

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -28,10 +28,18 @@ type AWSClustersDNSApi interface {
 	@return GetAWSCustomDNSApiRequest
 	*/
 	GetAWSCustomDNS(ctx context.Context, groupId string) GetAWSCustomDNSApiRequest
+	/*
+	GetAWSCustomDNS Return One Custom DNS Configuration for Atlas Clusters on AWS
 
-	// GetAWSCustomDNSExecute executes the request
-	//  @return AWSCustomDNSEnabled
-	GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetAWSCustomDNSApiParams - Parameters for the request
+	@return GetAWSCustomDNSApiRequest}}
+	*/
+	GetAWSCustomDNSWithParams(ctx context.Context, args *GetAWSCustomDNSApiParams) GetAWSCustomDNSApiRequest
+
+	// Interface only available internally
+	getAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 
 	/*
 	ToggleAWSCustomDNS Toggle State of One Custom DNS Configuration for Atlas Clusters on AWS
@@ -43,10 +51,18 @@ type AWSClustersDNSApi interface {
 	@return ToggleAWSCustomDNSApiRequest
 	*/
 	ToggleAWSCustomDNS(ctx context.Context, groupId string) ToggleAWSCustomDNSApiRequest
+	/*
+	ToggleAWSCustomDNS Toggle State of One Custom DNS Configuration for Atlas Clusters on AWS
 
-	// ToggleAWSCustomDNSExecute executes the request
-	//  @return AWSCustomDNSEnabled
-	ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ToggleAWSCustomDNSApiParams - Parameters for the request
+	@return ToggleAWSCustomDNSApiRequest}}
+	*/
+	ToggleAWSCustomDNSWithParams(ctx context.Context, args *ToggleAWSCustomDNSApiParams) ToggleAWSCustomDNSApiRequest
+
+	// Interface only available internally
+	toggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error)
 }
 
 // AWSClustersDNSApiService AWSClustersDNSApi service
@@ -62,13 +78,16 @@ type GetAWSCustomDNSApiParams struct {
 		GroupId string
 }
 
-func (r GetAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
-	return r.ApiService.GetAWSCustomDNSExecute(r)
+func (a *AWSClustersDNSApiService) GetAWSCustomDNSWithParams(ctx context.Context, args *GetAWSCustomDNSApiParams) GetAWSCustomDNSApiRequest {
+	return GetAWSCustomDNSApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetAWSCustomDNSApiRequest) ExecuteWithParams(params *GetAWSCustomDNSApiParams) (*AWSCustomDNSEnabled, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
+	return r.ApiService.getAWSCustomDNSExecute(r)
 }
 
 /*
@@ -90,7 +109,7 @@ func (a *AWSClustersDNSApiService) GetAWSCustomDNS(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return AWSCustomDNSEnabled
-func (a *AWSClustersDNSApiService) GetAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
+func (a *AWSClustersDNSApiService) getAWSCustomDNSExecute(r GetAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -190,6 +209,15 @@ type ToggleAWSCustomDNSApiParams struct {
 		AWSCustomDNSEnabled *AWSCustomDNSEnabled
 }
 
+func (a *AWSClustersDNSApiService) ToggleAWSCustomDNSWithParams(ctx context.Context, args *ToggleAWSCustomDNSApiParams) ToggleAWSCustomDNSApiRequest {
+	return ToggleAWSCustomDNSApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		aWSCustomDNSEnabled: args.AWSCustomDNSEnabled,
+	}
+}
+
 // Enables or disables the custom DNS configuration for AWS clusters in the specified project.
 func (r ToggleAWSCustomDNSApiRequest) AWSCustomDNSEnabled(aWSCustomDNSEnabled AWSCustomDNSEnabled) ToggleAWSCustomDNSApiRequest {
 	r.aWSCustomDNSEnabled = &aWSCustomDNSEnabled
@@ -197,13 +225,7 @@ func (r ToggleAWSCustomDNSApiRequest) AWSCustomDNSEnabled(aWSCustomDNSEnabled AW
 }
 
 func (r ToggleAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
-	return r.ApiService.ToggleAWSCustomDNSExecute(r)
-}
-
-func (r ToggleAWSCustomDNSApiRequest) ExecuteWithParams(params *ToggleAWSCustomDNSApiParams) (*AWSCustomDNSEnabled, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.aWSCustomDNSEnabled = params.AWSCustomDNSEnabled 
-	return r.Execute()
+	return r.ApiService.toggleAWSCustomDNSExecute(r)
 }
 
 /*
@@ -225,7 +247,7 @@ func (a *AWSClustersDNSApiService) ToggleAWSCustomDNS(ctx context.Context, group
 
 // Execute executes the request
 //  @return AWSCustomDNSEnabled
-func (a *AWSClustersDNSApiService) ToggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
+func (a *AWSClustersDNSApiService) toggleAWSCustomDNSExecute(r ToggleAWSCustomDNSApiRequest) (*AWSCustomDNSEnabled, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_aws_clusters_dns.go
+++ b/mongodbatlasv2/api_aws_clusters_dns.go
@@ -66,6 +66,11 @@ func (r GetAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Respon
 	return r.ApiService.GetAWSCustomDNSExecute(r)
 }
 
+func (r GetAWSCustomDNSApiRequest) ExecuteWithParams(params *GetAWSCustomDNSApiParams) (*AWSCustomDNSEnabled, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 GetAWSCustomDNS Return One Custom DNS Configuration for Atlas Clusters on AWS
 
@@ -193,6 +198,12 @@ func (r ToggleAWSCustomDNSApiRequest) AWSCustomDNSEnabled(aWSCustomDNSEnabled AW
 
 func (r ToggleAWSCustomDNSApiRequest) Execute() (*AWSCustomDNSEnabled, *http.Response, error) {
 	return r.ApiService.ToggleAWSCustomDNSExecute(r)
+}
+
+func (r ToggleAWSCustomDNSApiRequest) ExecuteWithParams(params *ToggleAWSCustomDNSApiParams) (*AWSCustomDNSEnabled, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.aWSCustomDNSEnabled = params.AWSCustomDNSEnabled 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -30,9 +30,18 @@ type CloudBackupsApi interface {
 	@return CancelBackupRestoreJobApiRequest
 	*/
 	CancelBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) CancelBackupRestoreJobApiRequest
+	/*
+	CancelBackupRestoreJob Cancel One Restore Job of One Cluster
 
-	// CancelBackupRestoreJobExecute executes the request
-	CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CancelBackupRestoreJobApiParams - Parameters for the request
+	@return CancelBackupRestoreJobApiRequest}}
+	*/
+	CancelBackupRestoreJobWithParams(ctx context.Context, args *CancelBackupRestoreJobApiParams) CancelBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	cancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (*http.Response, error)
 
 	/*
 	CreateBackupExportJob Create One Cloud Backup Snapshot Export Job
@@ -45,10 +54,18 @@ type CloudBackupsApi interface {
 	@return CreateBackupExportJobApiRequest
 	*/
 	CreateBackupExportJob(ctx context.Context, groupId string, clusterName string) CreateBackupExportJobApiRequest
+	/*
+	CreateBackupExportJob Create One Cloud Backup Snapshot Export Job
 
-	// CreateBackupExportJobExecute executes the request
-	//  @return DiskBackupExportJob
-	CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateBackupExportJobApiParams - Parameters for the request
+	@return CreateBackupExportJobApiRequest}}
+	*/
+	CreateBackupExportJobWithParams(ctx context.Context, args *CreateBackupExportJobApiParams) CreateBackupExportJobApiRequest
+
+	// Interface only available internally
+	createBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
 	CreateBackupRestoreJob Restore One Snapshot of One Cluster
@@ -63,10 +80,18 @@ type CloudBackupsApi interface {
 	@return CreateBackupRestoreJobApiRequest
 	*/
 	CreateBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateBackupRestoreJobApiRequest
+	/*
+	CreateBackupRestoreJob Restore One Snapshot of One Cluster
 
-	// CreateBackupRestoreJobExecute executes the request
-	//  @return DiskBackupRestoreJob
-	CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateBackupRestoreJobApiParams - Parameters for the request
+	@return CreateBackupRestoreJobApiRequest}}
+	*/
+	CreateBackupRestoreJobWithParams(ctx context.Context, args *CreateBackupRestoreJobApiParams) CreateBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	createBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error)
 
 	/*
 	CreateExportBucket Grant Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
@@ -78,10 +103,18 @@ type CloudBackupsApi interface {
 	@return CreateExportBucketApiRequest
 	*/
 	CreateExportBucket(ctx context.Context, groupId string) CreateExportBucketApiRequest
+	/*
+	CreateExportBucket Grant Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
 
-	// CreateExportBucketExecute executes the request
-	//  @return DiskBackupSnapshotAWSExportBucket
-	CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateExportBucketApiParams - Parameters for the request
+	@return CreateExportBucketApiRequest}}
+	*/
+	CreateExportBucketWithParams(ctx context.Context, args *CreateExportBucketApiParams) CreateExportBucketApiRequest
+
+	// Interface only available internally
+	createExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
 	CreateServerlessBackupRestoreJob Restore One Snapshot of One Serverless Instance
@@ -94,10 +127,18 @@ type CloudBackupsApi interface {
 	@return CreateServerlessBackupRestoreJobApiRequest
 	*/
 	CreateServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateServerlessBackupRestoreJobApiRequest
+	/*
+	CreateServerlessBackupRestoreJob Restore One Snapshot of One Serverless Instance
 
-	// CreateServerlessBackupRestoreJobExecute executes the request
-	//  @return ServerlessBackupRestoreJob
-	CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateServerlessBackupRestoreJobApiParams - Parameters for the request
+	@return CreateServerlessBackupRestoreJobApiRequest}}
+	*/
+	CreateServerlessBackupRestoreJobWithParams(ctx context.Context, args *CreateServerlessBackupRestoreJobApiParams) CreateServerlessBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	createServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 	DeleteAllBackupSchedules Remove All Cloud Backup Schedules
@@ -110,10 +151,18 @@ type CloudBackupsApi interface {
 	@return DeleteAllBackupSchedulesApiRequest
 	*/
 	DeleteAllBackupSchedules(ctx context.Context, groupId string, clusterName string) DeleteAllBackupSchedulesApiRequest
+	/*
+	DeleteAllBackupSchedules Remove All Cloud Backup Schedules
 
-	// DeleteAllBackupSchedulesExecute executes the request
-	//  @return DiskBackupSnapshotSchedule
-	DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteAllBackupSchedulesApiParams - Parameters for the request
+	@return DeleteAllBackupSchedulesApiRequest}}
+	*/
+	DeleteAllBackupSchedulesWithParams(ctx context.Context, args *DeleteAllBackupSchedulesApiParams) DeleteAllBackupSchedulesApiRequest
+
+	// Interface only available internally
+	deleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 	DeleteExportBucket Revoke Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
@@ -126,9 +175,18 @@ type CloudBackupsApi interface {
 	@return DeleteExportBucketApiRequest
 	*/
 	DeleteExportBucket(ctx context.Context, groupId string, exportBucketId string) DeleteExportBucketApiRequest
+	/*
+	DeleteExportBucket Revoke Access to AWS S3 Bucket for Cloud Backup Snapshot Exports
 
-	// DeleteExportBucketExecute executes the request
-	DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteExportBucketApiParams - Parameters for the request
+	@return DeleteExportBucketApiRequest}}
+	*/
+	DeleteExportBucketWithParams(ctx context.Context, args *DeleteExportBucketApiParams) DeleteExportBucketApiRequest
+
+	// Interface only available internally
+	deleteExportBucketExecute(r DeleteExportBucketApiRequest) (*http.Response, error)
 
 	/*
 	DeleteReplicaSetBackup Remove One Replica Set Cloud Backup
@@ -142,9 +200,18 @@ type CloudBackupsApi interface {
 	@return DeleteReplicaSetBackupApiRequest
 	*/
 	DeleteReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteReplicaSetBackupApiRequest
+	/*
+	DeleteReplicaSetBackup Remove One Replica Set Cloud Backup
 
-	// DeleteReplicaSetBackupExecute executes the request
-	DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteReplicaSetBackupApiParams - Parameters for the request
+	@return DeleteReplicaSetBackupApiRequest}}
+	*/
+	DeleteReplicaSetBackupWithParams(ctx context.Context, args *DeleteReplicaSetBackupApiParams) DeleteReplicaSetBackupApiRequest
+
+	// Interface only available internally
+	deleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (*http.Response, error)
 
 	/*
 	DeleteShardedClusterBackup Remove One Sharded Cluster Cloud Backup
@@ -158,9 +225,18 @@ type CloudBackupsApi interface {
 	@return DeleteShardedClusterBackupApiRequest
 	*/
 	DeleteShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteShardedClusterBackupApiRequest
+	/*
+	DeleteShardedClusterBackup Remove One Sharded Cluster Cloud Backup
 
-	// DeleteShardedClusterBackupExecute executes the request
-	DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteShardedClusterBackupApiParams - Parameters for the request
+	@return DeleteShardedClusterBackupApiRequest}}
+	*/
+	DeleteShardedClusterBackupWithParams(ctx context.Context, args *DeleteShardedClusterBackupApiParams) DeleteShardedClusterBackupApiRequest
+
+	// Interface only available internally
+	deleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (*http.Response, error)
 
 	/*
 	GetBackupExportJob Return One Cloud Backup Snapshot Export Job
@@ -174,10 +250,18 @@ type CloudBackupsApi interface {
 	@return GetBackupExportJobApiRequest
 	*/
 	GetBackupExportJob(ctx context.Context, groupId string, clusterName string, exportId string) GetBackupExportJobApiRequest
+	/*
+	GetBackupExportJob Return One Cloud Backup Snapshot Export Job
 
-	// GetBackupExportJobExecute executes the request
-	//  @return DiskBackupExportJob
-	GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetBackupExportJobApiParams - Parameters for the request
+	@return GetBackupExportJobApiRequest}}
+	*/
+	GetBackupExportJobWithParams(ctx context.Context, args *GetBackupExportJobApiParams) GetBackupExportJobApiRequest
+
+	// Interface only available internally
+	getBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error)
 
 	/*
 	GetBackupRestoreJob Return One Restore Job of One Cluster
@@ -191,10 +275,18 @@ type CloudBackupsApi interface {
 	@return GetBackupRestoreJobApiRequest
 	*/
 	GetBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) GetBackupRestoreJobApiRequest
+	/*
+	GetBackupRestoreJob Return One Restore Job of One Cluster
 
-	// GetBackupRestoreJobExecute executes the request
-	//  @return DiskBackupRestoreJob
-	GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetBackupRestoreJobApiParams - Parameters for the request
+	@return GetBackupRestoreJobApiRequest}}
+	*/
+	GetBackupRestoreJobWithParams(ctx context.Context, args *GetBackupRestoreJobApiParams) GetBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	getBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error)
 
 	/*
 	GetBackupSchedule Return One Cloud Backup Schedule
@@ -207,10 +299,18 @@ type CloudBackupsApi interface {
 	@return GetBackupScheduleApiRequest
 	*/
 	GetBackupSchedule(ctx context.Context, groupId string, clusterName string) GetBackupScheduleApiRequest
+	/*
+	GetBackupSchedule Return One Cloud Backup Schedule
 
-	// GetBackupScheduleExecute executes the request
-	//  @return DiskBackupSnapshotSchedule
-	GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetBackupScheduleApiParams - Parameters for the request
+	@return GetBackupScheduleApiRequest}}
+	*/
+	GetBackupScheduleWithParams(ctx context.Context, args *GetBackupScheduleApiParams) GetBackupScheduleApiRequest
+
+	// Interface only available internally
+	getBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 	GetDataProtectionSettings Return the Backup Compliance Policy settings
@@ -222,10 +322,18 @@ type CloudBackupsApi interface {
 	@return GetDataProtectionSettingsApiRequest
 	*/
 	GetDataProtectionSettings(ctx context.Context, groupId string) GetDataProtectionSettingsApiRequest
+	/*
+	GetDataProtectionSettings Return the Backup Compliance Policy settings
 
-	// GetDataProtectionSettingsExecute executes the request
-	//  @return DataProtectionSettings
-	GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetDataProtectionSettingsApiParams - Parameters for the request
+	@return GetDataProtectionSettingsApiRequest}}
+	*/
+	GetDataProtectionSettingsWithParams(ctx context.Context, args *GetDataProtectionSettingsApiParams) GetDataProtectionSettingsApiRequest
+
+	// Interface only available internally
+	getDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error)
 
 	/*
 	GetExportBucket Return One AWS S3 Bucket Used for Cloud Backup Snapshot Exports
@@ -238,10 +346,18 @@ type CloudBackupsApi interface {
 	@return GetExportBucketApiRequest
 	*/
 	GetExportBucket(ctx context.Context, groupId string, exportBucketId string) GetExportBucketApiRequest
+	/*
+	GetExportBucket Return One AWS S3 Bucket Used for Cloud Backup Snapshot Exports
 
-	// GetExportBucketExecute executes the request
-	//  @return DiskBackupSnapshotAWSExportBucket
-	GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetExportBucketApiParams - Parameters for the request
+	@return GetExportBucketApiRequest}}
+	*/
+	GetExportBucketWithParams(ctx context.Context, args *GetExportBucketApiParams) GetExportBucketApiRequest
+
+	// Interface only available internally
+	getExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error)
 
 	/*
 	GetReplicaSetBackup Return One Replica Set Cloud Backup
@@ -255,10 +371,18 @@ type CloudBackupsApi interface {
 	@return GetReplicaSetBackupApiRequest
 	*/
 	GetReplicaSetBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetReplicaSetBackupApiRequest
+	/*
+	GetReplicaSetBackup Return One Replica Set Cloud Backup
 
-	// GetReplicaSetBackupExecute executes the request
-	//  @return DiskBackupReplicaSet
-	GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetReplicaSetBackupApiParams - Parameters for the request
+	@return GetReplicaSetBackupApiRequest}}
+	*/
+	GetReplicaSetBackupWithParams(ctx context.Context, args *GetReplicaSetBackupApiParams) GetReplicaSetBackupApiRequest
+
+	// Interface only available internally
+	getReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 
 	/*
 	GetServerlessBackup Return One Snapshot of One Serverless Instance
@@ -272,10 +396,18 @@ type CloudBackupsApi interface {
 	@return GetServerlessBackupApiRequest
 	*/
 	GetServerlessBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetServerlessBackupApiRequest
+	/*
+	GetServerlessBackup Return One Snapshot of One Serverless Instance
 
-	// GetServerlessBackupExecute executes the request
-	//  @return ServerlessBackupSnapshot
-	GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetServerlessBackupApiParams - Parameters for the request
+	@return GetServerlessBackupApiRequest}}
+	*/
+	GetServerlessBackupWithParams(ctx context.Context, args *GetServerlessBackupApiParams) GetServerlessBackupApiRequest
+
+	// Interface only available internally
+	getServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error)
 
 	/*
 	GetServerlessBackupRestoreJob Return One Restore Job for One Serverless Instance
@@ -289,10 +421,18 @@ type CloudBackupsApi interface {
 	@return GetServerlessBackupRestoreJobApiRequest
 	*/
 	GetServerlessBackupRestoreJob(ctx context.Context, groupId string, clusterName string, restoreJobId string) GetServerlessBackupRestoreJobApiRequest
+	/*
+	GetServerlessBackupRestoreJob Return One Restore Job for One Serverless Instance
 
-	// GetServerlessBackupRestoreJobExecute executes the request
-	//  @return ServerlessBackupRestoreJob
-	GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetServerlessBackupRestoreJobApiParams - Parameters for the request
+	@return GetServerlessBackupRestoreJobApiRequest}}
+	*/
+	GetServerlessBackupRestoreJobWithParams(ctx context.Context, args *GetServerlessBackupRestoreJobApiParams) GetServerlessBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	getServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 	GetShardedClusterBackup Return One Sharded Cluster Cloud Backup
@@ -306,10 +446,18 @@ type CloudBackupsApi interface {
 	@return GetShardedClusterBackupApiRequest
 	*/
 	GetShardedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetShardedClusterBackupApiRequest
+	/*
+	GetShardedClusterBackup Return One Sharded Cluster Cloud Backup
 
-	// GetShardedClusterBackupExecute executes the request
-	//  @return DiskBackupShardedClusterSnapshot
-	GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetShardedClusterBackupApiParams - Parameters for the request
+	@return GetShardedClusterBackupApiRequest}}
+	*/
+	GetShardedClusterBackupWithParams(ctx context.Context, args *GetShardedClusterBackupApiParams) GetShardedClusterBackupApiRequest
+
+	// Interface only available internally
+	getShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
 	ListBackupExportJobs Return All Cloud Backup Snapshot Export Jobs
@@ -322,10 +470,18 @@ type CloudBackupsApi interface {
 	@return ListBackupExportJobsApiRequest
 	*/
 	ListBackupExportJobs(ctx context.Context, groupId string, clusterName string) ListBackupExportJobsApiRequest
+	/*
+	ListBackupExportJobs Return All Cloud Backup Snapshot Export Jobs
 
-	// ListBackupExportJobsExecute executes the request
-	//  @return PaginatedApiAtlasDiskBackupExportJob
-	ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListBackupExportJobsApiParams - Parameters for the request
+	@return ListBackupExportJobsApiRequest}}
+	*/
+	ListBackupExportJobsWithParams(ctx context.Context, args *ListBackupExportJobsApiParams) ListBackupExportJobsApiRequest
+
+	// Interface only available internally
+	listBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error)
 
 	/*
 	ListBackupRestoreJobs Return All Restore Jobs for One Cluster
@@ -338,10 +494,18 @@ type CloudBackupsApi interface {
 	@return ListBackupRestoreJobsApiRequest
 	*/
 	ListBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListBackupRestoreJobsApiRequest
+	/*
+	ListBackupRestoreJobs Return All Restore Jobs for One Cluster
 
-	// ListBackupRestoreJobsExecute executes the request
-	//  @return PaginatedCloudBackupRestoreJob
-	ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListBackupRestoreJobsApiParams - Parameters for the request
+	@return ListBackupRestoreJobsApiRequest}}
+	*/
+	ListBackupRestoreJobsWithParams(ctx context.Context, args *ListBackupRestoreJobsApiParams) ListBackupRestoreJobsApiRequest
+
+	// Interface only available internally
+	listBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error)
 
 	/*
 	ListExportBuckets Return All AWS S3 Buckets Used for Cloud Backup Snapshot Exports
@@ -353,10 +517,18 @@ type CloudBackupsApi interface {
 	@return ListExportBucketsApiRequest
 	*/
 	ListExportBuckets(ctx context.Context, groupId string) ListExportBucketsApiRequest
+	/*
+	ListExportBuckets Return All AWS S3 Buckets Used for Cloud Backup Snapshot Exports
 
-	// ListExportBucketsExecute executes the request
-	//  @return PaginatedBackupSnapshotExportBucket
-	ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListExportBucketsApiParams - Parameters for the request
+	@return ListExportBucketsApiRequest}}
+	*/
+	ListExportBucketsWithParams(ctx context.Context, args *ListExportBucketsApiParams) ListExportBucketsApiRequest
+
+	// Interface only available internally
+	listExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error)
 
 	/*
 	ListReplicaSetBackups Return All Replica Set Cloud Backups
@@ -369,10 +541,18 @@ type CloudBackupsApi interface {
 	@return ListReplicaSetBackupsApiRequest
 	*/
 	ListReplicaSetBackups(ctx context.Context, groupId string, clusterName string) ListReplicaSetBackupsApiRequest
+	/*
+	ListReplicaSetBackups Return All Replica Set Cloud Backups
 
-	// ListReplicaSetBackupsExecute executes the request
-	//  @return PaginatedCloudBackupReplicaSet
-	ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListReplicaSetBackupsApiParams - Parameters for the request
+	@return ListReplicaSetBackupsApiRequest}}
+	*/
+	ListReplicaSetBackupsWithParams(ctx context.Context, args *ListReplicaSetBackupsApiParams) ListReplicaSetBackupsApiRequest
+
+	// Interface only available internally
+	listReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error)
 
 	/*
 	ListServerlessBackupRestoreJobs Return All Restore Jobs for One Serverless Instance
@@ -385,10 +565,18 @@ type CloudBackupsApi interface {
 	@return ListServerlessBackupRestoreJobsApiRequest
 	*/
 	ListServerlessBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListServerlessBackupRestoreJobsApiRequest
+	/*
+	ListServerlessBackupRestoreJobs Return All Restore Jobs for One Serverless Instance
 
-	// ListServerlessBackupRestoreJobsExecute executes the request
-	//  @return PaginatedApiAtlasServerlessBackupRestoreJob
-	ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListServerlessBackupRestoreJobsApiParams - Parameters for the request
+	@return ListServerlessBackupRestoreJobsApiRequest}}
+	*/
+	ListServerlessBackupRestoreJobsWithParams(ctx context.Context, args *ListServerlessBackupRestoreJobsApiParams) ListServerlessBackupRestoreJobsApiRequest
+
+	// Interface only available internally
+	listServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error)
 
 	/*
 	ListServerlessBackups Return All Snapshots of One Serverless Instance
@@ -401,10 +589,18 @@ type CloudBackupsApi interface {
 	@return ListServerlessBackupsApiRequest
 	*/
 	ListServerlessBackups(ctx context.Context, groupId string, clusterName string) ListServerlessBackupsApiRequest
+	/*
+	ListServerlessBackups Return All Snapshots of One Serverless Instance
 
-	// ListServerlessBackupsExecute executes the request
-	//  @return PaginatedApiAtlasServerlessBackupSnapshot
-	ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListServerlessBackupsApiParams - Parameters for the request
+	@return ListServerlessBackupsApiRequest}}
+	*/
+	ListServerlessBackupsWithParams(ctx context.Context, args *ListServerlessBackupsApiParams) ListServerlessBackupsApiRequest
+
+	// Interface only available internally
+	listServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error)
 
 	/*
 	ListShardedClusterBackups Return All Sharded Cluster Cloud Backups
@@ -417,10 +613,18 @@ type CloudBackupsApi interface {
 	@return ListShardedClusterBackupsApiRequest
 	*/
 	ListShardedClusterBackups(ctx context.Context, groupId string, clusterName string) ListShardedClusterBackupsApiRequest
+	/*
+	ListShardedClusterBackups Return All Sharded Cluster Cloud Backups
 
-	// ListShardedClusterBackupsExecute executes the request
-	//  @return PaginatedCloudBackupShardedClusterSnapshot
-	ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListShardedClusterBackupsApiParams - Parameters for the request
+	@return ListShardedClusterBackupsApiRequest}}
+	*/
+	ListShardedClusterBackupsWithParams(ctx context.Context, args *ListShardedClusterBackupsApiParams) ListShardedClusterBackupsApiRequest
+
+	// Interface only available internally
+	listShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error)
 
 	/*
 	TakeSnapshot Take One On-Demand Snapshot
@@ -435,10 +639,18 @@ type CloudBackupsApi interface {
 	@return TakeSnapshotApiRequest
 	*/
 	TakeSnapshot(ctx context.Context, groupId string, clusterName string) TakeSnapshotApiRequest
+	/*
+	TakeSnapshot Take One On-Demand Snapshot
 
-	// TakeSnapshotExecute executes the request
-	//  @return DiskBackupSnapshot
-	TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param TakeSnapshotApiParams - Parameters for the request
+	@return TakeSnapshotApiRequest}}
+	*/
+	TakeSnapshotWithParams(ctx context.Context, args *TakeSnapshotApiParams) TakeSnapshotApiRequest
+
+	// Interface only available internally
+	takeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error)
 
 	/*
 	UpdateBackupSchedule Update Cloud Backup Schedule for One Cluster
@@ -451,10 +663,18 @@ type CloudBackupsApi interface {
 	@return UpdateBackupScheduleApiRequest
 	*/
 	UpdateBackupSchedule(ctx context.Context, groupId string, clusterName string) UpdateBackupScheduleApiRequest
+	/*
+	UpdateBackupSchedule Update Cloud Backup Schedule for One Cluster
 
-	// UpdateBackupScheduleExecute executes the request
-	//  @return DiskBackupSnapshotSchedule
-	UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateBackupScheduleApiParams - Parameters for the request
+	@return UpdateBackupScheduleApiRequest}}
+	*/
+	UpdateBackupScheduleWithParams(ctx context.Context, args *UpdateBackupScheduleApiParams) UpdateBackupScheduleApiRequest
+
+	// Interface only available internally
+	updateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error)
 
 	/*
 	UpdateDataProtectionSettings Update or enable the Backup Compliance Policy settings
@@ -466,10 +686,18 @@ type CloudBackupsApi interface {
 	@return UpdateDataProtectionSettingsApiRequest
 	*/
 	UpdateDataProtectionSettings(ctx context.Context, groupId string) UpdateDataProtectionSettingsApiRequest
+	/*
+	UpdateDataProtectionSettings Update or enable the Backup Compliance Policy settings
 
-	// UpdateDataProtectionSettingsExecute executes the request
-	//  @return DataProtectionSettings
-	UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateDataProtectionSettingsApiParams - Parameters for the request
+	@return UpdateDataProtectionSettingsApiRequest}}
+	*/
+	UpdateDataProtectionSettingsWithParams(ctx context.Context, args *UpdateDataProtectionSettingsApiParams) UpdateDataProtectionSettingsApiRequest
+
+	// Interface only available internally
+	updateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error)
 
 	/*
 	UpdateSnapshotRetention Change Expiration Date for One Cloud Backup
@@ -483,10 +711,18 @@ type CloudBackupsApi interface {
 	@return UpdateSnapshotRetentionApiRequest
 	*/
 	UpdateSnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) UpdateSnapshotRetentionApiRequest
+	/*
+	UpdateSnapshotRetention Change Expiration Date for One Cloud Backup
 
-	// UpdateSnapshotRetentionExecute executes the request
-	//  @return DiskBackupReplicaSet
-	UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateSnapshotRetentionApiParams - Parameters for the request
+	@return UpdateSnapshotRetentionApiRequest}}
+	*/
+	UpdateSnapshotRetentionWithParams(ctx context.Context, args *UpdateSnapshotRetentionApiParams) UpdateSnapshotRetentionApiRequest
+
+	// Interface only available internally
+	updateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error)
 }
 
 // CloudBackupsApiService CloudBackupsApi service
@@ -506,8 +742,18 @@ type CancelBackupRestoreJobApiParams struct {
 		RestoreJobId string
 }
 
+func (a *CloudBackupsApiService) CancelBackupRestoreJobWithParams(ctx context.Context, args *CancelBackupRestoreJobApiParams) CancelBackupRestoreJobApiRequest {
+	return CancelBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		restoreJobId: args.RestoreJobId,
+	}
+}
+
 func (r CancelBackupRestoreJobApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.CancelBackupRestoreJobExecute(r)
+	return r.ApiService.cancelBackupRestoreJobExecute(r)
 }
 
 /*
@@ -532,7 +778,7 @@ func (a *CloudBackupsApiService) CancelBackupRestoreJob(ctx context.Context, gro
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) CancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) cancelBackupRestoreJobExecute(r CancelBackupRestoreJobApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -638,6 +884,16 @@ type CreateBackupExportJobApiParams struct {
 		DiskBackupExportJobRequest *DiskBackupExportJobRequest
 }
 
+func (a *CloudBackupsApiService) CreateBackupExportJobWithParams(ctx context.Context, args *CreateBackupExportJobApiParams) CreateBackupExportJobApiRequest {
+	return CreateBackupExportJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		diskBackupExportJobRequest: args.DiskBackupExportJobRequest,
+	}
+}
+
 // Information about the Cloud Backup Snapshot Export Job to create.
 func (r CreateBackupExportJobApiRequest) DiskBackupExportJobRequest(diskBackupExportJobRequest DiskBackupExportJobRequest) CreateBackupExportJobApiRequest {
 	r.diskBackupExportJobRequest = &diskBackupExportJobRequest
@@ -645,7 +901,7 @@ func (r CreateBackupExportJobApiRequest) DiskBackupExportJobRequest(diskBackupEx
 }
 
 func (r CreateBackupExportJobApiRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
-	return r.ApiService.CreateBackupExportJobExecute(r)
+	return r.ApiService.createBackupExportJobExecute(r)
 }
 
 /*
@@ -669,7 +925,7 @@ func (a *CloudBackupsApiService) CreateBackupExportJob(ctx context.Context, grou
 
 // Execute executes the request
 //  @return DiskBackupExportJob
-func (a *CloudBackupsApiService) CreateBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) createBackupExportJobExecute(r CreateBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -783,6 +1039,16 @@ type CreateBackupRestoreJobApiParams struct {
 		DiskBackupRestoreJob *DiskBackupRestoreJob
 }
 
+func (a *CloudBackupsApiService) CreateBackupRestoreJobWithParams(ctx context.Context, args *CreateBackupRestoreJobApiParams) CreateBackupRestoreJobApiRequest {
+	return CreateBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		diskBackupRestoreJob: args.DiskBackupRestoreJob,
+	}
+}
+
 // Restores one snapshot of one cluster from the specified project.
 func (r CreateBackupRestoreJobApiRequest) DiskBackupRestoreJob(diskBackupRestoreJob DiskBackupRestoreJob) CreateBackupRestoreJobApiRequest {
 	r.diskBackupRestoreJob = &diskBackupRestoreJob
@@ -790,7 +1056,7 @@ func (r CreateBackupRestoreJobApiRequest) DiskBackupRestoreJob(diskBackupRestore
 }
 
 func (r CreateBackupRestoreJobApiRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.CreateBackupRestoreJobExecute(r)
+	return r.ApiService.createBackupRestoreJobExecute(r)
 }
 
 /*
@@ -816,7 +1082,7 @@ func (a *CloudBackupsApiService) CreateBackupRestoreJob(ctx context.Context, gro
 
 // Execute executes the request
 //  @return DiskBackupRestoreJob
-func (a *CloudBackupsApiService) CreateBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) createBackupRestoreJobExecute(r CreateBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -928,6 +1194,15 @@ type CreateExportBucketApiParams struct {
 		DiskBackupSnapshotAWSExportBucket *DiskBackupSnapshotAWSExportBucket
 }
 
+func (a *CloudBackupsApiService) CreateExportBucketWithParams(ctx context.Context, args *CreateExportBucketApiParams) CreateExportBucketApiRequest {
+	return CreateExportBucketApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		diskBackupSnapshotAWSExportBucket: args.DiskBackupSnapshotAWSExportBucket,
+	}
+}
+
 // Grants MongoDB Cloud access to the specified AWS S3 bucket.
 func (r CreateExportBucketApiRequest) DiskBackupSnapshotAWSExportBucket(diskBackupSnapshotAWSExportBucket DiskBackupSnapshotAWSExportBucket) CreateExportBucketApiRequest {
 	r.diskBackupSnapshotAWSExportBucket = &diskBackupSnapshotAWSExportBucket
@@ -935,7 +1210,7 @@ func (r CreateExportBucketApiRequest) DiskBackupSnapshotAWSExportBucket(diskBack
 }
 
 func (r CreateExportBucketApiRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
-	return r.ApiService.CreateExportBucketExecute(r)
+	return r.ApiService.createExportBucketExecute(r)
 }
 
 /*
@@ -957,7 +1232,7 @@ func (a *CloudBackupsApiService) CreateExportBucket(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return DiskBackupSnapshotAWSExportBucket
-func (a *CloudBackupsApiService) CreateExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) createExportBucketExecute(r CreateExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1064,6 +1339,16 @@ type CreateServerlessBackupRestoreJobApiParams struct {
 		ServerlessBackupRestoreJob *ServerlessBackupRestoreJob
 }
 
+func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobWithParams(ctx context.Context, args *CreateServerlessBackupRestoreJobApiParams) CreateServerlessBackupRestoreJobApiRequest {
+	return CreateServerlessBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		serverlessBackupRestoreJob: args.ServerlessBackupRestoreJob,
+	}
+}
+
 // Restores one snapshot of one serverless instance from the specified project.
 func (r CreateServerlessBackupRestoreJobApiRequest) ServerlessBackupRestoreJob(serverlessBackupRestoreJob ServerlessBackupRestoreJob) CreateServerlessBackupRestoreJobApiRequest {
 	r.serverlessBackupRestoreJob = &serverlessBackupRestoreJob
@@ -1071,7 +1356,7 @@ func (r CreateServerlessBackupRestoreJobApiRequest) ServerlessBackupRestoreJob(s
 }
 
 func (r CreateServerlessBackupRestoreJobApiRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.CreateServerlessBackupRestoreJobExecute(r)
+	return r.ApiService.createServerlessBackupRestoreJobExecute(r)
 }
 
 /*
@@ -1095,7 +1380,7 @@ func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJob(ctx context.Co
 
 // Execute executes the request
 //  @return ServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) CreateServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) createServerlessBackupRestoreJobExecute(r CreateServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1207,8 +1492,17 @@ type DeleteAllBackupSchedulesApiParams struct {
 		ClusterName string
 }
 
+func (a *CloudBackupsApiService) DeleteAllBackupSchedulesWithParams(ctx context.Context, args *DeleteAllBackupSchedulesApiParams) DeleteAllBackupSchedulesApiRequest {
+	return DeleteAllBackupSchedulesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
+}
+
 func (r DeleteAllBackupSchedulesApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.DeleteAllBackupSchedulesExecute(r)
+	return r.ApiService.deleteAllBackupSchedulesExecute(r)
 }
 
 /*
@@ -1232,7 +1526,7 @@ func (a *CloudBackupsApiService) DeleteAllBackupSchedules(ctx context.Context, g
 
 // Execute executes the request
 //  @return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) DeleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) deleteAllBackupSchedulesExecute(r DeleteAllBackupSchedulesApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1339,8 +1633,17 @@ type DeleteExportBucketApiParams struct {
 		ExportBucketId string
 }
 
+func (a *CloudBackupsApiService) DeleteExportBucketWithParams(ctx context.Context, args *DeleteExportBucketApiParams) DeleteExportBucketApiRequest {
+	return DeleteExportBucketApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		exportBucketId: args.ExportBucketId,
+	}
+}
+
 func (r DeleteExportBucketApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteExportBucketExecute(r)
+	return r.ApiService.deleteExportBucketExecute(r)
 }
 
 /*
@@ -1363,7 +1666,7 @@ func (a *CloudBackupsApiService) DeleteExportBucket(ctx context.Context, groupId
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) DeleteExportBucketExecute(r DeleteExportBucketApiRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) deleteExportBucketExecute(r DeleteExportBucketApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1462,8 +1765,18 @@ type DeleteReplicaSetBackupApiParams struct {
 		SnapshotId string
 }
 
+func (a *CloudBackupsApiService) DeleteReplicaSetBackupWithParams(ctx context.Context, args *DeleteReplicaSetBackupApiParams) DeleteReplicaSetBackupApiRequest {
+	return DeleteReplicaSetBackupApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
+}
+
 func (r DeleteReplicaSetBackupApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteReplicaSetBackupExecute(r)
+	return r.ApiService.deleteReplicaSetBackupExecute(r)
 }
 
 /*
@@ -1488,7 +1801,7 @@ func (a *CloudBackupsApiService) DeleteReplicaSetBackup(ctx context.Context, gro
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) DeleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) deleteReplicaSetBackupExecute(r DeleteReplicaSetBackupApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1594,8 +1907,18 @@ type DeleteShardedClusterBackupApiParams struct {
 		SnapshotId string
 }
 
+func (a *CloudBackupsApiService) DeleteShardedClusterBackupWithParams(ctx context.Context, args *DeleteShardedClusterBackupApiParams) DeleteShardedClusterBackupApiRequest {
+	return DeleteShardedClusterBackupApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
+}
+
 func (r DeleteShardedClusterBackupApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteShardedClusterBackupExecute(r)
+	return r.ApiService.deleteShardedClusterBackupExecute(r)
 }
 
 /*
@@ -1620,7 +1943,7 @@ func (a *CloudBackupsApiService) DeleteShardedClusterBackup(ctx context.Context,
 }
 
 // Execute executes the request
-func (a *CloudBackupsApiService) DeleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (*http.Response, error) {
+func (a *CloudBackupsApiService) deleteShardedClusterBackupExecute(r DeleteShardedClusterBackupApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1726,8 +2049,18 @@ type GetBackupExportJobApiParams struct {
 		ExportId string
 }
 
+func (a *CloudBackupsApiService) GetBackupExportJobWithParams(ctx context.Context, args *GetBackupExportJobApiParams) GetBackupExportJobApiRequest {
+	return GetBackupExportJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		exportId: args.ExportId,
+	}
+}
+
 func (r GetBackupExportJobApiRequest) Execute() (*DiskBackupExportJob, *http.Response, error) {
-	return r.ApiService.GetBackupExportJobExecute(r)
+	return r.ApiService.getBackupExportJobExecute(r)
 }
 
 /*
@@ -1753,7 +2086,7 @@ func (a *CloudBackupsApiService) GetBackupExportJob(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return DiskBackupExportJob
-func (a *CloudBackupsApiService) GetBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) getBackupExportJobExecute(r GetBackupExportJobApiRequest) (*DiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1863,8 +2196,18 @@ type GetBackupRestoreJobApiParams struct {
 		RestoreJobId string
 }
 
+func (a *CloudBackupsApiService) GetBackupRestoreJobWithParams(ctx context.Context, args *GetBackupRestoreJobApiParams) GetBackupRestoreJobApiRequest {
+	return GetBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		restoreJobId: args.RestoreJobId,
+	}
+}
+
 func (r GetBackupRestoreJobApiRequest) Execute() (*DiskBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.GetBackupRestoreJobExecute(r)
+	return r.ApiService.getBackupRestoreJobExecute(r)
 }
 
 /*
@@ -1890,7 +2233,7 @@ func (a *CloudBackupsApiService) GetBackupRestoreJob(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DiskBackupRestoreJob
-func (a *CloudBackupsApiService) GetBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) getBackupRestoreJobExecute(r GetBackupRestoreJobApiRequest) (*DiskBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2004,8 +2347,17 @@ type GetBackupScheduleApiParams struct {
 		ClusterName string
 }
 
+func (a *CloudBackupsApiService) GetBackupScheduleWithParams(ctx context.Context, args *GetBackupScheduleApiParams) GetBackupScheduleApiRequest {
+	return GetBackupScheduleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
+}
+
 func (r GetBackupScheduleApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.GetBackupScheduleExecute(r)
+	return r.ApiService.getBackupScheduleExecute(r)
 }
 
 /*
@@ -2029,7 +2381,7 @@ func (a *CloudBackupsApiService) GetBackupSchedule(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) GetBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) getBackupScheduleExecute(r GetBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2134,8 +2486,16 @@ type GetDataProtectionSettingsApiParams struct {
 		GroupId string
 }
 
+func (a *CloudBackupsApiService) GetDataProtectionSettingsWithParams(ctx context.Context, args *GetDataProtectionSettingsApiParams) GetDataProtectionSettingsApiRequest {
+	return GetDataProtectionSettingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
+}
+
 func (r GetDataProtectionSettingsApiRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
-	return r.ApiService.GetDataProtectionSettingsExecute(r)
+	return r.ApiService.getDataProtectionSettingsExecute(r)
 }
 
 /*
@@ -2157,7 +2517,7 @@ func (a *CloudBackupsApiService) GetDataProtectionSettings(ctx context.Context, 
 
 // Execute executes the request
 //  @return DataProtectionSettings
-func (a *CloudBackupsApiService) GetDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error) {
+func (a *CloudBackupsApiService) getDataProtectionSettingsExecute(r GetDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2257,8 +2617,17 @@ type GetExportBucketApiParams struct {
 		ExportBucketId string
 }
 
+func (a *CloudBackupsApiService) GetExportBucketWithParams(ctx context.Context, args *GetExportBucketApiParams) GetExportBucketApiRequest {
+	return GetExportBucketApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		exportBucketId: args.ExportBucketId,
+	}
+}
+
 func (r GetExportBucketApiRequest) Execute() (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
-	return r.ApiService.GetExportBucketExecute(r)
+	return r.ApiService.getExportBucketExecute(r)
 }
 
 /*
@@ -2282,7 +2651,7 @@ func (a *CloudBackupsApiService) GetExportBucket(ctx context.Context, groupId st
 
 // Execute executes the request
 //  @return DiskBackupSnapshotAWSExportBucket
-func (a *CloudBackupsApiService) GetExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) getExportBucketExecute(r GetExportBucketApiRequest) (*DiskBackupSnapshotAWSExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2391,8 +2760,18 @@ type GetReplicaSetBackupApiParams struct {
 		SnapshotId string
 }
 
+func (a *CloudBackupsApiService) GetReplicaSetBackupWithParams(ctx context.Context, args *GetReplicaSetBackupApiParams) GetReplicaSetBackupApiRequest {
+	return GetReplicaSetBackupApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
+}
+
 func (r GetReplicaSetBackupApiRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
-	return r.ApiService.GetReplicaSetBackupExecute(r)
+	return r.ApiService.getReplicaSetBackupExecute(r)
 }
 
 /*
@@ -2418,7 +2797,7 @@ func (a *CloudBackupsApiService) GetReplicaSetBackup(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DiskBackupReplicaSet
-func (a *CloudBackupsApiService) GetReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) getReplicaSetBackupExecute(r GetReplicaSetBackupApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2534,8 +2913,18 @@ type GetServerlessBackupApiParams struct {
 		SnapshotId string
 }
 
+func (a *CloudBackupsApiService) GetServerlessBackupWithParams(ctx context.Context, args *GetServerlessBackupApiParams) GetServerlessBackupApiRequest {
+	return GetServerlessBackupApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
+}
+
 func (r GetServerlessBackupApiRequest) Execute() (*ServerlessBackupSnapshot, *http.Response, error) {
-	return r.ApiService.GetServerlessBackupExecute(r)
+	return r.ApiService.getServerlessBackupExecute(r)
 }
 
 /*
@@ -2561,7 +2950,7 @@ func (a *CloudBackupsApiService) GetServerlessBackup(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return ServerlessBackupSnapshot
-func (a *CloudBackupsApiService) GetServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) getServerlessBackupExecute(r GetServerlessBackupApiRequest) (*ServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2677,8 +3066,18 @@ type GetServerlessBackupRestoreJobApiParams struct {
 		RestoreJobId string
 }
 
+func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobWithParams(ctx context.Context, args *GetServerlessBackupRestoreJobApiParams) GetServerlessBackupRestoreJobApiRequest {
+	return GetServerlessBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		restoreJobId: args.RestoreJobId,
+	}
+}
+
 func (r GetServerlessBackupRestoreJobApiRequest) Execute() (*ServerlessBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.GetServerlessBackupRestoreJobExecute(r)
+	return r.ApiService.getServerlessBackupRestoreJobExecute(r)
 }
 
 /*
@@ -2704,7 +3103,7 @@ func (a *CloudBackupsApiService) GetServerlessBackupRestoreJob(ctx context.Conte
 
 // Execute executes the request
 //  @return ServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) GetServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) getServerlessBackupRestoreJobExecute(r GetServerlessBackupRestoreJobApiRequest) (*ServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2820,8 +3219,18 @@ type GetShardedClusterBackupApiParams struct {
 		SnapshotId string
 }
 
+func (a *CloudBackupsApiService) GetShardedClusterBackupWithParams(ctx context.Context, args *GetShardedClusterBackupApiParams) GetShardedClusterBackupApiRequest {
+	return GetShardedClusterBackupApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
+}
+
 func (r GetShardedClusterBackupApiRequest) Execute() (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
-	return r.ApiService.GetShardedClusterBackupExecute(r)
+	return r.ApiService.getShardedClusterBackupExecute(r)
 }
 
 /*
@@ -2847,7 +3256,7 @@ func (a *CloudBackupsApiService) GetShardedClusterBackup(ctx context.Context, gr
 
 // Execute executes the request
 //  @return DiskBackupShardedClusterSnapshot
-func (a *CloudBackupsApiService) GetShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) getShardedClusterBackupExecute(r GetShardedClusterBackupApiRequest) (*DiskBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2967,6 +3376,18 @@ type ListBackupExportJobsApiParams struct {
 		PageNum *int32
 }
 
+func (a *CloudBackupsApiService) ListBackupExportJobsWithParams(ctx context.Context, args *ListBackupExportJobsApiParams) ListBackupExportJobsApiRequest {
+	return ListBackupExportJobsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListBackupExportJobsApiRequest) IncludeCount(includeCount bool) ListBackupExportJobsApiRequest {
 	r.includeCount = &includeCount
@@ -2986,7 +3407,7 @@ func (r ListBackupExportJobsApiRequest) PageNum(pageNum int32) ListBackupExportJ
 }
 
 func (r ListBackupExportJobsApiRequest) Execute() (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
-	return r.ApiService.ListBackupExportJobsExecute(r)
+	return r.ApiService.listBackupExportJobsExecute(r)
 }
 
 /*
@@ -3010,7 +3431,7 @@ func (a *CloudBackupsApiService) ListBackupExportJobs(ctx context.Context, group
 
 // Execute executes the request
 //  @return PaginatedApiAtlasDiskBackupExportJob
-func (a *CloudBackupsApiService) ListBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
+func (a *CloudBackupsApiService) listBackupExportJobsExecute(r ListBackupExportJobsApiRequest) (*PaginatedApiAtlasDiskBackupExportJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3144,6 +3565,18 @@ type ListBackupRestoreJobsApiParams struct {
 		PageNum *int32
 }
 
+func (a *CloudBackupsApiService) ListBackupRestoreJobsWithParams(ctx context.Context, args *ListBackupRestoreJobsApiParams) ListBackupRestoreJobsApiRequest {
+	return ListBackupRestoreJobsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListBackupRestoreJobsApiRequest) IncludeCount(includeCount bool) ListBackupRestoreJobsApiRequest {
 	r.includeCount = &includeCount
@@ -3163,7 +3596,7 @@ func (r ListBackupRestoreJobsApiRequest) PageNum(pageNum int32) ListBackupRestor
 }
 
 func (r ListBackupRestoreJobsApiRequest) Execute() (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.ListBackupRestoreJobsExecute(r)
+	return r.ApiService.listBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -3187,7 +3620,7 @@ func (a *CloudBackupsApiService) ListBackupRestoreJobs(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedCloudBackupRestoreJob
-func (a *CloudBackupsApiService) ListBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) listBackupRestoreJobsExecute(r ListBackupRestoreJobsApiRequest) (*PaginatedCloudBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3313,8 +3746,16 @@ type ListExportBucketsApiParams struct {
 		GroupId string
 }
 
+func (a *CloudBackupsApiService) ListExportBucketsWithParams(ctx context.Context, args *ListExportBucketsApiParams) ListExportBucketsApiRequest {
+	return ListExportBucketsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
+}
+
 func (r ListExportBucketsApiRequest) Execute() (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
-	return r.ApiService.ListExportBucketsExecute(r)
+	return r.ApiService.listExportBucketsExecute(r)
 }
 
 /*
@@ -3336,7 +3777,7 @@ func (a *CloudBackupsApiService) ListExportBuckets(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return PaginatedBackupSnapshotExportBucket
-func (a *CloudBackupsApiService) ListExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
+func (a *CloudBackupsApiService) listExportBucketsExecute(r ListExportBucketsApiRequest) (*PaginatedBackupSnapshotExportBucket, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3442,6 +3883,18 @@ type ListReplicaSetBackupsApiParams struct {
 		PageNum *int32
 }
 
+func (a *CloudBackupsApiService) ListReplicaSetBackupsWithParams(ctx context.Context, args *ListReplicaSetBackupsApiParams) ListReplicaSetBackupsApiRequest {
+	return ListReplicaSetBackupsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListReplicaSetBackupsApiRequest) IncludeCount(includeCount bool) ListReplicaSetBackupsApiRequest {
 	r.includeCount = &includeCount
@@ -3461,7 +3914,7 @@ func (r ListReplicaSetBackupsApiRequest) PageNum(pageNum int32) ListReplicaSetBa
 }
 
 func (r ListReplicaSetBackupsApiRequest) Execute() (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
-	return r.ApiService.ListReplicaSetBackupsExecute(r)
+	return r.ApiService.listReplicaSetBackupsExecute(r)
 }
 
 /*
@@ -3485,7 +3938,7 @@ func (a *CloudBackupsApiService) ListReplicaSetBackups(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedCloudBackupReplicaSet
-func (a *CloudBackupsApiService) ListReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) listReplicaSetBackupsExecute(r ListReplicaSetBackupsApiRequest) (*PaginatedCloudBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3613,8 +4066,17 @@ type ListServerlessBackupRestoreJobsApiParams struct {
 		ClusterName string
 }
 
+func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobsWithParams(ctx context.Context, args *ListServerlessBackupRestoreJobsApiParams) ListServerlessBackupRestoreJobsApiRequest {
+	return ListServerlessBackupRestoreJobsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
+}
+
 func (r ListServerlessBackupRestoreJobsApiRequest) Execute() (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
-	return r.ApiService.ListServerlessBackupRestoreJobsExecute(r)
+	return r.ApiService.listServerlessBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -3638,7 +4100,7 @@ func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobs(ctx context.Con
 
 // Execute executes the request
 //  @return PaginatedApiAtlasServerlessBackupRestoreJob
-func (a *CloudBackupsApiService) ListServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
+func (a *CloudBackupsApiService) listServerlessBackupRestoreJobsExecute(r ListServerlessBackupRestoreJobsApiRequest) (*PaginatedApiAtlasServerlessBackupRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3751,6 +4213,18 @@ type ListServerlessBackupsApiParams struct {
 		PageNum *int32
 }
 
+func (a *CloudBackupsApiService) ListServerlessBackupsWithParams(ctx context.Context, args *ListServerlessBackupsApiParams) ListServerlessBackupsApiRequest {
+	return ListServerlessBackupsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListServerlessBackupsApiRequest) IncludeCount(includeCount bool) ListServerlessBackupsApiRequest {
 	r.includeCount = &includeCount
@@ -3770,7 +4244,7 @@ func (r ListServerlessBackupsApiRequest) PageNum(pageNum int32) ListServerlessBa
 }
 
 func (r ListServerlessBackupsApiRequest) Execute() (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
-	return r.ApiService.ListServerlessBackupsExecute(r)
+	return r.ApiService.listServerlessBackupsExecute(r)
 }
 
 /*
@@ -3794,7 +4268,7 @@ func (a *CloudBackupsApiService) ListServerlessBackups(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedApiAtlasServerlessBackupSnapshot
-func (a *CloudBackupsApiService) ListServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) listServerlessBackupsExecute(r ListServerlessBackupsApiRequest) (*PaginatedApiAtlasServerlessBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -3922,8 +4396,17 @@ type ListShardedClusterBackupsApiParams struct {
 		ClusterName string
 }
 
+func (a *CloudBackupsApiService) ListShardedClusterBackupsWithParams(ctx context.Context, args *ListShardedClusterBackupsApiParams) ListShardedClusterBackupsApiRequest {
+	return ListShardedClusterBackupsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
+}
+
 func (r ListShardedClusterBackupsApiRequest) Execute() (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
-	return r.ApiService.ListShardedClusterBackupsExecute(r)
+	return r.ApiService.listShardedClusterBackupsExecute(r)
 }
 
 /*
@@ -3947,7 +4430,7 @@ func (a *CloudBackupsApiService) ListShardedClusterBackups(ctx context.Context, 
 
 // Execute executes the request
 //  @return PaginatedCloudBackupShardedClusterSnapshot
-func (a *CloudBackupsApiService) ListShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) listShardedClusterBackupsExecute(r ListShardedClusterBackupsApiRequest) (*PaginatedCloudBackupShardedClusterSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -4056,6 +4539,16 @@ type TakeSnapshotApiParams struct {
 		DiskBackupOnDemandSnapshotRequest *DiskBackupOnDemandSnapshotRequest
 }
 
+func (a *CloudBackupsApiService) TakeSnapshotWithParams(ctx context.Context, args *TakeSnapshotApiParams) TakeSnapshotApiRequest {
+	return TakeSnapshotApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		diskBackupOnDemandSnapshotRequest: args.DiskBackupOnDemandSnapshotRequest,
+	}
+}
+
 // Takes one on-demand snapshot.
 func (r TakeSnapshotApiRequest) DiskBackupOnDemandSnapshotRequest(diskBackupOnDemandSnapshotRequest DiskBackupOnDemandSnapshotRequest) TakeSnapshotApiRequest {
 	r.diskBackupOnDemandSnapshotRequest = &diskBackupOnDemandSnapshotRequest
@@ -4063,7 +4556,7 @@ func (r TakeSnapshotApiRequest) DiskBackupOnDemandSnapshotRequest(diskBackupOnDe
 }
 
 func (r TakeSnapshotApiRequest) Execute() (*DiskBackupSnapshot, *http.Response, error) {
-	return r.ApiService.TakeSnapshotExecute(r)
+	return r.ApiService.takeSnapshotExecute(r)
 }
 
 /*
@@ -4089,7 +4582,7 @@ func (a *CloudBackupsApiService) TakeSnapshot(ctx context.Context, groupId strin
 
 // Execute executes the request
 //  @return DiskBackupSnapshot
-func (a *CloudBackupsApiService) TakeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error) {
+func (a *CloudBackupsApiService) takeSnapshotExecute(r TakeSnapshotApiRequest) (*DiskBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -4203,6 +4696,16 @@ type UpdateBackupScheduleApiParams struct {
 		DiskBackupSnapshotSchedule *DiskBackupSnapshotSchedule
 }
 
+func (a *CloudBackupsApiService) UpdateBackupScheduleWithParams(ctx context.Context, args *UpdateBackupScheduleApiParams) UpdateBackupScheduleApiRequest {
+	return UpdateBackupScheduleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		diskBackupSnapshotSchedule: args.DiskBackupSnapshotSchedule,
+	}
+}
+
 // Updates the cloud backup schedule for one cluster within the specified project.  **Note**: In the request body, provide only the fields that you want to update.
 func (r UpdateBackupScheduleApiRequest) DiskBackupSnapshotSchedule(diskBackupSnapshotSchedule DiskBackupSnapshotSchedule) UpdateBackupScheduleApiRequest {
 	r.diskBackupSnapshotSchedule = &diskBackupSnapshotSchedule
@@ -4210,7 +4713,7 @@ func (r UpdateBackupScheduleApiRequest) DiskBackupSnapshotSchedule(diskBackupSna
 }
 
 func (r UpdateBackupScheduleApiRequest) Execute() (*DiskBackupSnapshotSchedule, *http.Response, error) {
-	return r.ApiService.UpdateBackupScheduleExecute(r)
+	return r.ApiService.updateBackupScheduleExecute(r)
 }
 
 /*
@@ -4234,7 +4737,7 @@ func (a *CloudBackupsApiService) UpdateBackupSchedule(ctx context.Context, group
 
 // Execute executes the request
 //  @return DiskBackupSnapshotSchedule
-func (a *CloudBackupsApiService) UpdateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
+func (a *CloudBackupsApiService) updateBackupScheduleExecute(r UpdateBackupScheduleApiRequest) (*DiskBackupSnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -4346,6 +4849,15 @@ type UpdateDataProtectionSettingsApiParams struct {
 		DataProtectionSettings *DataProtectionSettings
 }
 
+func (a *CloudBackupsApiService) UpdateDataProtectionSettingsWithParams(ctx context.Context, args *UpdateDataProtectionSettingsApiParams) UpdateDataProtectionSettingsApiRequest {
+	return UpdateDataProtectionSettingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		dataProtectionSettings: args.DataProtectionSettings,
+	}
+}
+
 // The new Backup Compliance Policy settings.
 func (r UpdateDataProtectionSettingsApiRequest) DataProtectionSettings(dataProtectionSettings DataProtectionSettings) UpdateDataProtectionSettingsApiRequest {
 	r.dataProtectionSettings = &dataProtectionSettings
@@ -4353,7 +4865,7 @@ func (r UpdateDataProtectionSettingsApiRequest) DataProtectionSettings(dataProte
 }
 
 func (r UpdateDataProtectionSettingsApiRequest) Execute() (*DataProtectionSettings, *http.Response, error) {
-	return r.ApiService.UpdateDataProtectionSettingsExecute(r)
+	return r.ApiService.updateDataProtectionSettingsExecute(r)
 }
 
 /*
@@ -4375,7 +4887,7 @@ func (a *CloudBackupsApiService) UpdateDataProtectionSettings(ctx context.Contex
 
 // Execute executes the request
 //  @return DataProtectionSettings
-func (a *CloudBackupsApiService) UpdateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error) {
+func (a *CloudBackupsApiService) updateDataProtectionSettingsExecute(r UpdateDataProtectionSettingsApiRequest) (*DataProtectionSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}
@@ -4484,6 +4996,17 @@ type UpdateSnapshotRetentionApiParams struct {
 		SnapshotRetention *SnapshotRetention
 }
 
+func (a *CloudBackupsApiService) UpdateSnapshotRetentionWithParams(ctx context.Context, args *UpdateSnapshotRetentionApiParams) UpdateSnapshotRetentionApiRequest {
+	return UpdateSnapshotRetentionApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+		snapshotRetention: args.SnapshotRetention,
+	}
+}
+
 // Changes the expiration date for one cloud backup snapshot for one cluster in the specified project.
 func (r UpdateSnapshotRetentionApiRequest) SnapshotRetention(snapshotRetention SnapshotRetention) UpdateSnapshotRetentionApiRequest {
 	r.snapshotRetention = &snapshotRetention
@@ -4491,7 +5014,7 @@ func (r UpdateSnapshotRetentionApiRequest) SnapshotRetention(snapshotRetention S
 }
 
 func (r UpdateSnapshotRetentionApiRequest) Execute() (*DiskBackupReplicaSet, *http.Response, error) {
-	return r.ApiService.UpdateSnapshotRetentionExecute(r)
+	return r.ApiService.updateSnapshotRetentionExecute(r)
 }
 
 /*
@@ -4517,7 +5040,7 @@ func (a *CloudBackupsApiService) UpdateSnapshotRetention(ctx context.Context, gr
 
 // Execute executes the request
 //  @return DiskBackupReplicaSet
-func (a *CloudBackupsApiService) UpdateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
+func (a *CloudBackupsApiService) updateSnapshotRetentionExecute(r UpdateSnapshotRetentionApiRequest) (*DiskBackupReplicaSet, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cloud_backups.go
+++ b/mongodbatlasv2/api_cloud_backups.go
@@ -36,7 +36,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CancelBackupRestoreJobApiParams - Parameters for the request
-	@return CancelBackupRestoreJobApiRequest}}
+	@return CancelBackupRestoreJobApiRequest
 	*/
 	CancelBackupRestoreJobWithParams(ctx context.Context, args *CancelBackupRestoreJobApiParams) CancelBackupRestoreJobApiRequest
 
@@ -60,7 +60,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateBackupExportJobApiParams - Parameters for the request
-	@return CreateBackupExportJobApiRequest}}
+	@return CreateBackupExportJobApiRequest
 	*/
 	CreateBackupExportJobWithParams(ctx context.Context, args *CreateBackupExportJobApiParams) CreateBackupExportJobApiRequest
 
@@ -86,7 +86,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateBackupRestoreJobApiParams - Parameters for the request
-	@return CreateBackupRestoreJobApiRequest}}
+	@return CreateBackupRestoreJobApiRequest
 	*/
 	CreateBackupRestoreJobWithParams(ctx context.Context, args *CreateBackupRestoreJobApiParams) CreateBackupRestoreJobApiRequest
 
@@ -109,7 +109,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateExportBucketApiParams - Parameters for the request
-	@return CreateExportBucketApiRequest}}
+	@return CreateExportBucketApiRequest
 	*/
 	CreateExportBucketWithParams(ctx context.Context, args *CreateExportBucketApiParams) CreateExportBucketApiRequest
 
@@ -133,7 +133,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateServerlessBackupRestoreJobApiParams - Parameters for the request
-	@return CreateServerlessBackupRestoreJobApiRequest}}
+	@return CreateServerlessBackupRestoreJobApiRequest
 	*/
 	CreateServerlessBackupRestoreJobWithParams(ctx context.Context, args *CreateServerlessBackupRestoreJobApiParams) CreateServerlessBackupRestoreJobApiRequest
 
@@ -157,7 +157,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteAllBackupSchedulesApiParams - Parameters for the request
-	@return DeleteAllBackupSchedulesApiRequest}}
+	@return DeleteAllBackupSchedulesApiRequest
 	*/
 	DeleteAllBackupSchedulesWithParams(ctx context.Context, args *DeleteAllBackupSchedulesApiParams) DeleteAllBackupSchedulesApiRequest
 
@@ -181,7 +181,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteExportBucketApiParams - Parameters for the request
-	@return DeleteExportBucketApiRequest}}
+	@return DeleteExportBucketApiRequest
 	*/
 	DeleteExportBucketWithParams(ctx context.Context, args *DeleteExportBucketApiParams) DeleteExportBucketApiRequest
 
@@ -206,7 +206,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteReplicaSetBackupApiParams - Parameters for the request
-	@return DeleteReplicaSetBackupApiRequest}}
+	@return DeleteReplicaSetBackupApiRequest
 	*/
 	DeleteReplicaSetBackupWithParams(ctx context.Context, args *DeleteReplicaSetBackupApiParams) DeleteReplicaSetBackupApiRequest
 
@@ -231,7 +231,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteShardedClusterBackupApiParams - Parameters for the request
-	@return DeleteShardedClusterBackupApiRequest}}
+	@return DeleteShardedClusterBackupApiRequest
 	*/
 	DeleteShardedClusterBackupWithParams(ctx context.Context, args *DeleteShardedClusterBackupApiParams) DeleteShardedClusterBackupApiRequest
 
@@ -256,7 +256,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetBackupExportJobApiParams - Parameters for the request
-	@return GetBackupExportJobApiRequest}}
+	@return GetBackupExportJobApiRequest
 	*/
 	GetBackupExportJobWithParams(ctx context.Context, args *GetBackupExportJobApiParams) GetBackupExportJobApiRequest
 
@@ -281,7 +281,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetBackupRestoreJobApiParams - Parameters for the request
-	@return GetBackupRestoreJobApiRequest}}
+	@return GetBackupRestoreJobApiRequest
 	*/
 	GetBackupRestoreJobWithParams(ctx context.Context, args *GetBackupRestoreJobApiParams) GetBackupRestoreJobApiRequest
 
@@ -305,7 +305,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetBackupScheduleApiParams - Parameters for the request
-	@return GetBackupScheduleApiRequest}}
+	@return GetBackupScheduleApiRequest
 	*/
 	GetBackupScheduleWithParams(ctx context.Context, args *GetBackupScheduleApiParams) GetBackupScheduleApiRequest
 
@@ -328,7 +328,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetDataProtectionSettingsApiParams - Parameters for the request
-	@return GetDataProtectionSettingsApiRequest}}
+	@return GetDataProtectionSettingsApiRequest
 	*/
 	GetDataProtectionSettingsWithParams(ctx context.Context, args *GetDataProtectionSettingsApiParams) GetDataProtectionSettingsApiRequest
 
@@ -352,7 +352,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetExportBucketApiParams - Parameters for the request
-	@return GetExportBucketApiRequest}}
+	@return GetExportBucketApiRequest
 	*/
 	GetExportBucketWithParams(ctx context.Context, args *GetExportBucketApiParams) GetExportBucketApiRequest
 
@@ -377,7 +377,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetReplicaSetBackupApiParams - Parameters for the request
-	@return GetReplicaSetBackupApiRequest}}
+	@return GetReplicaSetBackupApiRequest
 	*/
 	GetReplicaSetBackupWithParams(ctx context.Context, args *GetReplicaSetBackupApiParams) GetReplicaSetBackupApiRequest
 
@@ -402,7 +402,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetServerlessBackupApiParams - Parameters for the request
-	@return GetServerlessBackupApiRequest}}
+	@return GetServerlessBackupApiRequest
 	*/
 	GetServerlessBackupWithParams(ctx context.Context, args *GetServerlessBackupApiParams) GetServerlessBackupApiRequest
 
@@ -427,7 +427,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetServerlessBackupRestoreJobApiParams - Parameters for the request
-	@return GetServerlessBackupRestoreJobApiRequest}}
+	@return GetServerlessBackupRestoreJobApiRequest
 	*/
 	GetServerlessBackupRestoreJobWithParams(ctx context.Context, args *GetServerlessBackupRestoreJobApiParams) GetServerlessBackupRestoreJobApiRequest
 
@@ -452,7 +452,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetShardedClusterBackupApiParams - Parameters for the request
-	@return GetShardedClusterBackupApiRequest}}
+	@return GetShardedClusterBackupApiRequest
 	*/
 	GetShardedClusterBackupWithParams(ctx context.Context, args *GetShardedClusterBackupApiParams) GetShardedClusterBackupApiRequest
 
@@ -476,7 +476,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListBackupExportJobsApiParams - Parameters for the request
-	@return ListBackupExportJobsApiRequest}}
+	@return ListBackupExportJobsApiRequest
 	*/
 	ListBackupExportJobsWithParams(ctx context.Context, args *ListBackupExportJobsApiParams) ListBackupExportJobsApiRequest
 
@@ -500,7 +500,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListBackupRestoreJobsApiParams - Parameters for the request
-	@return ListBackupRestoreJobsApiRequest}}
+	@return ListBackupRestoreJobsApiRequest
 	*/
 	ListBackupRestoreJobsWithParams(ctx context.Context, args *ListBackupRestoreJobsApiParams) ListBackupRestoreJobsApiRequest
 
@@ -523,7 +523,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListExportBucketsApiParams - Parameters for the request
-	@return ListExportBucketsApiRequest}}
+	@return ListExportBucketsApiRequest
 	*/
 	ListExportBucketsWithParams(ctx context.Context, args *ListExportBucketsApiParams) ListExportBucketsApiRequest
 
@@ -547,7 +547,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListReplicaSetBackupsApiParams - Parameters for the request
-	@return ListReplicaSetBackupsApiRequest}}
+	@return ListReplicaSetBackupsApiRequest
 	*/
 	ListReplicaSetBackupsWithParams(ctx context.Context, args *ListReplicaSetBackupsApiParams) ListReplicaSetBackupsApiRequest
 
@@ -571,7 +571,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListServerlessBackupRestoreJobsApiParams - Parameters for the request
-	@return ListServerlessBackupRestoreJobsApiRequest}}
+	@return ListServerlessBackupRestoreJobsApiRequest
 	*/
 	ListServerlessBackupRestoreJobsWithParams(ctx context.Context, args *ListServerlessBackupRestoreJobsApiParams) ListServerlessBackupRestoreJobsApiRequest
 
@@ -595,7 +595,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListServerlessBackupsApiParams - Parameters for the request
-	@return ListServerlessBackupsApiRequest}}
+	@return ListServerlessBackupsApiRequest
 	*/
 	ListServerlessBackupsWithParams(ctx context.Context, args *ListServerlessBackupsApiParams) ListServerlessBackupsApiRequest
 
@@ -619,7 +619,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListShardedClusterBackupsApiParams - Parameters for the request
-	@return ListShardedClusterBackupsApiRequest}}
+	@return ListShardedClusterBackupsApiRequest
 	*/
 	ListShardedClusterBackupsWithParams(ctx context.Context, args *ListShardedClusterBackupsApiParams) ListShardedClusterBackupsApiRequest
 
@@ -645,7 +645,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param TakeSnapshotApiParams - Parameters for the request
-	@return TakeSnapshotApiRequest}}
+	@return TakeSnapshotApiRequest
 	*/
 	TakeSnapshotWithParams(ctx context.Context, args *TakeSnapshotApiParams) TakeSnapshotApiRequest
 
@@ -669,7 +669,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateBackupScheduleApiParams - Parameters for the request
-	@return UpdateBackupScheduleApiRequest}}
+	@return UpdateBackupScheduleApiRequest
 	*/
 	UpdateBackupScheduleWithParams(ctx context.Context, args *UpdateBackupScheduleApiParams) UpdateBackupScheduleApiRequest
 
@@ -692,7 +692,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateDataProtectionSettingsApiParams - Parameters for the request
-	@return UpdateDataProtectionSettingsApiRequest}}
+	@return UpdateDataProtectionSettingsApiRequest
 	*/
 	UpdateDataProtectionSettingsWithParams(ctx context.Context, args *UpdateDataProtectionSettingsApiParams) UpdateDataProtectionSettingsApiRequest
 
@@ -717,7 +717,7 @@ type CloudBackupsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateSnapshotRetentionApiParams - Parameters for the request
-	@return UpdateSnapshotRetentionApiRequest}}
+	@return UpdateSnapshotRetentionApiRequest
 	*/
 	UpdateSnapshotRetentionWithParams(ctx context.Context, args *UpdateSnapshotRetentionApiParams) UpdateSnapshotRetentionApiRequest
 

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -34,7 +34,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateLinkTokenApiParams - Parameters for the request
-	@return CreateLinkTokenApiRequest}}
+	@return CreateLinkTokenApiRequest
 	*/
 	CreateLinkTokenWithParams(ctx context.Context, args *CreateLinkTokenApiParams) CreateLinkTokenApiRequest
 
@@ -61,7 +61,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreatePushMigrationApiParams - Parameters for the request
-	@return CreatePushMigrationApiRequest}}
+	@return CreatePushMigrationApiRequest
 	*/
 	CreatePushMigrationWithParams(ctx context.Context, args *CreatePushMigrationApiParams) CreatePushMigrationApiRequest
 
@@ -85,7 +85,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CutoverMigrationApiParams - Parameters for the request
-	@return CutoverMigrationApiRequest}}
+	@return CutoverMigrationApiRequest
 	*/
 	CutoverMigrationWithParams(ctx context.Context, args *CutoverMigrationApiParams) CutoverMigrationApiRequest
 
@@ -108,7 +108,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteLinkTokenApiParams - Parameters for the request
-	@return DeleteLinkTokenApiRequest}}
+	@return DeleteLinkTokenApiRequest
 	*/
 	DeleteLinkTokenWithParams(ctx context.Context, args *DeleteLinkTokenApiParams) DeleteLinkTokenApiRequest
 
@@ -132,7 +132,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetPushMigrationApiParams - Parameters for the request
-	@return GetPushMigrationApiRequest}}
+	@return GetPushMigrationApiRequest
 	*/
 	GetPushMigrationWithParams(ctx context.Context, args *GetPushMigrationApiParams) GetPushMigrationApiRequest
 
@@ -156,7 +156,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetValidationStatusApiParams - Parameters for the request
-	@return GetValidationStatusApiRequest}}
+	@return GetValidationStatusApiRequest
 	*/
 	GetValidationStatusWithParams(ctx context.Context, args *GetValidationStatusApiParams) GetValidationStatusApiRequest
 
@@ -179,7 +179,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListSourceProjectsApiParams - Parameters for the request
-	@return ListSourceProjectsApiRequest}}
+	@return ListSourceProjectsApiRequest
 	*/
 	ListSourceProjectsWithParams(ctx context.Context, args *ListSourceProjectsApiParams) ListSourceProjectsApiRequest
 
@@ -202,7 +202,7 @@ type CloudMigrationServiceApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ValidateMigrationApiParams - Parameters for the request
-	@return ValidateMigrationApiRequest}}
+	@return ValidateMigrationApiRequest
 	*/
 	ValidateMigrationWithParams(ctx context.Context, args *ValidateMigrationApiParams) ValidateMigrationApiRequest
 

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -28,10 +28,18 @@ type CloudMigrationServiceApi interface {
 	@return CreateLinkTokenApiRequest
 	*/
 	CreateLinkToken(ctx context.Context, orgId string) CreateLinkTokenApiRequest
+	/*
+	CreateLinkToken Create One Link-Token
 
-	// CreateLinkTokenExecute executes the request
-	//  @return TargetOrg
-	CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateLinkTokenApiParams - Parameters for the request
+	@return CreateLinkTokenApiRequest}}
+	*/
+	CreateLinkTokenWithParams(ctx context.Context, args *CreateLinkTokenApiParams) CreateLinkTokenApiRequest
+
+	// Interface only available internally
+	createLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error)
 
 	/*
 	CreatePushMigration Migrate One Local Managed Cluster to MongoDB Atlas
@@ -47,10 +55,18 @@ type CloudMigrationServiceApi interface {
 	@return CreatePushMigrationApiRequest
 	*/
 	CreatePushMigration(ctx context.Context, groupId string) CreatePushMigrationApiRequest
+	/*
+	CreatePushMigration Migrate One Local Managed Cluster to MongoDB Atlas
 
-	// CreatePushMigrationExecute executes the request
-	//  @return LiveMigrationResponse
-	CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreatePushMigrationApiParams - Parameters for the request
+	@return CreatePushMigrationApiRequest}}
+	*/
+	CreatePushMigrationWithParams(ctx context.Context, args *CreatePushMigrationApiParams) CreatePushMigrationApiRequest
+
+	// Interface only available internally
+	createPushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
 	CutoverMigration Cut Over the Migrated Cluster
@@ -63,9 +79,18 @@ type CloudMigrationServiceApi interface {
 	@return CutoverMigrationApiRequest
 	*/
 	CutoverMigration(ctx context.Context, groupId string, liveMigrationId string) CutoverMigrationApiRequest
+	/*
+	CutoverMigration Cut Over the Migrated Cluster
 
-	// CutoverMigrationExecute executes the request
-	CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CutoverMigrationApiParams - Parameters for the request
+	@return CutoverMigrationApiRequest}}
+	*/
+	CutoverMigrationWithParams(ctx context.Context, args *CutoverMigrationApiParams) CutoverMigrationApiRequest
+
+	// Interface only available internally
+	cutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error)
 
 	/*
 	DeleteLinkToken Remove One Link-Token
@@ -77,9 +102,18 @@ type CloudMigrationServiceApi interface {
 	@return DeleteLinkTokenApiRequest
 	*/
 	DeleteLinkToken(ctx context.Context, orgId string) DeleteLinkTokenApiRequest
+	/*
+	DeleteLinkToken Remove One Link-Token
 
-	// DeleteLinkTokenExecute executes the request
-	DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteLinkTokenApiParams - Parameters for the request
+	@return DeleteLinkTokenApiRequest}}
+	*/
+	DeleteLinkTokenWithParams(ctx context.Context, args *DeleteLinkTokenApiParams) DeleteLinkTokenApiRequest
+
+	// Interface only available internally
+	deleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (*http.Response, error)
 
 	/*
 	GetPushMigration Return One Migration Job
@@ -92,10 +126,18 @@ type CloudMigrationServiceApi interface {
 	@return GetPushMigrationApiRequest
 	*/
 	GetPushMigration(ctx context.Context, groupId string, liveMigrationId string) GetPushMigrationApiRequest
+	/*
+	GetPushMigration Return One Migration Job
 
-	// GetPushMigrationExecute executes the request
-	//  @return LiveMigrationResponse
-	GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetPushMigrationApiParams - Parameters for the request
+	@return GetPushMigrationApiRequest}}
+	*/
+	GetPushMigrationWithParams(ctx context.Context, args *GetPushMigrationApiParams) GetPushMigrationApiRequest
+
+	// Interface only available internally
+	getPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error)
 
 	/*
 	GetValidationStatus Return One Migration Validation Job
@@ -108,10 +150,18 @@ type CloudMigrationServiceApi interface {
 	@return GetValidationStatusApiRequest
 	*/
 	GetValidationStatus(ctx context.Context, groupId string, validationId string) GetValidationStatusApiRequest
+	/*
+	GetValidationStatus Return One Migration Validation Job
 
-	// GetValidationStatusExecute executes the request
-	//  @return Validation
-	GetValidationStatusExecute(r GetValidationStatusApiRequest) (*Validation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetValidationStatusApiParams - Parameters for the request
+	@return GetValidationStatusApiRequest}}
+	*/
+	GetValidationStatusWithParams(ctx context.Context, args *GetValidationStatusApiParams) GetValidationStatusApiRequest
+
+	// Interface only available internally
+	getValidationStatusExecute(r GetValidationStatusApiRequest) (*Validation, *http.Response, error)
 
 	/*
 	ListSourceProjects Return All Projects Available for Migration
@@ -123,10 +173,18 @@ type CloudMigrationServiceApi interface {
 	@return ListSourceProjectsApiRequest
 	*/
 	ListSourceProjects(ctx context.Context, orgId string) ListSourceProjectsApiRequest
+	/*
+	ListSourceProjects Return All Projects Available for Migration
 
-	// ListSourceProjectsExecute executes the request
-	//  @return []AvailableProject
-	ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]AvailableProject, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListSourceProjectsApiParams - Parameters for the request
+	@return ListSourceProjectsApiRequest}}
+	*/
+	ListSourceProjectsWithParams(ctx context.Context, args *ListSourceProjectsApiParams) ListSourceProjectsApiRequest
+
+	// Interface only available internally
+	listSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]AvailableProject, *http.Response, error)
 
 	/*
 	ValidateMigration Validate One Migration Request
@@ -138,10 +196,18 @@ type CloudMigrationServiceApi interface {
 	@return ValidateMigrationApiRequest
 	*/
 	ValidateMigration(ctx context.Context, groupId string) ValidateMigrationApiRequest
+	/*
+	ValidateMigration Validate One Migration Request
 
-	// ValidateMigrationExecute executes the request
-	//  @return Validation
-	ValidateMigrationExecute(r ValidateMigrationApiRequest) (*Validation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ValidateMigrationApiParams - Parameters for the request
+	@return ValidateMigrationApiRequest}}
+	*/
+	ValidateMigrationWithParams(ctx context.Context, args *ValidateMigrationApiParams) ValidateMigrationApiRequest
+
+	// Interface only available internally
+	validateMigrationExecute(r ValidateMigrationApiRequest) (*Validation, *http.Response, error)
 }
 
 // CloudMigrationServiceApiService CloudMigrationServiceApi service
@@ -159,6 +225,15 @@ type CreateLinkTokenApiParams struct {
 		TargetOrgRequest *TargetOrgRequest
 }
 
+func (a *CloudMigrationServiceApiService) CreateLinkTokenWithParams(ctx context.Context, args *CreateLinkTokenApiParams) CreateLinkTokenApiRequest {
+	return CreateLinkTokenApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		targetOrgRequest: args.TargetOrgRequest,
+	}
+}
+
 // IP address access list entries associated with the migration.
 func (r CreateLinkTokenApiRequest) TargetOrgRequest(targetOrgRequest TargetOrgRequest) CreateLinkTokenApiRequest {
 	r.targetOrgRequest = &targetOrgRequest
@@ -166,13 +241,7 @@ func (r CreateLinkTokenApiRequest) TargetOrgRequest(targetOrgRequest TargetOrgRe
 }
 
 func (r CreateLinkTokenApiRequest) Execute() (*TargetOrg, *http.Response, error) {
-	return r.ApiService.CreateLinkTokenExecute(r)
-}
-
-func (r CreateLinkTokenApiRequest) ExecuteWithParams(params *CreateLinkTokenApiParams) (*TargetOrg, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.targetOrgRequest = params.TargetOrgRequest 
-	return r.Execute()
+	return r.ApiService.createLinkTokenExecute(r)
 }
 
 /*
@@ -194,7 +263,7 @@ func (a *CloudMigrationServiceApiService) CreateLinkToken(ctx context.Context, o
 
 // Execute executes the request
 //  @return TargetOrg
-func (a *CloudMigrationServiceApiService) CreateLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) createLinkTokenExecute(r CreateLinkTokenApiRequest) (*TargetOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -299,6 +368,15 @@ type CreatePushMigrationApiParams struct {
 		LiveMigrationRequest *LiveMigrationRequest
 }
 
+func (a *CloudMigrationServiceApiService) CreatePushMigrationWithParams(ctx context.Context, args *CreatePushMigrationApiParams) CreatePushMigrationApiRequest {
+	return CreatePushMigrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		liveMigrationRequest: args.LiveMigrationRequest,
+	}
+}
+
 // One migration to be created.
 func (r CreatePushMigrationApiRequest) LiveMigrationRequest(liveMigrationRequest LiveMigrationRequest) CreatePushMigrationApiRequest {
 	r.liveMigrationRequest = &liveMigrationRequest
@@ -306,13 +384,7 @@ func (r CreatePushMigrationApiRequest) LiveMigrationRequest(liveMigrationRequest
 }
 
 func (r CreatePushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
-	return r.ApiService.CreatePushMigrationExecute(r)
-}
-
-func (r CreatePushMigrationApiRequest) ExecuteWithParams(params *CreatePushMigrationApiParams) (*LiveMigrationResponse, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.liveMigrationRequest = params.LiveMigrationRequest 
-	return r.Execute()
+	return r.ApiService.createPushMigrationExecute(r)
 }
 
 /*
@@ -338,7 +410,7 @@ func (a *CloudMigrationServiceApiService) CreatePushMigration(ctx context.Contex
 
 // Execute executes the request
 //  @return LiveMigrationResponse
-func (a *CloudMigrationServiceApiService) CreatePushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) createPushMigrationExecute(r CreatePushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -443,14 +515,17 @@ type CutoverMigrationApiParams struct {
 		LiveMigrationId string
 }
 
-func (r CutoverMigrationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.CutoverMigrationExecute(r)
+func (a *CloudMigrationServiceApiService) CutoverMigrationWithParams(ctx context.Context, args *CutoverMigrationApiParams) CutoverMigrationApiRequest {
+	return CutoverMigrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		liveMigrationId: args.LiveMigrationId,
+	}
 }
 
-func (r CutoverMigrationApiRequest) ExecuteWithParams(params *CutoverMigrationApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.liveMigrationId = params.LiveMigrationId 
-	return r.Execute()
+func (r CutoverMigrationApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.cutoverMigrationExecute(r)
 }
 
 /*
@@ -473,7 +548,7 @@ func (a *CloudMigrationServiceApiService) CutoverMigration(ctx context.Context, 
 }
 
 // Execute executes the request
-func (a *CloudMigrationServiceApiService) CutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error) {
+func (a *CloudMigrationServiceApiService) cutoverMigrationExecute(r CutoverMigrationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}
@@ -568,13 +643,16 @@ type DeleteLinkTokenApiParams struct {
 		OrgId string
 }
 
-func (r DeleteLinkTokenApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteLinkTokenExecute(r)
+func (a *CloudMigrationServiceApiService) DeleteLinkTokenWithParams(ctx context.Context, args *DeleteLinkTokenApiParams) DeleteLinkTokenApiRequest {
+	return DeleteLinkTokenApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+	}
 }
 
-func (r DeleteLinkTokenApiRequest) ExecuteWithParams(params *DeleteLinkTokenApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r DeleteLinkTokenApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteLinkTokenExecute(r)
 }
 
 /*
@@ -595,7 +673,7 @@ func (a *CloudMigrationServiceApiService) DeleteLinkToken(ctx context.Context, o
 }
 
 // Execute executes the request
-func (a *CloudMigrationServiceApiService) DeleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (*http.Response, error) {
+func (a *CloudMigrationServiceApiService) deleteLinkTokenExecute(r DeleteLinkTokenApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -685,14 +763,17 @@ type GetPushMigrationApiParams struct {
 		LiveMigrationId string
 }
 
-func (r GetPushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
-	return r.ApiService.GetPushMigrationExecute(r)
+func (a *CloudMigrationServiceApiService) GetPushMigrationWithParams(ctx context.Context, args *GetPushMigrationApiParams) GetPushMigrationApiRequest {
+	return GetPushMigrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		liveMigrationId: args.LiveMigrationId,
+	}
 }
 
-func (r GetPushMigrationApiRequest) ExecuteWithParams(params *GetPushMigrationApiParams) (*LiveMigrationResponse, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.liveMigrationId = params.LiveMigrationId 
-	return r.Execute()
+func (r GetPushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
+	return r.ApiService.getPushMigrationExecute(r)
 }
 
 /*
@@ -716,7 +797,7 @@ func (a *CloudMigrationServiceApiService) GetPushMigration(ctx context.Context, 
 
 // Execute executes the request
 //  @return LiveMigrationResponse
-func (a *CloudMigrationServiceApiService) GetPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) getPushMigrationExecute(r GetPushMigrationApiRequest) (*LiveMigrationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -823,14 +904,17 @@ type GetValidationStatusApiParams struct {
 		ValidationId string
 }
 
-func (r GetValidationStatusApiRequest) Execute() (*Validation, *http.Response, error) {
-	return r.ApiService.GetValidationStatusExecute(r)
+func (a *CloudMigrationServiceApiService) GetValidationStatusWithParams(ctx context.Context, args *GetValidationStatusApiParams) GetValidationStatusApiRequest {
+	return GetValidationStatusApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		validationId: args.ValidationId,
+	}
 }
 
-func (r GetValidationStatusApiRequest) ExecuteWithParams(params *GetValidationStatusApiParams) (*Validation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.validationId = params.ValidationId 
-	return r.Execute()
+func (r GetValidationStatusApiRequest) Execute() (*Validation, *http.Response, error) {
+	return r.ApiService.getValidationStatusExecute(r)
 }
 
 /*
@@ -854,7 +938,7 @@ func (a *CloudMigrationServiceApiService) GetValidationStatus(ctx context.Contex
 
 // Execute executes the request
 //  @return Validation
-func (a *CloudMigrationServiceApiService) GetValidationStatusExecute(r GetValidationStatusApiRequest) (*Validation, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) getValidationStatusExecute(r GetValidationStatusApiRequest) (*Validation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -959,13 +1043,16 @@ type ListSourceProjectsApiParams struct {
 		OrgId string
 }
 
-func (r ListSourceProjectsApiRequest) Execute() ([]AvailableProject, *http.Response, error) {
-	return r.ApiService.ListSourceProjectsExecute(r)
+func (a *CloudMigrationServiceApiService) ListSourceProjectsWithParams(ctx context.Context, args *ListSourceProjectsApiParams) ListSourceProjectsApiRequest {
+	return ListSourceProjectsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+	}
 }
 
-func (r ListSourceProjectsApiRequest) ExecuteWithParams(params *ListSourceProjectsApiParams) ([]AvailableProject, *http.Response, error) {
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r ListSourceProjectsApiRequest) Execute() ([]AvailableProject, *http.Response, error) {
+	return r.ApiService.listSourceProjectsExecute(r)
 }
 
 /*
@@ -987,7 +1074,7 @@ func (a *CloudMigrationServiceApiService) ListSourceProjects(ctx context.Context
 
 // Execute executes the request
 //  @return []AvailableProject
-func (a *CloudMigrationServiceApiService) ListSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]AvailableProject, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) listSourceProjectsExecute(r ListSourceProjectsApiRequest) ([]AvailableProject, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1087,6 +1174,15 @@ type ValidateMigrationApiParams struct {
 		LiveMigrationRequest *LiveMigrationRequest
 }
 
+func (a *CloudMigrationServiceApiService) ValidateMigrationWithParams(ctx context.Context, args *ValidateMigrationApiParams) ValidateMigrationApiRequest {
+	return ValidateMigrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		liveMigrationRequest: args.LiveMigrationRequest,
+	}
+}
+
 // One migration to be validated.
 func (r ValidateMigrationApiRequest) LiveMigrationRequest(liveMigrationRequest LiveMigrationRequest) ValidateMigrationApiRequest {
 	r.liveMigrationRequest = &liveMigrationRequest
@@ -1094,13 +1190,7 @@ func (r ValidateMigrationApiRequest) LiveMigrationRequest(liveMigrationRequest L
 }
 
 func (r ValidateMigrationApiRequest) Execute() (*Validation, *http.Response, error) {
-	return r.ApiService.ValidateMigrationExecute(r)
-}
-
-func (r ValidateMigrationApiRequest) ExecuteWithParams(params *ValidateMigrationApiParams) (*Validation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.liveMigrationRequest = params.LiveMigrationRequest 
-	return r.Execute()
+	return r.ApiService.validateMigrationExecute(r)
 }
 
 /*
@@ -1122,7 +1212,7 @@ func (a *CloudMigrationServiceApiService) ValidateMigration(ctx context.Context,
 
 // Execute executes the request
 //  @return Validation
-func (a *CloudMigrationServiceApiService) ValidateMigrationExecute(r ValidateMigrationApiRequest) (*Validation, *http.Response, error) {
+func (a *CloudMigrationServiceApiService) validateMigrationExecute(r ValidateMigrationApiRequest) (*Validation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cloud_migration_service.go
+++ b/mongodbatlasv2/api_cloud_migration_service.go
@@ -169,6 +169,12 @@ func (r CreateLinkTokenApiRequest) Execute() (*TargetOrg, *http.Response, error)
 	return r.ApiService.CreateLinkTokenExecute(r)
 }
 
+func (r CreateLinkTokenApiRequest) ExecuteWithParams(params *CreateLinkTokenApiParams) (*TargetOrg, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.targetOrgRequest = params.TargetOrgRequest 
+	return r.Execute()
+}
+
 /*
 CreateLinkToken Create One Link-Token
 
@@ -303,6 +309,12 @@ func (r CreatePushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.
 	return r.ApiService.CreatePushMigrationExecute(r)
 }
 
+func (r CreatePushMigrationApiRequest) ExecuteWithParams(params *CreatePushMigrationApiParams) (*LiveMigrationResponse, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.liveMigrationRequest = params.LiveMigrationRequest 
+	return r.Execute()
+}
+
 /*
 CreatePushMigration Migrate One Local Managed Cluster to MongoDB Atlas
 
@@ -435,6 +447,12 @@ func (r CutoverMigrationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CutoverMigrationExecute(r)
 }
 
+func (r CutoverMigrationApiRequest) ExecuteWithParams(params *CutoverMigrationApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.liveMigrationId = params.LiveMigrationId 
+	return r.Execute()
+}
+
 /*
 CutoverMigration Cut Over the Migrated Cluster
 
@@ -554,6 +572,11 @@ func (r DeleteLinkTokenApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLinkTokenExecute(r)
 }
 
+func (r DeleteLinkTokenApiRequest) ExecuteWithParams(params *DeleteLinkTokenApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	return r.Execute()
+}
+
 /*
 DeleteLinkToken Remove One Link-Token
 
@@ -664,6 +687,12 @@ type GetPushMigrationApiParams struct {
 
 func (r GetPushMigrationApiRequest) Execute() (*LiveMigrationResponse, *http.Response, error) {
 	return r.ApiService.GetPushMigrationExecute(r)
+}
+
+func (r GetPushMigrationApiRequest) ExecuteWithParams(params *GetPushMigrationApiParams) (*LiveMigrationResponse, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.liveMigrationId = params.LiveMigrationId 
+	return r.Execute()
 }
 
 /*
@@ -798,6 +827,12 @@ func (r GetValidationStatusApiRequest) Execute() (*Validation, *http.Response, e
 	return r.ApiService.GetValidationStatusExecute(r)
 }
 
+func (r GetValidationStatusApiRequest) ExecuteWithParams(params *GetValidationStatusApiParams) (*Validation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.validationId = params.ValidationId 
+	return r.Execute()
+}
+
 /*
 GetValidationStatus Return One Migration Validation Job
 
@@ -928,6 +963,11 @@ func (r ListSourceProjectsApiRequest) Execute() ([]AvailableProject, *http.Respo
 	return r.ApiService.ListSourceProjectsExecute(r)
 }
 
+func (r ListSourceProjectsApiRequest) ExecuteWithParams(params *ListSourceProjectsApiParams) ([]AvailableProject, *http.Response, error) {
+	r.orgId = params.OrgId 
+	return r.Execute()
+}
+
 /*
 ListSourceProjects Return All Projects Available for Migration
 
@@ -1055,6 +1095,12 @@ func (r ValidateMigrationApiRequest) LiveMigrationRequest(liveMigrationRequest L
 
 func (r ValidateMigrationApiRequest) Execute() (*Validation, *http.Response, error) {
 	return r.ApiService.ValidateMigrationExecute(r)
+}
+
+func (r ValidateMigrationApiRequest) ExecuteWithParams(params *ValidateMigrationApiParams) (*Validation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.liveMigrationRequest = params.LiveMigrationRequest 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -35,7 +35,7 @@ type CloudProviderAccessApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param AuthorizeCloudProviderAccessRoleApiParams - Parameters for the request
-	@return AuthorizeCloudProviderAccessRoleApiRequest}}
+	@return AuthorizeCloudProviderAccessRoleApiRequest
 	*/
 	AuthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *AuthorizeCloudProviderAccessRoleApiParams) AuthorizeCloudProviderAccessRoleApiRequest
 
@@ -60,7 +60,7 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateCloudProviderAccessRoleApiParams - Parameters for the request
-	@return CreateCloudProviderAccessRoleApiRequest}}
+	@return CreateCloudProviderAccessRoleApiRequest
 	*/
 	CreateCloudProviderAccessRoleWithParams(ctx context.Context, args *CreateCloudProviderAccessRoleApiParams) CreateCloudProviderAccessRoleApiRequest
 
@@ -85,7 +85,7 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeauthorizeCloudProviderAccessRoleApiParams - Parameters for the request
-	@return DeauthorizeCloudProviderAccessRoleApiRequest}}
+	@return DeauthorizeCloudProviderAccessRoleApiRequest
 	*/
 	DeauthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *DeauthorizeCloudProviderAccessRoleApiParams) DeauthorizeCloudProviderAccessRoleApiRequest
 
@@ -109,7 +109,7 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetCloudProviderAccessRoleApiParams - Parameters for the request
-	@return GetCloudProviderAccessRoleApiRequest}}
+	@return GetCloudProviderAccessRoleApiRequest
 	*/
 	GetCloudProviderAccessRoleWithParams(ctx context.Context, args *GetCloudProviderAccessRoleApiParams) GetCloudProviderAccessRoleApiRequest
 
@@ -132,7 +132,7 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListCloudProviderAccessRolesApiParams - Parameters for the request
-	@return ListCloudProviderAccessRolesApiRequest}}
+	@return ListCloudProviderAccessRolesApiRequest
 	*/
 	ListCloudProviderAccessRolesWithParams(ctx context.Context, args *ListCloudProviderAccessRolesApiParams) ListCloudProviderAccessRolesApiRequest
 

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -29,10 +29,18 @@ type CloudProviderAccessApi interface {
 	@return AuthorizeCloudProviderAccessRoleApiRequest
 	*/
 	AuthorizeCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) AuthorizeCloudProviderAccessRoleApiRequest
+	/*
+	AuthorizeCloudProviderAccessRole Authorize One Cloud Provider Access Role
 
-	// AuthorizeCloudProviderAccessRoleExecute executes the request
-	//  @return CloudProviderAccessRole
-	AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param AuthorizeCloudProviderAccessRoleApiParams - Parameters for the request
+	@return AuthorizeCloudProviderAccessRoleApiRequest}}
+	*/
+	AuthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *AuthorizeCloudProviderAccessRoleApiParams) AuthorizeCloudProviderAccessRoleApiRequest
+
+	// Interface only available internally
+	authorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
 	CreateCloudProviderAccessRole Create One Cloud Provider Access Role
@@ -46,10 +54,18 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 	@return CreateCloudProviderAccessRoleApiRequest
 	*/
 	CreateCloudProviderAccessRole(ctx context.Context, groupId string) CreateCloudProviderAccessRoleApiRequest
+	/*
+	CreateCloudProviderAccessRole Create One Cloud Provider Access Role
 
-	// CreateCloudProviderAccessRoleExecute executes the request
-	//  @return CloudProviderAccessRole
-	CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateCloudProviderAccessRoleApiParams - Parameters for the request
+	@return CreateCloudProviderAccessRoleApiRequest}}
+	*/
+	CreateCloudProviderAccessRoleWithParams(ctx context.Context, args *CreateCloudProviderAccessRoleApiParams) CreateCloudProviderAccessRoleApiRequest
+
+	// Interface only available internally
+	createCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error)
 
 	/*
 	DeauthorizeCloudProviderAccessRole Deauthorize One Cloud Provider Access Role
@@ -63,9 +79,18 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 	@return DeauthorizeCloudProviderAccessRoleApiRequest
 	*/
 	DeauthorizeCloudProviderAccessRole(ctx context.Context, groupId string, cloudProvider string, roleId string) DeauthorizeCloudProviderAccessRoleApiRequest
+	/*
+	DeauthorizeCloudProviderAccessRole Deauthorize One Cloud Provider Access Role
 
-	// DeauthorizeCloudProviderAccessRoleExecute executes the request
-	DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeauthorizeCloudProviderAccessRoleApiParams - Parameters for the request
+	@return DeauthorizeCloudProviderAccessRoleApiRequest}}
+	*/
+	DeauthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *DeauthorizeCloudProviderAccessRoleApiParams) DeauthorizeCloudProviderAccessRoleApiRequest
+
+	// Interface only available internally
+	deauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error)
 
 	/*
 	GetCloudProviderAccessRole Return specified Cloud Provider Access Role
@@ -78,10 +103,18 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 	@return GetCloudProviderAccessRoleApiRequest
 	*/
 	GetCloudProviderAccessRole(ctx context.Context, groupId string, roleId string) GetCloudProviderAccessRoleApiRequest
+	/*
+	GetCloudProviderAccessRole Return specified Cloud Provider Access Role
 
-	// GetCloudProviderAccessRoleExecute executes the request
-	//  @return CloudProviderAccess
-	GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccess, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetCloudProviderAccessRoleApiParams - Parameters for the request
+	@return GetCloudProviderAccessRoleApiRequest}}
+	*/
+	GetCloudProviderAccessRoleWithParams(ctx context.Context, args *GetCloudProviderAccessRoleApiParams) GetCloudProviderAccessRoleApiRequest
+
+	// Interface only available internally
+	getCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccess, *http.Response, error)
 
 	/*
 	ListCloudProviderAccessRoles Return All Cloud Provider Access Roles
@@ -93,10 +126,18 @@ After a successful request to this API endpoint, you can add the **atlasAWSAccou
 	@return ListCloudProviderAccessRolesApiRequest
 	*/
 	ListCloudProviderAccessRoles(ctx context.Context, groupId string) ListCloudProviderAccessRolesApiRequest
+	/*
+	ListCloudProviderAccessRoles Return All Cloud Provider Access Roles
 
-	// ListCloudProviderAccessRolesExecute executes the request
-	//  @return CloudProviderAccess
-	ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccess, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListCloudProviderAccessRolesApiParams - Parameters for the request
+	@return ListCloudProviderAccessRolesApiRequest}}
+	*/
+	ListCloudProviderAccessRolesWithParams(ctx context.Context, args *ListCloudProviderAccessRolesApiParams) ListCloudProviderAccessRolesApiRequest
+
+	// Interface only available internally
+	listCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccess, *http.Response, error)
 }
 
 // CloudProviderAccessApiService CloudProviderAccessApi service
@@ -116,6 +157,16 @@ type AuthorizeCloudProviderAccessRoleApiParams struct {
 		CloudProviderAccessRole *CloudProviderAccessRole
 }
 
+func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *AuthorizeCloudProviderAccessRoleApiParams) AuthorizeCloudProviderAccessRoleApiRequest {
+	return AuthorizeCloudProviderAccessRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		roleId: args.RoleId,
+		cloudProviderAccessRole: args.CloudProviderAccessRole,
+	}
+}
+
 // Grants access to the specified project for the specified AWS IAM role.
 func (r AuthorizeCloudProviderAccessRoleApiRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) AuthorizeCloudProviderAccessRoleApiRequest {
 	r.cloudProviderAccessRole = &cloudProviderAccessRole
@@ -123,14 +174,7 @@ func (r AuthorizeCloudProviderAccessRoleApiRequest) CloudProviderAccessRole(clou
 }
 
 func (r AuthorizeCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
-	return r.ApiService.AuthorizeCloudProviderAccessRoleExecute(r)
-}
-
-func (r AuthorizeCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *AuthorizeCloudProviderAccessRoleApiParams) (*CloudProviderAccessRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.roleId = params.RoleId 
-	r.cloudProviderAccessRole = params.CloudProviderAccessRole 
-	return r.Execute()
+	return r.ApiService.authorizeCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -154,7 +198,7 @@ func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRole(ctx con
 
 // Execute executes the request
 //  @return CloudProviderAccessRole
-func (a *CloudProviderAccessApiService) AuthorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
+func (a *CloudProviderAccessApiService) authorizeCloudProviderAccessRoleExecute(r AuthorizeCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -266,6 +310,15 @@ type CreateCloudProviderAccessRoleApiParams struct {
 		CloudProviderAccessRole *CloudProviderAccessRole
 }
 
+func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleWithParams(ctx context.Context, args *CreateCloudProviderAccessRoleApiParams) CreateCloudProviderAccessRoleApiRequest {
+	return CreateCloudProviderAccessRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProviderAccessRole: args.CloudProviderAccessRole,
+	}
+}
+
 // Creates one AWS IAM role.
 func (r CreateCloudProviderAccessRoleApiRequest) CloudProviderAccessRole(cloudProviderAccessRole CloudProviderAccessRole) CreateCloudProviderAccessRoleApiRequest {
 	r.cloudProviderAccessRole = &cloudProviderAccessRole
@@ -273,13 +326,7 @@ func (r CreateCloudProviderAccessRoleApiRequest) CloudProviderAccessRole(cloudPr
 }
 
 func (r CreateCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccessRole, *http.Response, error) {
-	return r.ApiService.CreateCloudProviderAccessRoleExecute(r)
-}
-
-func (r CreateCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *CreateCloudProviderAccessRoleApiParams) (*CloudProviderAccessRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProviderAccessRole = params.CloudProviderAccessRole 
-	return r.Execute()
+	return r.ApiService.createCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -303,7 +350,7 @@ func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRole(ctx contex
 
 // Execute executes the request
 //  @return CloudProviderAccessRole
-func (a *CloudProviderAccessApiService) CreateCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
+func (a *CloudProviderAccessApiService) createCloudProviderAccessRoleExecute(r CreateCloudProviderAccessRoleApiRequest) (*CloudProviderAccessRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -410,15 +457,18 @@ type DeauthorizeCloudProviderAccessRoleApiParams struct {
 		RoleId string
 }
 
-func (r DeauthorizeCloudProviderAccessRoleApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeauthorizeCloudProviderAccessRoleExecute(r)
+func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleWithParams(ctx context.Context, args *DeauthorizeCloudProviderAccessRoleApiParams) DeauthorizeCloudProviderAccessRoleApiRequest {
+	return DeauthorizeCloudProviderAccessRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProvider: args.CloudProvider,
+		roleId: args.RoleId,
+	}
 }
 
-func (r DeauthorizeCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *DeauthorizeCloudProviderAccessRoleApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProvider = params.CloudProvider 
-	r.roleId = params.RoleId 
-	return r.Execute()
+func (r DeauthorizeCloudProviderAccessRoleApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deauthorizeCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -443,7 +493,7 @@ func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRole(ctx c
 }
 
 // Execute executes the request
-func (a *CloudProviderAccessApiService) DeauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error) {
+func (a *CloudProviderAccessApiService) deauthorizeCloudProviderAccessRoleExecute(r DeauthorizeCloudProviderAccessRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -541,14 +591,17 @@ type GetCloudProviderAccessRoleApiParams struct {
 		RoleId string
 }
 
-func (r GetCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
-	return r.ApiService.GetCloudProviderAccessRoleExecute(r)
+func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleWithParams(ctx context.Context, args *GetCloudProviderAccessRoleApiParams) GetCloudProviderAccessRoleApiRequest {
+	return GetCloudProviderAccessRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		roleId: args.RoleId,
+	}
 }
 
-func (r GetCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *GetCloudProviderAccessRoleApiParams) (*CloudProviderAccess, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.roleId = params.RoleId 
-	return r.Execute()
+func (r GetCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
+	return r.ApiService.getCloudProviderAccessRoleExecute(r)
 }
 
 /*
@@ -572,7 +625,7 @@ func (a *CloudProviderAccessApiService) GetCloudProviderAccessRole(ctx context.C
 
 // Execute executes the request
 //  @return CloudProviderAccess
-func (a *CloudProviderAccessApiService) GetCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccess, *http.Response, error) {
+func (a *CloudProviderAccessApiService) getCloudProviderAccessRoleExecute(r GetCloudProviderAccessRoleApiRequest) (*CloudProviderAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -677,13 +730,16 @@ type ListCloudProviderAccessRolesApiParams struct {
 		GroupId string
 }
 
-func (r ListCloudProviderAccessRolesApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
-	return r.ApiService.ListCloudProviderAccessRolesExecute(r)
+func (a *CloudProviderAccessApiService) ListCloudProviderAccessRolesWithParams(ctx context.Context, args *ListCloudProviderAccessRolesApiParams) ListCloudProviderAccessRolesApiRequest {
+	return ListCloudProviderAccessRolesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ListCloudProviderAccessRolesApiRequest) ExecuteWithParams(params *ListCloudProviderAccessRolesApiParams) (*CloudProviderAccess, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ListCloudProviderAccessRolesApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
+	return r.ApiService.listCloudProviderAccessRolesExecute(r)
 }
 
 /*
@@ -705,7 +761,7 @@ func (a *CloudProviderAccessApiService) ListCloudProviderAccessRoles(ctx context
 
 // Execute executes the request
 //  @return CloudProviderAccess
-func (a *CloudProviderAccessApiService) ListCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccess, *http.Response, error) {
+func (a *CloudProviderAccessApiService) listCloudProviderAccessRolesExecute(r ListCloudProviderAccessRolesApiRequest) (*CloudProviderAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cloud_provider_access.go
+++ b/mongodbatlasv2/api_cloud_provider_access.go
@@ -126,6 +126,13 @@ func (r AuthorizeCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAcc
 	return r.ApiService.AuthorizeCloudProviderAccessRoleExecute(r)
 }
 
+func (r AuthorizeCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *AuthorizeCloudProviderAccessRoleApiParams) (*CloudProviderAccessRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.roleId = params.RoleId 
+	r.cloudProviderAccessRole = params.CloudProviderAccessRole 
+	return r.Execute()
+}
+
 /*
 AuthorizeCloudProviderAccessRole Authorize One Cloud Provider Access Role
 
@@ -269,6 +276,12 @@ func (r CreateCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccess
 	return r.ApiService.CreateCloudProviderAccessRoleExecute(r)
 }
 
+func (r CreateCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *CreateCloudProviderAccessRoleApiParams) (*CloudProviderAccessRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProviderAccessRole = params.CloudProviderAccessRole 
+	return r.Execute()
+}
+
 /*
 CreateCloudProviderAccessRole Create One Cloud Provider Access Role
 
@@ -401,6 +414,13 @@ func (r DeauthorizeCloudProviderAccessRoleApiRequest) Execute() (*http.Response,
 	return r.ApiService.DeauthorizeCloudProviderAccessRoleExecute(r)
 }
 
+func (r DeauthorizeCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *DeauthorizeCloudProviderAccessRoleApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProvider = params.CloudProvider 
+	r.roleId = params.RoleId 
+	return r.Execute()
+}
+
 /*
 DeauthorizeCloudProviderAccessRole Deauthorize One Cloud Provider Access Role
 
@@ -523,6 +543,12 @@ type GetCloudProviderAccessRoleApiParams struct {
 
 func (r GetCloudProviderAccessRoleApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
 	return r.ApiService.GetCloudProviderAccessRoleExecute(r)
+}
+
+func (r GetCloudProviderAccessRoleApiRequest) ExecuteWithParams(params *GetCloudProviderAccessRoleApiParams) (*CloudProviderAccess, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.roleId = params.RoleId 
+	return r.Execute()
 }
 
 /*
@@ -653,6 +679,11 @@ type ListCloudProviderAccessRolesApiParams struct {
 
 func (r ListCloudProviderAccessRolesApiRequest) Execute() (*CloudProviderAccess, *http.Response, error) {
 	return r.ApiService.ListCloudProviderAccessRolesExecute(r)
+}
+
+func (r ListCloudProviderAccessRolesApiRequest) ExecuteWithParams(params *ListCloudProviderAccessRolesApiParams) (*CloudProviderAccess, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -86,6 +86,12 @@ func (r EndOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *htt
 	return r.ApiService.EndOutageSimulationExecute(r)
 }
 
+func (r EndOutageSimulationApiRequest) ExecuteWithParams(params *EndOutageSimulationApiParams) (*ClusterOutageSimulation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
+}
+
 /*
 EndOutageSimulation End an Outage Simulation
 
@@ -216,6 +222,12 @@ type GetOutageSimulationApiParams struct {
 
 func (r GetOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
 	return r.ApiService.GetOutageSimulationExecute(r)
+}
+
+func (r GetOutageSimulationApiRequest) ExecuteWithParams(params *GetOutageSimulationApiParams) (*ClusterOutageSimulation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*
@@ -356,6 +368,13 @@ func (r StartOutageSimulationApiRequest) ClusterOutageSimulation(clusterOutageSi
 
 func (r StartOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
 	return r.ApiService.StartOutageSimulationExecute(r)
+}
+
+func (r StartOutageSimulationApiRequest) ExecuteWithParams(params *StartOutageSimulationApiParams) (*ClusterOutageSimulation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.clusterOutageSimulation = params.ClusterOutageSimulation 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -29,10 +29,18 @@ type ClusterOutageSimulationApi interface {
 	@return EndOutageSimulationApiRequest
 	*/
 	EndOutageSimulation(ctx context.Context, groupId string, clusterName string) EndOutageSimulationApiRequest
+	/*
+	EndOutageSimulation End an Outage Simulation
 
-	// EndOutageSimulationExecute executes the request
-	//  @return ClusterOutageSimulation
-	EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param EndOutageSimulationApiParams - Parameters for the request
+	@return EndOutageSimulationApiRequest}}
+	*/
+	EndOutageSimulationWithParams(ctx context.Context, args *EndOutageSimulationApiParams) EndOutageSimulationApiRequest
+
+	// Interface only available internally
+	endOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
 	GetOutageSimulation Return One Outage Simulation
@@ -45,10 +53,18 @@ type ClusterOutageSimulationApi interface {
 	@return GetOutageSimulationApiRequest
 	*/
 	GetOutageSimulation(ctx context.Context, groupId string, clusterName string) GetOutageSimulationApiRequest
+	/*
+	GetOutageSimulation Return One Outage Simulation
 
-	// GetOutageSimulationExecute executes the request
-	//  @return ClusterOutageSimulation
-	GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetOutageSimulationApiParams - Parameters for the request
+	@return GetOutageSimulationApiRequest}}
+	*/
+	GetOutageSimulationWithParams(ctx context.Context, args *GetOutageSimulationApiParams) GetOutageSimulationApiRequest
+
+	// Interface only available internally
+	getOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 
 	/*
 	StartOutageSimulation Start an Outage Simulation
@@ -61,10 +77,18 @@ type ClusterOutageSimulationApi interface {
 	@return StartOutageSimulationApiRequest
 	*/
 	StartOutageSimulation(ctx context.Context, groupId string, clusterName string) StartOutageSimulationApiRequest
+	/*
+	StartOutageSimulation Start an Outage Simulation
 
-	// StartOutageSimulationExecute executes the request
-	//  @return ClusterOutageSimulation
-	StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param StartOutageSimulationApiParams - Parameters for the request
+	@return StartOutageSimulationApiRequest}}
+	*/
+	StartOutageSimulationWithParams(ctx context.Context, args *StartOutageSimulationApiParams) StartOutageSimulationApiRequest
+
+	// Interface only available internally
+	startOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error)
 }
 
 // ClusterOutageSimulationApiService ClusterOutageSimulationApi service
@@ -82,14 +106,17 @@ type EndOutageSimulationApiParams struct {
 		ClusterName string
 }
 
-func (r EndOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
-	return r.ApiService.EndOutageSimulationExecute(r)
+func (a *ClusterOutageSimulationApiService) EndOutageSimulationWithParams(ctx context.Context, args *EndOutageSimulationApiParams) EndOutageSimulationApiRequest {
+	return EndOutageSimulationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r EndOutageSimulationApiRequest) ExecuteWithParams(params *EndOutageSimulationApiParams) (*ClusterOutageSimulation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r EndOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
+	return r.ApiService.endOutageSimulationExecute(r)
 }
 
 /*
@@ -113,7 +140,7 @@ func (a *ClusterOutageSimulationApiService) EndOutageSimulation(ctx context.Cont
 
 // Execute executes the request
 //  @return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) EndOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) endOutageSimulationExecute(r EndOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -220,14 +247,17 @@ type GetOutageSimulationApiParams struct {
 		ClusterName string
 }
 
-func (r GetOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
-	return r.ApiService.GetOutageSimulationExecute(r)
+func (a *ClusterOutageSimulationApiService) GetOutageSimulationWithParams(ctx context.Context, args *GetOutageSimulationApiParams) GetOutageSimulationApiRequest {
+	return GetOutageSimulationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetOutageSimulationApiRequest) ExecuteWithParams(params *GetOutageSimulationApiParams) (*ClusterOutageSimulation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
+	return r.ApiService.getOutageSimulationExecute(r)
 }
 
 /*
@@ -251,7 +281,7 @@ func (a *ClusterOutageSimulationApiService) GetOutageSimulation(ctx context.Cont
 
 // Execute executes the request
 //  @return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) GetOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) getOutageSimulationExecute(r GetOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -360,6 +390,16 @@ type StartOutageSimulationApiParams struct {
 		ClusterOutageSimulation *ClusterOutageSimulation
 }
 
+func (a *ClusterOutageSimulationApiService) StartOutageSimulationWithParams(ctx context.Context, args *StartOutageSimulationApiParams) StartOutageSimulationApiRequest {
+	return StartOutageSimulationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		clusterOutageSimulation: args.ClusterOutageSimulation,
+	}
+}
+
 // Describes the outage simulation.
 func (r StartOutageSimulationApiRequest) ClusterOutageSimulation(clusterOutageSimulation ClusterOutageSimulation) StartOutageSimulationApiRequest {
 	r.clusterOutageSimulation = &clusterOutageSimulation
@@ -367,14 +407,7 @@ func (r StartOutageSimulationApiRequest) ClusterOutageSimulation(clusterOutageSi
 }
 
 func (r StartOutageSimulationApiRequest) Execute() (*ClusterOutageSimulation, *http.Response, error) {
-	return r.ApiService.StartOutageSimulationExecute(r)
-}
-
-func (r StartOutageSimulationApiRequest) ExecuteWithParams(params *StartOutageSimulationApiParams) (*ClusterOutageSimulation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.clusterOutageSimulation = params.ClusterOutageSimulation 
-	return r.Execute()
+	return r.ApiService.startOutageSimulationExecute(r)
 }
 
 /*
@@ -398,7 +431,7 @@ func (a *ClusterOutageSimulationApiService) StartOutageSimulation(ctx context.Co
 
 // Execute executes the request
 //  @return ClusterOutageSimulation
-func (a *ClusterOutageSimulationApiService) StartOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
+func (a *ClusterOutageSimulationApiService) startOutageSimulationExecute(r StartOutageSimulationApiRequest) (*ClusterOutageSimulation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_cluster_outage_simulation.go
+++ b/mongodbatlasv2/api_cluster_outage_simulation.go
@@ -35,7 +35,7 @@ type ClusterOutageSimulationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param EndOutageSimulationApiParams - Parameters for the request
-	@return EndOutageSimulationApiRequest}}
+	@return EndOutageSimulationApiRequest
 	*/
 	EndOutageSimulationWithParams(ctx context.Context, args *EndOutageSimulationApiParams) EndOutageSimulationApiRequest
 
@@ -59,7 +59,7 @@ type ClusterOutageSimulationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetOutageSimulationApiParams - Parameters for the request
-	@return GetOutageSimulationApiRequest}}
+	@return GetOutageSimulationApiRequest
 	*/
 	GetOutageSimulationWithParams(ctx context.Context, args *GetOutageSimulationApiParams) GetOutageSimulationApiRequest
 
@@ -83,7 +83,7 @@ type ClusterOutageSimulationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param StartOutageSimulationApiParams - Parameters for the request
-	@return StartOutageSimulationApiRequest}}
+	@return StartOutageSimulationApiRequest
 	*/
 	StartOutageSimulationWithParams(ctx context.Context, args *StartOutageSimulationApiParams) StartOutageSimulationApiRequest
 

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -30,10 +30,18 @@ type ClustersApi interface {
 	@return GetClusterAdvancedConfigurationApiRequest
 	*/
 	GetClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) GetClusterAdvancedConfigurationApiRequest
+	/*
+	GetClusterAdvancedConfiguration Return One Advanced Configuration Options for One Cluster
 
-	// GetClusterAdvancedConfigurationExecute executes the request
-	//  @return ClusterDescriptionProcessArgs
-	GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetClusterAdvancedConfigurationApiParams - Parameters for the request
+	@return GetClusterAdvancedConfigurationApiRequest}}
+	*/
+	GetClusterAdvancedConfigurationWithParams(ctx context.Context, args *GetClusterAdvancedConfigurationApiParams) GetClusterAdvancedConfigurationApiRequest
+
+	// Interface only available internally
+	getClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
 	GetClusterStatus Return Status of All Cluster Operations
@@ -46,10 +54,18 @@ type ClustersApi interface {
 	@return GetClusterStatusApiRequest
 	*/
 	GetClusterStatus(ctx context.Context, groupId string, clusterName string) GetClusterStatusApiRequest
+	/*
+	GetClusterStatus Return Status of All Cluster Operations
 
-	// GetClusterStatusExecute executes the request
-	//  @return ClusterStatus
-	GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetClusterStatusApiParams - Parameters for the request
+	@return GetClusterStatusApiRequest}}
+	*/
+	GetClusterStatusWithParams(ctx context.Context, args *GetClusterStatusApiParams) GetClusterStatusApiRequest
+
+	// Interface only available internally
+	getClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error)
 
 	/*
 	GetSampleDatasetLoadStatus Check Status of Cluster Sample Dataset Request
@@ -62,10 +78,18 @@ type ClustersApi interface {
 	@return GetSampleDatasetLoadStatusApiRequest
 	*/
 	GetSampleDatasetLoadStatus(ctx context.Context, groupId string, sampleDatasetId string) GetSampleDatasetLoadStatusApiRequest
+	/*
+	GetSampleDatasetLoadStatus Check Status of Cluster Sample Dataset Request
 
-	// GetSampleDatasetLoadStatusExecute executes the request
-	//  @return SampleDatasetStatus
-	GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetSampleDatasetLoadStatusApiParams - Parameters for the request
+	@return GetSampleDatasetLoadStatusApiRequest}}
+	*/
+	GetSampleDatasetLoadStatusWithParams(ctx context.Context, args *GetSampleDatasetLoadStatusApiParams) GetSampleDatasetLoadStatusApiRequest
+
+	// Interface only available internally
+	getSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error)
 
 	/*
 	ListCloudProviderRegions Return All Cloud Provider Regions
@@ -77,10 +101,18 @@ type ClustersApi interface {
 	@return ListCloudProviderRegionsApiRequest
 	*/
 	ListCloudProviderRegions(ctx context.Context, groupId string) ListCloudProviderRegionsApiRequest
+	/*
+	ListCloudProviderRegions Return All Cloud Provider Regions
 
-	// ListCloudProviderRegionsExecute executes the request
-	//  @return PaginatedApiAtlasProviderRegions
-	ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListCloudProviderRegionsApiParams - Parameters for the request
+	@return ListCloudProviderRegionsApiRequest}}
+	*/
+	ListCloudProviderRegionsWithParams(ctx context.Context, args *ListCloudProviderRegionsApiParams) ListCloudProviderRegionsApiRequest
+
+	// Interface only available internally
+	listCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error)
 
 	/*
 	ListClustersForAllProjects Return All Authorized Clusters in All Projects
@@ -91,10 +123,18 @@ type ClustersApi interface {
 	@return ListClustersForAllProjectsApiRequest
 	*/
 	ListClustersForAllProjects(ctx context.Context) ListClustersForAllProjectsApiRequest
+	/*
+	ListClustersForAllProjects Return All Authorized Clusters in All Projects
 
-	// ListClustersForAllProjectsExecute executes the request
-	//  @return PaginatedOrgGroup
-	ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListClustersForAllProjectsApiParams - Parameters for the request
+	@return ListClustersForAllProjectsApiRequest}}
+	*/
+	ListClustersForAllProjectsWithParams(ctx context.Context, args *ListClustersForAllProjectsApiParams) ListClustersForAllProjectsApiRequest
+
+	// Interface only available internally
+	listClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error)
 
 	/*
 	LoadSampleDataset Load Sample Dataset Request into Cluster
@@ -107,10 +147,18 @@ type ClustersApi interface {
 	@return LoadSampleDatasetApiRequest
 	*/
 	LoadSampleDataset(ctx context.Context, groupId string, name string) LoadSampleDatasetApiRequest
+	/*
+	LoadSampleDataset Load Sample Dataset Request into Cluster
 
-	// LoadSampleDatasetExecute executes the request
-	//  @return []SampleDatasetStatus
-	LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) ([]SampleDatasetStatus, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param LoadSampleDatasetApiParams - Parameters for the request
+	@return LoadSampleDatasetApiRequest}}
+	*/
+	LoadSampleDatasetWithParams(ctx context.Context, args *LoadSampleDatasetApiParams) LoadSampleDatasetApiRequest
+
+	// Interface only available internally
+	loadSampleDatasetExecute(r LoadSampleDatasetApiRequest) ([]SampleDatasetStatus, *http.Response, error)
 
 	/*
 	UpdateClusterAdvancedConfiguration Update Advanced Configuration Options for One Cluster
@@ -123,10 +171,18 @@ type ClustersApi interface {
 	@return UpdateClusterAdvancedConfigurationApiRequest
 	*/
 	UpdateClusterAdvancedConfiguration(ctx context.Context, groupId string, clusterName string) UpdateClusterAdvancedConfigurationApiRequest
+	/*
+	UpdateClusterAdvancedConfiguration Update Advanced Configuration Options for One Cluster
 
-	// UpdateClusterAdvancedConfigurationExecute executes the request
-	//  @return ClusterDescriptionProcessArgs
-	UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateClusterAdvancedConfigurationApiParams - Parameters for the request
+	@return UpdateClusterAdvancedConfigurationApiRequest}}
+	*/
+	UpdateClusterAdvancedConfigurationWithParams(ctx context.Context, args *UpdateClusterAdvancedConfigurationApiParams) UpdateClusterAdvancedConfigurationApiRequest
+
+	// Interface only available internally
+	updateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error)
 
 	/*
 	UpgradeSharedCluster Upgrade One Shared-tier Cluster
@@ -138,10 +194,18 @@ type ClustersApi interface {
 	@return UpgradeSharedClusterApiRequest
 	*/
 	UpgradeSharedCluster(ctx context.Context, groupId string) UpgradeSharedClusterApiRequest
+	/*
+	UpgradeSharedCluster Upgrade One Shared-tier Cluster
 
-	// UpgradeSharedClusterExecute executes the request
-	//  @return LegacyClusterDescription
-	UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyClusterDescription, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpgradeSharedClusterApiParams - Parameters for the request
+	@return UpgradeSharedClusterApiRequest}}
+	*/
+	UpgradeSharedClusterWithParams(ctx context.Context, args *UpgradeSharedClusterApiParams) UpgradeSharedClusterApiRequest
+
+	// Interface only available internally
+	upgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyClusterDescription, *http.Response, error)
 
 	/*
 	UpgradeSharedClusterToServerless Upgrades One Shared-Tier Cluster to the Serverless Instance
@@ -153,10 +217,18 @@ type ClustersApi interface {
 	@return UpgradeSharedClusterToServerlessApiRequest
 	*/
 	UpgradeSharedClusterToServerless(ctx context.Context, groupId string) UpgradeSharedClusterToServerlessApiRequest
+	/*
+	UpgradeSharedClusterToServerless Upgrades One Shared-Tier Cluster to the Serverless Instance
 
-	// UpgradeSharedClusterToServerlessExecute executes the request
-	//  @return ServerlessInstanceDescription
-	UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpgradeSharedClusterToServerlessApiParams - Parameters for the request
+	@return UpgradeSharedClusterToServerlessApiRequest}}
+	*/
+	UpgradeSharedClusterToServerlessWithParams(ctx context.Context, args *UpgradeSharedClusterToServerlessApiParams) UpgradeSharedClusterToServerlessApiRequest
+
+	// Interface only available internally
+	upgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 
 // ClustersApiService ClustersApi service
@@ -174,14 +246,17 @@ type GetClusterAdvancedConfigurationApiParams struct {
 		ClusterName string
 }
 
-func (r GetClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
-	return r.ApiService.GetClusterAdvancedConfigurationExecute(r)
+func (a *ClustersApiService) GetClusterAdvancedConfigurationWithParams(ctx context.Context, args *GetClusterAdvancedConfigurationApiParams) GetClusterAdvancedConfigurationApiRequest {
+	return GetClusterAdvancedConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetClusterAdvancedConfigurationApiRequest) ExecuteWithParams(params *GetClusterAdvancedConfigurationApiParams) (*ClusterDescriptionProcessArgs, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
+	return r.ApiService.getClusterAdvancedConfigurationExecute(r)
 }
 
 /*
@@ -205,7 +280,7 @@ func (a *ClustersApiService) GetClusterAdvancedConfiguration(ctx context.Context
 
 // Execute executes the request
 //  @return ClusterDescriptionProcessArgs
-func (a *ClustersApiService) GetClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (a *ClustersApiService) getClusterAdvancedConfigurationExecute(r GetClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -312,14 +387,17 @@ type GetClusterStatusApiParams struct {
 		ClusterName string
 }
 
-func (r GetClusterStatusApiRequest) Execute() (*ClusterStatus, *http.Response, error) {
-	return r.ApiService.GetClusterStatusExecute(r)
+func (a *ClustersApiService) GetClusterStatusWithParams(ctx context.Context, args *GetClusterStatusApiParams) GetClusterStatusApiRequest {
+	return GetClusterStatusApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetClusterStatusApiRequest) ExecuteWithParams(params *GetClusterStatusApiParams) (*ClusterStatus, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetClusterStatusApiRequest) Execute() (*ClusterStatus, *http.Response, error) {
+	return r.ApiService.getClusterStatusExecute(r)
 }
 
 /*
@@ -343,7 +421,7 @@ func (a *ClustersApiService) GetClusterStatus(ctx context.Context, groupId strin
 
 // Execute executes the request
 //  @return ClusterStatus
-func (a *ClustersApiService) GetClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error) {
+func (a *ClustersApiService) getClusterStatusExecute(r GetClusterStatusApiRequest) (*ClusterStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -450,14 +528,17 @@ type GetSampleDatasetLoadStatusApiParams struct {
 		SampleDatasetId string
 }
 
-func (r GetSampleDatasetLoadStatusApiRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
-	return r.ApiService.GetSampleDatasetLoadStatusExecute(r)
+func (a *ClustersApiService) GetSampleDatasetLoadStatusWithParams(ctx context.Context, args *GetSampleDatasetLoadStatusApiParams) GetSampleDatasetLoadStatusApiRequest {
+	return GetSampleDatasetLoadStatusApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		sampleDatasetId: args.SampleDatasetId,
+	}
 }
 
-func (r GetSampleDatasetLoadStatusApiRequest) ExecuteWithParams(params *GetSampleDatasetLoadStatusApiParams) (*SampleDatasetStatus, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.sampleDatasetId = params.SampleDatasetId 
-	return r.Execute()
+func (r GetSampleDatasetLoadStatusApiRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
+	return r.ApiService.getSampleDatasetLoadStatusExecute(r)
 }
 
 /*
@@ -481,7 +562,7 @@ func (a *ClustersApiService) GetSampleDatasetLoadStatus(ctx context.Context, gro
 
 // Execute executes the request
 //  @return SampleDatasetStatus
-func (a *ClustersApiService) GetSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error) {
+func (a *ClustersApiService) getSampleDatasetLoadStatusExecute(r GetSampleDatasetLoadStatusApiRequest) (*SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -596,6 +677,19 @@ type ListCloudProviderRegionsApiParams struct {
 		Tier *string
 }
 
+func (a *ClustersApiService) ListCloudProviderRegionsWithParams(ctx context.Context, args *ListCloudProviderRegionsApiParams) ListCloudProviderRegionsApiRequest {
+	return ListCloudProviderRegionsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		providers: args.Providers,
+		tier: args.Tier,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListCloudProviderRegionsApiRequest) IncludeCount(includeCount bool) ListCloudProviderRegionsApiRequest {
 	r.includeCount = &includeCount
@@ -627,17 +721,7 @@ func (r ListCloudProviderRegionsApiRequest) Tier(tier string) ListCloudProviderR
 }
 
 func (r ListCloudProviderRegionsApiRequest) Execute() (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
-	return r.ApiService.ListCloudProviderRegionsExecute(r)
-}
-
-func (r ListCloudProviderRegionsApiRequest) ExecuteWithParams(params *ListCloudProviderRegionsApiParams) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.providers = params.Providers 
-	r.tier = params.Tier 
-	return r.Execute()
+	return r.ApiService.listCloudProviderRegionsExecute(r)
 }
 
 /*
@@ -659,7 +743,7 @@ func (a *ClustersApiService) ListCloudProviderRegions(ctx context.Context, group
 
 // Execute executes the request
 //  @return PaginatedApiAtlasProviderRegions
-func (a *ClustersApiService) ListCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
+func (a *ClustersApiService) listCloudProviderRegionsExecute(r ListCloudProviderRegionsApiRequest) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -796,6 +880,16 @@ type ListClustersForAllProjectsApiParams struct {
 		PageNum *int32
 }
 
+func (a *ClustersApiService) ListClustersForAllProjectsWithParams(ctx context.Context, args *ListClustersForAllProjectsApiParams) ListClustersForAllProjectsApiRequest {
+	return ListClustersForAllProjectsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListClustersForAllProjectsApiRequest) IncludeCount(includeCount bool) ListClustersForAllProjectsApiRequest {
 	r.includeCount = &includeCount
@@ -815,14 +909,7 @@ func (r ListClustersForAllProjectsApiRequest) PageNum(pageNum int32) ListCluster
 }
 
 func (r ListClustersForAllProjectsApiRequest) Execute() (*PaginatedOrgGroup, *http.Response, error) {
-	return r.ApiService.ListClustersForAllProjectsExecute(r)
-}
-
-func (r ListClustersForAllProjectsApiRequest) ExecuteWithParams(params *ListClustersForAllProjectsApiParams) (*PaginatedOrgGroup, *http.Response, error) {
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listClustersForAllProjectsExecute(r)
 }
 
 /*
@@ -842,7 +929,7 @@ func (a *ClustersApiService) ListClustersForAllProjects(ctx context.Context) Lis
 
 // Execute executes the request
 //  @return PaginatedOrgGroup
-func (a *ClustersApiService) ListClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error) {
+func (a *ClustersApiService) listClustersForAllProjectsExecute(r ListClustersForAllProjectsApiRequest) (*PaginatedOrgGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -958,6 +1045,16 @@ type LoadSampleDatasetApiParams struct {
 		SampleDatasetStatus *SampleDatasetStatus
 }
 
+func (a *ClustersApiService) LoadSampleDatasetWithParams(ctx context.Context, args *LoadSampleDatasetApiParams) LoadSampleDatasetApiRequest {
+	return LoadSampleDatasetApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		name: args.Name,
+		sampleDatasetStatus: args.SampleDatasetStatus,
+	}
+}
+
 // Cluster into which to load the sample dataset.
 func (r LoadSampleDatasetApiRequest) SampleDatasetStatus(sampleDatasetStatus SampleDatasetStatus) LoadSampleDatasetApiRequest {
 	r.sampleDatasetStatus = &sampleDatasetStatus
@@ -965,14 +1062,7 @@ func (r LoadSampleDatasetApiRequest) SampleDatasetStatus(sampleDatasetStatus Sam
 }
 
 func (r LoadSampleDatasetApiRequest) Execute() ([]SampleDatasetStatus, *http.Response, error) {
-	return r.ApiService.LoadSampleDatasetExecute(r)
-}
-
-func (r LoadSampleDatasetApiRequest) ExecuteWithParams(params *LoadSampleDatasetApiParams) ([]SampleDatasetStatus, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.name = params.Name 
-	r.sampleDatasetStatus = params.SampleDatasetStatus 
-	return r.Execute()
+	return r.ApiService.loadSampleDatasetExecute(r)
 }
 
 /*
@@ -996,7 +1086,7 @@ func (a *ClustersApiService) LoadSampleDataset(ctx context.Context, groupId stri
 
 // Execute executes the request
 //  @return []SampleDatasetStatus
-func (a *ClustersApiService) LoadSampleDatasetExecute(r LoadSampleDatasetApiRequest) ([]SampleDatasetStatus, *http.Response, error) {
+func (a *ClustersApiService) loadSampleDatasetExecute(r LoadSampleDatasetApiRequest) ([]SampleDatasetStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1110,6 +1200,16 @@ type UpdateClusterAdvancedConfigurationApiParams struct {
 		ClusterDescriptionProcessArgs *ClusterDescriptionProcessArgs
 }
 
+func (a *ClustersApiService) UpdateClusterAdvancedConfigurationWithParams(ctx context.Context, args *UpdateClusterAdvancedConfigurationApiParams) UpdateClusterAdvancedConfigurationApiRequest {
+	return UpdateClusterAdvancedConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		clusterDescriptionProcessArgs: args.ClusterDescriptionProcessArgs,
+	}
+}
+
 // Advanced configuration details to add for one cluster in the specified project.
 func (r UpdateClusterAdvancedConfigurationApiRequest) ClusterDescriptionProcessArgs(clusterDescriptionProcessArgs ClusterDescriptionProcessArgs) UpdateClusterAdvancedConfigurationApiRequest {
 	r.clusterDescriptionProcessArgs = &clusterDescriptionProcessArgs
@@ -1117,14 +1217,7 @@ func (r UpdateClusterAdvancedConfigurationApiRequest) ClusterDescriptionProcessA
 }
 
 func (r UpdateClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptionProcessArgs, *http.Response, error) {
-	return r.ApiService.UpdateClusterAdvancedConfigurationExecute(r)
-}
-
-func (r UpdateClusterAdvancedConfigurationApiRequest) ExecuteWithParams(params *UpdateClusterAdvancedConfigurationApiParams) (*ClusterDescriptionProcessArgs, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.clusterDescriptionProcessArgs = params.ClusterDescriptionProcessArgs 
-	return r.Execute()
+	return r.ApiService.updateClusterAdvancedConfigurationExecute(r)
 }
 
 /*
@@ -1148,7 +1241,7 @@ func (a *ClustersApiService) UpdateClusterAdvancedConfiguration(ctx context.Cont
 
 // Execute executes the request
 //  @return ClusterDescriptionProcessArgs
-func (a *ClustersApiService) UpdateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+func (a *ClustersApiService) updateClusterAdvancedConfigurationExecute(r UpdateClusterAdvancedConfigurationApiRequest) (*ClusterDescriptionProcessArgs, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1260,6 +1353,15 @@ type UpgradeSharedClusterApiParams struct {
 		LegacyClusterDescription *LegacyClusterDescription
 }
 
+func (a *ClustersApiService) UpgradeSharedClusterWithParams(ctx context.Context, args *UpgradeSharedClusterApiParams) UpgradeSharedClusterApiRequest {
+	return UpgradeSharedClusterApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		legacyClusterDescription: args.LegacyClusterDescription,
+	}
+}
+
 // Details of the shared-tier cluster upgrade in the specified project.
 func (r UpgradeSharedClusterApiRequest) LegacyClusterDescription(legacyClusterDescription LegacyClusterDescription) UpgradeSharedClusterApiRequest {
 	r.legacyClusterDescription = &legacyClusterDescription
@@ -1267,13 +1369,7 @@ func (r UpgradeSharedClusterApiRequest) LegacyClusterDescription(legacyClusterDe
 }
 
 func (r UpgradeSharedClusterApiRequest) Execute() (*LegacyClusterDescription, *http.Response, error) {
-	return r.ApiService.UpgradeSharedClusterExecute(r)
-}
-
-func (r UpgradeSharedClusterApiRequest) ExecuteWithParams(params *UpgradeSharedClusterApiParams) (*LegacyClusterDescription, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.legacyClusterDescription = params.LegacyClusterDescription 
-	return r.Execute()
+	return r.ApiService.upgradeSharedClusterExecute(r)
 }
 
 /*
@@ -1295,7 +1391,7 @@ func (a *ClustersApiService) UpgradeSharedCluster(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return LegacyClusterDescription
-func (a *ClustersApiService) UpgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyClusterDescription, *http.Response, error) {
+func (a *ClustersApiService) upgradeSharedClusterExecute(r UpgradeSharedClusterApiRequest) (*LegacyClusterDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1400,6 +1496,15 @@ type UpgradeSharedClusterToServerlessApiParams struct {
 		ServerlessInstanceDescription *ServerlessInstanceDescription
 }
 
+func (a *ClustersApiService) UpgradeSharedClusterToServerlessWithParams(ctx context.Context, args *UpgradeSharedClusterToServerlessApiParams) UpgradeSharedClusterToServerlessApiRequest {
+	return UpgradeSharedClusterToServerlessApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		serverlessInstanceDescription: args.ServerlessInstanceDescription,
+	}
+}
+
 // Details of the shared-tier cluster upgrade in the specified project.
 func (r UpgradeSharedClusterToServerlessApiRequest) ServerlessInstanceDescription(serverlessInstanceDescription ServerlessInstanceDescription) UpgradeSharedClusterToServerlessApiRequest {
 	r.serverlessInstanceDescription = &serverlessInstanceDescription
@@ -1407,13 +1512,7 @@ func (r UpgradeSharedClusterToServerlessApiRequest) ServerlessInstanceDescriptio
 }
 
 func (r UpgradeSharedClusterToServerlessApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.UpgradeSharedClusterToServerlessExecute(r)
-}
-
-func (r UpgradeSharedClusterToServerlessApiRequest) ExecuteWithParams(params *UpgradeSharedClusterToServerlessApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.serverlessInstanceDescription = params.ServerlessInstanceDescription 
-	return r.Execute()
+	return r.ApiService.upgradeSharedClusterToServerlessExecute(r)
 }
 
 /*
@@ -1435,7 +1534,7 @@ func (a *ClustersApiService) UpgradeSharedClusterToServerless(ctx context.Contex
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ClustersApiService) UpgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ClustersApiService) upgradeSharedClusterToServerlessExecute(r UpgradeSharedClusterToServerlessApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -178,6 +178,12 @@ func (r GetClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescriptio
 	return r.ApiService.GetClusterAdvancedConfigurationExecute(r)
 }
 
+func (r GetClusterAdvancedConfigurationApiRequest) ExecuteWithParams(params *GetClusterAdvancedConfigurationApiParams) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
+}
+
 /*
 GetClusterAdvancedConfiguration Return One Advanced Configuration Options for One Cluster
 
@@ -310,6 +316,12 @@ func (r GetClusterStatusApiRequest) Execute() (*ClusterStatus, *http.Response, e
 	return r.ApiService.GetClusterStatusExecute(r)
 }
 
+func (r GetClusterStatusApiRequest) ExecuteWithParams(params *GetClusterStatusApiParams) (*ClusterStatus, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
+}
+
 /*
 GetClusterStatus Return Status of All Cluster Operations
 
@@ -440,6 +452,12 @@ type GetSampleDatasetLoadStatusApiParams struct {
 
 func (r GetSampleDatasetLoadStatusApiRequest) Execute() (*SampleDatasetStatus, *http.Response, error) {
 	return r.ApiService.GetSampleDatasetLoadStatusExecute(r)
+}
+
+func (r GetSampleDatasetLoadStatusApiRequest) ExecuteWithParams(params *GetSampleDatasetLoadStatusApiParams) (*SampleDatasetStatus, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.sampleDatasetId = params.SampleDatasetId 
+	return r.Execute()
 }
 
 /*
@@ -610,6 +628,16 @@ func (r ListCloudProviderRegionsApiRequest) Tier(tier string) ListCloudProviderR
 
 func (r ListCloudProviderRegionsApiRequest) Execute() (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
 	return r.ApiService.ListCloudProviderRegionsExecute(r)
+}
+
+func (r ListCloudProviderRegionsApiRequest) ExecuteWithParams(params *ListCloudProviderRegionsApiParams) (*PaginatedApiAtlasProviderRegions, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.providers = params.Providers 
+	r.tier = params.Tier 
+	return r.Execute()
 }
 
 /*
@@ -790,6 +818,13 @@ func (r ListClustersForAllProjectsApiRequest) Execute() (*PaginatedOrgGroup, *ht
 	return r.ApiService.ListClustersForAllProjectsExecute(r)
 }
 
+func (r ListClustersForAllProjectsApiRequest) ExecuteWithParams(params *ListClustersForAllProjectsApiParams) (*PaginatedOrgGroup, *http.Response, error) {
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListClustersForAllProjects Return All Authorized Clusters in All Projects
 
@@ -931,6 +966,13 @@ func (r LoadSampleDatasetApiRequest) SampleDatasetStatus(sampleDatasetStatus Sam
 
 func (r LoadSampleDatasetApiRequest) Execute() ([]SampleDatasetStatus, *http.Response, error) {
 	return r.ApiService.LoadSampleDatasetExecute(r)
+}
+
+func (r LoadSampleDatasetApiRequest) ExecuteWithParams(params *LoadSampleDatasetApiParams) ([]SampleDatasetStatus, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.name = params.Name 
+	r.sampleDatasetStatus = params.SampleDatasetStatus 
+	return r.Execute()
 }
 
 /*
@@ -1078,6 +1120,13 @@ func (r UpdateClusterAdvancedConfigurationApiRequest) Execute() (*ClusterDescrip
 	return r.ApiService.UpdateClusterAdvancedConfigurationExecute(r)
 }
 
+func (r UpdateClusterAdvancedConfigurationApiRequest) ExecuteWithParams(params *UpdateClusterAdvancedConfigurationApiParams) (*ClusterDescriptionProcessArgs, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.clusterDescriptionProcessArgs = params.ClusterDescriptionProcessArgs 
+	return r.Execute()
+}
+
 /*
 UpdateClusterAdvancedConfiguration Update Advanced Configuration Options for One Cluster
 
@@ -1221,6 +1270,12 @@ func (r UpgradeSharedClusterApiRequest) Execute() (*LegacyClusterDescription, *h
 	return r.ApiService.UpgradeSharedClusterExecute(r)
 }
 
+func (r UpgradeSharedClusterApiRequest) ExecuteWithParams(params *UpgradeSharedClusterApiParams) (*LegacyClusterDescription, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.legacyClusterDescription = params.LegacyClusterDescription 
+	return r.Execute()
+}
+
 /*
 UpgradeSharedCluster Upgrade One Shared-tier Cluster
 
@@ -1353,6 +1408,12 @@ func (r UpgradeSharedClusterToServerlessApiRequest) ServerlessInstanceDescriptio
 
 func (r UpgradeSharedClusterToServerlessApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.UpgradeSharedClusterToServerlessExecute(r)
+}
+
+func (r UpgradeSharedClusterToServerlessApiRequest) ExecuteWithParams(params *UpgradeSharedClusterToServerlessApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.serverlessInstanceDescription = params.ServerlessInstanceDescription 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_clusters.go
+++ b/mongodbatlasv2/api_clusters.go
@@ -36,7 +36,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetClusterAdvancedConfigurationApiParams - Parameters for the request
-	@return GetClusterAdvancedConfigurationApiRequest}}
+	@return GetClusterAdvancedConfigurationApiRequest
 	*/
 	GetClusterAdvancedConfigurationWithParams(ctx context.Context, args *GetClusterAdvancedConfigurationApiParams) GetClusterAdvancedConfigurationApiRequest
 
@@ -60,7 +60,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetClusterStatusApiParams - Parameters for the request
-	@return GetClusterStatusApiRequest}}
+	@return GetClusterStatusApiRequest
 	*/
 	GetClusterStatusWithParams(ctx context.Context, args *GetClusterStatusApiParams) GetClusterStatusApiRequest
 
@@ -84,7 +84,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetSampleDatasetLoadStatusApiParams - Parameters for the request
-	@return GetSampleDatasetLoadStatusApiRequest}}
+	@return GetSampleDatasetLoadStatusApiRequest
 	*/
 	GetSampleDatasetLoadStatusWithParams(ctx context.Context, args *GetSampleDatasetLoadStatusApiParams) GetSampleDatasetLoadStatusApiRequest
 
@@ -107,7 +107,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListCloudProviderRegionsApiParams - Parameters for the request
-	@return ListCloudProviderRegionsApiRequest}}
+	@return ListCloudProviderRegionsApiRequest
 	*/
 	ListCloudProviderRegionsWithParams(ctx context.Context, args *ListCloudProviderRegionsApiParams) ListCloudProviderRegionsApiRequest
 
@@ -129,7 +129,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListClustersForAllProjectsApiParams - Parameters for the request
-	@return ListClustersForAllProjectsApiRequest}}
+	@return ListClustersForAllProjectsApiRequest
 	*/
 	ListClustersForAllProjectsWithParams(ctx context.Context, args *ListClustersForAllProjectsApiParams) ListClustersForAllProjectsApiRequest
 
@@ -153,7 +153,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param LoadSampleDatasetApiParams - Parameters for the request
-	@return LoadSampleDatasetApiRequest}}
+	@return LoadSampleDatasetApiRequest
 	*/
 	LoadSampleDatasetWithParams(ctx context.Context, args *LoadSampleDatasetApiParams) LoadSampleDatasetApiRequest
 
@@ -177,7 +177,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateClusterAdvancedConfigurationApiParams - Parameters for the request
-	@return UpdateClusterAdvancedConfigurationApiRequest}}
+	@return UpdateClusterAdvancedConfigurationApiRequest
 	*/
 	UpdateClusterAdvancedConfigurationWithParams(ctx context.Context, args *UpdateClusterAdvancedConfigurationApiParams) UpdateClusterAdvancedConfigurationApiRequest
 
@@ -200,7 +200,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpgradeSharedClusterApiParams - Parameters for the request
-	@return UpgradeSharedClusterApiRequest}}
+	@return UpgradeSharedClusterApiRequest
 	*/
 	UpgradeSharedClusterWithParams(ctx context.Context, args *UpgradeSharedClusterApiParams) UpgradeSharedClusterApiRequest
 
@@ -223,7 +223,7 @@ type ClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpgradeSharedClusterToServerlessApiParams - Parameters for the request
-	@return UpgradeSharedClusterToServerlessApiRequest}}
+	@return UpgradeSharedClusterToServerlessApiRequest
 	*/
 	UpgradeSharedClusterToServerlessWithParams(ctx context.Context, args *UpgradeSharedClusterToServerlessApiParams) UpgradeSharedClusterToServerlessApiRequest
 

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -34,7 +34,7 @@ type CustomDatabaseRolesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateCustomDatabaseRoleApiParams - Parameters for the request
-	@return CreateCustomDatabaseRoleApiRequest}}
+	@return CreateCustomDatabaseRoleApiRequest
 	*/
 	CreateCustomDatabaseRoleWithParams(ctx context.Context, args *CreateCustomDatabaseRoleApiParams) CreateCustomDatabaseRoleApiRequest
 
@@ -58,7 +58,7 @@ type CustomDatabaseRolesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteCustomDatabaseRoleApiParams - Parameters for the request
-	@return DeleteCustomDatabaseRoleApiRequest}}
+	@return DeleteCustomDatabaseRoleApiRequest
 	*/
 	DeleteCustomDatabaseRoleWithParams(ctx context.Context, args *DeleteCustomDatabaseRoleApiParams) DeleteCustomDatabaseRoleApiRequest
 
@@ -82,7 +82,7 @@ type CustomDatabaseRolesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetCustomDatabaseRoleApiParams - Parameters for the request
-	@return GetCustomDatabaseRoleApiRequest}}
+	@return GetCustomDatabaseRoleApiRequest
 	*/
 	GetCustomDatabaseRoleWithParams(ctx context.Context, args *GetCustomDatabaseRoleApiParams) GetCustomDatabaseRoleApiRequest
 
@@ -105,7 +105,7 @@ type CustomDatabaseRolesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListCustomDatabaseRolesApiParams - Parameters for the request
-	@return ListCustomDatabaseRolesApiRequest}}
+	@return ListCustomDatabaseRolesApiRequest
 	*/
 	ListCustomDatabaseRolesWithParams(ctx context.Context, args *ListCustomDatabaseRolesApiParams) ListCustomDatabaseRolesApiRequest
 
@@ -129,7 +129,7 @@ type CustomDatabaseRolesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateCustomDatabaseRoleApiParams - Parameters for the request
-	@return UpdateCustomDatabaseRoleApiRequest}}
+	@return UpdateCustomDatabaseRoleApiRequest
 	*/
 	UpdateCustomDatabaseRoleWithParams(ctx context.Context, args *UpdateCustomDatabaseRoleApiParams) UpdateCustomDatabaseRoleApiRequest
 

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -121,6 +121,12 @@ func (r CreateCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Resp
 	return r.ApiService.CreateCustomDatabaseRoleExecute(r)
 }
 
+func (r CreateCustomDatabaseRoleApiRequest) ExecuteWithParams(params *CreateCustomDatabaseRoleApiParams) (*CustomDBRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.customDBRole = params.CustomDBRole 
+	return r.Execute()
+}
+
 /*
 CreateCustomDatabaseRole Create One Custom Role
 
@@ -249,6 +255,12 @@ func (r DeleteCustomDatabaseRoleApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteCustomDatabaseRoleExecute(r)
 }
 
+func (r DeleteCustomDatabaseRoleApiRequest) ExecuteWithParams(params *DeleteCustomDatabaseRoleApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.roleName = params.RoleName 
+	return r.Execute()
+}
+
 /*
 DeleteCustomDatabaseRole Remove One Custom Role from One Project
 
@@ -362,6 +374,12 @@ type GetCustomDatabaseRoleApiParams struct {
 
 func (r GetCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
 	return r.ApiService.GetCustomDatabaseRoleExecute(r)
+}
+
+func (r GetCustomDatabaseRoleApiRequest) ExecuteWithParams(params *GetCustomDatabaseRoleApiParams) (*CustomDBRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.roleName = params.RoleName 
+	return r.Execute()
 }
 
 /*
@@ -486,6 +504,11 @@ type ListCustomDatabaseRolesApiParams struct {
 
 func (r ListCustomDatabaseRolesApiRequest) Execute() ([]CustomDBRole, *http.Response, error) {
 	return r.ApiService.ListCustomDatabaseRolesExecute(r)
+}
+
+func (r ListCustomDatabaseRolesApiRequest) ExecuteWithParams(params *ListCustomDatabaseRolesApiParams) ([]CustomDBRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -617,6 +640,13 @@ func (r UpdateCustomDatabaseRoleApiRequest) UpdateCustomDBRole(updateCustomDBRol
 
 func (r UpdateCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
 	return r.ApiService.UpdateCustomDatabaseRoleExecute(r)
+}
+
+func (r UpdateCustomDatabaseRoleApiRequest) ExecuteWithParams(params *UpdateCustomDatabaseRoleApiParams) (*CustomDBRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.roleName = params.RoleName 
+	r.updateCustomDBRole = params.UpdateCustomDBRole 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_custom_database_roles.go
+++ b/mongodbatlasv2/api_custom_database_roles.go
@@ -28,10 +28,18 @@ type CustomDatabaseRolesApi interface {
 	@return CreateCustomDatabaseRoleApiRequest
 	*/
 	CreateCustomDatabaseRole(ctx context.Context, groupId string) CreateCustomDatabaseRoleApiRequest
+	/*
+	CreateCustomDatabaseRole Create One Custom Role
 
-	// CreateCustomDatabaseRoleExecute executes the request
-	//  @return CustomDBRole
-	CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateCustomDatabaseRoleApiParams - Parameters for the request
+	@return CreateCustomDatabaseRoleApiRequest}}
+	*/
+	CreateCustomDatabaseRoleWithParams(ctx context.Context, args *CreateCustomDatabaseRoleApiParams) CreateCustomDatabaseRoleApiRequest
+
+	// Interface only available internally
+	createCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
 
 	/*
 	DeleteCustomDatabaseRole Remove One Custom Role from One Project
@@ -44,9 +52,18 @@ type CustomDatabaseRolesApi interface {
 	@return DeleteCustomDatabaseRoleApiRequest
 	*/
 	DeleteCustomDatabaseRole(ctx context.Context, groupId string, roleName string) DeleteCustomDatabaseRoleApiRequest
+	/*
+	DeleteCustomDatabaseRole Remove One Custom Role from One Project
 
-	// DeleteCustomDatabaseRoleExecute executes the request
-	DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteCustomDatabaseRoleApiParams - Parameters for the request
+	@return DeleteCustomDatabaseRoleApiRequest}}
+	*/
+	DeleteCustomDatabaseRoleWithParams(ctx context.Context, args *DeleteCustomDatabaseRoleApiParams) DeleteCustomDatabaseRoleApiRequest
+
+	// Interface only available internally
+	deleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error)
 
 	/*
 	GetCustomDatabaseRole Return One Custom Role in One Project
@@ -59,10 +76,18 @@ type CustomDatabaseRolesApi interface {
 	@return GetCustomDatabaseRoleApiRequest
 	*/
 	GetCustomDatabaseRole(ctx context.Context, groupId string, roleName string) GetCustomDatabaseRoleApiRequest
+	/*
+	GetCustomDatabaseRole Return One Custom Role in One Project
 
-	// GetCustomDatabaseRoleExecute executes the request
-	//  @return CustomDBRole
-	GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetCustomDatabaseRoleApiParams - Parameters for the request
+	@return GetCustomDatabaseRoleApiRequest}}
+	*/
+	GetCustomDatabaseRoleWithParams(ctx context.Context, args *GetCustomDatabaseRoleApiParams) GetCustomDatabaseRoleApiRequest
+
+	// Interface only available internally
+	getCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
 
 	/*
 	ListCustomDatabaseRoles Return All Custom Roles in One Project
@@ -74,10 +99,18 @@ type CustomDatabaseRolesApi interface {
 	@return ListCustomDatabaseRolesApiRequest
 	*/
 	ListCustomDatabaseRoles(ctx context.Context, groupId string) ListCustomDatabaseRolesApiRequest
+	/*
+	ListCustomDatabaseRoles Return All Custom Roles in One Project
 
-	// ListCustomDatabaseRolesExecute executes the request
-	//  @return []CustomDBRole
-	ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]CustomDBRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListCustomDatabaseRolesApiParams - Parameters for the request
+	@return ListCustomDatabaseRolesApiRequest}}
+	*/
+	ListCustomDatabaseRolesWithParams(ctx context.Context, args *ListCustomDatabaseRolesApiParams) ListCustomDatabaseRolesApiRequest
+
+	// Interface only available internally
+	listCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]CustomDBRole, *http.Response, error)
 
 	/*
 	UpdateCustomDatabaseRole Update One Custom Role in One Project
@@ -90,10 +123,18 @@ type CustomDatabaseRolesApi interface {
 	@return UpdateCustomDatabaseRoleApiRequest
 	*/
 	UpdateCustomDatabaseRole(ctx context.Context, groupId string, roleName string) UpdateCustomDatabaseRoleApiRequest
+	/*
+	UpdateCustomDatabaseRole Update One Custom Role in One Project
 
-	// UpdateCustomDatabaseRoleExecute executes the request
-	//  @return CustomDBRole
-	UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateCustomDatabaseRoleApiParams - Parameters for the request
+	@return UpdateCustomDatabaseRoleApiRequest}}
+	*/
+	UpdateCustomDatabaseRoleWithParams(ctx context.Context, args *UpdateCustomDatabaseRoleApiParams) UpdateCustomDatabaseRoleApiRequest
+
+	// Interface only available internally
+	updateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error)
 }
 
 // CustomDatabaseRolesApiService CustomDatabaseRolesApi service
@@ -111,6 +152,15 @@ type CreateCustomDatabaseRoleApiParams struct {
 		CustomDBRole *CustomDBRole
 }
 
+func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleWithParams(ctx context.Context, args *CreateCustomDatabaseRoleApiParams) CreateCustomDatabaseRoleApiRequest {
+	return CreateCustomDatabaseRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		customDBRole: args.CustomDBRole,
+	}
+}
+
 // Creates one custom role in the specified project.
 func (r CreateCustomDatabaseRoleApiRequest) CustomDBRole(customDBRole CustomDBRole) CreateCustomDatabaseRoleApiRequest {
 	r.customDBRole = &customDBRole
@@ -118,13 +168,7 @@ func (r CreateCustomDatabaseRoleApiRequest) CustomDBRole(customDBRole CustomDBRo
 }
 
 func (r CreateCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
-	return r.ApiService.CreateCustomDatabaseRoleExecute(r)
-}
-
-func (r CreateCustomDatabaseRoleApiRequest) ExecuteWithParams(params *CreateCustomDatabaseRoleApiParams) (*CustomDBRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.customDBRole = params.CustomDBRole 
-	return r.Execute()
+	return r.ApiService.createCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -146,7 +190,7 @@ func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRole(ctx context.Con
 
 // Execute executes the request
 //  @return CustomDBRole
-func (a *CustomDatabaseRolesApiService) CreateCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) createCustomDatabaseRoleExecute(r CreateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -251,14 +295,17 @@ type DeleteCustomDatabaseRoleApiParams struct {
 		RoleName string
 }
 
-func (r DeleteCustomDatabaseRoleApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteCustomDatabaseRoleExecute(r)
+func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleWithParams(ctx context.Context, args *DeleteCustomDatabaseRoleApiParams) DeleteCustomDatabaseRoleApiRequest {
+	return DeleteCustomDatabaseRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		roleName: args.RoleName,
+	}
 }
 
-func (r DeleteCustomDatabaseRoleApiRequest) ExecuteWithParams(params *DeleteCustomDatabaseRoleApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.roleName = params.RoleName 
-	return r.Execute()
+func (r DeleteCustomDatabaseRoleApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -281,7 +328,7 @@ func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRole(ctx context.Con
 }
 
 // Execute executes the request
-func (a *CustomDatabaseRolesApiService) DeleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error) {
+func (a *CustomDatabaseRolesApiService) deleteCustomDatabaseRoleExecute(r DeleteCustomDatabaseRoleApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -372,14 +419,17 @@ type GetCustomDatabaseRoleApiParams struct {
 		RoleName string
 }
 
-func (r GetCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
-	return r.ApiService.GetCustomDatabaseRoleExecute(r)
+func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleWithParams(ctx context.Context, args *GetCustomDatabaseRoleApiParams) GetCustomDatabaseRoleApiRequest {
+	return GetCustomDatabaseRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		roleName: args.RoleName,
+	}
 }
 
-func (r GetCustomDatabaseRoleApiRequest) ExecuteWithParams(params *GetCustomDatabaseRoleApiParams) (*CustomDBRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.roleName = params.RoleName 
-	return r.Execute()
+func (r GetCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
+	return r.ApiService.getCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -403,7 +453,7 @@ func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRole(ctx context.Contex
 
 // Execute executes the request
 //  @return CustomDBRole
-func (a *CustomDatabaseRolesApiService) GetCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) getCustomDatabaseRoleExecute(r GetCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -502,13 +552,16 @@ type ListCustomDatabaseRolesApiParams struct {
 		GroupId string
 }
 
-func (r ListCustomDatabaseRolesApiRequest) Execute() ([]CustomDBRole, *http.Response, error) {
-	return r.ApiService.ListCustomDatabaseRolesExecute(r)
+func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesWithParams(ctx context.Context, args *ListCustomDatabaseRolesApiParams) ListCustomDatabaseRolesApiRequest {
+	return ListCustomDatabaseRolesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ListCustomDatabaseRolesApiRequest) ExecuteWithParams(params *ListCustomDatabaseRolesApiParams) ([]CustomDBRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ListCustomDatabaseRolesApiRequest) Execute() ([]CustomDBRole, *http.Response, error) {
+	return r.ApiService.listCustomDatabaseRolesExecute(r)
 }
 
 /*
@@ -530,7 +583,7 @@ func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRoles(ctx context.Cont
 
 // Execute executes the request
 //  @return []CustomDBRole
-func (a *CustomDatabaseRolesApiService) ListCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) listCustomDatabaseRolesExecute(r ListCustomDatabaseRolesApiRequest) ([]CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -632,6 +685,16 @@ type UpdateCustomDatabaseRoleApiParams struct {
 		UpdateCustomDBRole *UpdateCustomDBRole
 }
 
+func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRoleWithParams(ctx context.Context, args *UpdateCustomDatabaseRoleApiParams) UpdateCustomDatabaseRoleApiRequest {
+	return UpdateCustomDatabaseRoleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		roleName: args.RoleName,
+		updateCustomDBRole: args.UpdateCustomDBRole,
+	}
+}
+
 // Updates one custom role in the specified project.
 func (r UpdateCustomDatabaseRoleApiRequest) UpdateCustomDBRole(updateCustomDBRole UpdateCustomDBRole) UpdateCustomDatabaseRoleApiRequest {
 	r.updateCustomDBRole = &updateCustomDBRole
@@ -639,14 +702,7 @@ func (r UpdateCustomDatabaseRoleApiRequest) UpdateCustomDBRole(updateCustomDBRol
 }
 
 func (r UpdateCustomDatabaseRoleApiRequest) Execute() (*CustomDBRole, *http.Response, error) {
-	return r.ApiService.UpdateCustomDatabaseRoleExecute(r)
-}
-
-func (r UpdateCustomDatabaseRoleApiRequest) ExecuteWithParams(params *UpdateCustomDatabaseRoleApiParams) (*CustomDBRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.roleName = params.RoleName 
-	r.updateCustomDBRole = params.UpdateCustomDBRole 
-	return r.Execute()
+	return r.ApiService.updateCustomDatabaseRoleExecute(r)
 }
 
 /*
@@ -670,7 +726,7 @@ func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRole(ctx context.Con
 
 // Execute executes the request
 //  @return CustomDBRole
-func (a *CustomDatabaseRolesApiService) UpdateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
+func (a *CustomDatabaseRolesApiService) updateCustomDatabaseRoleExecute(r UpdateCustomDatabaseRoleApiRequest) (*CustomDBRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -283,6 +283,12 @@ func (r CreateDataFederationPrivateEndpointApiRequest) Execute() ([]PrivateNetwo
 	return r.ApiService.CreateDataFederationPrivateEndpointExecute(r)
 }
 
+func (r CreateDataFederationPrivateEndpointApiRequest) ExecuteWithParams(params *CreateDataFederationPrivateEndpointApiParams) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.privateNetworkEndpointIdEntry = params.PrivateNetworkEndpointIdEntry 
+	return r.Execute()
+}
+
 /*
 CreateDataFederationPrivateEndpoint Create One Federated Database Instance and Online Archive Private Endpoint for One Project
 
@@ -443,6 +449,13 @@ func (r CreateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Res
 	return r.ApiService.CreateFederatedDatabaseExecute(r)
 }
 
+func (r CreateFederatedDatabaseApiRequest) ExecuteWithParams(params *CreateFederatedDatabaseApiParams) (*DataLakeTenant, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.dataLakeTenant = params.DataLakeTenant 
+	r.skipRoleValidation = params.SkipRoleValidation 
+	return r.Execute()
+}
+
 /*
 CreateFederatedDatabase Create One Federated Database Instance in One Project
 
@@ -588,6 +601,14 @@ func (r CreateOneDataFederationQueryLimitApiRequest) Execute() ([]DataFederation
 	return r.ApiService.CreateOneDataFederationQueryLimitExecute(r)
 }
 
+func (r CreateOneDataFederationQueryLimitApiRequest) ExecuteWithParams(params *CreateOneDataFederationQueryLimitApiParams) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	r.limitName = params.LimitName 
+	r.dataFederationTenantQueryLimit = params.DataFederationTenantQueryLimit 
+	return r.Execute()
+}
+
 /*
 CreateOneDataFederationQueryLimit Configure One Query Limit for One Federated Database Instance
 
@@ -722,6 +743,12 @@ func (r DeleteDataFederationPrivateEndpointApiRequest) Execute() (*http.Response
 	return r.ApiService.DeleteDataFederationPrivateEndpointExecute(r)
 }
 
+func (r DeleteDataFederationPrivateEndpointApiRequest) ExecuteWithParams(params *DeleteDataFederationPrivateEndpointApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.endpointId = params.EndpointId 
+	return r.Execute()
+}
+
 /*
 DeleteDataFederationPrivateEndpoint Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
 
@@ -843,6 +870,12 @@ func (r DeleteFederatedDatabaseApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteFederatedDatabaseExecute(r)
 }
 
+func (r DeleteFederatedDatabaseApiRequest) ExecuteWithParams(params *DeleteFederatedDatabaseApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	return r.Execute()
+}
+
 /*
 DeleteFederatedDatabase Remove One Federated Database Instance from One Project
 
@@ -958,6 +991,13 @@ type DeleteOneDataFederationInstanceQueryLimitApiParams struct {
 
 func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOneDataFederationInstanceQueryLimitExecute(r)
+}
+
+func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) ExecuteWithParams(params *DeleteOneDataFederationInstanceQueryLimitApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	r.limitName = params.LimitName 
+	return r.Execute()
 }
 
 /*
@@ -1094,6 +1134,14 @@ func (r DownloadFederatedDatabaseQueryLogsApiRequest) Execute() (*os.File, *http
 	return r.ApiService.DownloadFederatedDatabaseQueryLogsExecute(r)
 }
 
+func (r DownloadFederatedDatabaseQueryLogsApiRequest) ExecuteWithParams(params *DownloadFederatedDatabaseQueryLogsApiParams) (*os.File, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	r.endDate = params.EndDate 
+	r.startDate = params.StartDate 
+	return r.Execute()
+}
+
 /*
 DownloadFederatedDatabaseQueryLogs Download Query Logs for One Federated Database Instance
 
@@ -1224,6 +1272,12 @@ type GetDataFederationPrivateEndpointApiParams struct {
 
 func (r GetDataFederationPrivateEndpointApiRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	return r.ApiService.GetDataFederationPrivateEndpointExecute(r)
+}
+
+func (r GetDataFederationPrivateEndpointApiRequest) ExecuteWithParams(params *GetDataFederationPrivateEndpointApiParams) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.endpointId = params.EndpointId 
+	return r.Execute()
 }
 
 /*
@@ -1358,6 +1412,12 @@ func (r GetFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Respon
 	return r.ApiService.GetFederatedDatabaseExecute(r)
 }
 
+func (r GetFederatedDatabaseApiRequest) ExecuteWithParams(params *GetFederatedDatabaseApiParams) (*DataLakeTenant, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	return r.Execute()
+}
+
 /*
 GetFederatedDatabase Return One Federated Database Instance in One Project
 
@@ -1480,6 +1540,11 @@ type ListDataFederationPrivateEndpointsApiParams struct {
 
 func (r ListDataFederationPrivateEndpointsApiRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	return r.ApiService.ListDataFederationPrivateEndpointsExecute(r)
+}
+
+func (r ListDataFederationPrivateEndpointsApiRequest) ExecuteWithParams(params *ListDataFederationPrivateEndpointsApiParams) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -1609,6 +1674,12 @@ func (r ListFederatedDatabasesApiRequest) Type_(type_ string) ListFederatedDatab
 
 func (r ListFederatedDatabasesApiRequest) Execute() ([]DataLakeTenant, *http.Response, error) {
 	return r.ApiService.ListFederatedDatabasesExecute(r)
+}
+
+func (r ListFederatedDatabasesApiRequest) ExecuteWithParams(params *ListFederatedDatabasesApiParams) ([]DataLakeTenant, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.type_ = params.Type_ 
+	return r.Execute()
 }
 
 /*
@@ -1743,6 +1814,13 @@ func (r ReturnFederatedDatabaseQueryLimitApiRequest) Execute() ([]DataFederation
 	return r.ApiService.ReturnFederatedDatabaseQueryLimitExecute(r)
 }
 
+func (r ReturnFederatedDatabaseQueryLimitApiRequest) ExecuteWithParams(params *ReturnFederatedDatabaseQueryLimitApiParams) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	r.limitName = params.LimitName 
+	return r.Execute()
+}
+
 /*
 ReturnFederatedDatabaseQueryLimit Return One Federated Database Instance Query Limit for One Project
 
@@ -1870,6 +1948,12 @@ type ReturnFederatedDatabaseQueryLimitsApiParams struct {
 
 func (r ReturnFederatedDatabaseQueryLimitsApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	return r.ApiService.ReturnFederatedDatabaseQueryLimitsExecute(r)
+}
+
+func (r ReturnFederatedDatabaseQueryLimitsApiRequest) ExecuteWithParams(params *ReturnFederatedDatabaseQueryLimitsApiParams) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	return r.Execute()
 }
 
 /*
@@ -2012,6 +2096,14 @@ func (r UpdateFederatedDatabaseApiRequest) DataLakeTenant(dataLakeTenant DataLak
 
 func (r UpdateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
 	return r.ApiService.UpdateFederatedDatabaseExecute(r)
+}
+
+func (r UpdateFederatedDatabaseApiRequest) ExecuteWithParams(params *UpdateFederatedDatabaseApiParams) (*DataLakeTenant, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.tenantName = params.TenantName 
+	r.skipRoleValidation = params.SkipRoleValidation 
+	r.dataLakeTenant = params.DataLakeTenant 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -47,10 +47,18 @@ type DataFederationApi interface {
 	@return CreateDataFederationPrivateEndpointApiRequest
 	*/
 	CreateDataFederationPrivateEndpoint(ctx context.Context, groupId string) CreateDataFederationPrivateEndpointApiRequest
+	/*
+	CreateDataFederationPrivateEndpoint Create One Federated Database Instance and Online Archive Private Endpoint for One Project
 
-	// CreateDataFederationPrivateEndpointExecute executes the request
-	//  @return []PrivateNetworkEndpointIdEntry
-	CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateDataFederationPrivateEndpointApiParams - Parameters for the request
+	@return CreateDataFederationPrivateEndpointApiRequest}}
+	*/
+	CreateDataFederationPrivateEndpointWithParams(ctx context.Context, args *CreateDataFederationPrivateEndpointApiParams) CreateDataFederationPrivateEndpointApiRequest
+
+	// Interface only available internally
+	createDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 	CreateFederatedDatabase Create One Federated Database Instance in One Project
@@ -62,10 +70,18 @@ type DataFederationApi interface {
 	@return CreateFederatedDatabaseApiRequest
 	*/
 	CreateFederatedDatabase(ctx context.Context, groupId string) CreateFederatedDatabaseApiRequest
+	/*
+	CreateFederatedDatabase Create One Federated Database Instance in One Project
 
-	// CreateFederatedDatabaseExecute executes the request
-	//  @return DataLakeTenant
-	CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateFederatedDatabaseApiParams - Parameters for the request
+	@return CreateFederatedDatabaseApiRequest}}
+	*/
+	CreateFederatedDatabaseWithParams(ctx context.Context, args *CreateFederatedDatabaseApiParams) CreateFederatedDatabaseApiRequest
+
+	// Interface only available internally
+	createFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
 	CreateOneDataFederationQueryLimit Configure One Query Limit for One Federated Database Instance
@@ -79,10 +95,18 @@ type DataFederationApi interface {
 	@return CreateOneDataFederationQueryLimitApiRequest
 	*/
 	CreateOneDataFederationQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) CreateOneDataFederationQueryLimitApiRequest
+	/*
+	CreateOneDataFederationQueryLimit Configure One Query Limit for One Federated Database Instance
 
-	// CreateOneDataFederationQueryLimitExecute executes the request
-	//  @return []DataFederationTenantQueryLimit
-	CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateOneDataFederationQueryLimitApiParams - Parameters for the request
+	@return CreateOneDataFederationQueryLimitApiRequest}}
+	*/
+	CreateOneDataFederationQueryLimitWithParams(ctx context.Context, args *CreateOneDataFederationQueryLimitApiParams) CreateOneDataFederationQueryLimitApiRequest
+
+	// Interface only available internally
+	createOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 	DeleteDataFederationPrivateEndpoint Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
@@ -95,9 +119,18 @@ type DataFederationApi interface {
 	@return DeleteDataFederationPrivateEndpointApiRequest
 	*/
 	DeleteDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) DeleteDataFederationPrivateEndpointApiRequest
+	/*
+	DeleteDataFederationPrivateEndpoint Remove One Federated Database Instance and Online Archive Private Endpoint from One Project
 
-	// DeleteDataFederationPrivateEndpointExecute executes the request
-	DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteDataFederationPrivateEndpointApiParams - Parameters for the request
+	@return DeleteDataFederationPrivateEndpointApiRequest}}
+	*/
+	DeleteDataFederationPrivateEndpointWithParams(ctx context.Context, args *DeleteDataFederationPrivateEndpointApiParams) DeleteDataFederationPrivateEndpointApiRequest
+
+	// Interface only available internally
+	deleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (*http.Response, error)
 
 	/*
 	DeleteFederatedDatabase Remove One Federated Database Instance from One Project
@@ -110,9 +143,18 @@ type DataFederationApi interface {
 	@return DeleteFederatedDatabaseApiRequest
 	*/
 	DeleteFederatedDatabase(ctx context.Context, groupId string, tenantName string) DeleteFederatedDatabaseApiRequest
+	/*
+	DeleteFederatedDatabase Remove One Federated Database Instance from One Project
 
-	// DeleteFederatedDatabaseExecute executes the request
-	DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteFederatedDatabaseApiParams - Parameters for the request
+	@return DeleteFederatedDatabaseApiRequest}}
+	*/
+	DeleteFederatedDatabaseWithParams(ctx context.Context, args *DeleteFederatedDatabaseApiParams) DeleteFederatedDatabaseApiRequest
+
+	// Interface only available internally
+	deleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (*http.Response, error)
 
 	/*
 	DeleteOneDataFederationInstanceQueryLimit Delete One Query Limit For One Federated Database Instance
@@ -126,9 +168,18 @@ type DataFederationApi interface {
 	@return DeleteOneDataFederationInstanceQueryLimitApiRequest
 	*/
 	DeleteOneDataFederationInstanceQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) DeleteOneDataFederationInstanceQueryLimitApiRequest
+	/*
+	DeleteOneDataFederationInstanceQueryLimit Delete One Query Limit For One Federated Database Instance
 
-	// DeleteOneDataFederationInstanceQueryLimitExecute executes the request
-	DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteOneDataFederationInstanceQueryLimitApiParams - Parameters for the request
+	@return DeleteOneDataFederationInstanceQueryLimitApiRequest}}
+	*/
+	DeleteOneDataFederationInstanceQueryLimitWithParams(ctx context.Context, args *DeleteOneDataFederationInstanceQueryLimitApiParams) DeleteOneDataFederationInstanceQueryLimitApiRequest
+
+	// Interface only available internally
+	deleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (*http.Response, error)
 
 	/*
 	DownloadFederatedDatabaseQueryLogs Download Query Logs for One Federated Database Instance
@@ -141,10 +192,18 @@ type DataFederationApi interface {
 	@return DownloadFederatedDatabaseQueryLogsApiRequest
 	*/
 	DownloadFederatedDatabaseQueryLogs(ctx context.Context, groupId string, tenantName string) DownloadFederatedDatabaseQueryLogsApiRequest
+	/*
+	DownloadFederatedDatabaseQueryLogs Download Query Logs for One Federated Database Instance
 
-	// DownloadFederatedDatabaseQueryLogsExecute executes the request
-	//  @return *os.File
-	DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DownloadFederatedDatabaseQueryLogsApiParams - Parameters for the request
+	@return DownloadFederatedDatabaseQueryLogsApiRequest}}
+	*/
+	DownloadFederatedDatabaseQueryLogsWithParams(ctx context.Context, args *DownloadFederatedDatabaseQueryLogsApiParams) DownloadFederatedDatabaseQueryLogsApiRequest
+
+	// Interface only available internally
+	downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error)
 
 	/*
 	GetDataFederationPrivateEndpoint Return One Federated Database Instance and Online Archive Private Endpoint in One Project
@@ -157,10 +216,18 @@ type DataFederationApi interface {
 	@return GetDataFederationPrivateEndpointApiRequest
 	*/
 	GetDataFederationPrivateEndpoint(ctx context.Context, groupId string, endpointId string) GetDataFederationPrivateEndpointApiRequest
+	/*
+	GetDataFederationPrivateEndpoint Return One Federated Database Instance and Online Archive Private Endpoint in One Project
 
-	// GetDataFederationPrivateEndpointExecute executes the request
-	//  @return PrivateNetworkEndpointIdEntry
-	GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetDataFederationPrivateEndpointApiParams - Parameters for the request
+	@return GetDataFederationPrivateEndpointApiRequest}}
+	*/
+	GetDataFederationPrivateEndpointWithParams(ctx context.Context, args *GetDataFederationPrivateEndpointApiParams) GetDataFederationPrivateEndpointApiRequest
+
+	// Interface only available internally
+	getDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 	GetFederatedDatabase Return One Federated Database Instance in One Project
@@ -173,10 +240,18 @@ type DataFederationApi interface {
 	@return GetFederatedDatabaseApiRequest
 	*/
 	GetFederatedDatabase(ctx context.Context, groupId string, tenantName string) GetFederatedDatabaseApiRequest
+	/*
+	GetFederatedDatabase Return One Federated Database Instance in One Project
 
-	// GetFederatedDatabaseExecute executes the request
-	//  @return DataLakeTenant
-	GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetFederatedDatabaseApiParams - Parameters for the request
+	@return GetFederatedDatabaseApiRequest}}
+	*/
+	GetFederatedDatabaseWithParams(ctx context.Context, args *GetFederatedDatabaseApiParams) GetFederatedDatabaseApiRequest
+
+	// Interface only available internally
+	getFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 
 	/*
 	ListDataFederationPrivateEndpoints Return All Federated Database Instance and Online Archive Private Endpoints in One Project
@@ -188,10 +263,18 @@ type DataFederationApi interface {
 	@return ListDataFederationPrivateEndpointsApiRequest
 	*/
 	ListDataFederationPrivateEndpoints(ctx context.Context, groupId string) ListDataFederationPrivateEndpointsApiRequest
+	/*
+	ListDataFederationPrivateEndpoints Return All Federated Database Instance and Online Archive Private Endpoints in One Project
 
-	// ListDataFederationPrivateEndpointsExecute executes the request
-	//  @return []PrivateNetworkEndpointIdEntry
-	ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListDataFederationPrivateEndpointsApiParams - Parameters for the request
+	@return ListDataFederationPrivateEndpointsApiRequest}}
+	*/
+	ListDataFederationPrivateEndpointsWithParams(ctx context.Context, args *ListDataFederationPrivateEndpointsApiParams) ListDataFederationPrivateEndpointsApiRequest
+
+	// Interface only available internally
+	listDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error)
 
 	/*
 	ListFederatedDatabases Return All Federated Database Instances in One Project
@@ -203,10 +286,18 @@ type DataFederationApi interface {
 	@return ListFederatedDatabasesApiRequest
 	*/
 	ListFederatedDatabases(ctx context.Context, groupId string) ListFederatedDatabasesApiRequest
+	/*
+	ListFederatedDatabases Return All Federated Database Instances in One Project
 
-	// ListFederatedDatabasesExecute executes the request
-	//  @return []DataLakeTenant
-	ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListFederatedDatabasesApiParams - Parameters for the request
+	@return ListFederatedDatabasesApiRequest}}
+	*/
+	ListFederatedDatabasesWithParams(ctx context.Context, args *ListFederatedDatabasesApiParams) ListFederatedDatabasesApiRequest
+
+	// Interface only available internally
+	listFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error)
 
 	/*
 	ReturnFederatedDatabaseQueryLimit Return One Federated Database Instance Query Limit for One Project
@@ -220,10 +311,18 @@ type DataFederationApi interface {
 	@return ReturnFederatedDatabaseQueryLimitApiRequest
 	*/
 	ReturnFederatedDatabaseQueryLimit(ctx context.Context, groupId string, tenantName string, limitName string) ReturnFederatedDatabaseQueryLimitApiRequest
+	/*
+	ReturnFederatedDatabaseQueryLimit Return One Federated Database Instance Query Limit for One Project
 
-	// ReturnFederatedDatabaseQueryLimitExecute executes the request
-	//  @return []DataFederationTenantQueryLimit
-	ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ReturnFederatedDatabaseQueryLimitApiParams - Parameters for the request
+	@return ReturnFederatedDatabaseQueryLimitApiRequest}}
+	*/
+	ReturnFederatedDatabaseQueryLimitWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitApiParams) ReturnFederatedDatabaseQueryLimitApiRequest
+
+	// Interface only available internally
+	returnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 	ReturnFederatedDatabaseQueryLimits Return All Query Limits for One Federated Database Instance
@@ -236,10 +335,18 @@ type DataFederationApi interface {
 	@return ReturnFederatedDatabaseQueryLimitsApiRequest
 	*/
 	ReturnFederatedDatabaseQueryLimits(ctx context.Context, groupId string, tenantName string) ReturnFederatedDatabaseQueryLimitsApiRequest
+	/*
+	ReturnFederatedDatabaseQueryLimits Return All Query Limits for One Federated Database Instance
 
-	// ReturnFederatedDatabaseQueryLimitsExecute executes the request
-	//  @return []DataFederationTenantQueryLimit
-	ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ReturnFederatedDatabaseQueryLimitsApiParams - Parameters for the request
+	@return ReturnFederatedDatabaseQueryLimitsApiRequest}}
+	*/
+	ReturnFederatedDatabaseQueryLimitsWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitsApiParams) ReturnFederatedDatabaseQueryLimitsApiRequest
+
+	// Interface only available internally
+	returnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error)
 
 	/*
 	UpdateFederatedDatabase Update One Federated Database Instance in One Project
@@ -252,10 +359,18 @@ type DataFederationApi interface {
 	@return UpdateFederatedDatabaseApiRequest
 	*/
 	UpdateFederatedDatabase(ctx context.Context, groupId string, tenantName string) UpdateFederatedDatabaseApiRequest
+	/*
+	UpdateFederatedDatabase Update One Federated Database Instance in One Project
 
-	// UpdateFederatedDatabaseExecute executes the request
-	//  @return DataLakeTenant
-	UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateFederatedDatabaseApiParams - Parameters for the request
+	@return UpdateFederatedDatabaseApiRequest}}
+	*/
+	UpdateFederatedDatabaseWithParams(ctx context.Context, args *UpdateFederatedDatabaseApiParams) UpdateFederatedDatabaseApiRequest
+
+	// Interface only available internally
+	updateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error)
 }
 
 // DataFederationApiService DataFederationApi service
@@ -273,6 +388,15 @@ type CreateDataFederationPrivateEndpointApiParams struct {
 		PrivateNetworkEndpointIdEntry *PrivateNetworkEndpointIdEntry
 }
 
+func (a *DataFederationApiService) CreateDataFederationPrivateEndpointWithParams(ctx context.Context, args *CreateDataFederationPrivateEndpointApiParams) CreateDataFederationPrivateEndpointApiRequest {
+	return CreateDataFederationPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		privateNetworkEndpointIdEntry: args.PrivateNetworkEndpointIdEntry,
+	}
+}
+
 // Private endpoint for Federated Database Instances and Online Archives to add to the specified project.
 func (r CreateDataFederationPrivateEndpointApiRequest) PrivateNetworkEndpointIdEntry(privateNetworkEndpointIdEntry PrivateNetworkEndpointIdEntry) CreateDataFederationPrivateEndpointApiRequest {
 	r.privateNetworkEndpointIdEntry = &privateNetworkEndpointIdEntry
@@ -280,13 +404,7 @@ func (r CreateDataFederationPrivateEndpointApiRequest) PrivateNetworkEndpointIdE
 }
 
 func (r CreateDataFederationPrivateEndpointApiRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
-	return r.ApiService.CreateDataFederationPrivateEndpointExecute(r)
-}
-
-func (r CreateDataFederationPrivateEndpointApiRequest) ExecuteWithParams(params *CreateDataFederationPrivateEndpointApiParams) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.privateNetworkEndpointIdEntry = params.PrivateNetworkEndpointIdEntry 
-	return r.Execute()
+	return r.ApiService.createDataFederationPrivateEndpointExecute(r)
 }
 
 /*
@@ -326,7 +444,7 @@ func (a *DataFederationApiService) CreateDataFederationPrivateEndpoint(ctx conte
 
 // Execute executes the request
 //  @return []PrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) CreateDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) createDataFederationPrivateEndpointExecute(r CreateDataFederationPrivateEndpointApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -433,6 +551,16 @@ type CreateFederatedDatabaseApiParams struct {
 		SkipRoleValidation *bool
 }
 
+func (a *DataFederationApiService) CreateFederatedDatabaseWithParams(ctx context.Context, args *CreateFederatedDatabaseApiParams) CreateFederatedDatabaseApiRequest {
+	return CreateFederatedDatabaseApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		dataLakeTenant: args.DataLakeTenant,
+		skipRoleValidation: args.SkipRoleValidation,
+	}
+}
+
 // Details to create one federated database instance in the specified project.
 func (r CreateFederatedDatabaseApiRequest) DataLakeTenant(dataLakeTenant DataLakeTenant) CreateFederatedDatabaseApiRequest {
 	r.dataLakeTenant = &dataLakeTenant
@@ -446,14 +574,7 @@ func (r CreateFederatedDatabaseApiRequest) SkipRoleValidation(skipRoleValidation
 }
 
 func (r CreateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
-	return r.ApiService.CreateFederatedDatabaseExecute(r)
-}
-
-func (r CreateFederatedDatabaseApiRequest) ExecuteWithParams(params *CreateFederatedDatabaseApiParams) (*DataLakeTenant, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.dataLakeTenant = params.DataLakeTenant 
-	r.skipRoleValidation = params.SkipRoleValidation 
-	return r.Execute()
+	return r.ApiService.createFederatedDatabaseExecute(r)
 }
 
 /*
@@ -475,7 +596,7 @@ func (a *DataFederationApiService) CreateFederatedDatabase(ctx context.Context, 
 
 // Execute executes the request
 //  @return DataLakeTenant
-func (a *DataFederationApiService) CreateFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) createFederatedDatabaseExecute(r CreateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -591,6 +712,17 @@ type CreateOneDataFederationQueryLimitApiParams struct {
 		DataFederationTenantQueryLimit *DataFederationTenantQueryLimit
 }
 
+func (a *DataFederationApiService) CreateOneDataFederationQueryLimitWithParams(ctx context.Context, args *CreateOneDataFederationQueryLimitApiParams) CreateOneDataFederationQueryLimitApiRequest {
+	return CreateOneDataFederationQueryLimitApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+		limitName: args.LimitName,
+		dataFederationTenantQueryLimit: args.DataFederationTenantQueryLimit,
+	}
+}
+
 // Creates or updates one query limit for one federated database instance.
 func (r CreateOneDataFederationQueryLimitApiRequest) DataFederationTenantQueryLimit(dataFederationTenantQueryLimit DataFederationTenantQueryLimit) CreateOneDataFederationQueryLimitApiRequest {
 	r.dataFederationTenantQueryLimit = &dataFederationTenantQueryLimit
@@ -598,15 +730,7 @@ func (r CreateOneDataFederationQueryLimitApiRequest) DataFederationTenantQueryLi
 }
 
 func (r CreateOneDataFederationQueryLimitApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
-	return r.ApiService.CreateOneDataFederationQueryLimitExecute(r)
-}
-
-func (r CreateOneDataFederationQueryLimitApiRequest) ExecuteWithParams(params *CreateOneDataFederationQueryLimitApiParams) ([]DataFederationTenantQueryLimit, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	r.limitName = params.LimitName 
-	r.dataFederationTenantQueryLimit = params.DataFederationTenantQueryLimit 
-	return r.Execute()
+	return r.ApiService.createOneDataFederationQueryLimitExecute(r)
 }
 
 /*
@@ -632,7 +756,7 @@ func (a *DataFederationApiService) CreateOneDataFederationQueryLimit(ctx context
 
 // Execute executes the request
 //  @return []DataFederationTenantQueryLimit
-func (a *DataFederationApiService) CreateOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) createOneDataFederationQueryLimitExecute(r CreateOneDataFederationQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -739,14 +863,17 @@ type DeleteDataFederationPrivateEndpointApiParams struct {
 		EndpointId string
 }
 
-func (r DeleteDataFederationPrivateEndpointApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteDataFederationPrivateEndpointExecute(r)
+func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointWithParams(ctx context.Context, args *DeleteDataFederationPrivateEndpointApiParams) DeleteDataFederationPrivateEndpointApiRequest {
+	return DeleteDataFederationPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		endpointId: args.EndpointId,
+	}
 }
 
-func (r DeleteDataFederationPrivateEndpointApiRequest) ExecuteWithParams(params *DeleteDataFederationPrivateEndpointApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.endpointId = params.EndpointId 
-	return r.Execute()
+func (r DeleteDataFederationPrivateEndpointApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteDataFederationPrivateEndpointExecute(r)
 }
 
 /*
@@ -769,7 +896,7 @@ func (a *DataFederationApiService) DeleteDataFederationPrivateEndpoint(ctx conte
 }
 
 // Execute executes the request
-func (a *DataFederationApiService) DeleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (*http.Response, error) {
+func (a *DataFederationApiService) deleteDataFederationPrivateEndpointExecute(r DeleteDataFederationPrivateEndpointApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -866,14 +993,17 @@ type DeleteFederatedDatabaseApiParams struct {
 		TenantName string
 }
 
-func (r DeleteFederatedDatabaseApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteFederatedDatabaseExecute(r)
+func (a *DataFederationApiService) DeleteFederatedDatabaseWithParams(ctx context.Context, args *DeleteFederatedDatabaseApiParams) DeleteFederatedDatabaseApiRequest {
+	return DeleteFederatedDatabaseApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+	}
 }
 
-func (r DeleteFederatedDatabaseApiRequest) ExecuteWithParams(params *DeleteFederatedDatabaseApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	return r.Execute()
+func (r DeleteFederatedDatabaseApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteFederatedDatabaseExecute(r)
 }
 
 /*
@@ -896,7 +1026,7 @@ func (a *DataFederationApiService) DeleteFederatedDatabase(ctx context.Context, 
 }
 
 // Execute executes the request
-func (a *DataFederationApiService) DeleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (*http.Response, error) {
+func (a *DataFederationApiService) deleteFederatedDatabaseExecute(r DeleteFederatedDatabaseApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -989,15 +1119,18 @@ type DeleteOneDataFederationInstanceQueryLimitApiParams struct {
 		LimitName string
 }
 
-func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteOneDataFederationInstanceQueryLimitExecute(r)
+func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitWithParams(ctx context.Context, args *DeleteOneDataFederationInstanceQueryLimitApiParams) DeleteOneDataFederationInstanceQueryLimitApiRequest {
+	return DeleteOneDataFederationInstanceQueryLimitApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+		limitName: args.LimitName,
+	}
 }
 
-func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) ExecuteWithParams(params *DeleteOneDataFederationInstanceQueryLimitApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	r.limitName = params.LimitName 
-	return r.Execute()
+func (r DeleteOneDataFederationInstanceQueryLimitApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteOneDataFederationInstanceQueryLimitExecute(r)
 }
 
 /*
@@ -1022,7 +1155,7 @@ func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimit(ctx
 }
 
 // Execute executes the request
-func (a *DataFederationApiService) DeleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (*http.Response, error) {
+func (a *DataFederationApiService) deleteOneDataFederationInstanceQueryLimitExecute(r DeleteOneDataFederationInstanceQueryLimitApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1118,6 +1251,17 @@ type DownloadFederatedDatabaseQueryLogsApiParams struct {
 		StartDate *int64
 }
 
+func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogsWithParams(ctx context.Context, args *DownloadFederatedDatabaseQueryLogsApiParams) DownloadFederatedDatabaseQueryLogsApiRequest {
+	return DownloadFederatedDatabaseQueryLogsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+		endDate: args.EndDate,
+		startDate: args.StartDate,
+	}
+}
+
 // Timestamp that specifies the end point for the range of log messages to download.  MongoDB Cloud expresses this timestamp in the number of seconds that have elapsed since the UNIX epoch.
 func (r DownloadFederatedDatabaseQueryLogsApiRequest) EndDate(endDate int64) DownloadFederatedDatabaseQueryLogsApiRequest {
 	r.endDate = &endDate
@@ -1131,15 +1275,7 @@ func (r DownloadFederatedDatabaseQueryLogsApiRequest) StartDate(startDate int64)
 }
 
 func (r DownloadFederatedDatabaseQueryLogsApiRequest) Execute() (*os.File, *http.Response, error) {
-	return r.ApiService.DownloadFederatedDatabaseQueryLogsExecute(r)
-}
-
-func (r DownloadFederatedDatabaseQueryLogsApiRequest) ExecuteWithParams(params *DownloadFederatedDatabaseQueryLogsApiParams) (*os.File, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	r.endDate = params.EndDate 
-	r.startDate = params.StartDate 
-	return r.Execute()
+	return r.ApiService.downloadFederatedDatabaseQueryLogsExecute(r)
 }
 
 /*
@@ -1163,7 +1299,7 @@ func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogs(ctx contex
 
 // Execute executes the request
 //  @return *os.File
-func (a *DataFederationApiService) DownloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error) {
+func (a *DataFederationApiService) downloadFederatedDatabaseQueryLogsExecute(r DownloadFederatedDatabaseQueryLogsApiRequest) (*os.File, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1270,14 +1406,17 @@ type GetDataFederationPrivateEndpointApiParams struct {
 		EndpointId string
 }
 
-func (r GetDataFederationPrivateEndpointApiRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
-	return r.ApiService.GetDataFederationPrivateEndpointExecute(r)
+func (a *DataFederationApiService) GetDataFederationPrivateEndpointWithParams(ctx context.Context, args *GetDataFederationPrivateEndpointApiParams) GetDataFederationPrivateEndpointApiRequest {
+	return GetDataFederationPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		endpointId: args.EndpointId,
+	}
 }
 
-func (r GetDataFederationPrivateEndpointApiRequest) ExecuteWithParams(params *GetDataFederationPrivateEndpointApiParams) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.endpointId = params.EndpointId 
-	return r.Execute()
+func (r GetDataFederationPrivateEndpointApiRequest) Execute() (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
+	return r.ApiService.getDataFederationPrivateEndpointExecute(r)
 }
 
 /*
@@ -1301,7 +1440,7 @@ func (a *DataFederationApiService) GetDataFederationPrivateEndpoint(ctx context.
 
 // Execute executes the request
 //  @return PrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) GetDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) getDataFederationPrivateEndpointExecute(r GetDataFederationPrivateEndpointApiRequest) (*PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1408,14 +1547,17 @@ type GetFederatedDatabaseApiParams struct {
 		TenantName string
 }
 
-func (r GetFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
-	return r.ApiService.GetFederatedDatabaseExecute(r)
+func (a *DataFederationApiService) GetFederatedDatabaseWithParams(ctx context.Context, args *GetFederatedDatabaseApiParams) GetFederatedDatabaseApiRequest {
+	return GetFederatedDatabaseApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+	}
 }
 
-func (r GetFederatedDatabaseApiRequest) ExecuteWithParams(params *GetFederatedDatabaseApiParams) (*DataLakeTenant, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	return r.Execute()
+func (r GetFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
+	return r.ApiService.getFederatedDatabaseExecute(r)
 }
 
 /*
@@ -1439,7 +1581,7 @@ func (a *DataFederationApiService) GetFederatedDatabase(ctx context.Context, gro
 
 // Execute executes the request
 //  @return DataLakeTenant
-func (a *DataFederationApiService) GetFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) getFederatedDatabaseExecute(r GetFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1538,13 +1680,16 @@ type ListDataFederationPrivateEndpointsApiParams struct {
 		GroupId string
 }
 
-func (r ListDataFederationPrivateEndpointsApiRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
-	return r.ApiService.ListDataFederationPrivateEndpointsExecute(r)
+func (a *DataFederationApiService) ListDataFederationPrivateEndpointsWithParams(ctx context.Context, args *ListDataFederationPrivateEndpointsApiParams) ListDataFederationPrivateEndpointsApiRequest {
+	return ListDataFederationPrivateEndpointsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ListDataFederationPrivateEndpointsApiRequest) ExecuteWithParams(params *ListDataFederationPrivateEndpointsApiParams) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ListDataFederationPrivateEndpointsApiRequest) Execute() ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+	return r.ApiService.listDataFederationPrivateEndpointsExecute(r)
 }
 
 /*
@@ -1566,7 +1711,7 @@ func (a *DataFederationApiService) ListDataFederationPrivateEndpoints(ctx contex
 
 // Execute executes the request
 //  @return []PrivateNetworkEndpointIdEntry
-func (a *DataFederationApiService) ListDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
+func (a *DataFederationApiService) listDataFederationPrivateEndpointsExecute(r ListDataFederationPrivateEndpointsApiRequest) ([]PrivateNetworkEndpointIdEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1666,6 +1811,15 @@ type ListFederatedDatabasesApiParams struct {
 		Type_ *string
 }
 
+func (a *DataFederationApiService) ListFederatedDatabasesWithParams(ctx context.Context, args *ListFederatedDatabasesApiParams) ListFederatedDatabasesApiRequest {
+	return ListFederatedDatabasesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		type_: args.Type_,
+	}
+}
+
 // Type of Federated Database Instances to return.
 func (r ListFederatedDatabasesApiRequest) Type_(type_ string) ListFederatedDatabasesApiRequest {
 	r.type_ = &type_
@@ -1673,13 +1827,7 @@ func (r ListFederatedDatabasesApiRequest) Type_(type_ string) ListFederatedDatab
 }
 
 func (r ListFederatedDatabasesApiRequest) Execute() ([]DataLakeTenant, *http.Response, error) {
-	return r.ApiService.ListFederatedDatabasesExecute(r)
-}
-
-func (r ListFederatedDatabasesApiRequest) ExecuteWithParams(params *ListFederatedDatabasesApiParams) ([]DataLakeTenant, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.type_ = params.Type_ 
-	return r.Execute()
+	return r.ApiService.listFederatedDatabasesExecute(r)
 }
 
 /*
@@ -1701,7 +1849,7 @@ func (a *DataFederationApiService) ListFederatedDatabases(ctx context.Context, g
 
 // Execute executes the request
 //  @return []DataLakeTenant
-func (a *DataFederationApiService) ListFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) listFederatedDatabasesExecute(r ListFederatedDatabasesApiRequest) ([]DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1810,15 +1958,18 @@ type ReturnFederatedDatabaseQueryLimitApiParams struct {
 		LimitName string
 }
 
-func (r ReturnFederatedDatabaseQueryLimitApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
-	return r.ApiService.ReturnFederatedDatabaseQueryLimitExecute(r)
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitApiParams) ReturnFederatedDatabaseQueryLimitApiRequest {
+	return ReturnFederatedDatabaseQueryLimitApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+		limitName: args.LimitName,
+	}
 }
 
-func (r ReturnFederatedDatabaseQueryLimitApiRequest) ExecuteWithParams(params *ReturnFederatedDatabaseQueryLimitApiParams) ([]DataFederationTenantQueryLimit, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	r.limitName = params.LimitName 
-	return r.Execute()
+func (r ReturnFederatedDatabaseQueryLimitApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
+	return r.ApiService.returnFederatedDatabaseQueryLimitExecute(r)
 }
 
 /*
@@ -1844,7 +1995,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimit(ctx context
 
 // Execute executes the request
 //  @return []DataFederationTenantQueryLimit
-func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) returnFederatedDatabaseQueryLimitExecute(r ReturnFederatedDatabaseQueryLimitApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1946,14 +2097,17 @@ type ReturnFederatedDatabaseQueryLimitsApiParams struct {
 		TenantName string
 }
 
-func (r ReturnFederatedDatabaseQueryLimitsApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
-	return r.ApiService.ReturnFederatedDatabaseQueryLimitsExecute(r)
+func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitsApiParams) ReturnFederatedDatabaseQueryLimitsApiRequest {
+	return ReturnFederatedDatabaseQueryLimitsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+	}
 }
 
-func (r ReturnFederatedDatabaseQueryLimitsApiRequest) ExecuteWithParams(params *ReturnFederatedDatabaseQueryLimitsApiParams) ([]DataFederationTenantQueryLimit, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	return r.Execute()
+func (r ReturnFederatedDatabaseQueryLimitsApiRequest) Execute() ([]DataFederationTenantQueryLimit, *http.Response, error) {
+	return r.ApiService.returnFederatedDatabaseQueryLimitsExecute(r)
 }
 
 /*
@@ -1977,7 +2131,7 @@ func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimits(ctx contex
 
 // Execute executes the request
 //  @return []DataFederationTenantQueryLimit
-func (a *DataFederationApiService) ReturnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
+func (a *DataFederationApiService) returnFederatedDatabaseQueryLimitsExecute(r ReturnFederatedDatabaseQueryLimitsApiRequest) ([]DataFederationTenantQueryLimit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2082,6 +2236,17 @@ type UpdateFederatedDatabaseApiParams struct {
 		DataLakeTenant *DataLakeTenant
 }
 
+func (a *DataFederationApiService) UpdateFederatedDatabaseWithParams(ctx context.Context, args *UpdateFederatedDatabaseApiParams) UpdateFederatedDatabaseApiRequest {
+	return UpdateFederatedDatabaseApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		tenantName: args.TenantName,
+		skipRoleValidation: args.SkipRoleValidation,
+		dataLakeTenant: args.DataLakeTenant,
+	}
+}
+
 // Flag that indicates whether this request should check if the requesting IAM role can read from the S3 bucket. AWS checks if the role can list the objects in the bucket before writing to it. Some IAM roles only need write permissions. This flag allows you to skip that check.
 func (r UpdateFederatedDatabaseApiRequest) SkipRoleValidation(skipRoleValidation bool) UpdateFederatedDatabaseApiRequest {
 	r.skipRoleValidation = &skipRoleValidation
@@ -2095,15 +2260,7 @@ func (r UpdateFederatedDatabaseApiRequest) DataLakeTenant(dataLakeTenant DataLak
 }
 
 func (r UpdateFederatedDatabaseApiRequest) Execute() (*DataLakeTenant, *http.Response, error) {
-	return r.ApiService.UpdateFederatedDatabaseExecute(r)
-}
-
-func (r UpdateFederatedDatabaseApiRequest) ExecuteWithParams(params *UpdateFederatedDatabaseApiParams) (*DataLakeTenant, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.tenantName = params.TenantName 
-	r.skipRoleValidation = params.SkipRoleValidation 
-	r.dataLakeTenant = params.DataLakeTenant 
-	return r.Execute()
+	return r.ApiService.updateFederatedDatabaseExecute(r)
 }
 
 /*
@@ -2127,7 +2284,7 @@ func (a *DataFederationApiService) UpdateFederatedDatabase(ctx context.Context, 
 
 // Execute executes the request
 //  @return DataLakeTenant
-func (a *DataFederationApiService) UpdateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
+func (a *DataFederationApiService) updateFederatedDatabaseExecute(r UpdateFederatedDatabaseApiRequest) (*DataLakeTenant, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_data_federation.go
+++ b/mongodbatlasv2/api_data_federation.go
@@ -53,7 +53,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateDataFederationPrivateEndpointApiParams - Parameters for the request
-	@return CreateDataFederationPrivateEndpointApiRequest}}
+	@return CreateDataFederationPrivateEndpointApiRequest
 	*/
 	CreateDataFederationPrivateEndpointWithParams(ctx context.Context, args *CreateDataFederationPrivateEndpointApiParams) CreateDataFederationPrivateEndpointApiRequest
 
@@ -76,7 +76,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateFederatedDatabaseApiParams - Parameters for the request
-	@return CreateFederatedDatabaseApiRequest}}
+	@return CreateFederatedDatabaseApiRequest
 	*/
 	CreateFederatedDatabaseWithParams(ctx context.Context, args *CreateFederatedDatabaseApiParams) CreateFederatedDatabaseApiRequest
 
@@ -101,7 +101,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateOneDataFederationQueryLimitApiParams - Parameters for the request
-	@return CreateOneDataFederationQueryLimitApiRequest}}
+	@return CreateOneDataFederationQueryLimitApiRequest
 	*/
 	CreateOneDataFederationQueryLimitWithParams(ctx context.Context, args *CreateOneDataFederationQueryLimitApiParams) CreateOneDataFederationQueryLimitApiRequest
 
@@ -125,7 +125,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteDataFederationPrivateEndpointApiParams - Parameters for the request
-	@return DeleteDataFederationPrivateEndpointApiRequest}}
+	@return DeleteDataFederationPrivateEndpointApiRequest
 	*/
 	DeleteDataFederationPrivateEndpointWithParams(ctx context.Context, args *DeleteDataFederationPrivateEndpointApiParams) DeleteDataFederationPrivateEndpointApiRequest
 
@@ -149,7 +149,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteFederatedDatabaseApiParams - Parameters for the request
-	@return DeleteFederatedDatabaseApiRequest}}
+	@return DeleteFederatedDatabaseApiRequest
 	*/
 	DeleteFederatedDatabaseWithParams(ctx context.Context, args *DeleteFederatedDatabaseApiParams) DeleteFederatedDatabaseApiRequest
 
@@ -174,7 +174,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteOneDataFederationInstanceQueryLimitApiParams - Parameters for the request
-	@return DeleteOneDataFederationInstanceQueryLimitApiRequest}}
+	@return DeleteOneDataFederationInstanceQueryLimitApiRequest
 	*/
 	DeleteOneDataFederationInstanceQueryLimitWithParams(ctx context.Context, args *DeleteOneDataFederationInstanceQueryLimitApiParams) DeleteOneDataFederationInstanceQueryLimitApiRequest
 
@@ -198,7 +198,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DownloadFederatedDatabaseQueryLogsApiParams - Parameters for the request
-	@return DownloadFederatedDatabaseQueryLogsApiRequest}}
+	@return DownloadFederatedDatabaseQueryLogsApiRequest
 	*/
 	DownloadFederatedDatabaseQueryLogsWithParams(ctx context.Context, args *DownloadFederatedDatabaseQueryLogsApiParams) DownloadFederatedDatabaseQueryLogsApiRequest
 
@@ -222,7 +222,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetDataFederationPrivateEndpointApiParams - Parameters for the request
-	@return GetDataFederationPrivateEndpointApiRequest}}
+	@return GetDataFederationPrivateEndpointApiRequest
 	*/
 	GetDataFederationPrivateEndpointWithParams(ctx context.Context, args *GetDataFederationPrivateEndpointApiParams) GetDataFederationPrivateEndpointApiRequest
 
@@ -246,7 +246,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetFederatedDatabaseApiParams - Parameters for the request
-	@return GetFederatedDatabaseApiRequest}}
+	@return GetFederatedDatabaseApiRequest
 	*/
 	GetFederatedDatabaseWithParams(ctx context.Context, args *GetFederatedDatabaseApiParams) GetFederatedDatabaseApiRequest
 
@@ -269,7 +269,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListDataFederationPrivateEndpointsApiParams - Parameters for the request
-	@return ListDataFederationPrivateEndpointsApiRequest}}
+	@return ListDataFederationPrivateEndpointsApiRequest
 	*/
 	ListDataFederationPrivateEndpointsWithParams(ctx context.Context, args *ListDataFederationPrivateEndpointsApiParams) ListDataFederationPrivateEndpointsApiRequest
 
@@ -292,7 +292,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListFederatedDatabasesApiParams - Parameters for the request
-	@return ListFederatedDatabasesApiRequest}}
+	@return ListFederatedDatabasesApiRequest
 	*/
 	ListFederatedDatabasesWithParams(ctx context.Context, args *ListFederatedDatabasesApiParams) ListFederatedDatabasesApiRequest
 
@@ -317,7 +317,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ReturnFederatedDatabaseQueryLimitApiParams - Parameters for the request
-	@return ReturnFederatedDatabaseQueryLimitApiRequest}}
+	@return ReturnFederatedDatabaseQueryLimitApiRequest
 	*/
 	ReturnFederatedDatabaseQueryLimitWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitApiParams) ReturnFederatedDatabaseQueryLimitApiRequest
 
@@ -341,7 +341,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ReturnFederatedDatabaseQueryLimitsApiParams - Parameters for the request
-	@return ReturnFederatedDatabaseQueryLimitsApiRequest}}
+	@return ReturnFederatedDatabaseQueryLimitsApiRequest
 	*/
 	ReturnFederatedDatabaseQueryLimitsWithParams(ctx context.Context, args *ReturnFederatedDatabaseQueryLimitsApiParams) ReturnFederatedDatabaseQueryLimitsApiRequest
 
@@ -365,7 +365,7 @@ type DataFederationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateFederatedDatabaseApiParams - Parameters for the request
-	@return UpdateFederatedDatabaseApiRequest}}
+	@return UpdateFederatedDatabaseApiRequest
 	*/
 	UpdateFederatedDatabaseWithParams(ctx context.Context, args *UpdateFederatedDatabaseApiParams) UpdateFederatedDatabaseApiRequest
 

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -29,10 +29,18 @@ type DataLakePipelinesApi interface {
 	@return CreatePipelineApiRequest
 	*/
 	CreatePipeline(ctx context.Context, groupId string) CreatePipelineApiRequest
+	/*
+	CreatePipeline Create One Data Lake Pipeline
 
-	// CreatePipelineExecute executes the request
-	//  @return IngestionPipeline
-	CreatePipelineExecute(r CreatePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreatePipelineApiParams - Parameters for the request
+	@return CreatePipelineApiRequest}}
+	*/
+	CreatePipelineWithParams(ctx context.Context, args *CreatePipelineApiParams) CreatePipelineApiRequest
+
+	// Interface only available internally
+	createPipelineExecute(r CreatePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	DeletePipeline Remove One Data Lake Pipeline
@@ -45,9 +53,18 @@ type DataLakePipelinesApi interface {
 	@return DeletePipelineApiRequest
 	*/
 	DeletePipeline(ctx context.Context, groupId string, pipelineName string) DeletePipelineApiRequest
+	/*
+	DeletePipeline Remove One Data Lake Pipeline
 
-	// DeletePipelineExecute executes the request
-	DeletePipelineExecute(r DeletePipelineApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeletePipelineApiParams - Parameters for the request
+	@return DeletePipelineApiRequest}}
+	*/
+	DeletePipelineWithParams(ctx context.Context, args *DeletePipelineApiParams) DeletePipelineApiRequest
+
+	// Interface only available internally
+	deletePipelineExecute(r DeletePipelineApiRequest) (*http.Response, error)
 
 	/*
 	DeletePipelineRunDataset Delete Pipeline Run Dataset
@@ -61,9 +78,18 @@ type DataLakePipelinesApi interface {
 	@return DeletePipelineRunDatasetApiRequest
 	*/
 	DeletePipelineRunDataset(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) DeletePipelineRunDatasetApiRequest
+	/*
+	DeletePipelineRunDataset Delete Pipeline Run Dataset
 
-	// DeletePipelineRunDatasetExecute executes the request
-	DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeletePipelineRunDatasetApiParams - Parameters for the request
+	@return DeletePipelineRunDatasetApiRequest}}
+	*/
+	DeletePipelineRunDatasetWithParams(ctx context.Context, args *DeletePipelineRunDatasetApiParams) DeletePipelineRunDatasetApiRequest
+
+	// Interface only available internally
+	deletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (*http.Response, error)
 
 	/*
 	GetPipeline Return One Data Lake Pipeline
@@ -76,10 +102,18 @@ type DataLakePipelinesApi interface {
 	@return GetPipelineApiRequest
 	*/
 	GetPipeline(ctx context.Context, groupId string, pipelineName string) GetPipelineApiRequest
+	/*
+	GetPipeline Return One Data Lake Pipeline
 
-	// GetPipelineExecute executes the request
-	//  @return IngestionPipeline
-	GetPipelineExecute(r GetPipelineApiRequest) (*IngestionPipeline, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetPipelineApiParams - Parameters for the request
+	@return GetPipelineApiRequest}}
+	*/
+	GetPipelineWithParams(ctx context.Context, args *GetPipelineApiParams) GetPipelineApiRequest
+
+	// Interface only available internally
+	getPipelineExecute(r GetPipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	GetPipelineRun Return One Data Lake Pipeline Run
@@ -93,10 +127,18 @@ type DataLakePipelinesApi interface {
 	@return GetPipelineRunApiRequest
 	*/
 	GetPipelineRun(ctx context.Context, groupId string, pipelineName string, pipelineRunId string) GetPipelineRunApiRequest
+	/*
+	GetPipelineRun Return One Data Lake Pipeline Run
 
-	// GetPipelineRunExecute executes the request
-	//  @return IngestionPipelineRun
-	GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetPipelineRunApiParams - Parameters for the request
+	@return GetPipelineRunApiRequest}}
+	*/
+	GetPipelineRunWithParams(ctx context.Context, args *GetPipelineRunApiParams) GetPipelineRunApiRequest
+
+	// Interface only available internally
+	getPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
 	ListPipelineRuns Return All Data Lake Pipeline Runs from One Project
@@ -109,10 +151,18 @@ type DataLakePipelinesApi interface {
 	@return ListPipelineRunsApiRequest
 	*/
 	ListPipelineRuns(ctx context.Context, groupId string, pipelineName string) ListPipelineRunsApiRequest
+	/*
+	ListPipelineRuns Return All Data Lake Pipeline Runs from One Project
 
-	// ListPipelineRunsExecute executes the request
-	//  @return PaginatedPipelineRun
-	ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPipelineRunsApiParams - Parameters for the request
+	@return ListPipelineRunsApiRequest}}
+	*/
+	ListPipelineRunsWithParams(ctx context.Context, args *ListPipelineRunsApiParams) ListPipelineRunsApiRequest
+
+	// Interface only available internally
+	listPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error)
 
 	/*
 	ListPipelineSchedules Return Available Ingestion Schedules for One Data Lake Pipeline
@@ -125,10 +175,18 @@ type DataLakePipelinesApi interface {
 	@return ListPipelineSchedulesApiRequest
 	*/
 	ListPipelineSchedules(ctx context.Context, groupId string, pipelineName string) ListPipelineSchedulesApiRequest
+	/*
+	ListPipelineSchedules Return Available Ingestion Schedules for One Data Lake Pipeline
 
-	// ListPipelineSchedulesExecute executes the request
-	//  @return []PolicyItem
-	ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]PolicyItem, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPipelineSchedulesApiParams - Parameters for the request
+	@return ListPipelineSchedulesApiRequest}}
+	*/
+	ListPipelineSchedulesWithParams(ctx context.Context, args *ListPipelineSchedulesApiParams) ListPipelineSchedulesApiRequest
+
+	// Interface only available internally
+	listPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]PolicyItem, *http.Response, error)
 
 	/*
 	ListPipelineSnapshots Return Available Backup Snapshots for One Data Lake Pipeline
@@ -141,10 +199,18 @@ type DataLakePipelinesApi interface {
 	@return ListPipelineSnapshotsApiRequest
 	*/
 	ListPipelineSnapshots(ctx context.Context, groupId string, pipelineName string) ListPipelineSnapshotsApiRequest
+	/*
+	ListPipelineSnapshots Return Available Backup Snapshots for One Data Lake Pipeline
 
-	// ListPipelineSnapshotsExecute executes the request
-	//  @return PaginatedBackupSnapshot
-	ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPipelineSnapshotsApiParams - Parameters for the request
+	@return ListPipelineSnapshotsApiRequest}}
+	*/
+	ListPipelineSnapshotsWithParams(ctx context.Context, args *ListPipelineSnapshotsApiParams) ListPipelineSnapshotsApiRequest
+
+	// Interface only available internally
+	listPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error)
 
 	/*
 	ListPipelines Return All Data Lake Pipelines from One Project
@@ -156,10 +222,18 @@ type DataLakePipelinesApi interface {
 	@return ListPipelinesApiRequest
 	*/
 	ListPipelines(ctx context.Context, groupId string) ListPipelinesApiRequest
+	/*
+	ListPipelines Return All Data Lake Pipelines from One Project
 
-	// ListPipelinesExecute executes the request
-	//  @return []IngestionPipeline
-	ListPipelinesExecute(r ListPipelinesApiRequest) ([]IngestionPipeline, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPipelinesApiParams - Parameters for the request
+	@return ListPipelinesApiRequest}}
+	*/
+	ListPipelinesWithParams(ctx context.Context, args *ListPipelinesApiParams) ListPipelinesApiRequest
+
+	// Interface only available internally
+	listPipelinesExecute(r ListPipelinesApiRequest) ([]IngestionPipeline, *http.Response, error)
 
 	/*
 	PausePipeline Pause One Data Lake Pipeline
@@ -172,10 +246,18 @@ type DataLakePipelinesApi interface {
 	@return PausePipelineApiRequest
 	*/
 	PausePipeline(ctx context.Context, groupId string, pipelineName string) PausePipelineApiRequest
+	/*
+	PausePipeline Pause One Data Lake Pipeline
 
-	// PausePipelineExecute executes the request
-	//  @return IngestionPipeline
-	PausePipelineExecute(r PausePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param PausePipelineApiParams - Parameters for the request
+	@return PausePipelineApiRequest}}
+	*/
+	PausePipelineWithParams(ctx context.Context, args *PausePipelineApiParams) PausePipelineApiRequest
+
+	// Interface only available internally
+	pausePipelineExecute(r PausePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	ResumePipeline Resume One Data Lake Pipeline
@@ -188,10 +270,18 @@ type DataLakePipelinesApi interface {
 	@return ResumePipelineApiRequest
 	*/
 	ResumePipeline(ctx context.Context, groupId string, pipelineName string) ResumePipelineApiRequest
+	/*
+	ResumePipeline Resume One Data Lake Pipeline
 
-	// ResumePipelineExecute executes the request
-	//  @return IngestionPipeline
-	ResumePipelineExecute(r ResumePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ResumePipelineApiParams - Parameters for the request
+	@return ResumePipelineApiRequest}}
+	*/
+	ResumePipelineWithParams(ctx context.Context, args *ResumePipelineApiParams) ResumePipelineApiRequest
+
+	// Interface only available internally
+	resumePipelineExecute(r ResumePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 
 	/*
 	TriggerSnapshotIngestion Trigger on demand snapshot ingestion
@@ -204,10 +294,18 @@ type DataLakePipelinesApi interface {
 	@return TriggerSnapshotIngestionApiRequest
 	*/
 	TriggerSnapshotIngestion(ctx context.Context, groupId string, pipelineName string) TriggerSnapshotIngestionApiRequest
+	/*
+	TriggerSnapshotIngestion Trigger on demand snapshot ingestion
 
-	// TriggerSnapshotIngestionExecute executes the request
-	//  @return IngestionPipelineRun
-	TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param TriggerSnapshotIngestionApiParams - Parameters for the request
+	@return TriggerSnapshotIngestionApiRequest}}
+	*/
+	TriggerSnapshotIngestionWithParams(ctx context.Context, args *TriggerSnapshotIngestionApiParams) TriggerSnapshotIngestionApiRequest
+
+	// Interface only available internally
+	triggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error)
 
 	/*
 	UpdatePipeline Update One Data Lake Pipeline
@@ -220,10 +318,18 @@ type DataLakePipelinesApi interface {
 	@return UpdatePipelineApiRequest
 	*/
 	UpdatePipeline(ctx context.Context, groupId string, pipelineName string) UpdatePipelineApiRequest
+	/*
+	UpdatePipeline Update One Data Lake Pipeline
 
-	// UpdatePipelineExecute executes the request
-	//  @return IngestionPipeline
-	UpdatePipelineExecute(r UpdatePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdatePipelineApiParams - Parameters for the request
+	@return UpdatePipelineApiRequest}}
+	*/
+	UpdatePipelineWithParams(ctx context.Context, args *UpdatePipelineApiParams) UpdatePipelineApiRequest
+
+	// Interface only available internally
+	updatePipelineExecute(r UpdatePipelineApiRequest) (*IngestionPipeline, *http.Response, error)
 }
 
 // DataLakePipelinesApiService DataLakePipelinesApi service
@@ -241,6 +347,15 @@ type CreatePipelineApiParams struct {
 		IngestionPipeline *IngestionPipeline
 }
 
+func (a *DataLakePipelinesApiService) CreatePipelineWithParams(ctx context.Context, args *CreatePipelineApiParams) CreatePipelineApiRequest {
+	return CreatePipelineApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		ingestionPipeline: args.IngestionPipeline,
+	}
+}
+
 // Creates one Data Lake Pipeline.
 func (r CreatePipelineApiRequest) IngestionPipeline(ingestionPipeline IngestionPipeline) CreatePipelineApiRequest {
 	r.ingestionPipeline = &ingestionPipeline
@@ -248,13 +363,7 @@ func (r CreatePipelineApiRequest) IngestionPipeline(ingestionPipeline IngestionP
 }
 
 func (r CreatePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
-	return r.ApiService.CreatePipelineExecute(r)
-}
-
-func (r CreatePipelineApiRequest) ExecuteWithParams(params *CreatePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.ingestionPipeline = params.IngestionPipeline 
-	return r.Execute()
+	return r.ApiService.createPipelineExecute(r)
 }
 
 /*
@@ -276,7 +385,7 @@ func (a *DataLakePipelinesApiService) CreatePipeline(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) CreatePipelineExecute(r CreatePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) createPipelineExecute(r CreatePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -381,14 +490,17 @@ type DeletePipelineApiParams struct {
 		PipelineName string
 }
 
-func (r DeletePipelineApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeletePipelineExecute(r)
+func (a *DataLakePipelinesApiService) DeletePipelineWithParams(ctx context.Context, args *DeletePipelineApiParams) DeletePipelineApiRequest {
+	return DeletePipelineApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+	}
 }
 
-func (r DeletePipelineApiRequest) ExecuteWithParams(params *DeletePipelineApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	return r.Execute()
+func (r DeletePipelineApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deletePipelineExecute(r)
 }
 
 /*
@@ -411,7 +523,7 @@ func (a *DataLakePipelinesApiService) DeletePipeline(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *DataLakePipelinesApiService) DeletePipelineExecute(r DeletePipelineApiRequest) (*http.Response, error) {
+func (a *DataLakePipelinesApiService) deletePipelineExecute(r DeletePipelineApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -510,15 +622,18 @@ type DeletePipelineRunDatasetApiParams struct {
 		PipelineRunId string
 }
 
-func (r DeletePipelineRunDatasetApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeletePipelineRunDatasetExecute(r)
+func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetWithParams(ctx context.Context, args *DeletePipelineRunDatasetApiParams) DeletePipelineRunDatasetApiRequest {
+	return DeletePipelineRunDatasetApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+		pipelineRunId: args.PipelineRunId,
+	}
 }
 
-func (r DeletePipelineRunDatasetApiRequest) ExecuteWithParams(params *DeletePipelineRunDatasetApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	r.pipelineRunId = params.PipelineRunId 
-	return r.Execute()
+func (r DeletePipelineRunDatasetApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deletePipelineRunDatasetExecute(r)
 }
 
 /*
@@ -543,7 +658,7 @@ func (a *DataLakePipelinesApiService) DeletePipelineRunDataset(ctx context.Conte
 }
 
 // Execute executes the request
-func (a *DataLakePipelinesApiService) DeletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (*http.Response, error) {
+func (a *DataLakePipelinesApiService) deletePipelineRunDatasetExecute(r DeletePipelineRunDatasetApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -647,14 +762,17 @@ type GetPipelineApiParams struct {
 		PipelineName string
 }
 
-func (r GetPipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
-	return r.ApiService.GetPipelineExecute(r)
+func (a *DataLakePipelinesApiService) GetPipelineWithParams(ctx context.Context, args *GetPipelineApiParams) GetPipelineApiRequest {
+	return GetPipelineApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+	}
 }
 
-func (r GetPipelineApiRequest) ExecuteWithParams(params *GetPipelineApiParams) (*IngestionPipeline, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	return r.Execute()
+func (r GetPipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+	return r.ApiService.getPipelineExecute(r)
 }
 
 /*
@@ -678,7 +796,7 @@ func (a *DataLakePipelinesApiService) GetPipeline(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) GetPipelineExecute(r GetPipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) getPipelineExecute(r GetPipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -787,15 +905,18 @@ type GetPipelineRunApiParams struct {
 		PipelineRunId string
 }
 
-func (r GetPipelineRunApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
-	return r.ApiService.GetPipelineRunExecute(r)
+func (a *DataLakePipelinesApiService) GetPipelineRunWithParams(ctx context.Context, args *GetPipelineRunApiParams) GetPipelineRunApiRequest {
+	return GetPipelineRunApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+		pipelineRunId: args.PipelineRunId,
+	}
 }
 
-func (r GetPipelineRunApiRequest) ExecuteWithParams(params *GetPipelineRunApiParams) (*IngestionPipelineRun, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	r.pipelineRunId = params.PipelineRunId 
-	return r.Execute()
+func (r GetPipelineRunApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
+	return r.ApiService.getPipelineRunExecute(r)
 }
 
 /*
@@ -821,7 +942,7 @@ func (a *DataLakePipelinesApiService) GetPipelineRun(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipelineRun
-func (a *DataLakePipelinesApiService) GetPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) getPipelineRunExecute(r GetPipelineRunApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -943,6 +1064,19 @@ type ListPipelineRunsApiParams struct {
 		CreatedBefore *time.Time
 }
 
+func (a *DataLakePipelinesApiService) ListPipelineRunsWithParams(ctx context.Context, args *ListPipelineRunsApiParams) ListPipelineRunsApiRequest {
+	return ListPipelineRunsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		createdBefore: args.CreatedBefore,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListPipelineRunsApiRequest) IncludeCount(includeCount bool) ListPipelineRunsApiRequest {
 	r.includeCount = &includeCount
@@ -968,17 +1102,7 @@ func (r ListPipelineRunsApiRequest) CreatedBefore(createdBefore time.Time) ListP
 }
 
 func (r ListPipelineRunsApiRequest) Execute() (*PaginatedPipelineRun, *http.Response, error) {
-	return r.ApiService.ListPipelineRunsExecute(r)
-}
-
-func (r ListPipelineRunsApiRequest) ExecuteWithParams(params *ListPipelineRunsApiParams) (*PaginatedPipelineRun, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.createdBefore = params.CreatedBefore 
-	return r.Execute()
+	return r.ApiService.listPipelineRunsExecute(r)
 }
 
 /*
@@ -1002,7 +1126,7 @@ func (a *DataLakePipelinesApiService) ListPipelineRuns(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PaginatedPipelineRun
-func (a *DataLakePipelinesApiService) ListPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) listPipelineRunsExecute(r ListPipelineRunsApiRequest) (*PaginatedPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1133,14 +1257,17 @@ type ListPipelineSchedulesApiParams struct {
 		PipelineName string
 }
 
-func (r ListPipelineSchedulesApiRequest) Execute() ([]PolicyItem, *http.Response, error) {
-	return r.ApiService.ListPipelineSchedulesExecute(r)
+func (a *DataLakePipelinesApiService) ListPipelineSchedulesWithParams(ctx context.Context, args *ListPipelineSchedulesApiParams) ListPipelineSchedulesApiRequest {
+	return ListPipelineSchedulesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+	}
 }
 
-func (r ListPipelineSchedulesApiRequest) ExecuteWithParams(params *ListPipelineSchedulesApiParams) ([]PolicyItem, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	return r.Execute()
+func (r ListPipelineSchedulesApiRequest) Execute() ([]PolicyItem, *http.Response, error) {
+	return r.ApiService.listPipelineSchedulesExecute(r)
 }
 
 /*
@@ -1164,7 +1291,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSchedules(ctx context.Context,
 
 // Execute executes the request
 //  @return []PolicyItem
-func (a *DataLakePipelinesApiService) ListPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]PolicyItem, *http.Response, error) {
+func (a *DataLakePipelinesApiService) listPipelineSchedulesExecute(r ListPipelineSchedulesApiRequest) ([]PolicyItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1279,6 +1406,19 @@ type ListPipelineSnapshotsApiParams struct {
 		CompletedAfter *time.Time
 }
 
+func (a *DataLakePipelinesApiService) ListPipelineSnapshotsWithParams(ctx context.Context, args *ListPipelineSnapshotsApiParams) ListPipelineSnapshotsApiRequest {
+	return ListPipelineSnapshotsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		completedAfter: args.CompletedAfter,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListPipelineSnapshotsApiRequest) IncludeCount(includeCount bool) ListPipelineSnapshotsApiRequest {
 	r.includeCount = &includeCount
@@ -1304,17 +1444,7 @@ func (r ListPipelineSnapshotsApiRequest) CompletedAfter(completedAfter time.Time
 }
 
 func (r ListPipelineSnapshotsApiRequest) Execute() (*PaginatedBackupSnapshot, *http.Response, error) {
-	return r.ApiService.ListPipelineSnapshotsExecute(r)
-}
-
-func (r ListPipelineSnapshotsApiRequest) ExecuteWithParams(params *ListPipelineSnapshotsApiParams) (*PaginatedBackupSnapshot, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.completedAfter = params.CompletedAfter 
-	return r.Execute()
+	return r.ApiService.listPipelineSnapshotsExecute(r)
 }
 
 /*
@@ -1338,7 +1468,7 @@ func (a *DataLakePipelinesApiService) ListPipelineSnapshots(ctx context.Context,
 
 // Execute executes the request
 //  @return PaginatedBackupSnapshot
-func (a *DataLakePipelinesApiService) ListPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error) {
+func (a *DataLakePipelinesApiService) listPipelineSnapshotsExecute(r ListPipelineSnapshotsApiRequest) (*PaginatedBackupSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1467,13 +1597,16 @@ type ListPipelinesApiParams struct {
 		GroupId string
 }
 
-func (r ListPipelinesApiRequest) Execute() ([]IngestionPipeline, *http.Response, error) {
-	return r.ApiService.ListPipelinesExecute(r)
+func (a *DataLakePipelinesApiService) ListPipelinesWithParams(ctx context.Context, args *ListPipelinesApiParams) ListPipelinesApiRequest {
+	return ListPipelinesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ListPipelinesApiRequest) ExecuteWithParams(params *ListPipelinesApiParams) ([]IngestionPipeline, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ListPipelinesApiRequest) Execute() ([]IngestionPipeline, *http.Response, error) {
+	return r.ApiService.listPipelinesExecute(r)
 }
 
 /*
@@ -1495,7 +1628,7 @@ func (a *DataLakePipelinesApiService) ListPipelines(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return []IngestionPipeline
-func (a *DataLakePipelinesApiService) ListPipelinesExecute(r ListPipelinesApiRequest) ([]IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) listPipelinesExecute(r ListPipelinesApiRequest) ([]IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1595,14 +1728,17 @@ type PausePipelineApiParams struct {
 		PipelineName string
 }
 
-func (r PausePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
-	return r.ApiService.PausePipelineExecute(r)
+func (a *DataLakePipelinesApiService) PausePipelineWithParams(ctx context.Context, args *PausePipelineApiParams) PausePipelineApiRequest {
+	return PausePipelineApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+	}
 }
 
-func (r PausePipelineApiRequest) ExecuteWithParams(params *PausePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	return r.Execute()
+func (r PausePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+	return r.ApiService.pausePipelineExecute(r)
 }
 
 /*
@@ -1626,7 +1762,7 @@ func (a *DataLakePipelinesApiService) PausePipeline(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) PausePipelineExecute(r PausePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) pausePipelineExecute(r PausePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1733,14 +1869,17 @@ type ResumePipelineApiParams struct {
 		PipelineName string
 }
 
-func (r ResumePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
-	return r.ApiService.ResumePipelineExecute(r)
+func (a *DataLakePipelinesApiService) ResumePipelineWithParams(ctx context.Context, args *ResumePipelineApiParams) ResumePipelineApiRequest {
+	return ResumePipelineApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+	}
 }
 
-func (r ResumePipelineApiRequest) ExecuteWithParams(params *ResumePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	return r.Execute()
+func (r ResumePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
+	return r.ApiService.resumePipelineExecute(r)
 }
 
 /*
@@ -1764,7 +1903,7 @@ func (a *DataLakePipelinesApiService) ResumePipeline(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) ResumePipelineExecute(r ResumePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) resumePipelineExecute(r ResumePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -1873,6 +2012,16 @@ type TriggerSnapshotIngestionApiParams struct {
 		TriggerIngestionRequest *TriggerIngestionRequest
 }
 
+func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionWithParams(ctx context.Context, args *TriggerSnapshotIngestionApiParams) TriggerSnapshotIngestionApiRequest {
+	return TriggerSnapshotIngestionApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+		triggerIngestionRequest: args.TriggerIngestionRequest,
+	}
+}
+
 // Triggers a single ingestion run of a snapshot.
 func (r TriggerSnapshotIngestionApiRequest) TriggerIngestionRequest(triggerIngestionRequest TriggerIngestionRequest) TriggerSnapshotIngestionApiRequest {
 	r.triggerIngestionRequest = &triggerIngestionRequest
@@ -1880,14 +2029,7 @@ func (r TriggerSnapshotIngestionApiRequest) TriggerIngestionRequest(triggerInges
 }
 
 func (r TriggerSnapshotIngestionApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
-	return r.ApiService.TriggerSnapshotIngestionExecute(r)
-}
-
-func (r TriggerSnapshotIngestionApiRequest) ExecuteWithParams(params *TriggerSnapshotIngestionApiParams) (*IngestionPipelineRun, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	r.triggerIngestionRequest = params.TriggerIngestionRequest 
-	return r.Execute()
+	return r.ApiService.triggerSnapshotIngestionExecute(r)
 }
 
 /*
@@ -1911,7 +2053,7 @@ func (a *DataLakePipelinesApiService) TriggerSnapshotIngestion(ctx context.Conte
 
 // Execute executes the request
 //  @return IngestionPipelineRun
-func (a *DataLakePipelinesApiService) TriggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error) {
+func (a *DataLakePipelinesApiService) triggerSnapshotIngestionExecute(r TriggerSnapshotIngestionApiRequest) (*IngestionPipelineRun, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -2025,6 +2167,16 @@ type UpdatePipelineApiParams struct {
 		IngestionPipeline *IngestionPipeline
 }
 
+func (a *DataLakePipelinesApiService) UpdatePipelineWithParams(ctx context.Context, args *UpdatePipelineApiParams) UpdatePipelineApiRequest {
+	return UpdatePipelineApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		pipelineName: args.PipelineName,
+		ingestionPipeline: args.IngestionPipeline,
+	}
+}
+
 // Updates one Data Lake Pipeline.
 func (r UpdatePipelineApiRequest) IngestionPipeline(ingestionPipeline IngestionPipeline) UpdatePipelineApiRequest {
 	r.ingestionPipeline = &ingestionPipeline
@@ -2032,14 +2184,7 @@ func (r UpdatePipelineApiRequest) IngestionPipeline(ingestionPipeline IngestionP
 }
 
 func (r UpdatePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
-	return r.ApiService.UpdatePipelineExecute(r)
-}
-
-func (r UpdatePipelineApiRequest) ExecuteWithParams(params *UpdatePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.pipelineName = params.PipelineName 
-	r.ingestionPipeline = params.IngestionPipeline 
-	return r.Execute()
+	return r.ApiService.updatePipelineExecute(r)
 }
 
 /*
@@ -2063,7 +2208,7 @@ func (a *DataLakePipelinesApiService) UpdatePipeline(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return IngestionPipeline
-func (a *DataLakePipelinesApiService) UpdatePipelineExecute(r UpdatePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
+func (a *DataLakePipelinesApiService) updatePipelineExecute(r UpdatePipelineApiRequest) (*IngestionPipeline, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -35,7 +35,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreatePipelineApiParams - Parameters for the request
-	@return CreatePipelineApiRequest}}
+	@return CreatePipelineApiRequest
 	*/
 	CreatePipelineWithParams(ctx context.Context, args *CreatePipelineApiParams) CreatePipelineApiRequest
 
@@ -59,7 +59,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeletePipelineApiParams - Parameters for the request
-	@return DeletePipelineApiRequest}}
+	@return DeletePipelineApiRequest
 	*/
 	DeletePipelineWithParams(ctx context.Context, args *DeletePipelineApiParams) DeletePipelineApiRequest
 
@@ -84,7 +84,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeletePipelineRunDatasetApiParams - Parameters for the request
-	@return DeletePipelineRunDatasetApiRequest}}
+	@return DeletePipelineRunDatasetApiRequest
 	*/
 	DeletePipelineRunDatasetWithParams(ctx context.Context, args *DeletePipelineRunDatasetApiParams) DeletePipelineRunDatasetApiRequest
 
@@ -108,7 +108,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetPipelineApiParams - Parameters for the request
-	@return GetPipelineApiRequest}}
+	@return GetPipelineApiRequest
 	*/
 	GetPipelineWithParams(ctx context.Context, args *GetPipelineApiParams) GetPipelineApiRequest
 
@@ -133,7 +133,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetPipelineRunApiParams - Parameters for the request
-	@return GetPipelineRunApiRequest}}
+	@return GetPipelineRunApiRequest
 	*/
 	GetPipelineRunWithParams(ctx context.Context, args *GetPipelineRunApiParams) GetPipelineRunApiRequest
 
@@ -157,7 +157,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPipelineRunsApiParams - Parameters for the request
-	@return ListPipelineRunsApiRequest}}
+	@return ListPipelineRunsApiRequest
 	*/
 	ListPipelineRunsWithParams(ctx context.Context, args *ListPipelineRunsApiParams) ListPipelineRunsApiRequest
 
@@ -181,7 +181,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPipelineSchedulesApiParams - Parameters for the request
-	@return ListPipelineSchedulesApiRequest}}
+	@return ListPipelineSchedulesApiRequest
 	*/
 	ListPipelineSchedulesWithParams(ctx context.Context, args *ListPipelineSchedulesApiParams) ListPipelineSchedulesApiRequest
 
@@ -205,7 +205,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPipelineSnapshotsApiParams - Parameters for the request
-	@return ListPipelineSnapshotsApiRequest}}
+	@return ListPipelineSnapshotsApiRequest
 	*/
 	ListPipelineSnapshotsWithParams(ctx context.Context, args *ListPipelineSnapshotsApiParams) ListPipelineSnapshotsApiRequest
 
@@ -228,7 +228,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPipelinesApiParams - Parameters for the request
-	@return ListPipelinesApiRequest}}
+	@return ListPipelinesApiRequest
 	*/
 	ListPipelinesWithParams(ctx context.Context, args *ListPipelinesApiParams) ListPipelinesApiRequest
 
@@ -252,7 +252,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param PausePipelineApiParams - Parameters for the request
-	@return PausePipelineApiRequest}}
+	@return PausePipelineApiRequest
 	*/
 	PausePipelineWithParams(ctx context.Context, args *PausePipelineApiParams) PausePipelineApiRequest
 
@@ -276,7 +276,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ResumePipelineApiParams - Parameters for the request
-	@return ResumePipelineApiRequest}}
+	@return ResumePipelineApiRequest
 	*/
 	ResumePipelineWithParams(ctx context.Context, args *ResumePipelineApiParams) ResumePipelineApiRequest
 
@@ -300,7 +300,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param TriggerSnapshotIngestionApiParams - Parameters for the request
-	@return TriggerSnapshotIngestionApiRequest}}
+	@return TriggerSnapshotIngestionApiRequest
 	*/
 	TriggerSnapshotIngestionWithParams(ctx context.Context, args *TriggerSnapshotIngestionApiParams) TriggerSnapshotIngestionApiRequest
 
@@ -324,7 +324,7 @@ type DataLakePipelinesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdatePipelineApiParams - Parameters for the request
-	@return UpdatePipelineApiRequest}}
+	@return UpdatePipelineApiRequest
 	*/
 	UpdatePipelineWithParams(ctx context.Context, args *UpdatePipelineApiParams) UpdatePipelineApiRequest
 

--- a/mongodbatlasv2/api_data_lake_pipelines.go
+++ b/mongodbatlasv2/api_data_lake_pipelines.go
@@ -251,6 +251,12 @@ func (r CreatePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response,
 	return r.ApiService.CreatePipelineExecute(r)
 }
 
+func (r CreatePipelineApiRequest) ExecuteWithParams(params *CreatePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.ingestionPipeline = params.IngestionPipeline 
+	return r.Execute()
+}
+
 /*
 CreatePipeline Create One Data Lake Pipeline
 
@@ -379,6 +385,12 @@ func (r DeletePipelineApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePipelineExecute(r)
 }
 
+func (r DeletePipelineApiRequest) ExecuteWithParams(params *DeletePipelineApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	return r.Execute()
+}
+
 /*
 DeletePipeline Remove One Data Lake Pipeline
 
@@ -500,6 +512,13 @@ type DeletePipelineRunDatasetApiParams struct {
 
 func (r DeletePipelineRunDatasetApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePipelineRunDatasetExecute(r)
+}
+
+func (r DeletePipelineRunDatasetApiRequest) ExecuteWithParams(params *DeletePipelineRunDatasetApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	r.pipelineRunId = params.PipelineRunId 
+	return r.Execute()
 }
 
 /*
@@ -630,6 +649,12 @@ type GetPipelineApiParams struct {
 
 func (r GetPipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.GetPipelineExecute(r)
+}
+
+func (r GetPipelineApiRequest) ExecuteWithParams(params *GetPipelineApiParams) (*IngestionPipeline, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	return r.Execute()
 }
 
 /*
@@ -764,6 +789,13 @@ type GetPipelineRunApiParams struct {
 
 func (r GetPipelineRunApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
 	return r.ApiService.GetPipelineRunExecute(r)
+}
+
+func (r GetPipelineRunApiRequest) ExecuteWithParams(params *GetPipelineRunApiParams) (*IngestionPipelineRun, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	r.pipelineRunId = params.PipelineRunId 
+	return r.Execute()
 }
 
 /*
@@ -939,6 +971,16 @@ func (r ListPipelineRunsApiRequest) Execute() (*PaginatedPipelineRun, *http.Resp
 	return r.ApiService.ListPipelineRunsExecute(r)
 }
 
+func (r ListPipelineRunsApiRequest) ExecuteWithParams(params *ListPipelineRunsApiParams) (*PaginatedPipelineRun, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.createdBefore = params.CreatedBefore 
+	return r.Execute()
+}
+
 /*
 ListPipelineRuns Return All Data Lake Pipeline Runs from One Project
 
@@ -1093,6 +1135,12 @@ type ListPipelineSchedulesApiParams struct {
 
 func (r ListPipelineSchedulesApiRequest) Execute() ([]PolicyItem, *http.Response, error) {
 	return r.ApiService.ListPipelineSchedulesExecute(r)
+}
+
+func (r ListPipelineSchedulesApiRequest) ExecuteWithParams(params *ListPipelineSchedulesApiParams) ([]PolicyItem, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	return r.Execute()
 }
 
 /*
@@ -1259,6 +1307,16 @@ func (r ListPipelineSnapshotsApiRequest) Execute() (*PaginatedBackupSnapshot, *h
 	return r.ApiService.ListPipelineSnapshotsExecute(r)
 }
 
+func (r ListPipelineSnapshotsApiRequest) ExecuteWithParams(params *ListPipelineSnapshotsApiParams) (*PaginatedBackupSnapshot, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.completedAfter = params.CompletedAfter 
+	return r.Execute()
+}
+
 /*
 ListPipelineSnapshots Return Available Backup Snapshots for One Data Lake Pipeline
 
@@ -1413,6 +1471,11 @@ func (r ListPipelinesApiRequest) Execute() ([]IngestionPipeline, *http.Response,
 	return r.ApiService.ListPipelinesExecute(r)
 }
 
+func (r ListPipelinesApiRequest) ExecuteWithParams(params *ListPipelinesApiParams) ([]IngestionPipeline, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 ListPipelines Return All Data Lake Pipelines from One Project
 
@@ -1534,6 +1597,12 @@ type PausePipelineApiParams struct {
 
 func (r PausePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.PausePipelineExecute(r)
+}
+
+func (r PausePipelineApiRequest) ExecuteWithParams(params *PausePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	return r.Execute()
 }
 
 /*
@@ -1666,6 +1735,12 @@ type ResumePipelineApiParams struct {
 
 func (r ResumePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.ResumePipelineExecute(r)
+}
+
+func (r ResumePipelineApiRequest) ExecuteWithParams(params *ResumePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	return r.Execute()
 }
 
 /*
@@ -1806,6 +1881,13 @@ func (r TriggerSnapshotIngestionApiRequest) TriggerIngestionRequest(triggerInges
 
 func (r TriggerSnapshotIngestionApiRequest) Execute() (*IngestionPipelineRun, *http.Response, error) {
 	return r.ApiService.TriggerSnapshotIngestionExecute(r)
+}
+
+func (r TriggerSnapshotIngestionApiRequest) ExecuteWithParams(params *TriggerSnapshotIngestionApiParams) (*IngestionPipelineRun, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	r.triggerIngestionRequest = params.TriggerIngestionRequest 
+	return r.Execute()
 }
 
 /*
@@ -1951,6 +2033,13 @@ func (r UpdatePipelineApiRequest) IngestionPipeline(ingestionPipeline IngestionP
 
 func (r UpdatePipelineApiRequest) Execute() (*IngestionPipeline, *http.Response, error) {
 	return r.ApiService.UpdatePipelineExecute(r)
+}
+
+func (r UpdatePipelineApiRequest) ExecuteWithParams(params *UpdatePipelineApiParams) (*IngestionPipeline, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.pipelineName = params.PipelineName 
+	r.ingestionPipeline = params.IngestionPipeline 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -34,7 +34,7 @@ type DatabaseUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateDatabaseUserApiParams - Parameters for the request
-	@return CreateDatabaseUserApiRequest}}
+	@return CreateDatabaseUserApiRequest
 	*/
 	CreateDatabaseUserWithParams(ctx context.Context, args *CreateDatabaseUserApiParams) CreateDatabaseUserApiRequest
 
@@ -59,7 +59,7 @@ type DatabaseUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteDatabaseUserApiParams - Parameters for the request
-	@return DeleteDatabaseUserApiRequest}}
+	@return DeleteDatabaseUserApiRequest
 	*/
 	DeleteDatabaseUserWithParams(ctx context.Context, args *DeleteDatabaseUserApiParams) DeleteDatabaseUserApiRequest
 
@@ -84,7 +84,7 @@ type DatabaseUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetDatabaseUserApiParams - Parameters for the request
-	@return GetDatabaseUserApiRequest}}
+	@return GetDatabaseUserApiRequest
 	*/
 	GetDatabaseUserWithParams(ctx context.Context, args *GetDatabaseUserApiParams) GetDatabaseUserApiRequest
 
@@ -107,7 +107,7 @@ type DatabaseUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListDatabaseUsersApiParams - Parameters for the request
-	@return ListDatabaseUsersApiRequest}}
+	@return ListDatabaseUsersApiRequest
 	*/
 	ListDatabaseUsersWithParams(ctx context.Context, args *ListDatabaseUsersApiParams) ListDatabaseUsersApiRequest
 
@@ -132,7 +132,7 @@ type DatabaseUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateDatabaseUserApiParams - Parameters for the request
-	@return UpdateDatabaseUserApiRequest}}
+	@return UpdateDatabaseUserApiRequest
 	*/
 	UpdateDatabaseUserWithParams(ctx context.Context, args *UpdateDatabaseUserApiParams) UpdateDatabaseUserApiRequest
 

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -124,6 +124,12 @@ func (r CreateDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, 
 	return r.ApiService.CreateDatabaseUserExecute(r)
 }
 
+func (r CreateDatabaseUserApiRequest) ExecuteWithParams(params *CreateDatabaseUserApiParams) (*DatabaseUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.databaseUser = params.DatabaseUser 
+	return r.Execute()
+}
+
 /*
 CreateDatabaseUser Create One Database User in One Project
 
@@ -254,6 +260,13 @@ func (r DeleteDatabaseUserApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteDatabaseUserExecute(r)
 }
 
+func (r DeleteDatabaseUserApiRequest) ExecuteWithParams(params *DeleteDatabaseUserApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.databaseName = params.DatabaseName 
+	r.username = params.Username 
+	return r.Execute()
+}
+
 /*
 DeleteDatabaseUser Remove One Database User from One Project
 
@@ -372,6 +385,13 @@ type GetDatabaseUserApiParams struct {
 
 func (r GetDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
 	return r.ApiService.GetDatabaseUserExecute(r)
+}
+
+func (r GetDatabaseUserApiRequest) ExecuteWithParams(params *GetDatabaseUserApiParams) (*DatabaseUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.databaseName = params.DatabaseName 
+	r.username = params.Username 
+	return r.Execute()
 }
 
 /*
@@ -523,6 +543,14 @@ func (r ListDatabaseUsersApiRequest) PageNum(pageNum int32) ListDatabaseUsersApi
 
 func (r ListDatabaseUsersApiRequest) Execute() (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
 	return r.ApiService.ListDatabaseUsersExecute(r)
+}
+
+func (r ListDatabaseUsersApiRequest) ExecuteWithParams(params *ListDatabaseUsersApiParams) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -677,6 +705,14 @@ func (r UpdateDatabaseUserApiRequest) DatabaseUser(databaseUser DatabaseUser) Up
 
 func (r UpdateDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
 	return r.ApiService.UpdateDatabaseUserExecute(r)
+}
+
+func (r UpdateDatabaseUserApiRequest) ExecuteWithParams(params *UpdateDatabaseUserApiParams) (*DatabaseUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.databaseName = params.DatabaseName 
+	r.username = params.Username 
+	r.databaseUser = params.DatabaseUser 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_database_users.go
+++ b/mongodbatlasv2/api_database_users.go
@@ -28,10 +28,18 @@ type DatabaseUsersApi interface {
 	@return CreateDatabaseUserApiRequest
 	*/
 	CreateDatabaseUser(ctx context.Context, groupId string) CreateDatabaseUserApiRequest
+	/*
+	CreateDatabaseUser Create One Database User in One Project
 
-	// CreateDatabaseUserExecute executes the request
-	//  @return DatabaseUser
-	CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateDatabaseUserApiParams - Parameters for the request
+	@return CreateDatabaseUserApiRequest}}
+	*/
+	CreateDatabaseUserWithParams(ctx context.Context, args *CreateDatabaseUserApiParams) CreateDatabaseUserApiRequest
+
+	// Interface only available internally
+	createDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
 
 	/*
 	DeleteDatabaseUser Remove One Database User from One Project
@@ -45,9 +53,18 @@ type DatabaseUsersApi interface {
 	@return DeleteDatabaseUserApiRequest
 	*/
 	DeleteDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) DeleteDatabaseUserApiRequest
+	/*
+	DeleteDatabaseUser Remove One Database User from One Project
 
-	// DeleteDatabaseUserExecute executes the request
-	DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteDatabaseUserApiParams - Parameters for the request
+	@return DeleteDatabaseUserApiRequest}}
+	*/
+	DeleteDatabaseUserWithParams(ctx context.Context, args *DeleteDatabaseUserApiParams) DeleteDatabaseUserApiRequest
+
+	// Interface only available internally
+	deleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (*http.Response, error)
 
 	/*
 	GetDatabaseUser Return One Database User from One Project
@@ -61,10 +78,18 @@ type DatabaseUsersApi interface {
 	@return GetDatabaseUserApiRequest
 	*/
 	GetDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) GetDatabaseUserApiRequest
+	/*
+	GetDatabaseUser Return One Database User from One Project
 
-	// GetDatabaseUserExecute executes the request
-	//  @return DatabaseUser
-	GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetDatabaseUserApiParams - Parameters for the request
+	@return GetDatabaseUserApiRequest}}
+	*/
+	GetDatabaseUserWithParams(ctx context.Context, args *GetDatabaseUserApiParams) GetDatabaseUserApiRequest
+
+	// Interface only available internally
+	getDatabaseUserExecute(r GetDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
 
 	/*
 	ListDatabaseUsers Return All Database Users from One Project
@@ -76,10 +101,18 @@ type DatabaseUsersApi interface {
 	@return ListDatabaseUsersApiRequest
 	*/
 	ListDatabaseUsers(ctx context.Context, groupId string) ListDatabaseUsersApiRequest
+	/*
+	ListDatabaseUsers Return All Database Users from One Project
 
-	// ListDatabaseUsersExecute executes the request
-	//  @return PaginatedApiAtlasDatabaseUser
-	ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListDatabaseUsersApiParams - Parameters for the request
+	@return ListDatabaseUsersApiRequest}}
+	*/
+	ListDatabaseUsersWithParams(ctx context.Context, args *ListDatabaseUsersApiParams) ListDatabaseUsersApiRequest
+
+	// Interface only available internally
+	listDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error)
 
 	/*
 	UpdateDatabaseUser Update One Database User in One Project
@@ -93,10 +126,18 @@ type DatabaseUsersApi interface {
 	@return UpdateDatabaseUserApiRequest
 	*/
 	UpdateDatabaseUser(ctx context.Context, groupId string, databaseName string, username string) UpdateDatabaseUserApiRequest
+	/*
+	UpdateDatabaseUser Update One Database User in One Project
 
-	// UpdateDatabaseUserExecute executes the request
-	//  @return DatabaseUser
-	UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateDatabaseUserApiParams - Parameters for the request
+	@return UpdateDatabaseUserApiRequest}}
+	*/
+	UpdateDatabaseUserWithParams(ctx context.Context, args *UpdateDatabaseUserApiParams) UpdateDatabaseUserApiRequest
+
+	// Interface only available internally
+	updateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error)
 }
 
 // DatabaseUsersApiService DatabaseUsersApi service
@@ -114,6 +155,15 @@ type CreateDatabaseUserApiParams struct {
 		DatabaseUser *DatabaseUser
 }
 
+func (a *DatabaseUsersApiService) CreateDatabaseUserWithParams(ctx context.Context, args *CreateDatabaseUserApiParams) CreateDatabaseUserApiRequest {
+	return CreateDatabaseUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		databaseUser: args.DatabaseUser,
+	}
+}
+
 // Creates one database user in the specified project.
 func (r CreateDatabaseUserApiRequest) DatabaseUser(databaseUser DatabaseUser) CreateDatabaseUserApiRequest {
 	r.databaseUser = &databaseUser
@@ -121,13 +171,7 @@ func (r CreateDatabaseUserApiRequest) DatabaseUser(databaseUser DatabaseUser) Cr
 }
 
 func (r CreateDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
-	return r.ApiService.CreateDatabaseUserExecute(r)
-}
-
-func (r CreateDatabaseUserApiRequest) ExecuteWithParams(params *CreateDatabaseUserApiParams) (*DatabaseUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.databaseUser = params.DatabaseUser 
-	return r.Execute()
+	return r.ApiService.createDatabaseUserExecute(r)
 }
 
 /*
@@ -149,7 +193,7 @@ func (a *DatabaseUsersApiService) CreateDatabaseUser(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DatabaseUser
-func (a *DatabaseUsersApiService) CreateDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) createDatabaseUserExecute(r CreateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -256,15 +300,18 @@ type DeleteDatabaseUserApiParams struct {
 		Username string
 }
 
-func (r DeleteDatabaseUserApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteDatabaseUserExecute(r)
+func (a *DatabaseUsersApiService) DeleteDatabaseUserWithParams(ctx context.Context, args *DeleteDatabaseUserApiParams) DeleteDatabaseUserApiRequest {
+	return DeleteDatabaseUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		databaseName: args.DatabaseName,
+		username: args.Username,
+	}
 }
 
-func (r DeleteDatabaseUserApiRequest) ExecuteWithParams(params *DeleteDatabaseUserApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.databaseName = params.DatabaseName 
-	r.username = params.Username 
-	return r.Execute()
+func (r DeleteDatabaseUserApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteDatabaseUserExecute(r)
 }
 
 /*
@@ -289,7 +336,7 @@ func (a *DatabaseUsersApiService) DeleteDatabaseUser(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *DatabaseUsersApiService) DeleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (*http.Response, error) {
+func (a *DatabaseUsersApiService) deleteDatabaseUserExecute(r DeleteDatabaseUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -383,15 +430,18 @@ type GetDatabaseUserApiParams struct {
 		Username string
 }
 
-func (r GetDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
-	return r.ApiService.GetDatabaseUserExecute(r)
+func (a *DatabaseUsersApiService) GetDatabaseUserWithParams(ctx context.Context, args *GetDatabaseUserApiParams) GetDatabaseUserApiRequest {
+	return GetDatabaseUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		databaseName: args.DatabaseName,
+		username: args.Username,
+	}
 }
 
-func (r GetDatabaseUserApiRequest) ExecuteWithParams(params *GetDatabaseUserApiParams) (*DatabaseUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.databaseName = params.DatabaseName 
-	r.username = params.Username 
-	return r.Execute()
+func (r GetDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
+	return r.ApiService.getDatabaseUserExecute(r)
 }
 
 /*
@@ -417,7 +467,7 @@ func (a *DatabaseUsersApiService) GetDatabaseUser(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return DatabaseUser
-func (a *DatabaseUsersApiService) GetDatabaseUserExecute(r GetDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) getDatabaseUserExecute(r GetDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -523,6 +573,17 @@ type ListDatabaseUsersApiParams struct {
 		PageNum *int32
 }
 
+func (a *DatabaseUsersApiService) ListDatabaseUsersWithParams(ctx context.Context, args *ListDatabaseUsersApiParams) ListDatabaseUsersApiRequest {
+	return ListDatabaseUsersApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListDatabaseUsersApiRequest) IncludeCount(includeCount bool) ListDatabaseUsersApiRequest {
 	r.includeCount = &includeCount
@@ -542,15 +603,7 @@ func (r ListDatabaseUsersApiRequest) PageNum(pageNum int32) ListDatabaseUsersApi
 }
 
 func (r ListDatabaseUsersApiRequest) Execute() (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
-	return r.ApiService.ListDatabaseUsersExecute(r)
-}
-
-func (r ListDatabaseUsersApiRequest) ExecuteWithParams(params *ListDatabaseUsersApiParams) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listDatabaseUsersExecute(r)
 }
 
 /*
@@ -572,7 +625,7 @@ func (a *DatabaseUsersApiService) ListDatabaseUsers(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return PaginatedApiAtlasDatabaseUser
-func (a *DatabaseUsersApiService) ListDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) listDatabaseUsersExecute(r ListDatabaseUsersApiRequest) (*PaginatedApiAtlasDatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -697,6 +750,17 @@ type UpdateDatabaseUserApiParams struct {
 		DatabaseUser *DatabaseUser
 }
 
+func (a *DatabaseUsersApiService) UpdateDatabaseUserWithParams(ctx context.Context, args *UpdateDatabaseUserApiParams) UpdateDatabaseUserApiRequest {
+	return UpdateDatabaseUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		databaseName: args.DatabaseName,
+		username: args.Username,
+		databaseUser: args.DatabaseUser,
+	}
+}
+
 // Updates one database user that belongs to the specified project.
 func (r UpdateDatabaseUserApiRequest) DatabaseUser(databaseUser DatabaseUser) UpdateDatabaseUserApiRequest {
 	r.databaseUser = &databaseUser
@@ -704,15 +768,7 @@ func (r UpdateDatabaseUserApiRequest) DatabaseUser(databaseUser DatabaseUser) Up
 }
 
 func (r UpdateDatabaseUserApiRequest) Execute() (*DatabaseUser, *http.Response, error) {
-	return r.ApiService.UpdateDatabaseUserExecute(r)
-}
-
-func (r UpdateDatabaseUserApiRequest) ExecuteWithParams(params *UpdateDatabaseUserApiParams) (*DatabaseUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.databaseName = params.DatabaseName 
-	r.username = params.Username 
-	r.databaseUser = params.DatabaseUser 
-	return r.Execute()
+	return r.ApiService.updateDatabaseUserExecute(r)
 }
 
 /*
@@ -738,7 +794,7 @@ func (a *DatabaseUsersApiService) UpdateDatabaseUser(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return DatabaseUser
-func (a *DatabaseUsersApiService) UpdateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
+func (a *DatabaseUsersApiService) updateDatabaseUserExecute(r UpdateDatabaseUserApiRequest) (*DatabaseUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -70,6 +70,11 @@ func (r GetEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Respo
 	return r.ApiService.GetEncryptionAtRestExecute(r)
 }
 
+func (r GetEncryptionAtRestApiRequest) ExecuteWithParams(params *GetEncryptionAtRestApiParams) (*EncryptionAtRest, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 GetEncryptionAtRest Return One Configuration for Encryption at Rest using Customer-Managed Keys for One Project
 
@@ -199,6 +204,12 @@ func (r UpdateEncryptionAtRestApiRequest) EncryptionAtRest(encryptionAtRest Encr
 
 func (r UpdateEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
 	return r.ApiService.UpdateEncryptionAtRestExecute(r)
+}
+
+func (r UpdateEncryptionAtRestApiRequest) ExecuteWithParams(params *UpdateEncryptionAtRestApiParams) (*EncryptionAtRest, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.encryptionAtRest = params.EncryptionAtRest 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -36,7 +36,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetEncryptionAtRestApiParams - Parameters for the request
-	@return GetEncryptionAtRestApiRequest}}
+	@return GetEncryptionAtRestApiRequest
 	*/
 	GetEncryptionAtRestWithParams(ctx context.Context, args *GetEncryptionAtRestApiParams) GetEncryptionAtRestApiRequest
 
@@ -61,7 +61,7 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateEncryptionAtRestApiParams - Parameters for the request
-	@return UpdateEncryptionAtRestApiRequest}}
+	@return UpdateEncryptionAtRestApiRequest
 	*/
 	UpdateEncryptionAtRestWithParams(ctx context.Context, args *UpdateEncryptionAtRestApiParams) UpdateEncryptionAtRestApiRequest
 

--- a/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
+++ b/mongodbatlasv2/api_encryption_at_rest_using_customer_key_management.go
@@ -30,10 +30,18 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 	@return GetEncryptionAtRestApiRequest
 	*/
 	GetEncryptionAtRest(ctx context.Context, groupId string) GetEncryptionAtRestApiRequest
+	/*
+	GetEncryptionAtRest Return One Configuration for Encryption at Rest using Customer-Managed Keys for One Project
 
-	// GetEncryptionAtRestExecute executes the request
-	//  @return EncryptionAtRest
-	GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetEncryptionAtRestApiParams - Parameters for the request
+	@return GetEncryptionAtRestApiRequest}}
+	*/
+	GetEncryptionAtRestWithParams(ctx context.Context, args *GetEncryptionAtRestApiParams) GetEncryptionAtRestApiRequest
+
+	// Interface only available internally
+	getEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 
 	/*
 	UpdateEncryptionAtRest Update Configuration for Encryption at Rest using Customer-Managed Keys for One Project
@@ -47,10 +55,18 @@ type EncryptionAtRestUsingCustomerKeyManagementApi interface {
 	@return UpdateEncryptionAtRestApiRequest
 	*/
 	UpdateEncryptionAtRest(ctx context.Context, groupId string) UpdateEncryptionAtRestApiRequest
+	/*
+	UpdateEncryptionAtRest Update Configuration for Encryption at Rest using Customer-Managed Keys for One Project
 
-	// UpdateEncryptionAtRestExecute executes the request
-	//  @return EncryptionAtRest
-	UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateEncryptionAtRestApiParams - Parameters for the request
+	@return UpdateEncryptionAtRestApiRequest}}
+	*/
+	UpdateEncryptionAtRestWithParams(ctx context.Context, args *UpdateEncryptionAtRestApiParams) UpdateEncryptionAtRestApiRequest
+
+	// Interface only available internally
+	updateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error)
 }
 
 // EncryptionAtRestUsingCustomerKeyManagementApiService EncryptionAtRestUsingCustomerKeyManagementApi service
@@ -66,13 +82,16 @@ type GetEncryptionAtRestApiParams struct {
 		GroupId string
 }
 
-func (r GetEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
-	return r.ApiService.GetEncryptionAtRestExecute(r)
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestWithParams(ctx context.Context, args *GetEncryptionAtRestApiParams) GetEncryptionAtRestApiRequest {
+	return GetEncryptionAtRestApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetEncryptionAtRestApiRequest) ExecuteWithParams(params *GetEncryptionAtRestApiParams) (*EncryptionAtRest, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
+	return r.ApiService.getEncryptionAtRestExecute(r)
 }
 
 /*
@@ -96,7 +115,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRe
 
 // Execute executes the request
 //  @return EncryptionAtRest
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) GetEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) getEncryptionAtRestExecute(r GetEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -196,6 +215,15 @@ type UpdateEncryptionAtRestApiParams struct {
 		EncryptionAtRest *EncryptionAtRest
 }
 
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRestWithParams(ctx context.Context, args *UpdateEncryptionAtRestApiParams) UpdateEncryptionAtRestApiRequest {
+	return UpdateEncryptionAtRestApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		encryptionAtRest: args.EncryptionAtRest,
+	}
+}
+
 // Required parameters depend on whether someone has enabled Encryption at Rest using Customer Key Management:  If you have enabled Encryption at Rest using Customer Key Management (CMK), Atlas requires all of the parameters for the desired encryption provider.  - To use AWS Key Management Service (KMS), MongoDB Cloud requires all the fields in the **awsKms** object. - To use Azure Key Vault, MongoDB Cloud requires all the fields in the **azureKeyVault** object. - To use Google Cloud Key Management Service (KMS), MongoDB Cloud requires all the fields in the **googleCloudKms** object.  If you enabled Encryption at Rest using Customer Key  Management, administrators can pass only the changed fields for the **awsKms**, **azureKeyVault**, or **googleCloudKms** object to update the configuration to this endpoint.
 func (r UpdateEncryptionAtRestApiRequest) EncryptionAtRest(encryptionAtRest EncryptionAtRest) UpdateEncryptionAtRestApiRequest {
 	r.encryptionAtRest = &encryptionAtRest
@@ -203,13 +231,7 @@ func (r UpdateEncryptionAtRestApiRequest) EncryptionAtRest(encryptionAtRest Encr
 }
 
 func (r UpdateEncryptionAtRestApiRequest) Execute() (*EncryptionAtRest, *http.Response, error) {
-	return r.ApiService.UpdateEncryptionAtRestExecute(r)
-}
-
-func (r UpdateEncryptionAtRestApiRequest) ExecuteWithParams(params *UpdateEncryptionAtRestApiParams) (*EncryptionAtRest, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.encryptionAtRest = params.EncryptionAtRest 
-	return r.Execute()
+	return r.ApiService.updateEncryptionAtRestExecute(r)
 }
 
 /*
@@ -233,7 +255,7 @@ func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionA
 
 // Execute executes the request
 //  @return EncryptionAtRest
-func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) UpdateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
+func (a *EncryptionAtRestUsingCustomerKeyManagementApiService) updateEncryptionAtRestExecute(r UpdateEncryptionAtRestApiRequest) (*EncryptionAtRest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -39,7 +39,7 @@ type EventsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetOrganizationEventApiParams - Parameters for the request
-	@return GetOrganizationEventApiRequest}}
+	@return GetOrganizationEventApiRequest
 	*/
 	GetOrganizationEventWithParams(ctx context.Context, args *GetOrganizationEventApiParams) GetOrganizationEventApiRequest
 
@@ -65,7 +65,7 @@ type EventsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectEventApiParams - Parameters for the request
-	@return GetProjectEventApiRequest}}
+	@return GetProjectEventApiRequest
 	*/
 	GetProjectEventWithParams(ctx context.Context, args *GetProjectEventApiParams) GetProjectEventApiRequest
 
@@ -90,7 +90,7 @@ type EventsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListOrganizationEventsApiParams - Parameters for the request
-	@return ListOrganizationEventsApiRequest}}
+	@return ListOrganizationEventsApiRequest
 	*/
 	ListOrganizationEventsWithParams(ctx context.Context, args *ListOrganizationEventsApiParams) ListOrganizationEventsApiRequest
 
@@ -115,7 +115,7 @@ type EventsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectEventsApiParams - Parameters for the request
-	@return ListProjectEventsApiRequest}}
+	@return ListProjectEventsApiRequest
 	*/
 	ListProjectEventsWithParams(ctx context.Context, args *ListProjectEventsApiParams) ListProjectEventsApiRequest
 

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -33,10 +33,18 @@ type EventsApi interface {
 	@return GetOrganizationEventApiRequest
 	*/
 	GetOrganizationEvent(ctx context.Context, orgId string, eventId string) GetOrganizationEventApiRequest
+	/*
+	GetOrganizationEvent Return One Event from One Organization
 
-	// GetOrganizationEventExecute executes the request
-	//  @return EventViewForOrg
-	GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetOrganizationEventApiParams - Parameters for the request
+	@return GetOrganizationEventApiRequest}}
+	*/
+	GetOrganizationEventWithParams(ctx context.Context, args *GetOrganizationEventApiParams) GetOrganizationEventApiRequest
+
+	// Interface only available internally
+	getOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error)
 
 	/*
 	GetProjectEvent Return One Event from One Project
@@ -51,10 +59,18 @@ type EventsApi interface {
 	@return GetProjectEventApiRequest
 	*/
 	GetProjectEvent(ctx context.Context, groupId string, eventId string) GetProjectEventApiRequest
+	/*
+	GetProjectEvent Return One Event from One Project
 
-	// GetProjectEventExecute executes the request
-	//  @return EventViewForNdsGroup
-	GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectEventApiParams - Parameters for the request
+	@return GetProjectEventApiRequest}}
+	*/
+	GetProjectEventWithParams(ctx context.Context, args *GetProjectEventApiParams) GetProjectEventApiRequest
+
+	// Interface only available internally
+	getProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error)
 
 	/*
 	ListOrganizationEvents Return All Events from One Organization
@@ -68,10 +84,18 @@ type EventsApi interface {
 	@return ListOrganizationEventsApiRequest
 	*/
 	ListOrganizationEvents(ctx context.Context, orgId string) ListOrganizationEventsApiRequest
+	/*
+	ListOrganizationEvents Return All Events from One Organization
 
-	// ListOrganizationEventsExecute executes the request
-	//  @return OrgPaginatedEvent
-	ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListOrganizationEventsApiParams - Parameters for the request
+	@return ListOrganizationEventsApiRequest}}
+	*/
+	ListOrganizationEventsWithParams(ctx context.Context, args *ListOrganizationEventsApiParams) ListOrganizationEventsApiRequest
+
+	// Interface only available internally
+	listOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error)
 
 	/*
 	ListProjectEvents Return All Events from One Project
@@ -85,10 +109,18 @@ type EventsApi interface {
 	@return ListProjectEventsApiRequest
 	*/
 	ListProjectEvents(ctx context.Context, groupId string) ListProjectEventsApiRequest
+	/*
+	ListProjectEvents Return All Events from One Project
 
-	// ListProjectEventsExecute executes the request
-	//  @return GroupPaginatedEvent
-	ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectEventsApiParams - Parameters for the request
+	@return ListProjectEventsApiRequest}}
+	*/
+	ListProjectEventsWithParams(ctx context.Context, args *ListProjectEventsApiParams) ListProjectEventsApiRequest
+
+	// Interface only available internally
+	listProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error)
 }
 
 // EventsApiService EventsApi service
@@ -108,6 +140,16 @@ type GetOrganizationEventApiParams struct {
 		IncludeRaw *bool
 }
 
+func (a *EventsApiService) GetOrganizationEventWithParams(ctx context.Context, args *GetOrganizationEventApiParams) GetOrganizationEventApiRequest {
+	return GetOrganizationEventApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		eventId: args.EventId,
+		includeRaw: args.IncludeRaw,
+	}
+}
+
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
 func (r GetOrganizationEventApiRequest) IncludeRaw(includeRaw bool) GetOrganizationEventApiRequest {
 	r.includeRaw = &includeRaw
@@ -115,14 +157,7 @@ func (r GetOrganizationEventApiRequest) IncludeRaw(includeRaw bool) GetOrganizat
 }
 
 func (r GetOrganizationEventApiRequest) Execute() (*EventViewForOrg, *http.Response, error) {
-	return r.ApiService.GetOrganizationEventExecute(r)
-}
-
-func (r GetOrganizationEventApiRequest) ExecuteWithParams(params *GetOrganizationEventApiParams) (*EventViewForOrg, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.eventId = params.EventId 
-	r.includeRaw = params.IncludeRaw 
-	return r.Execute()
+	return r.ApiService.getOrganizationEventExecute(r)
 }
 
 /*
@@ -148,7 +183,7 @@ func (a *EventsApiService) GetOrganizationEvent(ctx context.Context, orgId strin
 
 // Execute executes the request
 //  @return EventViewForOrg
-func (a *EventsApiService) GetOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error) {
+func (a *EventsApiService) getOrganizationEventExecute(r GetOrganizationEventApiRequest) (*EventViewForOrg, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -264,6 +299,16 @@ type GetProjectEventApiParams struct {
 		IncludeRaw *bool
 }
 
+func (a *EventsApiService) GetProjectEventWithParams(ctx context.Context, args *GetProjectEventApiParams) GetProjectEventApiRequest {
+	return GetProjectEventApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		eventId: args.EventId,
+		includeRaw: args.IncludeRaw,
+	}
+}
+
 // Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
 func (r GetProjectEventApiRequest) IncludeRaw(includeRaw bool) GetProjectEventApiRequest {
 	r.includeRaw = &includeRaw
@@ -271,14 +316,7 @@ func (r GetProjectEventApiRequest) IncludeRaw(includeRaw bool) GetProjectEventAp
 }
 
 func (r GetProjectEventApiRequest) Execute() (*EventViewForNdsGroup, *http.Response, error) {
-	return r.ApiService.GetProjectEventExecute(r)
-}
-
-func (r GetProjectEventApiRequest) ExecuteWithParams(params *GetProjectEventApiParams) (*EventViewForNdsGroup, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.eventId = params.EventId 
-	r.includeRaw = params.IncludeRaw 
-	return r.Execute()
+	return r.ApiService.getProjectEventExecute(r)
 }
 
 /*
@@ -304,7 +342,7 @@ func (a *EventsApiService) GetProjectEvent(ctx context.Context, groupId string, 
 
 // Execute executes the request
 //  @return EventViewForNdsGroup
-func (a *EventsApiService) GetProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error) {
+func (a *EventsApiService) getProjectEventExecute(r GetProjectEventApiRequest) (*EventViewForNdsGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -430,6 +468,21 @@ type ListOrganizationEventsApiParams struct {
 		MinDate *time.Time
 }
 
+func (a *EventsApiService) ListOrganizationEventsWithParams(ctx context.Context, args *ListOrganizationEventsApiParams) ListOrganizationEventsApiRequest {
+	return ListOrganizationEventsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		eventType: args.EventType,
+		includeRaw: args.IncludeRaw,
+		maxDate: args.MaxDate,
+		minDate: args.MinDate,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListOrganizationEventsApiRequest) IncludeCount(includeCount bool) ListOrganizationEventsApiRequest {
 	r.includeCount = &includeCount
@@ -473,19 +526,7 @@ func (r ListOrganizationEventsApiRequest) MinDate(minDate time.Time) ListOrganiz
 }
 
 func (r ListOrganizationEventsApiRequest) Execute() (*OrgPaginatedEvent, *http.Response, error) {
-	return r.ApiService.ListOrganizationEventsExecute(r)
-}
-
-func (r ListOrganizationEventsApiRequest) ExecuteWithParams(params *ListOrganizationEventsApiParams) (*OrgPaginatedEvent, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.eventType = params.EventType 
-	r.includeRaw = params.IncludeRaw 
-	r.maxDate = params.MaxDate 
-	r.minDate = params.MinDate 
-	return r.Execute()
+	return r.ApiService.listOrganizationEventsExecute(r)
 }
 
 /*
@@ -509,7 +550,7 @@ func (a *EventsApiService) ListOrganizationEvents(ctx context.Context, orgId str
 
 // Execute executes the request
 //  @return OrgPaginatedEvent
-func (a *EventsApiService) ListOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error) {
+func (a *EventsApiService) listOrganizationEventsExecute(r ListOrganizationEventsApiRequest) (*OrgPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -660,6 +701,22 @@ type ListProjectEventsApiParams struct {
 		MinDate *time.Time
 }
 
+func (a *EventsApiService) ListProjectEventsWithParams(ctx context.Context, args *ListProjectEventsApiParams) ListProjectEventsApiRequest {
+	return ListProjectEventsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		clusterNames: args.ClusterNames,
+		eventType: args.EventType,
+		includeRaw: args.IncludeRaw,
+		maxDate: args.MaxDate,
+		minDate: args.MinDate,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListProjectEventsApiRequest) IncludeCount(includeCount bool) ListProjectEventsApiRequest {
 	r.includeCount = &includeCount
@@ -709,20 +766,7 @@ func (r ListProjectEventsApiRequest) MinDate(minDate time.Time) ListProjectEvent
 }
 
 func (r ListProjectEventsApiRequest) Execute() (*GroupPaginatedEvent, *http.Response, error) {
-	return r.ApiService.ListProjectEventsExecute(r)
-}
-
-func (r ListProjectEventsApiRequest) ExecuteWithParams(params *ListProjectEventsApiParams) (*GroupPaginatedEvent, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.clusterNames = params.ClusterNames 
-	r.eventType = params.EventType 
-	r.includeRaw = params.IncludeRaw 
-	r.maxDate = params.MaxDate 
-	r.minDate = params.MinDate 
-	return r.Execute()
+	return r.ApiService.listProjectEventsExecute(r)
 }
 
 /*
@@ -746,7 +790,7 @@ func (a *EventsApiService) ListProjectEvents(ctx context.Context, groupId string
 
 // Execute executes the request
 //  @return GroupPaginatedEvent
-func (a *EventsApiService) ListProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error) {
+func (a *EventsApiService) listProjectEventsExecute(r ListProjectEventsApiRequest) (*GroupPaginatedEvent, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_events.go
+++ b/mongodbatlasv2/api_events.go
@@ -118,6 +118,13 @@ func (r GetOrganizationEventApiRequest) Execute() (*EventViewForOrg, *http.Respo
 	return r.ApiService.GetOrganizationEventExecute(r)
 }
 
+func (r GetOrganizationEventApiRequest) ExecuteWithParams(params *GetOrganizationEventApiParams) (*EventViewForOrg, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.eventId = params.EventId 
+	r.includeRaw = params.IncludeRaw 
+	return r.Execute()
+}
+
 /*
 GetOrganizationEvent Return One Event from One Organization
 
@@ -265,6 +272,13 @@ func (r GetProjectEventApiRequest) IncludeRaw(includeRaw bool) GetProjectEventAp
 
 func (r GetProjectEventApiRequest) Execute() (*EventViewForNdsGroup, *http.Response, error) {
 	return r.ApiService.GetProjectEventExecute(r)
+}
+
+func (r GetProjectEventApiRequest) ExecuteWithParams(params *GetProjectEventApiParams) (*EventViewForNdsGroup, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.eventId = params.EventId 
+	r.includeRaw = params.IncludeRaw 
+	return r.Execute()
 }
 
 /*
@@ -460,6 +474,18 @@ func (r ListOrganizationEventsApiRequest) MinDate(minDate time.Time) ListOrganiz
 
 func (r ListOrganizationEventsApiRequest) Execute() (*OrgPaginatedEvent, *http.Response, error) {
 	return r.ApiService.ListOrganizationEventsExecute(r)
+}
+
+func (r ListOrganizationEventsApiRequest) ExecuteWithParams(params *ListOrganizationEventsApiParams) (*OrgPaginatedEvent, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.eventType = params.EventType 
+	r.includeRaw = params.IncludeRaw 
+	r.maxDate = params.MaxDate 
+	r.minDate = params.MinDate 
+	return r.Execute()
 }
 
 /*
@@ -684,6 +710,19 @@ func (r ListProjectEventsApiRequest) MinDate(minDate time.Time) ListProjectEvent
 
 func (r ListProjectEventsApiRequest) Execute() (*GroupPaginatedEvent, *http.Response, error) {
 	return r.ApiService.ListProjectEventsExecute(r)
+}
+
+func (r ListProjectEventsApiRequest) ExecuteWithParams(params *ListProjectEventsApiParams) (*GroupPaginatedEvent, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.clusterNames = params.ClusterNames 
+	r.eventType = params.EventType 
+	r.includeRaw = params.IncludeRaw 
+	r.maxDate = params.MaxDate 
+	r.minDate = params.MinDate 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -288,6 +288,13 @@ func (r CreateRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, er
 	return r.ApiService.CreateRoleMappingExecute(r)
 }
 
+func (r CreateRoleMappingApiRequest) ExecuteWithParams(params *CreateRoleMappingApiParams) (*RoleMapping, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.orgId = params.OrgId 
+	r.roleMapping = params.RoleMapping 
+	return r.Execute()
+}
+
 /*
 CreateRoleMapping Add One Role Mapping to One Organization
 
@@ -423,6 +430,11 @@ func (r DeleteFederationAppApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteFederationAppExecute(r)
 }
 
+func (r DeleteFederationAppApiRequest) ExecuteWithParams(params *DeleteFederationAppApiParams) (*http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	return r.Execute()
+}
+
 /*
 DeleteFederationApp Delete the federation settings instance.
 
@@ -535,6 +547,13 @@ type DeleteRoleMappingApiParams struct {
 
 func (r DeleteRoleMappingApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteRoleMappingExecute(r)
+}
+
+func (r DeleteRoleMappingApiRequest) ExecuteWithParams(params *DeleteRoleMappingApiParams) (*http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.id = params.Id 
+	r.orgId = params.OrgId 
+	return r.Execute()
 }
 
 /*
@@ -667,6 +686,12 @@ func (r GetConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.R
 	return r.ApiService.GetConnectedOrgConfigExecute(r)
 }
 
+func (r GetConnectedOrgConfigApiRequest) ExecuteWithParams(params *GetConnectedOrgConfigApiParams) (*ConnectedOrgConfig, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.orgId = params.OrgId 
+	return r.Execute()
+}
+
 /*
 GetConnectedOrgConfig Return One Org Config Connected to One Federation
 
@@ -797,6 +822,11 @@ func (r GetFederationSettingsApiRequest) Execute() (*OrgFederationSettings, *htt
 	return r.ApiService.GetFederationSettingsExecute(r)
 }
 
+func (r GetFederationSettingsApiRequest) ExecuteWithParams(params *GetFederationSettingsApiParams) (*OrgFederationSettings, *http.Response, error) {
+	r.orgId = params.OrgId 
+	return r.Execute()
+}
+
 /*
 GetFederationSettings Return Federation Settings for One Organization
 
@@ -918,6 +948,12 @@ type GetIdentityProviderApiParams struct {
 
 func (r GetIdentityProviderApiRequest) Execute() (*IdentityProvider, *http.Response, error) {
 	return r.ApiService.GetIdentityProviderExecute(r)
+}
+
+func (r GetIdentityProviderApiRequest) ExecuteWithParams(params *GetIdentityProviderApiParams) (*IdentityProvider, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.identityProviderId = params.IdentityProviderId 
+	return r.Execute()
 }
 
 /*
@@ -1052,6 +1088,12 @@ func (r GetIdentityProviderMetadataApiRequest) Execute() (string, *http.Response
 	return r.ApiService.GetIdentityProviderMetadataExecute(r)
 }
 
+func (r GetIdentityProviderMetadataApiRequest) ExecuteWithParams(params *GetIdentityProviderMetadataApiParams) (string, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.identityProviderId = params.IdentityProviderId 
+	return r.Execute()
+}
+
 /*
 GetIdentityProviderMetadata Return the metadata of one identity provider in the specified federation.
 
@@ -1184,6 +1226,13 @@ type GetRoleMappingApiParams struct {
 
 func (r GetRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
 	return r.ApiService.GetRoleMappingExecute(r)
+}
+
+func (r GetRoleMappingApiRequest) ExecuteWithParams(params *GetRoleMappingApiParams) (*RoleMapping, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.id = params.Id 
+	r.orgId = params.OrgId 
+	return r.Execute()
 }
 
 /*
@@ -1325,6 +1374,11 @@ func (r ListConnectedOrgConfigsApiRequest) Execute() ([]ConnectedOrgConfig, *htt
 	return r.ApiService.ListConnectedOrgConfigsExecute(r)
 }
 
+func (r ListConnectedOrgConfigsApiRequest) ExecuteWithParams(params *ListConnectedOrgConfigsApiParams) ([]ConnectedOrgConfig, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	return r.Execute()
+}
+
 /*
 ListConnectedOrgConfigs Return All Connected Org Configs from the Federation
 
@@ -1444,6 +1498,11 @@ type ListIdentityProvidersApiParams struct {
 
 func (r ListIdentityProvidersApiRequest) Execute() ([]IdentityProvider, *http.Response, error) {
 	return r.ApiService.ListIdentityProvidersExecute(r)
+}
+
+func (r ListIdentityProvidersApiRequest) ExecuteWithParams(params *ListIdentityProvidersApiParams) ([]IdentityProvider, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	return r.Execute()
 }
 
 /*
@@ -1567,6 +1626,12 @@ type ListRoleMappingsApiParams struct {
 
 func (r ListRoleMappingsApiRequest) Execute() ([]RoleMapping, *http.Response, error) {
 	return r.ApiService.ListRoleMappingsExecute(r)
+}
+
+func (r ListRoleMappingsApiRequest) ExecuteWithParams(params *ListRoleMappingsApiParams) ([]RoleMapping, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.orgId = params.OrgId 
+	return r.Execute()
 }
 
 /*
@@ -1701,6 +1766,12 @@ func (r RemoveConnectedOrgConfigApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveConnectedOrgConfigExecute(r)
 }
 
+func (r RemoveConnectedOrgConfigApiRequest) ExecuteWithParams(params *RemoveConnectedOrgConfigApiParams) (*http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.orgId = params.OrgId 
+	return r.Execute()
+}
+
 /*
 RemoveConnectedOrgConfig Remove One Org Config Connected to One Federation
 
@@ -1828,6 +1899,13 @@ func (r UpdateConnectedOrgConfigApiRequest) ConnectedOrgConfig(connectedOrgConfi
 
 func (r UpdateConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
 	return r.ApiService.UpdateConnectedOrgConfigExecute(r)
+}
+
+func (r UpdateConnectedOrgConfigApiRequest) ExecuteWithParams(params *UpdateConnectedOrgConfigApiParams) (*ConnectedOrgConfig, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.orgId = params.OrgId 
+	r.connectedOrgConfig = params.ConnectedOrgConfig 
+	return r.Execute()
 }
 
 /*
@@ -1981,6 +2059,13 @@ func (r UpdateIdentityProviderApiRequest) Execute() (*IdentityProvider, *http.Re
 	return r.ApiService.UpdateIdentityProviderExecute(r)
 }
 
+func (r UpdateIdentityProviderApiRequest) ExecuteWithParams(params *UpdateIdentityProviderApiParams) (*IdentityProvider, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.identityProviderId = params.IdentityProviderId 
+	r.identityProviderUpdate = params.IdentityProviderUpdate 
+	return r.Execute()
+}
+
 /*
 UpdateIdentityProvider Update the identity provider.
 
@@ -2126,6 +2211,14 @@ func (r UpdateRoleMappingApiRequest) RoleMapping(roleMapping RoleMapping) Update
 
 func (r UpdateRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
 	return r.ApiService.UpdateRoleMappingExecute(r)
+}
+
+func (r UpdateRoleMappingApiRequest) ExecuteWithParams(params *UpdateRoleMappingApiParams) (*RoleMapping, *http.Response, error) {
+	r.federationSettingsId = params.FederationSettingsId 
+	r.id = params.Id 
+	r.orgId = params.OrgId 
+	r.roleMapping = params.RoleMapping 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -29,10 +29,18 @@ type FederatedAuthenticationApi interface {
 	@return CreateRoleMappingApiRequest
 	*/
 	CreateRoleMapping(ctx context.Context, federationSettingsId string, orgId string) CreateRoleMappingApiRequest
+	/*
+	CreateRoleMapping Add One Role Mapping to One Organization
 
-	// CreateRoleMappingExecute executes the request
-	//  @return RoleMapping
-	CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateRoleMappingApiParams - Parameters for the request
+	@return CreateRoleMappingApiRequest}}
+	*/
+	CreateRoleMappingWithParams(ctx context.Context, args *CreateRoleMappingApiParams) CreateRoleMappingApiRequest
+
+	// Interface only available internally
+	createRoleMappingExecute(r CreateRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
 
 	/*
 	DeleteFederationApp Delete the federation settings instance.
@@ -44,9 +52,18 @@ type FederatedAuthenticationApi interface {
 	@return DeleteFederationAppApiRequest
 	*/
 	DeleteFederationApp(ctx context.Context, federationSettingsId string) DeleteFederationAppApiRequest
+	/*
+	DeleteFederationApp Delete the federation settings instance.
 
-	// DeleteFederationAppExecute executes the request
-	DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteFederationAppApiParams - Parameters for the request
+	@return DeleteFederationAppApiRequest}}
+	*/
+	DeleteFederationAppWithParams(ctx context.Context, args *DeleteFederationAppApiParams) DeleteFederationAppApiRequest
+
+	// Interface only available internally
+	deleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error)
 
 	/*
 	DeleteRoleMapping Remove One Role Mapping from One Organization
@@ -60,9 +77,18 @@ type FederatedAuthenticationApi interface {
 	@return DeleteRoleMappingApiRequest
 	*/
 	DeleteRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) DeleteRoleMappingApiRequest
+	/*
+	DeleteRoleMapping Remove One Role Mapping from One Organization
 
-	// DeleteRoleMappingExecute executes the request
-	DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteRoleMappingApiParams - Parameters for the request
+	@return DeleteRoleMappingApiRequest}}
+	*/
+	DeleteRoleMappingWithParams(ctx context.Context, args *DeleteRoleMappingApiParams) DeleteRoleMappingApiRequest
+
+	// Interface only available internally
+	deleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error)
 
 	/*
 	GetConnectedOrgConfig Return One Org Config Connected to One Federation
@@ -75,10 +101,18 @@ type FederatedAuthenticationApi interface {
 	@return GetConnectedOrgConfigApiRequest
 	*/
 	GetConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) GetConnectedOrgConfigApiRequest
+	/*
+	GetConnectedOrgConfig Return One Org Config Connected to One Federation
 
-	// GetConnectedOrgConfigExecute executes the request
-	//  @return ConnectedOrgConfig
-	GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetConnectedOrgConfigApiParams - Parameters for the request
+	@return GetConnectedOrgConfigApiRequest}}
+	*/
+	GetConnectedOrgConfigWithParams(ctx context.Context, args *GetConnectedOrgConfigApiParams) GetConnectedOrgConfigApiRequest
+
+	// Interface only available internally
+	getConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
 	GetFederationSettings Return Federation Settings for One Organization
@@ -90,10 +124,18 @@ type FederatedAuthenticationApi interface {
 	@return GetFederationSettingsApiRequest
 	*/
 	GetFederationSettings(ctx context.Context, orgId string) GetFederationSettingsApiRequest
+	/*
+	GetFederationSettings Return Federation Settings for One Organization
 
-	// GetFederationSettingsExecute executes the request
-	//  @return OrgFederationSettings
-	GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetFederationSettingsApiParams - Parameters for the request
+	@return GetFederationSettingsApiRequest}}
+	*/
+	GetFederationSettingsWithParams(ctx context.Context, args *GetFederationSettingsApiParams) GetFederationSettingsApiRequest
+
+	// Interface only available internally
+	getFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error)
 
 	/*
 	GetIdentityProvider Return one identity provider from the specified federation.
@@ -106,10 +148,18 @@ type FederatedAuthenticationApi interface {
 	@return GetIdentityProviderApiRequest
 	*/
 	GetIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) GetIdentityProviderApiRequest
+	/*
+	GetIdentityProvider Return one identity provider from the specified federation.
 
-	// GetIdentityProviderExecute executes the request
-	//  @return IdentityProvider
-	GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetIdentityProviderApiParams - Parameters for the request
+	@return GetIdentityProviderApiRequest}}
+	*/
+	GetIdentityProviderWithParams(ctx context.Context, args *GetIdentityProviderApiParams) GetIdentityProviderApiRequest
+
+	// Interface only available internally
+	getIdentityProviderExecute(r GetIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error)
 
 	/*
 	GetIdentityProviderMetadata Return the metadata of one identity provider in the specified federation.
@@ -122,10 +172,18 @@ type FederatedAuthenticationApi interface {
 	@return GetIdentityProviderMetadataApiRequest
 	*/
 	GetIdentityProviderMetadata(ctx context.Context, federationSettingsId string, identityProviderId string) GetIdentityProviderMetadataApiRequest
+	/*
+	GetIdentityProviderMetadata Return the metadata of one identity provider in the specified federation.
 
-	// GetIdentityProviderMetadataExecute executes the request
-	//  @return string
-	GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetIdentityProviderMetadataApiParams - Parameters for the request
+	@return GetIdentityProviderMetadataApiRequest}}
+	*/
+	GetIdentityProviderMetadataWithParams(ctx context.Context, args *GetIdentityProviderMetadataApiParams) GetIdentityProviderMetadataApiRequest
+
+	// Interface only available internally
+	getIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error)
 
 	/*
 	GetRoleMapping Return One Role Mapping from One Organization
@@ -139,10 +197,18 @@ type FederatedAuthenticationApi interface {
 	@return GetRoleMappingApiRequest
 	*/
 	GetRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) GetRoleMappingApiRequest
+	/*
+	GetRoleMapping Return One Role Mapping from One Organization
 
-	// GetRoleMappingExecute executes the request
-	//  @return RoleMapping
-	GetRoleMappingExecute(r GetRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetRoleMappingApiParams - Parameters for the request
+	@return GetRoleMappingApiRequest}}
+	*/
+	GetRoleMappingWithParams(ctx context.Context, args *GetRoleMappingApiParams) GetRoleMappingApiRequest
+
+	// Interface only available internally
+	getRoleMappingExecute(r GetRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
 
 	/*
 	ListConnectedOrgConfigs Return All Connected Org Configs from the Federation
@@ -154,10 +220,18 @@ type FederatedAuthenticationApi interface {
 	@return ListConnectedOrgConfigsApiRequest
 	*/
 	ListConnectedOrgConfigs(ctx context.Context, federationSettingsId string) ListConnectedOrgConfigsApiRequest
+	/*
+	ListConnectedOrgConfigs Return All Connected Org Configs from the Federation
 
-	// ListConnectedOrgConfigsExecute executes the request
-	//  @return []ConnectedOrgConfig
-	ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListConnectedOrgConfigsApiParams - Parameters for the request
+	@return ListConnectedOrgConfigsApiRequest}}
+	*/
+	ListConnectedOrgConfigsWithParams(ctx context.Context, args *ListConnectedOrgConfigsApiParams) ListConnectedOrgConfigsApiRequest
+
+	// Interface only available internally
+	listConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error)
 
 	/*
 	ListIdentityProviders Return all identity providers from the specified federation.
@@ -169,10 +243,18 @@ type FederatedAuthenticationApi interface {
 	@return ListIdentityProvidersApiRequest
 	*/
 	ListIdentityProviders(ctx context.Context, federationSettingsId string) ListIdentityProvidersApiRequest
+	/*
+	ListIdentityProviders Return all identity providers from the specified federation.
 
-	// ListIdentityProvidersExecute executes the request
-	//  @return []IdentityProvider
-	ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) ([]IdentityProvider, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListIdentityProvidersApiParams - Parameters for the request
+	@return ListIdentityProvidersApiRequest}}
+	*/
+	ListIdentityProvidersWithParams(ctx context.Context, args *ListIdentityProvidersApiParams) ListIdentityProvidersApiRequest
+
+	// Interface only available internally
+	listIdentityProvidersExecute(r ListIdentityProvidersApiRequest) ([]IdentityProvider, *http.Response, error)
 
 	/*
 	ListRoleMappings Return All Role Mappings from One Organization
@@ -185,10 +267,18 @@ type FederatedAuthenticationApi interface {
 	@return ListRoleMappingsApiRequest
 	*/
 	ListRoleMappings(ctx context.Context, federationSettingsId string, orgId string) ListRoleMappingsApiRequest
+	/*
+	ListRoleMappings Return All Role Mappings from One Organization
 
-	// ListRoleMappingsExecute executes the request
-	//  @return []RoleMapping
-	ListRoleMappingsExecute(r ListRoleMappingsApiRequest) ([]RoleMapping, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListRoleMappingsApiParams - Parameters for the request
+	@return ListRoleMappingsApiRequest}}
+	*/
+	ListRoleMappingsWithParams(ctx context.Context, args *ListRoleMappingsApiParams) ListRoleMappingsApiRequest
+
+	// Interface only available internally
+	listRoleMappingsExecute(r ListRoleMappingsApiRequest) ([]RoleMapping, *http.Response, error)
 
 	/*
 	RemoveConnectedOrgConfig Remove One Org Config Connected to One Federation
@@ -201,9 +291,18 @@ type FederatedAuthenticationApi interface {
 	@return RemoveConnectedOrgConfigApiRequest
 	*/
 	RemoveConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) RemoveConnectedOrgConfigApiRequest
+	/*
+	RemoveConnectedOrgConfig Remove One Org Config Connected to One Federation
 
-	// RemoveConnectedOrgConfigExecute executes the request
-	RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param RemoveConnectedOrgConfigApiParams - Parameters for the request
+	@return RemoveConnectedOrgConfigApiRequest}}
+	*/
+	RemoveConnectedOrgConfigWithParams(ctx context.Context, args *RemoveConnectedOrgConfigApiParams) RemoveConnectedOrgConfigApiRequest
+
+	// Interface only available internally
+	removeConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (*http.Response, error)
 
 	/*
 	UpdateConnectedOrgConfig Update One Org Config Connected to One Federation
@@ -222,10 +321,18 @@ type FederatedAuthenticationApi interface {
 	@return UpdateConnectedOrgConfigApiRequest
 	*/
 	UpdateConnectedOrgConfig(ctx context.Context, federationSettingsId string, orgId string) UpdateConnectedOrgConfigApiRequest
+	/*
+	UpdateConnectedOrgConfig Update One Org Config Connected to One Federation
 
-	// UpdateConnectedOrgConfigExecute executes the request
-	//  @return ConnectedOrgConfig
-	UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateConnectedOrgConfigApiParams - Parameters for the request
+	@return UpdateConnectedOrgConfigApiRequest}}
+	*/
+	UpdateConnectedOrgConfigWithParams(ctx context.Context, args *UpdateConnectedOrgConfigApiParams) UpdateConnectedOrgConfigApiRequest
+
+	// Interface only available internally
+	updateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error)
 
 	/*
 	UpdateIdentityProvider Update the identity provider.
@@ -238,10 +345,18 @@ type FederatedAuthenticationApi interface {
 	@return UpdateIdentityProviderApiRequest
 	*/
 	UpdateIdentityProvider(ctx context.Context, federationSettingsId string, identityProviderId string) UpdateIdentityProviderApiRequest
+	/*
+	UpdateIdentityProvider Update the identity provider.
 
-	// UpdateIdentityProviderExecute executes the request
-	//  @return IdentityProvider
-	UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateIdentityProviderApiParams - Parameters for the request
+	@return UpdateIdentityProviderApiRequest}}
+	*/
+	UpdateIdentityProviderWithParams(ctx context.Context, args *UpdateIdentityProviderApiParams) UpdateIdentityProviderApiRequest
+
+	// Interface only available internally
+	updateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error)
 
 	/*
 	UpdateRoleMapping Update One Role Mapping in One Organization
@@ -255,10 +370,18 @@ type FederatedAuthenticationApi interface {
 	@return UpdateRoleMappingApiRequest
 	*/
 	UpdateRoleMapping(ctx context.Context, federationSettingsId string, id string, orgId string) UpdateRoleMappingApiRequest
+	/*
+	UpdateRoleMapping Update One Role Mapping in One Organization
 
-	// UpdateRoleMappingExecute executes the request
-	//  @return RoleMapping
-	UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateRoleMappingApiParams - Parameters for the request
+	@return UpdateRoleMappingApiRequest}}
+	*/
+	UpdateRoleMappingWithParams(ctx context.Context, args *UpdateRoleMappingApiParams) UpdateRoleMappingApiRequest
+
+	// Interface only available internally
+	updateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*RoleMapping, *http.Response, error)
 }
 
 // FederatedAuthenticationApiService FederatedAuthenticationApi service
@@ -278,6 +401,16 @@ type CreateRoleMappingApiParams struct {
 		RoleMapping *RoleMapping
 }
 
+func (a *FederatedAuthenticationApiService) CreateRoleMappingWithParams(ctx context.Context, args *CreateRoleMappingApiParams) CreateRoleMappingApiRequest {
+	return CreateRoleMappingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		orgId: args.OrgId,
+		roleMapping: args.RoleMapping,
+	}
+}
+
 // The role mapping that you want to create.
 func (r CreateRoleMappingApiRequest) RoleMapping(roleMapping RoleMapping) CreateRoleMappingApiRequest {
 	r.roleMapping = &roleMapping
@@ -285,14 +418,7 @@ func (r CreateRoleMappingApiRequest) RoleMapping(roleMapping RoleMapping) Create
 }
 
 func (r CreateRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
-	return r.ApiService.CreateRoleMappingExecute(r)
-}
-
-func (r CreateRoleMappingApiRequest) ExecuteWithParams(params *CreateRoleMappingApiParams) (*RoleMapping, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.orgId = params.OrgId 
-	r.roleMapping = params.RoleMapping 
-	return r.Execute()
+	return r.ApiService.createRoleMappingExecute(r)
 }
 
 /*
@@ -316,7 +442,7 @@ func (a *FederatedAuthenticationApiService) CreateRoleMapping(ctx context.Contex
 
 // Execute executes the request
 //  @return RoleMapping
-func (a *FederatedAuthenticationApiService) CreateRoleMappingExecute(r CreateRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) createRoleMappingExecute(r CreateRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -426,13 +552,16 @@ type DeleteFederationAppApiParams struct {
 		FederationSettingsId string
 }
 
-func (r DeleteFederationAppApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteFederationAppExecute(r)
+func (a *FederatedAuthenticationApiService) DeleteFederationAppWithParams(ctx context.Context, args *DeleteFederationAppApiParams) DeleteFederationAppApiRequest {
+	return DeleteFederationAppApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+	}
 }
 
-func (r DeleteFederationAppApiRequest) ExecuteWithParams(params *DeleteFederationAppApiParams) (*http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	return r.Execute()
+func (r DeleteFederationAppApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteFederationAppExecute(r)
 }
 
 /*
@@ -453,7 +582,7 @@ func (a *FederatedAuthenticationApiService) DeleteFederationApp(ctx context.Cont
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) DeleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) deleteFederationAppExecute(r DeleteFederationAppApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -545,15 +674,18 @@ type DeleteRoleMappingApiParams struct {
 		OrgId string
 }
 
-func (r DeleteRoleMappingApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteRoleMappingExecute(r)
+func (a *FederatedAuthenticationApiService) DeleteRoleMappingWithParams(ctx context.Context, args *DeleteRoleMappingApiParams) DeleteRoleMappingApiRequest {
+	return DeleteRoleMappingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		id: args.Id,
+		orgId: args.OrgId,
+	}
 }
 
-func (r DeleteRoleMappingApiRequest) ExecuteWithParams(params *DeleteRoleMappingApiParams) (*http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.id = params.Id 
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r DeleteRoleMappingApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteRoleMappingExecute(r)
 }
 
 /*
@@ -578,7 +710,7 @@ func (a *FederatedAuthenticationApiService) DeleteRoleMapping(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) DeleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) deleteRoleMappingExecute(r DeleteRoleMappingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -682,14 +814,17 @@ type GetConnectedOrgConfigApiParams struct {
 		OrgId string
 }
 
-func (r GetConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
-	return r.ApiService.GetConnectedOrgConfigExecute(r)
+func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigWithParams(ctx context.Context, args *GetConnectedOrgConfigApiParams) GetConnectedOrgConfigApiRequest {
+	return GetConnectedOrgConfigApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		orgId: args.OrgId,
+	}
 }
 
-func (r GetConnectedOrgConfigApiRequest) ExecuteWithParams(params *GetConnectedOrgConfigApiParams) (*ConnectedOrgConfig, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r GetConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
+	return r.ApiService.getConnectedOrgConfigExecute(r)
 }
 
 /*
@@ -713,7 +848,7 @@ func (a *FederatedAuthenticationApiService) GetConnectedOrgConfig(ctx context.Co
 
 // Execute executes the request
 //  @return ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) GetConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) getConnectedOrgConfigExecute(r GetConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -818,13 +953,16 @@ type GetFederationSettingsApiParams struct {
 		OrgId string
 }
 
-func (r GetFederationSettingsApiRequest) Execute() (*OrgFederationSettings, *http.Response, error) {
-	return r.ApiService.GetFederationSettingsExecute(r)
+func (a *FederatedAuthenticationApiService) GetFederationSettingsWithParams(ctx context.Context, args *GetFederationSettingsApiParams) GetFederationSettingsApiRequest {
+	return GetFederationSettingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+	}
 }
 
-func (r GetFederationSettingsApiRequest) ExecuteWithParams(params *GetFederationSettingsApiParams) (*OrgFederationSettings, *http.Response, error) {
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r GetFederationSettingsApiRequest) Execute() (*OrgFederationSettings, *http.Response, error) {
+	return r.ApiService.getFederationSettingsExecute(r)
 }
 
 /*
@@ -846,7 +984,7 @@ func (a *FederatedAuthenticationApiService) GetFederationSettings(ctx context.Co
 
 // Execute executes the request
 //  @return OrgFederationSettings
-func (a *FederatedAuthenticationApiService) GetFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) getFederationSettingsExecute(r GetFederationSettingsApiRequest) (*OrgFederationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -946,14 +1084,17 @@ type GetIdentityProviderApiParams struct {
 		IdentityProviderId string
 }
 
-func (r GetIdentityProviderApiRequest) Execute() (*IdentityProvider, *http.Response, error) {
-	return r.ApiService.GetIdentityProviderExecute(r)
+func (a *FederatedAuthenticationApiService) GetIdentityProviderWithParams(ctx context.Context, args *GetIdentityProviderApiParams) GetIdentityProviderApiRequest {
+	return GetIdentityProviderApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		identityProviderId: args.IdentityProviderId,
+	}
 }
 
-func (r GetIdentityProviderApiRequest) ExecuteWithParams(params *GetIdentityProviderApiParams) (*IdentityProvider, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.identityProviderId = params.IdentityProviderId 
-	return r.Execute()
+func (r GetIdentityProviderApiRequest) Execute() (*IdentityProvider, *http.Response, error) {
+	return r.ApiService.getIdentityProviderExecute(r)
 }
 
 /*
@@ -977,7 +1118,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProvider(ctx context.Cont
 
 // Execute executes the request
 //  @return IdentityProvider
-func (a *FederatedAuthenticationApiService) GetIdentityProviderExecute(r GetIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) getIdentityProviderExecute(r GetIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1084,14 +1225,17 @@ type GetIdentityProviderMetadataApiParams struct {
 		IdentityProviderId string
 }
 
-func (r GetIdentityProviderMetadataApiRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.GetIdentityProviderMetadataExecute(r)
+func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataWithParams(ctx context.Context, args *GetIdentityProviderMetadataApiParams) GetIdentityProviderMetadataApiRequest {
+	return GetIdentityProviderMetadataApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		identityProviderId: args.IdentityProviderId,
+	}
 }
 
-func (r GetIdentityProviderMetadataApiRequest) ExecuteWithParams(params *GetIdentityProviderMetadataApiParams) (string, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.identityProviderId = params.IdentityProviderId 
-	return r.Execute()
+func (r GetIdentityProviderMetadataApiRequest) Execute() (string, *http.Response, error) {
+	return r.ApiService.getIdentityProviderMetadataExecute(r)
 }
 
 /*
@@ -1115,7 +1259,7 @@ func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadata(ctx cont
 
 // Execute executes the request
 //  @return string
-func (a *FederatedAuthenticationApiService) GetIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) getIdentityProviderMetadataExecute(r GetIdentityProviderMetadataApiRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1224,15 +1368,18 @@ type GetRoleMappingApiParams struct {
 		OrgId string
 }
 
-func (r GetRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
-	return r.ApiService.GetRoleMappingExecute(r)
+func (a *FederatedAuthenticationApiService) GetRoleMappingWithParams(ctx context.Context, args *GetRoleMappingApiParams) GetRoleMappingApiRequest {
+	return GetRoleMappingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		id: args.Id,
+		orgId: args.OrgId,
+	}
 }
 
-func (r GetRoleMappingApiRequest) ExecuteWithParams(params *GetRoleMappingApiParams) (*RoleMapping, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.id = params.Id 
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r GetRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
+	return r.ApiService.getRoleMappingExecute(r)
 }
 
 /*
@@ -1258,7 +1405,7 @@ func (a *FederatedAuthenticationApiService) GetRoleMapping(ctx context.Context, 
 
 // Execute executes the request
 //  @return RoleMapping
-func (a *FederatedAuthenticationApiService) GetRoleMappingExecute(r GetRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) getRoleMappingExecute(r GetRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1370,13 +1517,16 @@ type ListConnectedOrgConfigsApiParams struct {
 		FederationSettingsId string
 }
 
-func (r ListConnectedOrgConfigsApiRequest) Execute() ([]ConnectedOrgConfig, *http.Response, error) {
-	return r.ApiService.ListConnectedOrgConfigsExecute(r)
+func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsWithParams(ctx context.Context, args *ListConnectedOrgConfigsApiParams) ListConnectedOrgConfigsApiRequest {
+	return ListConnectedOrgConfigsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+	}
 }
 
-func (r ListConnectedOrgConfigsApiRequest) ExecuteWithParams(params *ListConnectedOrgConfigsApiParams) ([]ConnectedOrgConfig, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	return r.Execute()
+func (r ListConnectedOrgConfigsApiRequest) Execute() ([]ConnectedOrgConfig, *http.Response, error) {
+	return r.ApiService.listConnectedOrgConfigsExecute(r)
 }
 
 /*
@@ -1398,7 +1548,7 @@ func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigs(ctx context.
 
 // Execute executes the request
 //  @return []ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) ListConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) listConnectedOrgConfigsExecute(r ListConnectedOrgConfigsApiRequest) ([]ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1496,13 +1646,16 @@ type ListIdentityProvidersApiParams struct {
 		FederationSettingsId string
 }
 
-func (r ListIdentityProvidersApiRequest) Execute() ([]IdentityProvider, *http.Response, error) {
-	return r.ApiService.ListIdentityProvidersExecute(r)
+func (a *FederatedAuthenticationApiService) ListIdentityProvidersWithParams(ctx context.Context, args *ListIdentityProvidersApiParams) ListIdentityProvidersApiRequest {
+	return ListIdentityProvidersApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+	}
 }
 
-func (r ListIdentityProvidersApiRequest) ExecuteWithParams(params *ListIdentityProvidersApiParams) ([]IdentityProvider, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	return r.Execute()
+func (r ListIdentityProvidersApiRequest) Execute() ([]IdentityProvider, *http.Response, error) {
+	return r.ApiService.listIdentityProvidersExecute(r)
 }
 
 /*
@@ -1524,7 +1677,7 @@ func (a *FederatedAuthenticationApiService) ListIdentityProviders(ctx context.Co
 
 // Execute executes the request
 //  @return []IdentityProvider
-func (a *FederatedAuthenticationApiService) ListIdentityProvidersExecute(r ListIdentityProvidersApiRequest) ([]IdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) listIdentityProvidersExecute(r ListIdentityProvidersApiRequest) ([]IdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1624,14 +1777,17 @@ type ListRoleMappingsApiParams struct {
 		OrgId string
 }
 
-func (r ListRoleMappingsApiRequest) Execute() ([]RoleMapping, *http.Response, error) {
-	return r.ApiService.ListRoleMappingsExecute(r)
+func (a *FederatedAuthenticationApiService) ListRoleMappingsWithParams(ctx context.Context, args *ListRoleMappingsApiParams) ListRoleMappingsApiRequest {
+	return ListRoleMappingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		orgId: args.OrgId,
+	}
 }
 
-func (r ListRoleMappingsApiRequest) ExecuteWithParams(params *ListRoleMappingsApiParams) ([]RoleMapping, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r ListRoleMappingsApiRequest) Execute() ([]RoleMapping, *http.Response, error) {
+	return r.ApiService.listRoleMappingsExecute(r)
 }
 
 /*
@@ -1655,7 +1811,7 @@ func (a *FederatedAuthenticationApiService) ListRoleMappings(ctx context.Context
 
 // Execute executes the request
 //  @return []RoleMapping
-func (a *FederatedAuthenticationApiService) ListRoleMappingsExecute(r ListRoleMappingsApiRequest) ([]RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) listRoleMappingsExecute(r ListRoleMappingsApiRequest) ([]RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1762,14 +1918,17 @@ type RemoveConnectedOrgConfigApiParams struct {
 		OrgId string
 }
 
-func (r RemoveConnectedOrgConfigApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.RemoveConnectedOrgConfigExecute(r)
+func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigWithParams(ctx context.Context, args *RemoveConnectedOrgConfigApiParams) RemoveConnectedOrgConfigApiRequest {
+	return RemoveConnectedOrgConfigApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		orgId: args.OrgId,
+	}
 }
 
-func (r RemoveConnectedOrgConfigApiRequest) ExecuteWithParams(params *RemoveConnectedOrgConfigApiParams) (*http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r RemoveConnectedOrgConfigApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.removeConnectedOrgConfigExecute(r)
 }
 
 /*
@@ -1792,7 +1951,7 @@ func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfig(ctx context
 }
 
 // Execute executes the request
-func (a *FederatedAuthenticationApiService) RemoveConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (*http.Response, error) {
+func (a *FederatedAuthenticationApiService) removeConnectedOrgConfigExecute(r RemoveConnectedOrgConfigApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1891,6 +2050,16 @@ type UpdateConnectedOrgConfigApiParams struct {
 		ConnectedOrgConfig *ConnectedOrgConfig
 }
 
+func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigWithParams(ctx context.Context, args *UpdateConnectedOrgConfigApiParams) UpdateConnectedOrgConfigApiRequest {
+	return UpdateConnectedOrgConfigApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		orgId: args.OrgId,
+		connectedOrgConfig: args.ConnectedOrgConfig,
+	}
+}
+
 // The connected organization configuration that you want to update.
 func (r UpdateConnectedOrgConfigApiRequest) ConnectedOrgConfig(connectedOrgConfig ConnectedOrgConfig) UpdateConnectedOrgConfigApiRequest {
 	r.connectedOrgConfig = &connectedOrgConfig
@@ -1898,14 +2067,7 @@ func (r UpdateConnectedOrgConfigApiRequest) ConnectedOrgConfig(connectedOrgConfi
 }
 
 func (r UpdateConnectedOrgConfigApiRequest) Execute() (*ConnectedOrgConfig, *http.Response, error) {
-	return r.ApiService.UpdateConnectedOrgConfigExecute(r)
-}
-
-func (r UpdateConnectedOrgConfigApiRequest) ExecuteWithParams(params *UpdateConnectedOrgConfigApiParams) (*ConnectedOrgConfig, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.orgId = params.OrgId 
-	r.connectedOrgConfig = params.ConnectedOrgConfig 
-	return r.Execute()
+	return r.ApiService.updateConnectedOrgConfigExecute(r)
 }
 
 /*
@@ -1935,7 +2097,7 @@ func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfig(ctx context
 
 // Execute executes the request
 //  @return ConnectedOrgConfig
-func (a *FederatedAuthenticationApiService) UpdateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) updateConnectedOrgConfigExecute(r UpdateConnectedOrgConfigApiRequest) (*ConnectedOrgConfig, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2049,6 +2211,16 @@ type UpdateIdentityProviderApiParams struct {
 		IdentityProviderUpdate *IdentityProviderUpdate
 }
 
+func (a *FederatedAuthenticationApiService) UpdateIdentityProviderWithParams(ctx context.Context, args *UpdateIdentityProviderApiParams) UpdateIdentityProviderApiRequest {
+	return UpdateIdentityProviderApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		identityProviderId: args.IdentityProviderId,
+		identityProviderUpdate: args.IdentityProviderUpdate,
+	}
+}
+
 // The identity provider that you want to update.
 func (r UpdateIdentityProviderApiRequest) IdentityProviderUpdate(identityProviderUpdate IdentityProviderUpdate) UpdateIdentityProviderApiRequest {
 	r.identityProviderUpdate = &identityProviderUpdate
@@ -2056,14 +2228,7 @@ func (r UpdateIdentityProviderApiRequest) IdentityProviderUpdate(identityProvide
 }
 
 func (r UpdateIdentityProviderApiRequest) Execute() (*IdentityProvider, *http.Response, error) {
-	return r.ApiService.UpdateIdentityProviderExecute(r)
-}
-
-func (r UpdateIdentityProviderApiRequest) ExecuteWithParams(params *UpdateIdentityProviderApiParams) (*IdentityProvider, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.identityProviderId = params.IdentityProviderId 
-	r.identityProviderUpdate = params.IdentityProviderUpdate 
-	return r.Execute()
+	return r.ApiService.updateIdentityProviderExecute(r)
 }
 
 /*
@@ -2087,7 +2252,7 @@ func (a *FederatedAuthenticationApiService) UpdateIdentityProvider(ctx context.C
 
 // Execute executes the request
 //  @return IdentityProvider
-func (a *FederatedAuthenticationApiService) UpdateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) updateIdentityProviderExecute(r UpdateIdentityProviderApiRequest) (*IdentityProvider, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2203,6 +2368,17 @@ type UpdateRoleMappingApiParams struct {
 		RoleMapping *RoleMapping
 }
 
+func (a *FederatedAuthenticationApiService) UpdateRoleMappingWithParams(ctx context.Context, args *UpdateRoleMappingApiParams) UpdateRoleMappingApiRequest {
+	return UpdateRoleMappingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		federationSettingsId: args.FederationSettingsId,
+		id: args.Id,
+		orgId: args.OrgId,
+		roleMapping: args.RoleMapping,
+	}
+}
+
 // The role mapping that you want to update.
 func (r UpdateRoleMappingApiRequest) RoleMapping(roleMapping RoleMapping) UpdateRoleMappingApiRequest {
 	r.roleMapping = &roleMapping
@@ -2210,15 +2386,7 @@ func (r UpdateRoleMappingApiRequest) RoleMapping(roleMapping RoleMapping) Update
 }
 
 func (r UpdateRoleMappingApiRequest) Execute() (*RoleMapping, *http.Response, error) {
-	return r.ApiService.UpdateRoleMappingExecute(r)
-}
-
-func (r UpdateRoleMappingApiRequest) ExecuteWithParams(params *UpdateRoleMappingApiParams) (*RoleMapping, *http.Response, error) {
-	r.federationSettingsId = params.FederationSettingsId 
-	r.id = params.Id 
-	r.orgId = params.OrgId 
-	r.roleMapping = params.RoleMapping 
-	return r.Execute()
+	return r.ApiService.updateRoleMappingExecute(r)
 }
 
 /*
@@ -2244,7 +2412,7 @@ func (a *FederatedAuthenticationApiService) UpdateRoleMapping(ctx context.Contex
 
 // Execute executes the request
 //  @return RoleMapping
-func (a *FederatedAuthenticationApiService) UpdateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
+func (a *FederatedAuthenticationApiService) updateRoleMappingExecute(r UpdateRoleMappingApiRequest) (*RoleMapping, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_federated_authentication.go
+++ b/mongodbatlasv2/api_federated_authentication.go
@@ -35,7 +35,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateRoleMappingApiParams - Parameters for the request
-	@return CreateRoleMappingApiRequest}}
+	@return CreateRoleMappingApiRequest
 	*/
 	CreateRoleMappingWithParams(ctx context.Context, args *CreateRoleMappingApiParams) CreateRoleMappingApiRequest
 
@@ -58,7 +58,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteFederationAppApiParams - Parameters for the request
-	@return DeleteFederationAppApiRequest}}
+	@return DeleteFederationAppApiRequest
 	*/
 	DeleteFederationAppWithParams(ctx context.Context, args *DeleteFederationAppApiParams) DeleteFederationAppApiRequest
 
@@ -83,7 +83,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteRoleMappingApiParams - Parameters for the request
-	@return DeleteRoleMappingApiRequest}}
+	@return DeleteRoleMappingApiRequest
 	*/
 	DeleteRoleMappingWithParams(ctx context.Context, args *DeleteRoleMappingApiParams) DeleteRoleMappingApiRequest
 
@@ -107,7 +107,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetConnectedOrgConfigApiParams - Parameters for the request
-	@return GetConnectedOrgConfigApiRequest}}
+	@return GetConnectedOrgConfigApiRequest
 	*/
 	GetConnectedOrgConfigWithParams(ctx context.Context, args *GetConnectedOrgConfigApiParams) GetConnectedOrgConfigApiRequest
 
@@ -130,7 +130,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetFederationSettingsApiParams - Parameters for the request
-	@return GetFederationSettingsApiRequest}}
+	@return GetFederationSettingsApiRequest
 	*/
 	GetFederationSettingsWithParams(ctx context.Context, args *GetFederationSettingsApiParams) GetFederationSettingsApiRequest
 
@@ -154,7 +154,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetIdentityProviderApiParams - Parameters for the request
-	@return GetIdentityProviderApiRequest}}
+	@return GetIdentityProviderApiRequest
 	*/
 	GetIdentityProviderWithParams(ctx context.Context, args *GetIdentityProviderApiParams) GetIdentityProviderApiRequest
 
@@ -178,7 +178,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetIdentityProviderMetadataApiParams - Parameters for the request
-	@return GetIdentityProviderMetadataApiRequest}}
+	@return GetIdentityProviderMetadataApiRequest
 	*/
 	GetIdentityProviderMetadataWithParams(ctx context.Context, args *GetIdentityProviderMetadataApiParams) GetIdentityProviderMetadataApiRequest
 
@@ -203,7 +203,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetRoleMappingApiParams - Parameters for the request
-	@return GetRoleMappingApiRequest}}
+	@return GetRoleMappingApiRequest
 	*/
 	GetRoleMappingWithParams(ctx context.Context, args *GetRoleMappingApiParams) GetRoleMappingApiRequest
 
@@ -226,7 +226,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListConnectedOrgConfigsApiParams - Parameters for the request
-	@return ListConnectedOrgConfigsApiRequest}}
+	@return ListConnectedOrgConfigsApiRequest
 	*/
 	ListConnectedOrgConfigsWithParams(ctx context.Context, args *ListConnectedOrgConfigsApiParams) ListConnectedOrgConfigsApiRequest
 
@@ -249,7 +249,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListIdentityProvidersApiParams - Parameters for the request
-	@return ListIdentityProvidersApiRequest}}
+	@return ListIdentityProvidersApiRequest
 	*/
 	ListIdentityProvidersWithParams(ctx context.Context, args *ListIdentityProvidersApiParams) ListIdentityProvidersApiRequest
 
@@ -273,7 +273,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListRoleMappingsApiParams - Parameters for the request
-	@return ListRoleMappingsApiRequest}}
+	@return ListRoleMappingsApiRequest
 	*/
 	ListRoleMappingsWithParams(ctx context.Context, args *ListRoleMappingsApiParams) ListRoleMappingsApiRequest
 
@@ -297,7 +297,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param RemoveConnectedOrgConfigApiParams - Parameters for the request
-	@return RemoveConnectedOrgConfigApiRequest}}
+	@return RemoveConnectedOrgConfigApiRequest
 	*/
 	RemoveConnectedOrgConfigWithParams(ctx context.Context, args *RemoveConnectedOrgConfigApiParams) RemoveConnectedOrgConfigApiRequest
 
@@ -327,7 +327,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateConnectedOrgConfigApiParams - Parameters for the request
-	@return UpdateConnectedOrgConfigApiRequest}}
+	@return UpdateConnectedOrgConfigApiRequest
 	*/
 	UpdateConnectedOrgConfigWithParams(ctx context.Context, args *UpdateConnectedOrgConfigApiParams) UpdateConnectedOrgConfigApiRequest
 
@@ -351,7 +351,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateIdentityProviderApiParams - Parameters for the request
-	@return UpdateIdentityProviderApiRequest}}
+	@return UpdateIdentityProviderApiRequest
 	*/
 	UpdateIdentityProviderWithParams(ctx context.Context, args *UpdateIdentityProviderApiParams) UpdateIdentityProviderApiRequest
 
@@ -376,7 +376,7 @@ type FederatedAuthenticationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateRoleMappingApiParams - Parameters for the request
-	@return UpdateRoleMappingApiRequest}}
+	@return UpdateRoleMappingApiRequest
 	*/
 	UpdateRoleMappingWithParams(ctx context.Context, args *UpdateRoleMappingApiParams) UpdateRoleMappingApiRequest
 

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -126,6 +126,13 @@ func (r CreateCustomZoneMappingApiRequest) Execute() (*GeoSharding, *http.Respon
 	return r.ApiService.CreateCustomZoneMappingExecute(r)
 }
 
+func (r CreateCustomZoneMappingApiRequest) ExecuteWithParams(params *CreateCustomZoneMappingApiParams) (*GeoSharding, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.geoSharding = params.GeoSharding 
+	return r.Execute()
+}
+
 /*
 CreateCustomZoneMapping Add One Entry to One Custom Zone Mapping
 
@@ -271,6 +278,13 @@ func (r CreateManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Respons
 	return r.ApiService.CreateManagedNamespaceExecute(r)
 }
 
+func (r CreateManagedNamespaceApiRequest) ExecuteWithParams(params *CreateManagedNamespaceApiParams) (*GeoSharding, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.managedNamespace = params.ManagedNamespace 
+	return r.Execute()
+}
+
 /*
 CreateManagedNamespace Create One Managed Namespace in One Global Multi-Cloud Cluster
 
@@ -406,6 +420,12 @@ type DeleteAllCustomZoneMappingsApiParams struct {
 
 func (r DeleteAllCustomZoneMappingsApiRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.DeleteAllCustomZoneMappingsExecute(r)
+}
+
+func (r DeleteAllCustomZoneMappingsApiRequest) ExecuteWithParams(params *DeleteAllCustomZoneMappingsApiParams) (*GeoSharding, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*
@@ -556,6 +576,14 @@ func (r DeleteManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Respons
 	return r.ApiService.DeleteManagedNamespaceExecute(r)
 }
 
+func (r DeleteManagedNamespaceApiRequest) ExecuteWithParams(params *DeleteManagedNamespaceApiParams) (*GeoSharding, *http.Response, error) {
+	r.clusterName = params.ClusterName 
+	r.groupId = params.GroupId 
+	r.db = params.Db 
+	r.collection = params.Collection 
+	return r.Execute()
+}
+
 /*
 DeleteManagedNamespace Remove One Managed Namespace from One Global Multi-Cloud Cluster
 
@@ -692,6 +720,12 @@ type GetManagedNamespaceApiParams struct {
 
 func (r GetManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
 	return r.ApiService.GetManagedNamespaceExecute(r)
+}
+
+func (r GetManagedNamespaceApiRequest) ExecuteWithParams(params *GetManagedNamespaceApiParams) (*GeoSharding, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -35,7 +35,7 @@ type GlobalClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateCustomZoneMappingApiParams - Parameters for the request
-	@return CreateCustomZoneMappingApiRequest}}
+	@return CreateCustomZoneMappingApiRequest
 	*/
 	CreateCustomZoneMappingWithParams(ctx context.Context, args *CreateCustomZoneMappingApiParams) CreateCustomZoneMappingApiRequest
 
@@ -59,7 +59,7 @@ type GlobalClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateManagedNamespaceApiParams - Parameters for the request
-	@return CreateManagedNamespaceApiRequest}}
+	@return CreateManagedNamespaceApiRequest
 	*/
 	CreateManagedNamespaceWithParams(ctx context.Context, args *CreateManagedNamespaceApiParams) CreateManagedNamespaceApiRequest
 
@@ -83,7 +83,7 @@ type GlobalClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteAllCustomZoneMappingsApiParams - Parameters for the request
-	@return DeleteAllCustomZoneMappingsApiRequest}}
+	@return DeleteAllCustomZoneMappingsApiRequest
 	*/
 	DeleteAllCustomZoneMappingsWithParams(ctx context.Context, args *DeleteAllCustomZoneMappingsApiParams) DeleteAllCustomZoneMappingsApiRequest
 
@@ -107,7 +107,7 @@ type GlobalClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteManagedNamespaceApiParams - Parameters for the request
-	@return DeleteManagedNamespaceApiRequest}}
+	@return DeleteManagedNamespaceApiRequest
 	*/
 	DeleteManagedNamespaceWithParams(ctx context.Context, args *DeleteManagedNamespaceApiParams) DeleteManagedNamespaceApiRequest
 
@@ -131,7 +131,7 @@ type GlobalClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetManagedNamespaceApiParams - Parameters for the request
-	@return GetManagedNamespaceApiRequest}}
+	@return GetManagedNamespaceApiRequest
 	*/
 	GetManagedNamespaceWithParams(ctx context.Context, args *GetManagedNamespaceApiParams) GetManagedNamespaceApiRequest
 

--- a/mongodbatlasv2/api_global_clusters.go
+++ b/mongodbatlasv2/api_global_clusters.go
@@ -29,10 +29,18 @@ type GlobalClustersApi interface {
 	@return CreateCustomZoneMappingApiRequest
 	*/
 	CreateCustomZoneMapping(ctx context.Context, groupId string, clusterName string) CreateCustomZoneMappingApiRequest
+	/*
+	CreateCustomZoneMapping Add One Entry to One Custom Zone Mapping
 
-	// CreateCustomZoneMappingExecute executes the request
-	//  @return GeoSharding
-	CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateCustomZoneMappingApiParams - Parameters for the request
+	@return CreateCustomZoneMappingApiRequest}}
+	*/
+	CreateCustomZoneMappingWithParams(ctx context.Context, args *CreateCustomZoneMappingApiParams) CreateCustomZoneMappingApiRequest
+
+	// Interface only available internally
+	createCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	CreateManagedNamespace Create One Managed Namespace in One Global Multi-Cloud Cluster
@@ -45,10 +53,18 @@ type GlobalClustersApi interface {
 	@return CreateManagedNamespaceApiRequest
 	*/
 	CreateManagedNamespace(ctx context.Context, groupId string, clusterName string) CreateManagedNamespaceApiRequest
+	/*
+	CreateManagedNamespace Create One Managed Namespace in One Global Multi-Cloud Cluster
 
-	// CreateManagedNamespaceExecute executes the request
-	//  @return GeoSharding
-	CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateManagedNamespaceApiParams - Parameters for the request
+	@return CreateManagedNamespaceApiRequest}}
+	*/
+	CreateManagedNamespaceWithParams(ctx context.Context, args *CreateManagedNamespaceApiParams) CreateManagedNamespaceApiRequest
+
+	// Interface only available internally
+	createManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	DeleteAllCustomZoneMappings Remove All Custom Zone Mappings from One Global Multi-Cloud Cluster
@@ -61,10 +77,18 @@ type GlobalClustersApi interface {
 	@return DeleteAllCustomZoneMappingsApiRequest
 	*/
 	DeleteAllCustomZoneMappings(ctx context.Context, groupId string, clusterName string) DeleteAllCustomZoneMappingsApiRequest
+	/*
+	DeleteAllCustomZoneMappings Remove All Custom Zone Mappings from One Global Multi-Cloud Cluster
 
-	// DeleteAllCustomZoneMappingsExecute executes the request
-	//  @return GeoSharding
-	DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteAllCustomZoneMappingsApiParams - Parameters for the request
+	@return DeleteAllCustomZoneMappingsApiRequest}}
+	*/
+	DeleteAllCustomZoneMappingsWithParams(ctx context.Context, args *DeleteAllCustomZoneMappingsApiParams) DeleteAllCustomZoneMappingsApiRequest
+
+	// Interface only available internally
+	deleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	DeleteManagedNamespace Remove One Managed Namespace from One Global Multi-Cloud Cluster
@@ -77,10 +101,18 @@ type GlobalClustersApi interface {
 	@return DeleteManagedNamespaceApiRequest
 	*/
 	DeleteManagedNamespace(ctx context.Context, clusterName string, groupId string) DeleteManagedNamespaceApiRequest
+	/*
+	DeleteManagedNamespace Remove One Managed Namespace from One Global Multi-Cloud Cluster
 
-	// DeleteManagedNamespaceExecute executes the request
-	//  @return GeoSharding
-	DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteManagedNamespaceApiParams - Parameters for the request
+	@return DeleteManagedNamespaceApiRequest}}
+	*/
+	DeleteManagedNamespaceWithParams(ctx context.Context, args *DeleteManagedNamespaceApiParams) DeleteManagedNamespaceApiRequest
+
+	// Interface only available internally
+	deleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 
 	/*
 	GetManagedNamespace Return One Managed Namespace in One Global Multi-Cloud Cluster
@@ -93,10 +125,18 @@ type GlobalClustersApi interface {
 	@return GetManagedNamespaceApiRequest
 	*/
 	GetManagedNamespace(ctx context.Context, groupId string, clusterName string) GetManagedNamespaceApiRequest
+	/*
+	GetManagedNamespace Return One Managed Namespace in One Global Multi-Cloud Cluster
 
-	// GetManagedNamespaceExecute executes the request
-	//  @return GeoSharding
-	GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetManagedNamespaceApiParams - Parameters for the request
+	@return GetManagedNamespaceApiRequest}}
+	*/
+	GetManagedNamespaceWithParams(ctx context.Context, args *GetManagedNamespaceApiParams) GetManagedNamespaceApiRequest
+
+	// Interface only available internally
+	getManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error)
 }
 
 // GlobalClustersApiService GlobalClustersApi service
@@ -116,6 +156,16 @@ type CreateCustomZoneMappingApiParams struct {
 		GeoSharding *GeoSharding
 }
 
+func (a *GlobalClustersApiService) CreateCustomZoneMappingWithParams(ctx context.Context, args *CreateCustomZoneMappingApiParams) CreateCustomZoneMappingApiRequest {
+	return CreateCustomZoneMappingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		geoSharding: args.GeoSharding,
+	}
+}
+
 // Custom zone mapping to add to the specified global cluster.
 func (r CreateCustomZoneMappingApiRequest) GeoSharding(geoSharding GeoSharding) CreateCustomZoneMappingApiRequest {
 	r.geoSharding = &geoSharding
@@ -123,14 +173,7 @@ func (r CreateCustomZoneMappingApiRequest) GeoSharding(geoSharding GeoSharding) 
 }
 
 func (r CreateCustomZoneMappingApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.CreateCustomZoneMappingExecute(r)
-}
-
-func (r CreateCustomZoneMappingApiRequest) ExecuteWithParams(params *CreateCustomZoneMappingApiParams) (*GeoSharding, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.geoSharding = params.GeoSharding 
-	return r.Execute()
+	return r.ApiService.createCustomZoneMappingExecute(r)
 }
 
 /*
@@ -154,7 +197,7 @@ func (a *GlobalClustersApiService) CreateCustomZoneMapping(ctx context.Context, 
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) CreateCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) createCustomZoneMappingExecute(r CreateCustomZoneMappingApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -268,6 +311,16 @@ type CreateManagedNamespaceApiParams struct {
 		ManagedNamespace *ManagedNamespace
 }
 
+func (a *GlobalClustersApiService) CreateManagedNamespaceWithParams(ctx context.Context, args *CreateManagedNamespaceApiParams) CreateManagedNamespaceApiRequest {
+	return CreateManagedNamespaceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		managedNamespace: args.ManagedNamespace,
+	}
+}
+
 // Managed namespace to create within the specified global cluster.
 func (r CreateManagedNamespaceApiRequest) ManagedNamespace(managedNamespace ManagedNamespace) CreateManagedNamespaceApiRequest {
 	r.managedNamespace = &managedNamespace
@@ -275,14 +328,7 @@ func (r CreateManagedNamespaceApiRequest) ManagedNamespace(managedNamespace Mana
 }
 
 func (r CreateManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.CreateManagedNamespaceExecute(r)
-}
-
-func (r CreateManagedNamespaceApiRequest) ExecuteWithParams(params *CreateManagedNamespaceApiParams) (*GeoSharding, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.managedNamespace = params.ManagedNamespace 
-	return r.Execute()
+	return r.ApiService.createManagedNamespaceExecute(r)
 }
 
 /*
@@ -306,7 +352,7 @@ func (a *GlobalClustersApiService) CreateManagedNamespace(ctx context.Context, g
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) CreateManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) createManagedNamespaceExecute(r CreateManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -418,14 +464,17 @@ type DeleteAllCustomZoneMappingsApiParams struct {
 		ClusterName string
 }
 
-func (r DeleteAllCustomZoneMappingsApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.DeleteAllCustomZoneMappingsExecute(r)
+func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsWithParams(ctx context.Context, args *DeleteAllCustomZoneMappingsApiParams) DeleteAllCustomZoneMappingsApiRequest {
+	return DeleteAllCustomZoneMappingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r DeleteAllCustomZoneMappingsApiRequest) ExecuteWithParams(params *DeleteAllCustomZoneMappingsApiParams) (*GeoSharding, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r DeleteAllCustomZoneMappingsApiRequest) Execute() (*GeoSharding, *http.Response, error) {
+	return r.ApiService.deleteAllCustomZoneMappingsExecute(r)
 }
 
 /*
@@ -449,7 +498,7 @@ func (a *GlobalClustersApiService) DeleteAllCustomZoneMappings(ctx context.Conte
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) DeleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) deleteAllCustomZoneMappingsExecute(r DeleteAllCustomZoneMappingsApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -560,6 +609,17 @@ type DeleteManagedNamespaceApiParams struct {
 		Collection *string
 }
 
+func (a *GlobalClustersApiService) DeleteManagedNamespaceWithParams(ctx context.Context, args *DeleteManagedNamespaceApiParams) DeleteManagedNamespaceApiRequest {
+	return DeleteManagedNamespaceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		clusterName: args.ClusterName,
+		groupId: args.GroupId,
+		db: args.Db,
+		collection: args.Collection,
+	}
+}
+
 // Human-readable label that identifies the database that contains the collection.
 func (r DeleteManagedNamespaceApiRequest) Db(db string) DeleteManagedNamespaceApiRequest {
 	r.db = &db
@@ -573,15 +633,7 @@ func (r DeleteManagedNamespaceApiRequest) Collection(collection string) DeleteMa
 }
 
 func (r DeleteManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.DeleteManagedNamespaceExecute(r)
-}
-
-func (r DeleteManagedNamespaceApiRequest) ExecuteWithParams(params *DeleteManagedNamespaceApiParams) (*GeoSharding, *http.Response, error) {
-	r.clusterName = params.ClusterName 
-	r.groupId = params.GroupId 
-	r.db = params.Db 
-	r.collection = params.Collection 
-	return r.Execute()
+	return r.ApiService.deleteManagedNamespaceExecute(r)
 }
 
 /*
@@ -605,7 +657,7 @@ func (a *GlobalClustersApiService) DeleteManagedNamespace(ctx context.Context, c
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) DeleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) deleteManagedNamespaceExecute(r DeleteManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -718,14 +770,17 @@ type GetManagedNamespaceApiParams struct {
 		ClusterName string
 }
 
-func (r GetManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
-	return r.ApiService.GetManagedNamespaceExecute(r)
+func (a *GlobalClustersApiService) GetManagedNamespaceWithParams(ctx context.Context, args *GetManagedNamespaceApiParams) GetManagedNamespaceApiRequest {
+	return GetManagedNamespaceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetManagedNamespaceApiRequest) ExecuteWithParams(params *GetManagedNamespaceApiParams) (*GeoSharding, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetManagedNamespaceApiRequest) Execute() (*GeoSharding, *http.Response, error) {
+	return r.ApiService.getManagedNamespaceExecute(r)
 }
 
 /*
@@ -749,7 +804,7 @@ func (a *GlobalClustersApiService) GetManagedNamespace(ctx context.Context, grou
 
 // Execute executes the request
 //  @return GeoSharding
-func (a *GlobalClustersApiService) GetManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
+func (a *GlobalClustersApiService) getManagedNamespaceExecute(r GetManagedNamespaceApiRequest) (*GeoSharding, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -35,7 +35,7 @@ type InvoicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DownloadInvoiceCSVApiParams - Parameters for the request
-	@return DownloadInvoiceCSVApiRequest}}
+	@return DownloadInvoiceCSVApiRequest
 	*/
 	DownloadInvoiceCSVWithParams(ctx context.Context, args *DownloadInvoiceCSVApiParams) DownloadInvoiceCSVApiRequest
 
@@ -59,7 +59,7 @@ type InvoicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetInvoiceApiParams - Parameters for the request
-	@return GetInvoiceApiRequest}}
+	@return GetInvoiceApiRequest
 	*/
 	GetInvoiceWithParams(ctx context.Context, args *GetInvoiceApiParams) GetInvoiceApiRequest
 
@@ -82,7 +82,7 @@ type InvoicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListInvoicesApiParams - Parameters for the request
-	@return ListInvoicesApiRequest}}
+	@return ListInvoicesApiRequest
 	*/
 	ListInvoicesWithParams(ctx context.Context, args *ListInvoicesApiParams) ListInvoicesApiRequest
 
@@ -105,7 +105,7 @@ type InvoicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPendingInvoicesApiParams - Parameters for the request
-	@return ListPendingInvoicesApiRequest}}
+	@return ListPendingInvoicesApiRequest
 	*/
 	ListPendingInvoicesWithParams(ctx context.Context, args *ListPendingInvoicesApiParams) ListPendingInvoicesApiRequest
 

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -99,6 +99,12 @@ func (r DownloadInvoiceCSVApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DownloadInvoiceCSVExecute(r)
 }
 
+func (r DownloadInvoiceCSVApiRequest) ExecuteWithParams(params *DownloadInvoiceCSVApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	r.invoiceId = params.InvoiceId 
+	return r.Execute()
+}
+
 /*
 DownloadInvoiceCSV Return One Organization Invoice as CSV
 
@@ -212,6 +218,12 @@ type GetInvoiceApiParams struct {
 
 func (r GetInvoiceApiRequest) Execute() (*Invoice, *http.Response, error) {
 	return r.ApiService.GetInvoiceExecute(r)
+}
+
+func (r GetInvoiceApiRequest) ExecuteWithParams(params *GetInvoiceApiParams) (*Invoice, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.invoiceId = params.InvoiceId 
+	return r.Execute()
 }
 
 /*
@@ -368,6 +380,14 @@ func (r ListInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response,
 	return r.ApiService.ListInvoicesExecute(r)
 }
 
+func (r ListInvoicesApiRequest) ExecuteWithParams(params *ListInvoicesApiParams) (*PaginatedApiInvoice, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListInvoices Return All Invoices for One Organization
 
@@ -508,6 +528,11 @@ type ListPendingInvoicesApiParams struct {
 
 func (r ListPendingInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
 	return r.ApiService.ListPendingInvoicesExecute(r)
+}
+
+func (r ListPendingInvoicesApiRequest) ExecuteWithParams(params *ListPendingInvoicesApiParams) (*PaginatedApiInvoice, *http.Response, error) {
+	r.orgId = params.OrgId 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_invoices.go
+++ b/mongodbatlasv2/api_invoices.go
@@ -29,9 +29,18 @@ type InvoicesApi interface {
 	@return DownloadInvoiceCSVApiRequest
 	*/
 	DownloadInvoiceCSV(ctx context.Context, orgId string, invoiceId string) DownloadInvoiceCSVApiRequest
+	/*
+	DownloadInvoiceCSV Return One Organization Invoice as CSV
 
-	// DownloadInvoiceCSVExecute executes the request
-	DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DownloadInvoiceCSVApiParams - Parameters for the request
+	@return DownloadInvoiceCSVApiRequest}}
+	*/
+	DownloadInvoiceCSVWithParams(ctx context.Context, args *DownloadInvoiceCSVApiParams) DownloadInvoiceCSVApiRequest
+
+	// Interface only available internally
+	downloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (*http.Response, error)
 
 	/*
 	GetInvoice Return One Organization Invoice
@@ -44,10 +53,18 @@ type InvoicesApi interface {
 	@return GetInvoiceApiRequest
 	*/
 	GetInvoice(ctx context.Context, orgId string, invoiceId string) GetInvoiceApiRequest
+	/*
+	GetInvoice Return One Organization Invoice
 
-	// GetInvoiceExecute executes the request
-	//  @return Invoice
-	GetInvoiceExecute(r GetInvoiceApiRequest) (*Invoice, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetInvoiceApiParams - Parameters for the request
+	@return GetInvoiceApiRequest}}
+	*/
+	GetInvoiceWithParams(ctx context.Context, args *GetInvoiceApiParams) GetInvoiceApiRequest
+
+	// Interface only available internally
+	getInvoiceExecute(r GetInvoiceApiRequest) (*Invoice, *http.Response, error)
 
 	/*
 	ListInvoices Return All Invoices for One Organization
@@ -59,10 +76,18 @@ type InvoicesApi interface {
 	@return ListInvoicesApiRequest
 	*/
 	ListInvoices(ctx context.Context, orgId string) ListInvoicesApiRequest
+	/*
+	ListInvoices Return All Invoices for One Organization
 
-	// ListInvoicesExecute executes the request
-	//  @return PaginatedApiInvoice
-	ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListInvoicesApiParams - Parameters for the request
+	@return ListInvoicesApiRequest}}
+	*/
+	ListInvoicesWithParams(ctx context.Context, args *ListInvoicesApiParams) ListInvoicesApiRequest
+
+	// Interface only available internally
+	listInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 
 	/*
 	ListPendingInvoices Return All Pending Invoices for One Organization
@@ -74,10 +99,18 @@ type InvoicesApi interface {
 	@return ListPendingInvoicesApiRequest
 	*/
 	ListPendingInvoices(ctx context.Context, orgId string) ListPendingInvoicesApiRequest
+	/*
+	ListPendingInvoices Return All Pending Invoices for One Organization
 
-	// ListPendingInvoicesExecute executes the request
-	//  @return PaginatedApiInvoice
-	ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPendingInvoicesApiParams - Parameters for the request
+	@return ListPendingInvoicesApiRequest}}
+	*/
+	ListPendingInvoicesWithParams(ctx context.Context, args *ListPendingInvoicesApiParams) ListPendingInvoicesApiRequest
+
+	// Interface only available internally
+	listPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error)
 }
 
 // InvoicesApiService InvoicesApi service
@@ -95,14 +128,17 @@ type DownloadInvoiceCSVApiParams struct {
 		InvoiceId string
 }
 
-func (r DownloadInvoiceCSVApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DownloadInvoiceCSVExecute(r)
+func (a *InvoicesApiService) DownloadInvoiceCSVWithParams(ctx context.Context, args *DownloadInvoiceCSVApiParams) DownloadInvoiceCSVApiRequest {
+	return DownloadInvoiceCSVApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		invoiceId: args.InvoiceId,
+	}
 }
 
-func (r DownloadInvoiceCSVApiRequest) ExecuteWithParams(params *DownloadInvoiceCSVApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	r.invoiceId = params.InvoiceId 
-	return r.Execute()
+func (r DownloadInvoiceCSVApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.downloadInvoiceCSVExecute(r)
 }
 
 /*
@@ -125,7 +161,7 @@ func (a *InvoicesApiService) DownloadInvoiceCSV(ctx context.Context, orgId strin
 }
 
 // Execute executes the request
-func (a *InvoicesApiService) DownloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (*http.Response, error) {
+func (a *InvoicesApiService) downloadInvoiceCSVExecute(r DownloadInvoiceCSVApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -216,14 +252,17 @@ type GetInvoiceApiParams struct {
 		InvoiceId string
 }
 
-func (r GetInvoiceApiRequest) Execute() (*Invoice, *http.Response, error) {
-	return r.ApiService.GetInvoiceExecute(r)
+func (a *InvoicesApiService) GetInvoiceWithParams(ctx context.Context, args *GetInvoiceApiParams) GetInvoiceApiRequest {
+	return GetInvoiceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		invoiceId: args.InvoiceId,
+	}
 }
 
-func (r GetInvoiceApiRequest) ExecuteWithParams(params *GetInvoiceApiParams) (*Invoice, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.invoiceId = params.InvoiceId 
-	return r.Execute()
+func (r GetInvoiceApiRequest) Execute() (*Invoice, *http.Response, error) {
+	return r.ApiService.getInvoiceExecute(r)
 }
 
 /*
@@ -247,7 +286,7 @@ func (a *InvoicesApiService) GetInvoice(ctx context.Context, orgId string, invoi
 
 // Execute executes the request
 //  @return Invoice
-func (a *InvoicesApiService) GetInvoiceExecute(r GetInvoiceApiRequest) (*Invoice, *http.Response, error) {
+func (a *InvoicesApiService) getInvoiceExecute(r GetInvoiceApiRequest) (*Invoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -358,6 +397,17 @@ type ListInvoicesApiParams struct {
 		PageNum *int32
 }
 
+func (a *InvoicesApiService) ListInvoicesWithParams(ctx context.Context, args *ListInvoicesApiParams) ListInvoicesApiRequest {
+	return ListInvoicesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListInvoicesApiRequest) IncludeCount(includeCount bool) ListInvoicesApiRequest {
 	r.includeCount = &includeCount
@@ -377,15 +427,7 @@ func (r ListInvoicesApiRequest) PageNum(pageNum int32) ListInvoicesApiRequest {
 }
 
 func (r ListInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
-	return r.ApiService.ListInvoicesExecute(r)
-}
-
-func (r ListInvoicesApiRequest) ExecuteWithParams(params *ListInvoicesApiParams) (*PaginatedApiInvoice, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listInvoicesExecute(r)
 }
 
 /*
@@ -407,7 +449,7 @@ func (a *InvoicesApiService) ListInvoices(ctx context.Context, orgId string) Lis
 
 // Execute executes the request
 //  @return PaginatedApiInvoice
-func (a *InvoicesApiService) ListInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
+func (a *InvoicesApiService) listInvoicesExecute(r ListInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -526,13 +568,16 @@ type ListPendingInvoicesApiParams struct {
 		OrgId string
 }
 
-func (r ListPendingInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
-	return r.ApiService.ListPendingInvoicesExecute(r)
+func (a *InvoicesApiService) ListPendingInvoicesWithParams(ctx context.Context, args *ListPendingInvoicesApiParams) ListPendingInvoicesApiRequest {
+	return ListPendingInvoicesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+	}
 }
 
-func (r ListPendingInvoicesApiRequest) ExecuteWithParams(params *ListPendingInvoicesApiParams) (*PaginatedApiInvoice, *http.Response, error) {
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r ListPendingInvoicesApiRequest) Execute() (*PaginatedApiInvoice, *http.Response, error) {
+	return r.ApiService.listPendingInvoicesExecute(r)
 }
 
 /*
@@ -554,7 +599,7 @@ func (a *InvoicesApiService) ListPendingInvoices(ctx context.Context, orgId stri
 
 // Execute executes the request
 //  @return PaginatedApiInvoice
-func (a *InvoicesApiService) ListPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
+func (a *InvoicesApiService) listPendingInvoicesExecute(r ListPendingInvoicesApiRequest) (*PaginatedApiInvoice, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -28,9 +28,18 @@ type LDAPConfigurationApi interface {
 	@return DeleteLDAPConfigurationApiRequest
 	*/
 	DeleteLDAPConfiguration(ctx context.Context, groupId string) DeleteLDAPConfigurationApiRequest
+	/*
+	DeleteLDAPConfiguration Remove the Current LDAP User to DN Mapping
 
-	// DeleteLDAPConfigurationExecute executes the request
-	DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteLDAPConfigurationApiParams - Parameters for the request
+	@return DeleteLDAPConfigurationApiRequest}}
+	*/
+	DeleteLDAPConfigurationWithParams(ctx context.Context, args *DeleteLDAPConfigurationApiParams) DeleteLDAPConfigurationApiRequest
+
+	// Interface only available internally
+	deleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*http.Response, error)
 
 	/*
 	GetLDAPConfiguration Return the Current LDAP or X.509 Configuration
@@ -42,10 +51,18 @@ type LDAPConfigurationApi interface {
 	@return GetLDAPConfigurationApiRequest
 	*/
 	GetLDAPConfiguration(ctx context.Context, groupId string) GetLDAPConfigurationApiRequest
+	/*
+	GetLDAPConfiguration Return the Current LDAP or X.509 Configuration
 
-	// GetLDAPConfigurationExecute executes the request
-	//  @return UserSecurity
-	GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetLDAPConfigurationApiParams - Parameters for the request
+	@return GetLDAPConfigurationApiRequest}}
+	*/
+	GetLDAPConfigurationWithParams(ctx context.Context, args *GetLDAPConfigurationApiParams) GetLDAPConfigurationApiRequest
+
+	// Interface only available internally
+	getLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 	GetLDAPConfigurationStatus Return the Status of One Verify LDAP Configuration Request
@@ -58,10 +75,18 @@ type LDAPConfigurationApi interface {
 	@return GetLDAPConfigurationStatusApiRequest
 	*/
 	GetLDAPConfigurationStatus(ctx context.Context, groupId string, requestId string) GetLDAPConfigurationStatusApiRequest
+	/*
+	GetLDAPConfigurationStatus Return the Status of One Verify LDAP Configuration Request
 
-	// GetLDAPConfigurationStatusExecute executes the request
-	//  @return NDSLDAPVerifyConnectivityJobRequest
-	GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetLDAPConfigurationStatusApiParams - Parameters for the request
+	@return GetLDAPConfigurationStatusApiRequest}}
+	*/
+	GetLDAPConfigurationStatusWithParams(ctx context.Context, args *GetLDAPConfigurationStatusApiParams) GetLDAPConfigurationStatusApiRequest
+
+	// Interface only available internally
+	getLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
 
 	/*
 	SaveLDAPConfiguration Edit the LDAP or X.509 Configuration
@@ -75,10 +100,18 @@ Updating this configuration triggers a rolling restart of the database.
 	@return SaveLDAPConfigurationApiRequest
 	*/
 	SaveLDAPConfiguration(ctx context.Context, groupId string) SaveLDAPConfigurationApiRequest
+	/*
+	SaveLDAPConfiguration Edit the LDAP or X.509 Configuration
 
-	// SaveLDAPConfigurationExecute executes the request
-	//  @return UserSecurity
-	SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param SaveLDAPConfigurationApiParams - Parameters for the request
+	@return SaveLDAPConfigurationApiRequest}}
+	*/
+	SaveLDAPConfigurationWithParams(ctx context.Context, args *SaveLDAPConfigurationApiParams) SaveLDAPConfigurationApiRequest
+
+	// Interface only available internally
+	saveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 	VerifyLDAPConfiguration Verify the LDAP Configuration in One Project
@@ -90,10 +123,18 @@ Updating this configuration triggers a rolling restart of the database.
 	@return VerifyLDAPConfigurationApiRequest
 	*/
 	VerifyLDAPConfiguration(ctx context.Context, groupId string) VerifyLDAPConfigurationApiRequest
+	/*
+	VerifyLDAPConfiguration Verify the LDAP Configuration in One Project
 
-	// VerifyLDAPConfigurationExecute executes the request
-	//  @return NDSLDAPVerifyConnectivityJobRequest
-	VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param VerifyLDAPConfigurationApiParams - Parameters for the request
+	@return VerifyLDAPConfigurationApiRequest}}
+	*/
+	VerifyLDAPConfigurationWithParams(ctx context.Context, args *VerifyLDAPConfigurationApiParams) VerifyLDAPConfigurationApiRequest
+
+	// Interface only available internally
+	verifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error)
 }
 
 // LDAPConfigurationApiService LDAPConfigurationApi service
@@ -109,13 +150,16 @@ type DeleteLDAPConfigurationApiParams struct {
 		GroupId string
 }
 
-func (r DeleteLDAPConfigurationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteLDAPConfigurationExecute(r)
+func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationWithParams(ctx context.Context, args *DeleteLDAPConfigurationApiParams) DeleteLDAPConfigurationApiRequest {
+	return DeleteLDAPConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r DeleteLDAPConfigurationApiRequest) ExecuteWithParams(params *DeleteLDAPConfigurationApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r DeleteLDAPConfigurationApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteLDAPConfigurationExecute(r)
 }
 
 /*
@@ -136,7 +180,7 @@ func (a *LDAPConfigurationApiService) DeleteLDAPConfiguration(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *LDAPConfigurationApiService) DeleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*http.Response, error) {
+func (a *LDAPConfigurationApiService) deleteLDAPConfigurationExecute(r DeleteLDAPConfigurationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -224,13 +268,16 @@ type GetLDAPConfigurationApiParams struct {
 		GroupId string
 }
 
-func (r GetLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
-	return r.ApiService.GetLDAPConfigurationExecute(r)
+func (a *LDAPConfigurationApiService) GetLDAPConfigurationWithParams(ctx context.Context, args *GetLDAPConfigurationApiParams) GetLDAPConfigurationApiRequest {
+	return GetLDAPConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetLDAPConfigurationApiRequest) ExecuteWithParams(params *GetLDAPConfigurationApiParams) (*UserSecurity, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
+	return r.ApiService.getLDAPConfigurationExecute(r)
 }
 
 /*
@@ -252,7 +299,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfiguration(ctx context.Context, 
 
 // Execute executes the request
 //  @return UserSecurity
-func (a *LDAPConfigurationApiService) GetLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
+func (a *LDAPConfigurationApiService) getLDAPConfigurationExecute(r GetLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -352,14 +399,17 @@ type GetLDAPConfigurationStatusApiParams struct {
 		RequestId string
 }
 
-func (r GetLDAPConfigurationStatusApiRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
-	return r.ApiService.GetLDAPConfigurationStatusExecute(r)
+func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusWithParams(ctx context.Context, args *GetLDAPConfigurationStatusApiParams) GetLDAPConfigurationStatusApiRequest {
+	return GetLDAPConfigurationStatusApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		requestId: args.RequestId,
+	}
 }
 
-func (r GetLDAPConfigurationStatusApiRequest) ExecuteWithParams(params *GetLDAPConfigurationStatusApiParams) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.requestId = params.RequestId 
-	return r.Execute()
+func (r GetLDAPConfigurationStatusApiRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+	return r.ApiService.getLDAPConfigurationStatusExecute(r)
 }
 
 /*
@@ -383,7 +433,7 @@ func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatus(ctx context.Con
 
 // Execute executes the request
 //  @return NDSLDAPVerifyConnectivityJobRequest
-func (a *LDAPConfigurationApiService) GetLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (a *LDAPConfigurationApiService) getLDAPConfigurationStatusExecute(r GetLDAPConfigurationStatusApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -490,6 +540,15 @@ type SaveLDAPConfigurationApiParams struct {
 		UserSecurity *UserSecurity
 }
 
+func (a *LDAPConfigurationApiService) SaveLDAPConfigurationWithParams(ctx context.Context, args *SaveLDAPConfigurationApiParams) SaveLDAPConfigurationApiRequest {
+	return SaveLDAPConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		userSecurity: args.UserSecurity,
+	}
+}
+
 // Updates the LDAP configuration for the specified project.
 func (r SaveLDAPConfigurationApiRequest) UserSecurity(userSecurity UserSecurity) SaveLDAPConfigurationApiRequest {
 	r.userSecurity = &userSecurity
@@ -497,13 +556,7 @@ func (r SaveLDAPConfigurationApiRequest) UserSecurity(userSecurity UserSecurity)
 }
 
 func (r SaveLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
-	return r.ApiService.SaveLDAPConfigurationExecute(r)
-}
-
-func (r SaveLDAPConfigurationApiRequest) ExecuteWithParams(params *SaveLDAPConfigurationApiParams) (*UserSecurity, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.userSecurity = params.UserSecurity 
-	return r.Execute()
+	return r.ApiService.saveLDAPConfigurationExecute(r)
 }
 
 /*
@@ -527,7 +580,7 @@ func (a *LDAPConfigurationApiService) SaveLDAPConfiguration(ctx context.Context,
 
 // Execute executes the request
 //  @return UserSecurity
-func (a *LDAPConfigurationApiService) SaveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
+func (a *LDAPConfigurationApiService) saveLDAPConfigurationExecute(r SaveLDAPConfigurationApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -632,6 +685,15 @@ type VerifyLDAPConfigurationApiParams struct {
 		NDSLDAPVerifyConnectivityJobRequestParams *NDSLDAPVerifyConnectivityJobRequestParams
 }
 
+func (a *LDAPConfigurationApiService) VerifyLDAPConfigurationWithParams(ctx context.Context, args *VerifyLDAPConfigurationApiParams) VerifyLDAPConfigurationApiRequest {
+	return VerifyLDAPConfigurationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		nDSLDAPVerifyConnectivityJobRequestParams: args.NDSLDAPVerifyConnectivityJobRequestParams,
+	}
+}
+
 // The LDAP configuration for the specified project that you want to verify.
 func (r VerifyLDAPConfigurationApiRequest) NDSLDAPVerifyConnectivityJobRequestParams(nDSLDAPVerifyConnectivityJobRequestParams NDSLDAPVerifyConnectivityJobRequestParams) VerifyLDAPConfigurationApiRequest {
 	r.nDSLDAPVerifyConnectivityJobRequestParams = &nDSLDAPVerifyConnectivityJobRequestParams
@@ -639,13 +701,7 @@ func (r VerifyLDAPConfigurationApiRequest) NDSLDAPVerifyConnectivityJobRequestPa
 }
 
 func (r VerifyLDAPConfigurationApiRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
-	return r.ApiService.VerifyLDAPConfigurationExecute(r)
-}
-
-func (r VerifyLDAPConfigurationApiRequest) ExecuteWithParams(params *VerifyLDAPConfigurationApiParams) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.nDSLDAPVerifyConnectivityJobRequestParams = params.NDSLDAPVerifyConnectivityJobRequestParams 
-	return r.Execute()
+	return r.ApiService.verifyLDAPConfigurationExecute(r)
 }
 
 /*
@@ -667,7 +723,7 @@ func (a *LDAPConfigurationApiService) VerifyLDAPConfiguration(ctx context.Contex
 
 // Execute executes the request
 //  @return NDSLDAPVerifyConnectivityJobRequest
-func (a *LDAPConfigurationApiService) VerifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+func (a *LDAPConfigurationApiService) verifyLDAPConfigurationExecute(r VerifyLDAPConfigurationApiRequest) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -34,7 +34,7 @@ type LDAPConfigurationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteLDAPConfigurationApiParams - Parameters for the request
-	@return DeleteLDAPConfigurationApiRequest}}
+	@return DeleteLDAPConfigurationApiRequest
 	*/
 	DeleteLDAPConfigurationWithParams(ctx context.Context, args *DeleteLDAPConfigurationApiParams) DeleteLDAPConfigurationApiRequest
 
@@ -57,7 +57,7 @@ type LDAPConfigurationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetLDAPConfigurationApiParams - Parameters for the request
-	@return GetLDAPConfigurationApiRequest}}
+	@return GetLDAPConfigurationApiRequest
 	*/
 	GetLDAPConfigurationWithParams(ctx context.Context, args *GetLDAPConfigurationApiParams) GetLDAPConfigurationApiRequest
 
@@ -81,7 +81,7 @@ type LDAPConfigurationApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetLDAPConfigurationStatusApiParams - Parameters for the request
-	@return GetLDAPConfigurationStatusApiRequest}}
+	@return GetLDAPConfigurationStatusApiRequest
 	*/
 	GetLDAPConfigurationStatusWithParams(ctx context.Context, args *GetLDAPConfigurationStatusApiParams) GetLDAPConfigurationStatusApiRequest
 
@@ -106,7 +106,7 @@ Updating this configuration triggers a rolling restart of the database.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param SaveLDAPConfigurationApiParams - Parameters for the request
-	@return SaveLDAPConfigurationApiRequest}}
+	@return SaveLDAPConfigurationApiRequest
 	*/
 	SaveLDAPConfigurationWithParams(ctx context.Context, args *SaveLDAPConfigurationApiParams) SaveLDAPConfigurationApiRequest
 
@@ -129,7 +129,7 @@ Updating this configuration triggers a rolling restart of the database.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param VerifyLDAPConfigurationApiParams - Parameters for the request
-	@return VerifyLDAPConfigurationApiRequest}}
+	@return VerifyLDAPConfigurationApiRequest
 	*/
 	VerifyLDAPConfigurationWithParams(ctx context.Context, args *VerifyLDAPConfigurationApiParams) VerifyLDAPConfigurationApiRequest
 

--- a/mongodbatlasv2/api_ldap_configuration.go
+++ b/mongodbatlasv2/api_ldap_configuration.go
@@ -113,6 +113,11 @@ func (r DeleteLDAPConfigurationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLDAPConfigurationExecute(r)
 }
 
+func (r DeleteLDAPConfigurationApiRequest) ExecuteWithParams(params *DeleteLDAPConfigurationApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 DeleteLDAPConfiguration Remove the Current LDAP User to DN Mapping
 
@@ -221,6 +226,11 @@ type GetLDAPConfigurationApiParams struct {
 
 func (r GetLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Response, error) {
 	return r.ApiService.GetLDAPConfigurationExecute(r)
+}
+
+func (r GetLDAPConfigurationApiRequest) ExecuteWithParams(params *GetLDAPConfigurationApiParams) (*UserSecurity, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -344,6 +354,12 @@ type GetLDAPConfigurationStatusApiParams struct {
 
 func (r GetLDAPConfigurationStatusApiRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	return r.ApiService.GetLDAPConfigurationStatusExecute(r)
+}
+
+func (r GetLDAPConfigurationStatusApiRequest) ExecuteWithParams(params *GetLDAPConfigurationStatusApiParams) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.requestId = params.RequestId 
+	return r.Execute()
 }
 
 /*
@@ -484,6 +500,12 @@ func (r SaveLDAPConfigurationApiRequest) Execute() (*UserSecurity, *http.Respons
 	return r.ApiService.SaveLDAPConfigurationExecute(r)
 }
 
+func (r SaveLDAPConfigurationApiRequest) ExecuteWithParams(params *SaveLDAPConfigurationApiParams) (*UserSecurity, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.userSecurity = params.UserSecurity 
+	return r.Execute()
+}
+
 /*
 SaveLDAPConfiguration Edit the LDAP or X.509 Configuration
 
@@ -618,6 +640,12 @@ func (r VerifyLDAPConfigurationApiRequest) NDSLDAPVerifyConnectivityJobRequestPa
 
 func (r VerifyLDAPConfigurationApiRequest) Execute() (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
 	return r.ApiService.VerifyLDAPConfigurationExecute(r)
+}
+
+func (r VerifyLDAPConfigurationApiRequest) ExecuteWithParams(params *VerifyLDAPConfigurationApiParams) (*NDSLDAPVerifyConnectivityJobRequest, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.nDSLDAPVerifyConnectivityJobRequestParams = params.NDSLDAPVerifyConnectivityJobRequestParams 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -32,10 +32,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	DeleteLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteLegacySnapshotApiRequest
+	/*
+	DeleteLegacySnapshot Remove One Legacy Backup Snapshot
 
-	// DeleteLegacySnapshotExecute executes the request
-	// Deprecated
-	DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteLegacySnapshotApiParams - Parameters for the request
+	@return DeleteLegacySnapshotApiRequest}}
+
+	Deprecated
+	*/
+	DeleteLegacySnapshotWithParams(ctx context.Context, args *DeleteLegacySnapshotApiParams) DeleteLegacySnapshotApiRequest
+
+	// Interface only available internally
+	deleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (*http.Response, error)
 
 	/*
 	GetLegacyBackupCheckpoint Return One Legacy Backup Checkpoint
@@ -51,11 +61,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupCheckpoint(ctx context.Context, groupId string, checkpointId string, clusterName string) GetLegacyBackupCheckpointApiRequest
+	/*
+	GetLegacyBackupCheckpoint Return One Legacy Backup Checkpoint
 
-	// GetLegacyBackupCheckpointExecute executes the request
-	//  @return Checkpoint
-	// Deprecated
-	GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*Checkpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetLegacyBackupCheckpointApiParams - Parameters for the request
+	@return GetLegacyBackupCheckpointApiRequest}}
+
+	Deprecated
+	*/
+	GetLegacyBackupCheckpointWithParams(ctx context.Context, args *GetLegacyBackupCheckpointApiParams) GetLegacyBackupCheckpointApiRequest
+
+	// Interface only available internally
+	getLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*Checkpoint, *http.Response, error)
 
 	/*
 	GetLegacyBackupRestoreJob Return One Legacy Backup Restore Job
@@ -73,11 +92,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string, jobId string) GetLegacyBackupRestoreJobApiRequest
+	/*
+	GetLegacyBackupRestoreJob Return One Legacy Backup Restore Job
 
-	// GetLegacyBackupRestoreJobExecute executes the request
-	//  @return RestoreJob
-	// Deprecated
-	GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*RestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetLegacyBackupRestoreJobApiParams - Parameters for the request
+	@return GetLegacyBackupRestoreJobApiRequest}}
+
+	Deprecated
+	*/
+	GetLegacyBackupRestoreJobWithParams(ctx context.Context, args *GetLegacyBackupRestoreJobApiParams) GetLegacyBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	getLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*RestoreJob, *http.Response, error)
 
 	/*
 	GetLegacySnapshot Return One Legacy Backup Snapshot
@@ -93,11 +121,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) GetLegacySnapshotApiRequest
+	/*
+	GetLegacySnapshot Return One Legacy Backup Snapshot
 
-	// GetLegacySnapshotExecute executes the request
-	//  @return Snapshot
-	// Deprecated
-	GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*Snapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetLegacySnapshotApiParams - Parameters for the request
+	@return GetLegacySnapshotApiRequest}}
+
+	Deprecated
+	*/
+	GetLegacySnapshotWithParams(ctx context.Context, args *GetLegacySnapshotApiParams) GetLegacySnapshotApiRequest
+
+	// Interface only available internally
+	getLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*Snapshot, *http.Response, error)
 
 	/*
 	GetLegacySnapshotSchedule Return One Snapshot Schedule
@@ -114,11 +151,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) GetLegacySnapshotScheduleApiRequest
+	/*
+	GetLegacySnapshotSchedule Return One Snapshot Schedule
 
-	// GetLegacySnapshotScheduleExecute executes the request
-	//  @return SnapshotSchedule
-	// Deprecated
-	GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetLegacySnapshotScheduleApiParams - Parameters for the request
+	@return GetLegacySnapshotScheduleApiRequest}}
+
+	Deprecated
+	*/
+	GetLegacySnapshotScheduleWithParams(ctx context.Context, args *GetLegacySnapshotScheduleApiParams) GetLegacySnapshotScheduleApiRequest
+
+	// Interface only available internally
+	getLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error)
 
 	/*
 	ListLegacyBackupCheckpoints Return All Legacy Backup Checkpoints
@@ -133,11 +179,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupCheckpoints(ctx context.Context, groupId string, clusterName string) ListLegacyBackupCheckpointsApiRequest
+	/*
+	ListLegacyBackupCheckpoints Return All Legacy Backup Checkpoints
 
-	// ListLegacyBackupCheckpointsExecute executes the request
-	//  @return PaginatedApiAtlasCheckpoint
-	// Deprecated
-	ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListLegacyBackupCheckpointsApiParams - Parameters for the request
+	@return ListLegacyBackupCheckpointsApiRequest}}
+
+	Deprecated
+	*/
+	ListLegacyBackupCheckpointsWithParams(ctx context.Context, args *ListLegacyBackupCheckpointsApiParams) ListLegacyBackupCheckpointsApiRequest
+
+	// Interface only available internally
+	listLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error)
 
 	/*
 	ListLegacyBackupRestoreJobs Return All Legacy Backup Restore Jobs
@@ -154,11 +209,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListLegacyBackupRestoreJobsApiRequest
+	/*
+	ListLegacyBackupRestoreJobs Return All Legacy Backup Restore Jobs
 
-	// ListLegacyBackupRestoreJobsExecute executes the request
-	//  @return PaginatedRestoreJob
-	// Deprecated
-	ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListLegacyBackupRestoreJobsApiParams - Parameters for the request
+	@return ListLegacyBackupRestoreJobsApiRequest}}
+
+	Deprecated
+	*/
+	ListLegacyBackupRestoreJobsWithParams(ctx context.Context, args *ListLegacyBackupRestoreJobsApiParams) ListLegacyBackupRestoreJobsApiRequest
+
+	// Interface only available internally
+	listLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 
 	/*
 	ListLegacySnapshots Return All Legacy Backup Snapshots
@@ -173,11 +237,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacySnapshots(ctx context.Context, groupId string, clusterName string) ListLegacySnapshotsApiRequest
+	/*
+	ListLegacySnapshots Return All Legacy Backup Snapshots
 
-	// ListLegacySnapshotsExecute executes the request
-	//  @return PaginatedSnapshot
-	// Deprecated
-	ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListLegacySnapshotsApiParams - Parameters for the request
+	@return ListLegacySnapshotsApiRequest}}
+
+	Deprecated
+	*/
+	ListLegacySnapshotsWithParams(ctx context.Context, args *ListLegacySnapshotsApiParams) ListLegacySnapshotsApiRequest
+
+	// Interface only available internally
+	listLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error)
 
 	/*
 	UpdateLegacySnapshotRetention Change One Legacy Backup Snapshot Expiration
@@ -193,11 +266,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) UpdateLegacySnapshotRetentionApiRequest
+	/*
+	UpdateLegacySnapshotRetention Change One Legacy Backup Snapshot Expiration
 
-	// UpdateLegacySnapshotRetentionExecute executes the request
-	//  @return Snapshot
-	// Deprecated
-	UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*Snapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateLegacySnapshotRetentionApiParams - Parameters for the request
+	@return UpdateLegacySnapshotRetentionApiRequest}}
+
+	Deprecated
+	*/
+	UpdateLegacySnapshotRetentionWithParams(ctx context.Context, args *UpdateLegacySnapshotRetentionApiParams) UpdateLegacySnapshotRetentionApiRequest
+
+	// Interface only available internally
+	updateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*Snapshot, *http.Response, error)
 
 	/*
 	UpdateLegacySnapshotSchedule Update Snapshot Schedule for One Cluster
@@ -214,11 +296,20 @@ type LegacyBackupApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) UpdateLegacySnapshotScheduleApiRequest
+	/*
+	UpdateLegacySnapshotSchedule Update Snapshot Schedule for One Cluster
 
-	// UpdateLegacySnapshotScheduleExecute executes the request
-	//  @return SnapshotSchedule
-	// Deprecated
-	UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateLegacySnapshotScheduleApiParams - Parameters for the request
+	@return UpdateLegacySnapshotScheduleApiRequest}}
+
+	Deprecated
+	*/
+	UpdateLegacySnapshotScheduleWithParams(ctx context.Context, args *UpdateLegacySnapshotScheduleApiParams) UpdateLegacySnapshotScheduleApiRequest
+
+	// Interface only available internally
+	updateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error)
 }
 
 // LegacyBackupApiService LegacyBackupApi service
@@ -238,15 +329,18 @@ type DeleteLegacySnapshotApiParams struct {
 		SnapshotId string
 }
 
-func (r DeleteLegacySnapshotApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteLegacySnapshotExecute(r)
+func (a *LegacyBackupApiService) DeleteLegacySnapshotWithParams(ctx context.Context, args *DeleteLegacySnapshotApiParams) DeleteLegacySnapshotApiRequest {
+	return DeleteLegacySnapshotApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
 }
 
-func (r DeleteLegacySnapshotApiRequest) ExecuteWithParams(params *DeleteLegacySnapshotApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.snapshotId = params.SnapshotId 
-	return r.Execute()
+func (r DeleteLegacySnapshotApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteLegacySnapshotExecute(r)
 }
 
 /*
@@ -274,7 +368,7 @@ func (a *LegacyBackupApiService) DeleteLegacySnapshot(ctx context.Context, group
 
 // Execute executes the request
 // Deprecated
-func (a *LegacyBackupApiService) DeleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (*http.Response, error) {
+func (a *LegacyBackupApiService) deleteLegacySnapshotExecute(r DeleteLegacySnapshotApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -380,15 +474,18 @@ type GetLegacyBackupCheckpointApiParams struct {
 		ClusterName string
 }
 
-func (r GetLegacyBackupCheckpointApiRequest) Execute() (*Checkpoint, *http.Response, error) {
-	return r.ApiService.GetLegacyBackupCheckpointExecute(r)
+func (a *LegacyBackupApiService) GetLegacyBackupCheckpointWithParams(ctx context.Context, args *GetLegacyBackupCheckpointApiParams) GetLegacyBackupCheckpointApiRequest {
+	return GetLegacyBackupCheckpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		checkpointId: args.CheckpointId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetLegacyBackupCheckpointApiRequest) ExecuteWithParams(params *GetLegacyBackupCheckpointApiParams) (*Checkpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.checkpointId = params.CheckpointId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetLegacyBackupCheckpointApiRequest) Execute() (*Checkpoint, *http.Response, error) {
+	return r.ApiService.getLegacyBackupCheckpointExecute(r)
 }
 
 /*
@@ -417,7 +514,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupCheckpoint(ctx context.Context, 
 // Execute executes the request
 //  @return Checkpoint
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*Checkpoint, *http.Response, error) {
+func (a *LegacyBackupApiService) getLegacyBackupCheckpointExecute(r GetLegacyBackupCheckpointApiRequest) (*Checkpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -533,15 +630,18 @@ type GetLegacyBackupRestoreJobApiParams struct {
 		JobId string
 }
 
-func (r GetLegacyBackupRestoreJobApiRequest) Execute() (*RestoreJob, *http.Response, error) {
-	return r.ApiService.GetLegacyBackupRestoreJobExecute(r)
+func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobWithParams(ctx context.Context, args *GetLegacyBackupRestoreJobApiParams) GetLegacyBackupRestoreJobApiRequest {
+	return GetLegacyBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		jobId: args.JobId,
+	}
 }
 
-func (r GetLegacyBackupRestoreJobApiRequest) ExecuteWithParams(params *GetLegacyBackupRestoreJobApiParams) (*RestoreJob, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.jobId = params.JobId 
-	return r.Execute()
+func (r GetLegacyBackupRestoreJobApiRequest) Execute() (*RestoreJob, *http.Response, error) {
+	return r.ApiService.getLegacyBackupRestoreJobExecute(r)
 }
 
 /*
@@ -572,7 +672,7 @@ func (a *LegacyBackupApiService) GetLegacyBackupRestoreJob(ctx context.Context, 
 // Execute executes the request
 //  @return RestoreJob
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*RestoreJob, *http.Response, error) {
+func (a *LegacyBackupApiService) getLegacyBackupRestoreJobExecute(r GetLegacyBackupRestoreJobApiRequest) (*RestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -688,15 +788,18 @@ type GetLegacySnapshotApiParams struct {
 		SnapshotId string
 }
 
-func (r GetLegacySnapshotApiRequest) Execute() (*Snapshot, *http.Response, error) {
-	return r.ApiService.GetLegacySnapshotExecute(r)
+func (a *LegacyBackupApiService) GetLegacySnapshotWithParams(ctx context.Context, args *GetLegacySnapshotApiParams) GetLegacySnapshotApiRequest {
+	return GetLegacySnapshotApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
 }
 
-func (r GetLegacySnapshotApiRequest) ExecuteWithParams(params *GetLegacySnapshotApiParams) (*Snapshot, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.snapshotId = params.SnapshotId 
-	return r.Execute()
+func (r GetLegacySnapshotApiRequest) Execute() (*Snapshot, *http.Response, error) {
+	return r.ApiService.getLegacySnapshotExecute(r)
 }
 
 /*
@@ -725,7 +828,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshot(ctx context.Context, groupId 
 // Execute executes the request
 //  @return Snapshot
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*Snapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) getLegacySnapshotExecute(r GetLegacySnapshotApiRequest) (*Snapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -839,14 +942,17 @@ type GetLegacySnapshotScheduleApiParams struct {
 		ClusterName string
 }
 
-func (r GetLegacySnapshotScheduleApiRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
-	return r.ApiService.GetLegacySnapshotScheduleExecute(r)
+func (a *LegacyBackupApiService) GetLegacySnapshotScheduleWithParams(ctx context.Context, args *GetLegacySnapshotScheduleApiParams) GetLegacySnapshotScheduleApiRequest {
+	return GetLegacySnapshotScheduleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetLegacySnapshotScheduleApiRequest) ExecuteWithParams(params *GetLegacySnapshotScheduleApiParams) (*SnapshotSchedule, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetLegacySnapshotScheduleApiRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
+	return r.ApiService.getLegacySnapshotScheduleExecute(r)
 }
 
 /*
@@ -875,7 +981,7 @@ func (a *LegacyBackupApiService) GetLegacySnapshotSchedule(ctx context.Context, 
 // Execute executes the request
 //  @return SnapshotSchedule
 // Deprecated
-func (a *LegacyBackupApiService) GetLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error) {
+func (a *LegacyBackupApiService) getLegacySnapshotScheduleExecute(r GetLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -988,6 +1094,18 @@ type ListLegacyBackupCheckpointsApiParams struct {
 		PageNum *int32
 }
 
+func (a *LegacyBackupApiService) ListLegacyBackupCheckpointsWithParams(ctx context.Context, args *ListLegacyBackupCheckpointsApiParams) ListLegacyBackupCheckpointsApiRequest {
+	return ListLegacyBackupCheckpointsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListLegacyBackupCheckpointsApiRequest) IncludeCount(includeCount bool) ListLegacyBackupCheckpointsApiRequest {
 	r.includeCount = &includeCount
@@ -1007,16 +1125,7 @@ func (r ListLegacyBackupCheckpointsApiRequest) PageNum(pageNum int32) ListLegacy
 }
 
 func (r ListLegacyBackupCheckpointsApiRequest) Execute() (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
-	return r.ApiService.ListLegacyBackupCheckpointsExecute(r)
-}
-
-func (r ListLegacyBackupCheckpointsApiRequest) ExecuteWithParams(params *ListLegacyBackupCheckpointsApiParams) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listLegacyBackupCheckpointsExecute(r)
 }
 
 /*
@@ -1043,7 +1152,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupCheckpoints(ctx context.Context
 // Execute executes the request
 //  @return PaginatedApiAtlasCheckpoint
 // Deprecated
-func (a *LegacyBackupApiService) ListLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
+func (a *LegacyBackupApiService) listLegacyBackupCheckpointsExecute(r ListLegacyBackupCheckpointsApiRequest) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1179,6 +1288,19 @@ type ListLegacyBackupRestoreJobsApiParams struct {
 		BatchId *string
 }
 
+func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobsWithParams(ctx context.Context, args *ListLegacyBackupRestoreJobsApiParams) ListLegacyBackupRestoreJobsApiRequest {
+	return ListLegacyBackupRestoreJobsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		batchId: args.BatchId,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListLegacyBackupRestoreJobsApiRequest) IncludeCount(includeCount bool) ListLegacyBackupRestoreJobsApiRequest {
 	r.includeCount = &includeCount
@@ -1204,17 +1326,7 @@ func (r ListLegacyBackupRestoreJobsApiRequest) BatchId(batchId string) ListLegac
 }
 
 func (r ListLegacyBackupRestoreJobsApiRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
-	return r.ApiService.ListLegacyBackupRestoreJobsExecute(r)
-}
-
-func (r ListLegacyBackupRestoreJobsApiRequest) ExecuteWithParams(params *ListLegacyBackupRestoreJobsApiParams) (*PaginatedRestoreJob, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.batchId = params.BatchId 
-	return r.Execute()
+	return r.ApiService.listLegacyBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -1243,7 +1355,7 @@ func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobs(ctx context.Context
 // Execute executes the request
 //  @return PaginatedRestoreJob
 // Deprecated
-func (a *LegacyBackupApiService) ListLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
+func (a *LegacyBackupApiService) listLegacyBackupRestoreJobsExecute(r ListLegacyBackupRestoreJobsApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1382,6 +1494,19 @@ type ListLegacySnapshotsApiParams struct {
 		Completed *string
 }
 
+func (a *LegacyBackupApiService) ListLegacySnapshotsWithParams(ctx context.Context, args *ListLegacySnapshotsApiParams) ListLegacySnapshotsApiRequest {
+	return ListLegacySnapshotsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		completed: args.Completed,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListLegacySnapshotsApiRequest) IncludeCount(includeCount bool) ListLegacySnapshotsApiRequest {
 	r.includeCount = &includeCount
@@ -1407,17 +1532,7 @@ func (r ListLegacySnapshotsApiRequest) Completed(completed string) ListLegacySna
 }
 
 func (r ListLegacySnapshotsApiRequest) Execute() (*PaginatedSnapshot, *http.Response, error) {
-	return r.ApiService.ListLegacySnapshotsExecute(r)
-}
-
-func (r ListLegacySnapshotsApiRequest) ExecuteWithParams(params *ListLegacySnapshotsApiParams) (*PaginatedSnapshot, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.completed = params.Completed 
-	return r.Execute()
+	return r.ApiService.listLegacySnapshotsExecute(r)
 }
 
 /*
@@ -1444,7 +1559,7 @@ func (a *LegacyBackupApiService) ListLegacySnapshots(ctx context.Context, groupI
 // Execute executes the request
 //  @return PaginatedSnapshot
 // Deprecated
-func (a *LegacyBackupApiService) ListLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) listLegacySnapshotsExecute(r ListLegacySnapshotsApiRequest) (*PaginatedSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1583,6 +1698,17 @@ type UpdateLegacySnapshotRetentionApiParams struct {
 		Snapshot *Snapshot
 }
 
+func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionWithParams(ctx context.Context, args *UpdateLegacySnapshotRetentionApiParams) UpdateLegacySnapshotRetentionApiRequest {
+	return UpdateLegacySnapshotRetentionApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+		snapshot: args.Snapshot,
+	}
+}
+
 // Changes One Legacy Backup Snapshot Expiration.
 func (r UpdateLegacySnapshotRetentionApiRequest) Snapshot(snapshot Snapshot) UpdateLegacySnapshotRetentionApiRequest {
 	r.snapshot = &snapshot
@@ -1590,15 +1716,7 @@ func (r UpdateLegacySnapshotRetentionApiRequest) Snapshot(snapshot Snapshot) Upd
 }
 
 func (r UpdateLegacySnapshotRetentionApiRequest) Execute() (*Snapshot, *http.Response, error) {
-	return r.ApiService.UpdateLegacySnapshotRetentionExecute(r)
-}
-
-func (r UpdateLegacySnapshotRetentionApiRequest) ExecuteWithParams(params *UpdateLegacySnapshotRetentionApiParams) (*Snapshot, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.snapshotId = params.SnapshotId 
-	r.snapshot = params.Snapshot 
-	return r.Execute()
+	return r.ApiService.updateLegacySnapshotRetentionExecute(r)
 }
 
 /*
@@ -1627,7 +1745,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotRetention(ctx context.Conte
 // Execute executes the request
 //  @return Snapshot
 // Deprecated
-func (a *LegacyBackupApiService) UpdateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*Snapshot, *http.Response, error) {
+func (a *LegacyBackupApiService) updateLegacySnapshotRetentionExecute(r UpdateLegacySnapshotRetentionApiRequest) (*Snapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1748,6 +1866,16 @@ type UpdateLegacySnapshotScheduleApiParams struct {
 		SnapshotSchedule *SnapshotSchedule
 }
 
+func (a *LegacyBackupApiService) UpdateLegacySnapshotScheduleWithParams(ctx context.Context, args *UpdateLegacySnapshotScheduleApiParams) UpdateLegacySnapshotScheduleApiRequest {
+	return UpdateLegacySnapshotScheduleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotSchedule: args.SnapshotSchedule,
+	}
+}
+
 // Update the snapshot schedule for one cluster in the specified project.
 func (r UpdateLegacySnapshotScheduleApiRequest) SnapshotSchedule(snapshotSchedule SnapshotSchedule) UpdateLegacySnapshotScheduleApiRequest {
 	r.snapshotSchedule = &snapshotSchedule
@@ -1755,14 +1883,7 @@ func (r UpdateLegacySnapshotScheduleApiRequest) SnapshotSchedule(snapshotSchedul
 }
 
 func (r UpdateLegacySnapshotScheduleApiRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
-	return r.ApiService.UpdateLegacySnapshotScheduleExecute(r)
-}
-
-func (r UpdateLegacySnapshotScheduleApiRequest) ExecuteWithParams(params *UpdateLegacySnapshotScheduleApiParams) (*SnapshotSchedule, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.snapshotSchedule = params.SnapshotSchedule 
-	return r.Execute()
+	return r.ApiService.updateLegacySnapshotScheduleExecute(r)
 }
 
 /*
@@ -1791,7 +1912,7 @@ func (a *LegacyBackupApiService) UpdateLegacySnapshotSchedule(ctx context.Contex
 // Execute executes the request
 //  @return SnapshotSchedule
 // Deprecated
-func (a *LegacyBackupApiService) UpdateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error) {
+func (a *LegacyBackupApiService) updateLegacySnapshotScheduleExecute(r UpdateLegacySnapshotScheduleApiRequest) (*SnapshotSchedule, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -242,6 +242,13 @@ func (r DeleteLegacySnapshotApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteLegacySnapshotExecute(r)
 }
 
+func (r DeleteLegacySnapshotApiRequest) ExecuteWithParams(params *DeleteLegacySnapshotApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.snapshotId = params.SnapshotId 
+	return r.Execute()
+}
+
 /*
 DeleteLegacySnapshot Remove One Legacy Backup Snapshot
 
@@ -375,6 +382,13 @@ type GetLegacyBackupCheckpointApiParams struct {
 
 func (r GetLegacyBackupCheckpointApiRequest) Execute() (*Checkpoint, *http.Response, error) {
 	return r.ApiService.GetLegacyBackupCheckpointExecute(r)
+}
+
+func (r GetLegacyBackupCheckpointApiRequest) ExecuteWithParams(params *GetLegacyBackupCheckpointApiParams) (*Checkpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.checkpointId = params.CheckpointId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*
@@ -521,6 +535,13 @@ type GetLegacyBackupRestoreJobApiParams struct {
 
 func (r GetLegacyBackupRestoreJobApiRequest) Execute() (*RestoreJob, *http.Response, error) {
 	return r.ApiService.GetLegacyBackupRestoreJobExecute(r)
+}
+
+func (r GetLegacyBackupRestoreJobApiRequest) ExecuteWithParams(params *GetLegacyBackupRestoreJobApiParams) (*RestoreJob, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.jobId = params.JobId 
+	return r.Execute()
 }
 
 /*
@@ -671,6 +692,13 @@ func (r GetLegacySnapshotApiRequest) Execute() (*Snapshot, *http.Response, error
 	return r.ApiService.GetLegacySnapshotExecute(r)
 }
 
+func (r GetLegacySnapshotApiRequest) ExecuteWithParams(params *GetLegacySnapshotApiParams) (*Snapshot, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.snapshotId = params.SnapshotId 
+	return r.Execute()
+}
+
 /*
 GetLegacySnapshot Return One Legacy Backup Snapshot
 
@@ -813,6 +841,12 @@ type GetLegacySnapshotScheduleApiParams struct {
 
 func (r GetLegacySnapshotScheduleApiRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
 	return r.ApiService.GetLegacySnapshotScheduleExecute(r)
+}
+
+func (r GetLegacySnapshotScheduleApiRequest) ExecuteWithParams(params *GetLegacySnapshotScheduleApiParams) (*SnapshotSchedule, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*
@@ -974,6 +1008,15 @@ func (r ListLegacyBackupCheckpointsApiRequest) PageNum(pageNum int32) ListLegacy
 
 func (r ListLegacyBackupCheckpointsApiRequest) Execute() (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
 	return r.ApiService.ListLegacyBackupCheckpointsExecute(r)
+}
+
+func (r ListLegacyBackupCheckpointsApiRequest) ExecuteWithParams(params *ListLegacyBackupCheckpointsApiParams) (*PaginatedApiAtlasCheckpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -1162,6 +1205,16 @@ func (r ListLegacyBackupRestoreJobsApiRequest) BatchId(batchId string) ListLegac
 
 func (r ListLegacyBackupRestoreJobsApiRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
 	return r.ApiService.ListLegacyBackupRestoreJobsExecute(r)
+}
+
+func (r ListLegacyBackupRestoreJobsApiRequest) ExecuteWithParams(params *ListLegacyBackupRestoreJobsApiParams) (*PaginatedRestoreJob, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.batchId = params.BatchId 
+	return r.Execute()
 }
 
 /*
@@ -1357,6 +1410,16 @@ func (r ListLegacySnapshotsApiRequest) Execute() (*PaginatedSnapshot, *http.Resp
 	return r.ApiService.ListLegacySnapshotsExecute(r)
 }
 
+func (r ListLegacySnapshotsApiRequest) ExecuteWithParams(params *ListLegacySnapshotsApiParams) (*PaginatedSnapshot, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.completed = params.Completed 
+	return r.Execute()
+}
+
 /*
 ListLegacySnapshots Return All Legacy Backup Snapshots
 
@@ -1530,6 +1593,14 @@ func (r UpdateLegacySnapshotRetentionApiRequest) Execute() (*Snapshot, *http.Res
 	return r.ApiService.UpdateLegacySnapshotRetentionExecute(r)
 }
 
+func (r UpdateLegacySnapshotRetentionApiRequest) ExecuteWithParams(params *UpdateLegacySnapshotRetentionApiParams) (*Snapshot, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.snapshotId = params.SnapshotId 
+	r.snapshot = params.Snapshot 
+	return r.Execute()
+}
+
 /*
 UpdateLegacySnapshotRetention Change One Legacy Backup Snapshot Expiration
 
@@ -1685,6 +1756,13 @@ func (r UpdateLegacySnapshotScheduleApiRequest) SnapshotSchedule(snapshotSchedul
 
 func (r UpdateLegacySnapshotScheduleApiRequest) Execute() (*SnapshotSchedule, *http.Response, error) {
 	return r.ApiService.UpdateLegacySnapshotScheduleExecute(r)
+}
+
+func (r UpdateLegacySnapshotScheduleApiRequest) ExecuteWithParams(params *UpdateLegacySnapshotScheduleApiParams) (*SnapshotSchedule, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.snapshotSchedule = params.SnapshotSchedule 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -29,7 +29,7 @@ type LegacyBackupApi interface {
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
 	@return DeleteLegacySnapshotApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	DeleteLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) DeleteLegacySnapshotApiRequest
 	/*
@@ -38,9 +38,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteLegacySnapshotApiParams - Parameters for the request
-	@return DeleteLegacySnapshotApiRequest}}
+	@return DeleteLegacySnapshotApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	DeleteLegacySnapshotWithParams(ctx context.Context, args *DeleteLegacySnapshotApiParams) DeleteLegacySnapshotApiRequest
 
@@ -58,7 +58,7 @@ type LegacyBackupApi interface {
 	@param clusterName Human-readable label that identifies the cluster that contains the checkpoints that you want to return.
 	@return GetLegacyBackupCheckpointApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupCheckpoint(ctx context.Context, groupId string, checkpointId string, clusterName string) GetLegacyBackupCheckpointApiRequest
 	/*
@@ -67,9 +67,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetLegacyBackupCheckpointApiParams - Parameters for the request
-	@return GetLegacyBackupCheckpointApiRequest}}
+	@return GetLegacyBackupCheckpointApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupCheckpointWithParams(ctx context.Context, args *GetLegacyBackupCheckpointApiParams) GetLegacyBackupCheckpointApiRequest
 
@@ -89,7 +89,7 @@ type LegacyBackupApi interface {
 	@param jobId Unique 24-hexadecimal digit string that identifies the restore job.
 	@return GetLegacyBackupRestoreJobApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string, jobId string) GetLegacyBackupRestoreJobApiRequest
 	/*
@@ -98,9 +98,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetLegacyBackupRestoreJobApiParams - Parameters for the request
-	@return GetLegacyBackupRestoreJobApiRequest}}
+	@return GetLegacyBackupRestoreJobApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupRestoreJobWithParams(ctx context.Context, args *GetLegacyBackupRestoreJobApiParams) GetLegacyBackupRestoreJobApiRequest
 
@@ -118,7 +118,7 @@ type LegacyBackupApi interface {
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
 	@return GetLegacySnapshotApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshot(ctx context.Context, groupId string, clusterName string, snapshotId string) GetLegacySnapshotApiRequest
 	/*
@@ -127,9 +127,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetLegacySnapshotApiParams - Parameters for the request
-	@return GetLegacySnapshotApiRequest}}
+	@return GetLegacySnapshotApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshotWithParams(ctx context.Context, args *GetLegacySnapshotApiParams) GetLegacySnapshotApiRequest
 
@@ -148,7 +148,7 @@ type LegacyBackupApi interface {
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
 	@return GetLegacySnapshotScheduleApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) GetLegacySnapshotScheduleApiRequest
 	/*
@@ -157,9 +157,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetLegacySnapshotScheduleApiParams - Parameters for the request
-	@return GetLegacySnapshotScheduleApiRequest}}
+	@return GetLegacySnapshotScheduleApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshotScheduleWithParams(ctx context.Context, args *GetLegacySnapshotScheduleApiParams) GetLegacySnapshotScheduleApiRequest
 
@@ -176,7 +176,7 @@ type LegacyBackupApi interface {
 	@param clusterName Human-readable label that identifies the cluster that contains the checkpoints that you want to return.
 	@return ListLegacyBackupCheckpointsApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupCheckpoints(ctx context.Context, groupId string, clusterName string) ListLegacyBackupCheckpointsApiRequest
 	/*
@@ -185,9 +185,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListLegacyBackupCheckpointsApiParams - Parameters for the request
-	@return ListLegacyBackupCheckpointsApiRequest}}
+	@return ListLegacyBackupCheckpointsApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupCheckpointsWithParams(ctx context.Context, args *ListLegacyBackupCheckpointsApiParams) ListLegacyBackupCheckpointsApiRequest
 
@@ -206,7 +206,7 @@ type LegacyBackupApi interface {
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
 	@return ListLegacyBackupRestoreJobsApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupRestoreJobs(ctx context.Context, groupId string, clusterName string) ListLegacyBackupRestoreJobsApiRequest
 	/*
@@ -215,9 +215,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListLegacyBackupRestoreJobsApiParams - Parameters for the request
-	@return ListLegacyBackupRestoreJobsApiRequest}}
+	@return ListLegacyBackupRestoreJobsApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupRestoreJobsWithParams(ctx context.Context, args *ListLegacyBackupRestoreJobsApiParams) ListLegacyBackupRestoreJobsApiRequest
 
@@ -234,7 +234,7 @@ type LegacyBackupApi interface {
 	@param clusterName Human-readable label that identifies the cluster.
 	@return ListLegacySnapshotsApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacySnapshots(ctx context.Context, groupId string, clusterName string) ListLegacySnapshotsApiRequest
 	/*
@@ -243,9 +243,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListLegacySnapshotsApiParams - Parameters for the request
-	@return ListLegacySnapshotsApiRequest}}
+	@return ListLegacySnapshotsApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacySnapshotsWithParams(ctx context.Context, args *ListLegacySnapshotsApiParams) ListLegacySnapshotsApiRequest
 
@@ -263,7 +263,7 @@ type LegacyBackupApi interface {
 	@param snapshotId Unique 24-hexadecimal digit string that identifies the desired snapshot.
 	@return UpdateLegacySnapshotRetentionApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotRetention(ctx context.Context, groupId string, clusterName string, snapshotId string) UpdateLegacySnapshotRetentionApiRequest
 	/*
@@ -272,9 +272,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateLegacySnapshotRetentionApiParams - Parameters for the request
-	@return UpdateLegacySnapshotRetentionApiRequest}}
+	@return UpdateLegacySnapshotRetentionApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotRetentionWithParams(ctx context.Context, args *UpdateLegacySnapshotRetentionApiParams) UpdateLegacySnapshotRetentionApiRequest
 
@@ -293,7 +293,7 @@ type LegacyBackupApi interface {
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
 	@return UpdateLegacySnapshotScheduleApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotSchedule(ctx context.Context, groupId string, clusterName string) UpdateLegacySnapshotScheduleApiRequest
 	/*
@@ -302,9 +302,9 @@ type LegacyBackupApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateLegacySnapshotScheduleApiParams - Parameters for the request
-	@return UpdateLegacySnapshotScheduleApiRequest}}
+	@return UpdateLegacySnapshotScheduleApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotScheduleWithParams(ctx context.Context, args *UpdateLegacySnapshotScheduleApiParams) UpdateLegacySnapshotScheduleApiRequest
 

--- a/mongodbatlasv2/api_legacy_backup.go
+++ b/mongodbatlasv2/api_legacy_backup.go
@@ -40,7 +40,7 @@ type LegacyBackupApi interface {
 	@param DeleteLegacySnapshotApiParams - Parameters for the request
 	@return DeleteLegacySnapshotApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	DeleteLegacySnapshotWithParams(ctx context.Context, args *DeleteLegacySnapshotApiParams) DeleteLegacySnapshotApiRequest
 
@@ -69,7 +69,7 @@ type LegacyBackupApi interface {
 	@param GetLegacyBackupCheckpointApiParams - Parameters for the request
 	@return GetLegacyBackupCheckpointApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupCheckpointWithParams(ctx context.Context, args *GetLegacyBackupCheckpointApiParams) GetLegacyBackupCheckpointApiRequest
 
@@ -100,7 +100,7 @@ type LegacyBackupApi interface {
 	@param GetLegacyBackupRestoreJobApiParams - Parameters for the request
 	@return GetLegacyBackupRestoreJobApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacyBackupRestoreJobWithParams(ctx context.Context, args *GetLegacyBackupRestoreJobApiParams) GetLegacyBackupRestoreJobApiRequest
 
@@ -129,7 +129,7 @@ type LegacyBackupApi interface {
 	@param GetLegacySnapshotApiParams - Parameters for the request
 	@return GetLegacySnapshotApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshotWithParams(ctx context.Context, args *GetLegacySnapshotApiParams) GetLegacySnapshotApiRequest
 
@@ -159,7 +159,7 @@ type LegacyBackupApi interface {
 	@param GetLegacySnapshotScheduleApiParams - Parameters for the request
 	@return GetLegacySnapshotScheduleApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	GetLegacySnapshotScheduleWithParams(ctx context.Context, args *GetLegacySnapshotScheduleApiParams) GetLegacySnapshotScheduleApiRequest
 
@@ -187,7 +187,7 @@ type LegacyBackupApi interface {
 	@param ListLegacyBackupCheckpointsApiParams - Parameters for the request
 	@return ListLegacyBackupCheckpointsApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupCheckpointsWithParams(ctx context.Context, args *ListLegacyBackupCheckpointsApiParams) ListLegacyBackupCheckpointsApiRequest
 
@@ -217,7 +217,7 @@ type LegacyBackupApi interface {
 	@param ListLegacyBackupRestoreJobsApiParams - Parameters for the request
 	@return ListLegacyBackupRestoreJobsApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacyBackupRestoreJobsWithParams(ctx context.Context, args *ListLegacyBackupRestoreJobsApiParams) ListLegacyBackupRestoreJobsApiRequest
 
@@ -245,7 +245,7 @@ type LegacyBackupApi interface {
 	@param ListLegacySnapshotsApiParams - Parameters for the request
 	@return ListLegacySnapshotsApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	ListLegacySnapshotsWithParams(ctx context.Context, args *ListLegacySnapshotsApiParams) ListLegacySnapshotsApiRequest
 
@@ -274,7 +274,7 @@ type LegacyBackupApi interface {
 	@param UpdateLegacySnapshotRetentionApiParams - Parameters for the request
 	@return UpdateLegacySnapshotRetentionApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotRetentionWithParams(ctx context.Context, args *UpdateLegacySnapshotRetentionApiParams) UpdateLegacySnapshotRetentionApiRequest
 
@@ -304,7 +304,7 @@ type LegacyBackupApi interface {
 	@param UpdateLegacySnapshotScheduleApiParams - Parameters for the request
 	@return UpdateLegacySnapshotScheduleApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupApi
 	*/
 	UpdateLegacySnapshotScheduleWithParams(ctx context.Context, args *UpdateLegacySnapshotScheduleApiParams) UpdateLegacySnapshotScheduleApiRequest
 

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -39,7 +39,7 @@ type LegacyBackupRestoreJobsApi interface {
 	@param CreateLegacyBackupRestoreJobApiParams - Parameters for the request
 	@return CreateLegacyBackupRestoreJobApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupRestoreJobsApi
 	*/
 	CreateLegacyBackupRestoreJobWithParams(ctx context.Context, args *CreateLegacyBackupRestoreJobApiParams) CreateLegacyBackupRestoreJobApiRequest
 

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -65,6 +65,13 @@ func (r CreateLegacyBackupRestoreJobApiRequest) Execute() (*PaginatedRestoreJob,
 	return r.ApiService.CreateLegacyBackupRestoreJobExecute(r)
 }
 
+func (r CreateLegacyBackupRestoreJobApiRequest) ExecuteWithParams(params *CreateLegacyBackupRestoreJobApiParams) (*PaginatedRestoreJob, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.restoreJob = params.RestoreJob 
+	return r.Execute()
+}
+
 /*
 CreateLegacyBackupRestoreJob Create One Legacy Backup Restore Job
 

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -31,11 +31,20 @@ type LegacyBackupRestoreJobsApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupRestoreJobsApi
 	*/
 	CreateLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateLegacyBackupRestoreJobApiRequest
+	/*
+	CreateLegacyBackupRestoreJob Create One Legacy Backup Restore Job
 
-	// CreateLegacyBackupRestoreJobExecute executes the request
-	//  @return PaginatedRestoreJob
-	// Deprecated
-	CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateLegacyBackupRestoreJobApiParams - Parameters for the request
+	@return CreateLegacyBackupRestoreJobApiRequest}}
+
+	Deprecated
+	*/
+	CreateLegacyBackupRestoreJobWithParams(ctx context.Context, args *CreateLegacyBackupRestoreJobApiParams) CreateLegacyBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	createLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error)
 }
 
 // LegacyBackupRestoreJobsApiService LegacyBackupRestoreJobsApi service
@@ -55,6 +64,16 @@ type CreateLegacyBackupRestoreJobApiParams struct {
 		RestoreJob *RestoreJob
 }
 
+func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJobWithParams(ctx context.Context, args *CreateLegacyBackupRestoreJobApiParams) CreateLegacyBackupRestoreJobApiRequest {
+	return CreateLegacyBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		restoreJob: args.RestoreJob,
+	}
+}
+
 // Legacy backup to restore to one cluster in the specified project.
 func (r CreateLegacyBackupRestoreJobApiRequest) RestoreJob(restoreJob RestoreJob) CreateLegacyBackupRestoreJobApiRequest {
 	r.restoreJob = &restoreJob
@@ -62,14 +81,7 @@ func (r CreateLegacyBackupRestoreJobApiRequest) RestoreJob(restoreJob RestoreJob
 }
 
 func (r CreateLegacyBackupRestoreJobApiRequest) Execute() (*PaginatedRestoreJob, *http.Response, error) {
-	return r.ApiService.CreateLegacyBackupRestoreJobExecute(r)
-}
-
-func (r CreateLegacyBackupRestoreJobApiRequest) ExecuteWithParams(params *CreateLegacyBackupRestoreJobApiParams) (*PaginatedRestoreJob, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.restoreJob = params.RestoreJob 
-	return r.Execute()
+	return r.ApiService.createLegacyBackupRestoreJobExecute(r)
 }
 
 /*
@@ -96,7 +108,7 @@ func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJob(ctx con
 // Execute executes the request
 //  @return PaginatedRestoreJob
 // Deprecated
-func (a *LegacyBackupRestoreJobsApiService) CreateLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
+func (a *LegacyBackupRestoreJobsApiService) createLegacyBackupRestoreJobExecute(r CreateLegacyBackupRestoreJobApiRequest) (*PaginatedRestoreJob, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_legacy_backup_restore_jobs.go
+++ b/mongodbatlasv2/api_legacy_backup_restore_jobs.go
@@ -28,7 +28,7 @@ type LegacyBackupRestoreJobsApi interface {
 	@param clusterName Human-readable label that identifies the cluster with the snapshot you want to return.
 	@return CreateLegacyBackupRestoreJobApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupRestoreJobsApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupRestoreJobsApi
 	*/
 	CreateLegacyBackupRestoreJob(ctx context.Context, groupId string, clusterName string) CreateLegacyBackupRestoreJobApiRequest
 	/*
@@ -37,9 +37,9 @@ type LegacyBackupRestoreJobsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateLegacyBackupRestoreJobApiParams - Parameters for the request
-	@return CreateLegacyBackupRestoreJobApiRequest}}
+	@return CreateLegacyBackupRestoreJobApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for LegacyBackupRestoreJobsApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for LegacyBackupRestoreJobsApi
 	*/
 	CreateLegacyBackupRestoreJobWithParams(ctx context.Context, args *CreateLegacyBackupRestoreJobApiParams) CreateLegacyBackupRestoreJobApiRequest
 

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -107,6 +107,11 @@ func (r DeferMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeferMaintenanceWindowExecute(r)
 }
 
+func (r DeferMaintenanceWindowApiRequest) ExecuteWithParams(params *DeferMaintenanceWindowApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 DeferMaintenanceWindow Defer One Maintenance Window for One Project
 
@@ -215,6 +220,11 @@ type GetMaintenanceWindowApiParams struct {
 
 func (r GetMaintenanceWindowApiRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
 	return r.ApiService.GetMaintenanceWindowExecute(r)
+}
+
+func (r GetMaintenanceWindowApiRequest) ExecuteWithParams(params *GetMaintenanceWindowApiParams) (*GroupMaintenanceWindow, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -338,6 +348,11 @@ func (r ResetMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.ResetMaintenanceWindowExecute(r)
 }
 
+func (r ResetMaintenanceWindowApiRequest) ExecuteWithParams(params *ResetMaintenanceWindowApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 ResetMaintenanceWindow Reset One Maintenance Window for One Project
 
@@ -446,6 +461,11 @@ type ToggleMaintenanceAutoDeferApiParams struct {
 
 func (r ToggleMaintenanceAutoDeferApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.ToggleMaintenanceAutoDeferExecute(r)
+}
+
+func (r ToggleMaintenanceAutoDeferApiRequest) ExecuteWithParams(params *ToggleMaintenanceAutoDeferApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -564,6 +584,12 @@ func (r UpdateMaintenanceWindowApiRequest) GroupMaintenanceWindow(groupMaintenan
 
 func (r UpdateMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.UpdateMaintenanceWindowExecute(r)
+}
+
+func (r UpdateMaintenanceWindowApiRequest) ExecuteWithParams(params *UpdateMaintenanceWindowApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.groupMaintenanceWindow = params.GroupMaintenanceWindow 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -34,7 +34,7 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeferMaintenanceWindowApiParams - Parameters for the request
-	@return DeferMaintenanceWindowApiRequest}}
+	@return DeferMaintenanceWindowApiRequest
 	*/
 	DeferMaintenanceWindowWithParams(ctx context.Context, args *DeferMaintenanceWindowApiParams) DeferMaintenanceWindowApiRequest
 
@@ -57,7 +57,7 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetMaintenanceWindowApiParams - Parameters for the request
-	@return GetMaintenanceWindowApiRequest}}
+	@return GetMaintenanceWindowApiRequest
 	*/
 	GetMaintenanceWindowWithParams(ctx context.Context, args *GetMaintenanceWindowApiParams) GetMaintenanceWindowApiRequest
 
@@ -80,7 +80,7 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ResetMaintenanceWindowApiParams - Parameters for the request
-	@return ResetMaintenanceWindowApiRequest}}
+	@return ResetMaintenanceWindowApiRequest
 	*/
 	ResetMaintenanceWindowWithParams(ctx context.Context, args *ResetMaintenanceWindowApiParams) ResetMaintenanceWindowApiRequest
 
@@ -103,7 +103,7 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ToggleMaintenanceAutoDeferApiParams - Parameters for the request
-	@return ToggleMaintenanceAutoDeferApiRequest}}
+	@return ToggleMaintenanceAutoDeferApiRequest
 	*/
 	ToggleMaintenanceAutoDeferWithParams(ctx context.Context, args *ToggleMaintenanceAutoDeferApiParams) ToggleMaintenanceAutoDeferApiRequest
 
@@ -126,7 +126,7 @@ type MaintenanceWindowsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateMaintenanceWindowApiParams - Parameters for the request
-	@return UpdateMaintenanceWindowApiRequest}}
+	@return UpdateMaintenanceWindowApiRequest
 	*/
 	UpdateMaintenanceWindowWithParams(ctx context.Context, args *UpdateMaintenanceWindowApiParams) UpdateMaintenanceWindowApiRequest
 

--- a/mongodbatlasv2/api_maintenance_windows_.go
+++ b/mongodbatlasv2/api_maintenance_windows_.go
@@ -28,9 +28,18 @@ type MaintenanceWindowsApi interface {
 	@return DeferMaintenanceWindowApiRequest
 	*/
 	DeferMaintenanceWindow(ctx context.Context, groupId string) DeferMaintenanceWindowApiRequest
+	/*
+	DeferMaintenanceWindow Defer One Maintenance Window for One Project
 
-	// DeferMaintenanceWindowExecute executes the request
-	DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeferMaintenanceWindowApiParams - Parameters for the request
+	@return DeferMaintenanceWindowApiRequest}}
+	*/
+	DeferMaintenanceWindowWithParams(ctx context.Context, args *DeferMaintenanceWindowApiParams) DeferMaintenanceWindowApiRequest
+
+	// Interface only available internally
+	deferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
 	GetMaintenanceWindow Return One Maintenance Window for One Project
@@ -42,10 +51,18 @@ type MaintenanceWindowsApi interface {
 	@return GetMaintenanceWindowApiRequest
 	*/
 	GetMaintenanceWindow(ctx context.Context, groupId string) GetMaintenanceWindowApiRequest
+	/*
+	GetMaintenanceWindow Return One Maintenance Window for One Project
 
-	// GetMaintenanceWindowExecute executes the request
-	//  @return GroupMaintenanceWindow
-	GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetMaintenanceWindowApiParams - Parameters for the request
+	@return GetMaintenanceWindowApiRequest}}
+	*/
+	GetMaintenanceWindowWithParams(ctx context.Context, args *GetMaintenanceWindowApiParams) GetMaintenanceWindowApiRequest
+
+	// Interface only available internally
+	getMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error)
 
 	/*
 	ResetMaintenanceWindow Reset One Maintenance Window for One Project
@@ -57,9 +74,18 @@ type MaintenanceWindowsApi interface {
 	@return ResetMaintenanceWindowApiRequest
 	*/
 	ResetMaintenanceWindow(ctx context.Context, groupId string) ResetMaintenanceWindowApiRequest
+	/*
+	ResetMaintenanceWindow Reset One Maintenance Window for One Project
 
-	// ResetMaintenanceWindowExecute executes the request
-	ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ResetMaintenanceWindowApiParams - Parameters for the request
+	@return ResetMaintenanceWindowApiRequest}}
+	*/
+	ResetMaintenanceWindowWithParams(ctx context.Context, args *ResetMaintenanceWindowApiParams) ResetMaintenanceWindowApiRequest
+
+	// Interface only available internally
+	resetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error)
 
 	/*
 	ToggleMaintenanceAutoDefer Toggle Automatic Deferral of Maintenance for One Project
@@ -71,9 +97,18 @@ type MaintenanceWindowsApi interface {
 	@return ToggleMaintenanceAutoDeferApiRequest
 	*/
 	ToggleMaintenanceAutoDefer(ctx context.Context, groupId string) ToggleMaintenanceAutoDeferApiRequest
+	/*
+	ToggleMaintenanceAutoDefer Toggle Automatic Deferral of Maintenance for One Project
 
-	// ToggleMaintenanceAutoDeferExecute executes the request
-	ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ToggleMaintenanceAutoDeferApiParams - Parameters for the request
+	@return ToggleMaintenanceAutoDeferApiRequest}}
+	*/
+	ToggleMaintenanceAutoDeferWithParams(ctx context.Context, args *ToggleMaintenanceAutoDeferApiParams) ToggleMaintenanceAutoDeferApiRequest
+
+	// Interface only available internally
+	toggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error)
 
 	/*
 	UpdateMaintenanceWindow Update Maintenance Window for One Project
@@ -85,9 +120,18 @@ type MaintenanceWindowsApi interface {
 	@return UpdateMaintenanceWindowApiRequest
 	*/
 	UpdateMaintenanceWindow(ctx context.Context, groupId string) UpdateMaintenanceWindowApiRequest
+	/*
+	UpdateMaintenanceWindow Update Maintenance Window for One Project
 
-	// UpdateMaintenanceWindowExecute executes the request
-	UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateMaintenanceWindowApiParams - Parameters for the request
+	@return UpdateMaintenanceWindowApiRequest}}
+	*/
+	UpdateMaintenanceWindowWithParams(ctx context.Context, args *UpdateMaintenanceWindowApiParams) UpdateMaintenanceWindowApiRequest
+
+	// Interface only available internally
+	updateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (*http.Response, error)
 }
 
 // MaintenanceWindowsApiService MaintenanceWindowsApi service
@@ -103,13 +147,16 @@ type DeferMaintenanceWindowApiParams struct {
 		GroupId string
 }
 
-func (r DeferMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeferMaintenanceWindowExecute(r)
+func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowWithParams(ctx context.Context, args *DeferMaintenanceWindowApiParams) DeferMaintenanceWindowApiRequest {
+	return DeferMaintenanceWindowApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r DeferMaintenanceWindowApiRequest) ExecuteWithParams(params *DeferMaintenanceWindowApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r DeferMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deferMaintenanceWindowExecute(r)
 }
 
 /*
@@ -130,7 +177,7 @@ func (a *MaintenanceWindowsApiService) DeferMaintenanceWindow(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) DeferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) deferMaintenanceWindowExecute(r DeferMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -218,13 +265,16 @@ type GetMaintenanceWindowApiParams struct {
 		GroupId string
 }
 
-func (r GetMaintenanceWindowApiRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
-	return r.ApiService.GetMaintenanceWindowExecute(r)
+func (a *MaintenanceWindowsApiService) GetMaintenanceWindowWithParams(ctx context.Context, args *GetMaintenanceWindowApiParams) GetMaintenanceWindowApiRequest {
+	return GetMaintenanceWindowApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetMaintenanceWindowApiRequest) ExecuteWithParams(params *GetMaintenanceWindowApiParams) (*GroupMaintenanceWindow, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetMaintenanceWindowApiRequest) Execute() (*GroupMaintenanceWindow, *http.Response, error) {
+	return r.ApiService.getMaintenanceWindowExecute(r)
 }
 
 /*
@@ -246,7 +296,7 @@ func (a *MaintenanceWindowsApiService) GetMaintenanceWindow(ctx context.Context,
 
 // Execute executes the request
 //  @return GroupMaintenanceWindow
-func (a *MaintenanceWindowsApiService) GetMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error) {
+func (a *MaintenanceWindowsApiService) getMaintenanceWindowExecute(r GetMaintenanceWindowApiRequest) (*GroupMaintenanceWindow, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -344,13 +394,16 @@ type ResetMaintenanceWindowApiParams struct {
 		GroupId string
 }
 
-func (r ResetMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.ResetMaintenanceWindowExecute(r)
+func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowWithParams(ctx context.Context, args *ResetMaintenanceWindowApiParams) ResetMaintenanceWindowApiRequest {
+	return ResetMaintenanceWindowApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ResetMaintenanceWindowApiRequest) ExecuteWithParams(params *ResetMaintenanceWindowApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ResetMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.resetMaintenanceWindowExecute(r)
 }
 
 /*
@@ -371,7 +424,7 @@ func (a *MaintenanceWindowsApiService) ResetMaintenanceWindow(ctx context.Contex
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) ResetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) resetMaintenanceWindowExecute(r ResetMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -459,13 +512,16 @@ type ToggleMaintenanceAutoDeferApiParams struct {
 		GroupId string
 }
 
-func (r ToggleMaintenanceAutoDeferApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.ToggleMaintenanceAutoDeferExecute(r)
+func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferWithParams(ctx context.Context, args *ToggleMaintenanceAutoDeferApiParams) ToggleMaintenanceAutoDeferApiRequest {
+	return ToggleMaintenanceAutoDeferApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ToggleMaintenanceAutoDeferApiRequest) ExecuteWithParams(params *ToggleMaintenanceAutoDeferApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ToggleMaintenanceAutoDeferApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.toggleMaintenanceAutoDeferExecute(r)
 }
 
 /*
@@ -486,7 +542,7 @@ func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDefer(ctx context.Co
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) ToggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) toggleMaintenanceAutoDeferExecute(r ToggleMaintenanceAutoDeferApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -576,6 +632,15 @@ type UpdateMaintenanceWindowApiParams struct {
 		GroupMaintenanceWindow *GroupMaintenanceWindow
 }
 
+func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowWithParams(ctx context.Context, args *UpdateMaintenanceWindowApiParams) UpdateMaintenanceWindowApiRequest {
+	return UpdateMaintenanceWindowApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		groupMaintenanceWindow: args.GroupMaintenanceWindow,
+	}
+}
+
 // Updates the maintenance window for the specified project.
 func (r UpdateMaintenanceWindowApiRequest) GroupMaintenanceWindow(groupMaintenanceWindow GroupMaintenanceWindow) UpdateMaintenanceWindowApiRequest {
 	r.groupMaintenanceWindow = &groupMaintenanceWindow
@@ -583,13 +648,7 @@ func (r UpdateMaintenanceWindowApiRequest) GroupMaintenanceWindow(groupMaintenan
 }
 
 func (r UpdateMaintenanceWindowApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.UpdateMaintenanceWindowExecute(r)
-}
-
-func (r UpdateMaintenanceWindowApiRequest) ExecuteWithParams(params *UpdateMaintenanceWindowApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.groupMaintenanceWindow = params.GroupMaintenanceWindow 
-	return r.Execute()
+	return r.ApiService.updateMaintenanceWindowExecute(r)
 }
 
 /*
@@ -610,7 +669,7 @@ func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindow(ctx context.Conte
 }
 
 // Execute executes the request
-func (a *MaintenanceWindowsApiService) UpdateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (*http.Response, error) {
+func (a *MaintenanceWindowsApiService) updateMaintenanceWindowExecute(r UpdateMaintenanceWindowApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -37,7 +37,7 @@ type MongoDBCloudUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateUserApiParams - Parameters for the request
-	@return CreateUserApiRequest}}
+	@return CreateUserApiRequest
 	*/
 	CreateUserWithParams(ctx context.Context, args *CreateUserApiParams) CreateUserApiRequest
 
@@ -60,7 +60,7 @@ type MongoDBCloudUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetUserApiParams - Parameters for the request
-	@return GetUserApiRequest}}
+	@return GetUserApiRequest
 	*/
 	GetUserWithParams(ctx context.Context, args *GetUserApiParams) GetUserApiRequest
 
@@ -83,7 +83,7 @@ type MongoDBCloudUsersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetUserByUsernameApiParams - Parameters for the request
-	@return GetUserByUsernameApiRequest}}
+	@return GetUserByUsernameApiRequest
 	*/
 	GetUserByUsernameWithParams(ctx context.Context, args *GetUserByUsernameApiParams) GetUserByUsernameApiRequest
 

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -31,10 +31,18 @@ type MongoDBCloudUsersApi interface {
 	@return CreateUserApiRequest
 	*/
 	CreateUser(ctx context.Context) CreateUserApiRequest
+	/*
+	CreateUser Create One MongoDB Cloud User
 
-	// CreateUserExecute executes the request
-	//  @return AppUser
-	CreateUserExecute(r CreateUserApiRequest) (*AppUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateUserApiParams - Parameters for the request
+	@return CreateUserApiRequest}}
+	*/
+	CreateUserWithParams(ctx context.Context, args *CreateUserApiParams) CreateUserApiRequest
+
+	// Interface only available internally
+	createUserExecute(r CreateUserApiRequest) (*AppUser, *http.Response, error)
 
 	/*
 	GetUser Return One MongoDB Cloud User using Its ID
@@ -46,10 +54,18 @@ type MongoDBCloudUsersApi interface {
 	@return GetUserApiRequest
 	*/
 	GetUser(ctx context.Context, userId string) GetUserApiRequest
+	/*
+	GetUser Return One MongoDB Cloud User using Its ID
 
-	// GetUserExecute executes the request
-	//  @return AppUser
-	GetUserExecute(r GetUserApiRequest) (*AppUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetUserApiParams - Parameters for the request
+	@return GetUserApiRequest}}
+	*/
+	GetUserWithParams(ctx context.Context, args *GetUserApiParams) GetUserApiRequest
+
+	// Interface only available internally
+	getUserExecute(r GetUserApiRequest) (*AppUser, *http.Response, error)
 
 	/*
 	GetUserByUsername Return One MongoDB Cloud User using Their Username
@@ -61,10 +77,18 @@ type MongoDBCloudUsersApi interface {
 	@return GetUserByUsernameApiRequest
 	*/
 	GetUserByUsername(ctx context.Context, userName string) GetUserByUsernameApiRequest
+	/*
+	GetUserByUsername Return One MongoDB Cloud User using Their Username
 
-	// GetUserByUsernameExecute executes the request
-	//  @return AppUser
-	GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*AppUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetUserByUsernameApiParams - Parameters for the request
+	@return GetUserByUsernameApiRequest}}
+	*/
+	GetUserByUsernameWithParams(ctx context.Context, args *GetUserByUsernameApiParams) GetUserByUsernameApiRequest
+
+	// Interface only available internally
+	getUserByUsernameExecute(r GetUserByUsernameApiRequest) (*AppUser, *http.Response, error)
 }
 
 // MongoDBCloudUsersApiService MongoDBCloudUsersApi service
@@ -80,6 +104,14 @@ type CreateUserApiParams struct {
 		AppUser *AppUser
 }
 
+func (a *MongoDBCloudUsersApiService) CreateUserWithParams(ctx context.Context, args *CreateUserApiParams) CreateUserApiRequest {
+	return CreateUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		appUser: args.AppUser,
+	}
+}
+
 // MongoDB Cloud user account to create.
 func (r CreateUserApiRequest) AppUser(appUser AppUser) CreateUserApiRequest {
 	r.appUser = &appUser
@@ -87,12 +119,7 @@ func (r CreateUserApiRequest) AppUser(appUser AppUser) CreateUserApiRequest {
 }
 
 func (r CreateUserApiRequest) Execute() (*AppUser, *http.Response, error) {
-	return r.ApiService.CreateUserExecute(r)
-}
-
-func (r CreateUserApiRequest) ExecuteWithParams(params *CreateUserApiParams) (*AppUser, *http.Response, error) {
-	r.appUser = params.AppUser 
-	return r.Execute()
+	return r.ApiService.createUserExecute(r)
 }
 
 /*
@@ -116,7 +143,7 @@ func (a *MongoDBCloudUsersApiService) CreateUser(ctx context.Context) CreateUser
 
 // Execute executes the request
 //  @return AppUser
-func (a *MongoDBCloudUsersApiService) CreateUserExecute(r CreateUserApiRequest) (*AppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) createUserExecute(r CreateUserApiRequest) (*AppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -212,13 +239,16 @@ type GetUserApiParams struct {
 		UserId string
 }
 
-func (r GetUserApiRequest) Execute() (*AppUser, *http.Response, error) {
-	return r.ApiService.GetUserExecute(r)
+func (a *MongoDBCloudUsersApiService) GetUserWithParams(ctx context.Context, args *GetUserApiParams) GetUserApiRequest {
+	return GetUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		userId: args.UserId,
+	}
 }
 
-func (r GetUserApiRequest) ExecuteWithParams(params *GetUserApiParams) (*AppUser, *http.Response, error) {
-	r.userId = params.UserId 
-	return r.Execute()
+func (r GetUserApiRequest) Execute() (*AppUser, *http.Response, error) {
+	return r.ApiService.getUserExecute(r)
 }
 
 /*
@@ -240,7 +270,7 @@ func (a *MongoDBCloudUsersApiService) GetUser(ctx context.Context, userId string
 
 // Execute executes the request
 //  @return AppUser
-func (a *MongoDBCloudUsersApiService) GetUserExecute(r GetUserApiRequest) (*AppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) getUserExecute(r GetUserApiRequest) (*AppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -338,13 +368,16 @@ type GetUserByUsernameApiParams struct {
 		UserName string
 }
 
-func (r GetUserByUsernameApiRequest) Execute() (*AppUser, *http.Response, error) {
-	return r.ApiService.GetUserByUsernameExecute(r)
+func (a *MongoDBCloudUsersApiService) GetUserByUsernameWithParams(ctx context.Context, args *GetUserByUsernameApiParams) GetUserByUsernameApiRequest {
+	return GetUserByUsernameApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		userName: args.UserName,
+	}
 }
 
-func (r GetUserByUsernameApiRequest) ExecuteWithParams(params *GetUserByUsernameApiParams) (*AppUser, *http.Response, error) {
-	r.userName = params.UserName 
-	return r.Execute()
+func (r GetUserByUsernameApiRequest) Execute() (*AppUser, *http.Response, error) {
+	return r.ApiService.getUserByUsernameExecute(r)
 }
 
 /*
@@ -366,7 +399,7 @@ func (a *MongoDBCloudUsersApiService) GetUserByUsername(ctx context.Context, use
 
 // Execute executes the request
 //  @return AppUser
-func (a *MongoDBCloudUsersApiService) GetUserByUsernameExecute(r GetUserByUsernameApiRequest) (*AppUser, *http.Response, error) {
+func (a *MongoDBCloudUsersApiService) getUserByUsernameExecute(r GetUserByUsernameApiRequest) (*AppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_mongo_db_cloud_users.go
+++ b/mongodbatlasv2/api_mongo_db_cloud_users.go
@@ -90,6 +90,11 @@ func (r CreateUserApiRequest) Execute() (*AppUser, *http.Response, error) {
 	return r.ApiService.CreateUserExecute(r)
 }
 
+func (r CreateUserApiRequest) ExecuteWithParams(params *CreateUserApiParams) (*AppUser, *http.Response, error) {
+	r.appUser = params.AppUser 
+	return r.Execute()
+}
+
 /*
 CreateUser Create One MongoDB Cloud User
 
@@ -211,6 +216,11 @@ func (r GetUserApiRequest) Execute() (*AppUser, *http.Response, error) {
 	return r.ApiService.GetUserExecute(r)
 }
 
+func (r GetUserApiRequest) ExecuteWithParams(params *GetUserApiParams) (*AppUser, *http.Response, error) {
+	r.userId = params.UserId 
+	return r.Execute()
+}
+
 /*
 GetUser Return One MongoDB Cloud User using Its ID
 
@@ -330,6 +340,11 @@ type GetUserByUsernameApiParams struct {
 
 func (r GetUserByUsernameApiRequest) Execute() (*AppUser, *http.Response, error) {
 	return r.ApiService.GetUserByUsernameExecute(r)
+}
+
+func (r GetUserByUsernameApiRequest) ExecuteWithParams(params *GetUserByUsernameApiParams) (*AppUser, *http.Response, error) {
+	r.userName = params.UserName 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -38,7 +38,7 @@ type MonitoringAndLogsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetAtlasProcessApiParams - Parameters for the request
-	@return GetAtlasProcessApiRequest}}
+	@return GetAtlasProcessApiRequest
 	*/
 	GetAtlasProcessWithParams(ctx context.Context, args *GetAtlasProcessApiParams) GetAtlasProcessApiRequest
 
@@ -63,7 +63,7 @@ type MonitoringAndLogsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetDatabaseApiParams - Parameters for the request
-	@return GetDatabaseApiRequest}}
+	@return GetDatabaseApiRequest
 	*/
 	GetDatabaseWithParams(ctx context.Context, args *GetDatabaseApiParams) GetDatabaseApiRequest
 
@@ -88,7 +88,7 @@ type MonitoringAndLogsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetDatabaseMeasurementsApiParams - Parameters for the request
-	@return GetDatabaseMeasurementsApiRequest}}
+	@return GetDatabaseMeasurementsApiRequest
 	*/
 	GetDatabaseMeasurementsWithParams(ctx context.Context, args *GetDatabaseMeasurementsApiParams) GetDatabaseMeasurementsApiRequest
 
@@ -119,7 +119,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetDiskMeasurementsApiParams - Parameters for the request
-	@return GetDiskMeasurementsApiRequest}}
+	@return GetDiskMeasurementsApiRequest
 	*/
 	GetDiskMeasurementsWithParams(ctx context.Context, args *GetDiskMeasurementsApiParams) GetDiskMeasurementsApiRequest
 
@@ -144,7 +144,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetHostLogsApiParams - Parameters for the request
-	@return GetHostLogsApiRequest}}
+	@return GetHostLogsApiRequest
 	*/
 	GetHostLogsWithParams(ctx context.Context, args *GetHostLogsApiParams) GetHostLogsApiRequest
 
@@ -174,7 +174,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetHostMeasurementsApiParams - Parameters for the request
-	@return GetHostMeasurementsApiRequest}}
+	@return GetHostMeasurementsApiRequest
 	*/
 	GetHostMeasurementsWithParams(ctx context.Context, args *GetHostMeasurementsApiParams) GetHostMeasurementsApiRequest
 
@@ -201,7 +201,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetIndexMetricsApiParams - Parameters for the request
-	@return GetIndexMetricsApiRequest}}
+	@return GetIndexMetricsApiRequest
 	*/
 	GetIndexMetricsWithParams(ctx context.Context, args *GetIndexMetricsApiParams) GetIndexMetricsApiRequest
 
@@ -225,7 +225,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetMeasurementsApiParams - Parameters for the request
-	@return GetMeasurementsApiRequest}}
+	@return GetMeasurementsApiRequest
 	*/
 	GetMeasurementsWithParams(ctx context.Context, args *GetMeasurementsApiParams) GetMeasurementsApiRequest
 
@@ -248,7 +248,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListAtlasProcessesApiParams - Parameters for the request
-	@return ListAtlasProcessesApiRequest}}
+	@return ListAtlasProcessesApiRequest
 	*/
 	ListAtlasProcessesWithParams(ctx context.Context, args *ListAtlasProcessesApiParams) ListAtlasProcessesApiRequest
 
@@ -272,7 +272,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListDatabasesApiParams - Parameters for the request
-	@return ListDatabasesApiRequest}}
+	@return ListDatabasesApiRequest
 	*/
 	ListDatabasesWithParams(ctx context.Context, args *ListDatabasesApiParams) ListDatabasesApiRequest
 
@@ -303,7 +303,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListDiskMeasurementsApiParams - Parameters for the request
-	@return ListDiskMeasurementsApiRequest}}
+	@return ListDiskMeasurementsApiRequest
 	*/
 	ListDiskMeasurementsWithParams(ctx context.Context, args *ListDiskMeasurementsApiParams) ListDiskMeasurementsApiRequest
 
@@ -327,7 +327,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListDiskPartitionsApiParams - Parameters for the request
-	@return ListDiskPartitionsApiRequest}}
+	@return ListDiskPartitionsApiRequest
 	*/
 	ListDiskPartitionsWithParams(ctx context.Context, args *ListDiskPartitionsApiParams) ListDiskPartitionsApiRequest
 
@@ -353,7 +353,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListIndexMetricsApiParams - Parameters for the request
-	@return ListIndexMetricsApiRequest}}
+	@return ListIndexMetricsApiRequest
 	*/
 	ListIndexMetricsWithParams(ctx context.Context, args *ListIndexMetricsApiParams) ListIndexMetricsApiRequest
 
@@ -377,7 +377,7 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListMetricTypesApiParams - Parameters for the request
-	@return ListMetricTypesApiRequest}}
+	@return ListMetricTypesApiRequest
 	*/
 	ListMetricTypesWithParams(ctx context.Context, args *ListMetricTypesApiParams) ListMetricTypesApiRequest
 

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -292,6 +292,12 @@ func (r GetAtlasProcessApiRequest) Execute() (*HostViewAtlas, *http.Response, er
 	return r.ApiService.GetAtlasProcessExecute(r)
 }
 
+func (r GetAtlasProcessApiRequest) ExecuteWithParams(params *GetAtlasProcessApiParams) (*HostViewAtlas, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	return r.Execute()
+}
+
 /*
 GetAtlasProcess Return One MongoDB Process by ID
 
@@ -418,6 +424,13 @@ type GetDatabaseApiParams struct {
 
 func (r GetDatabaseApiRequest) Execute() (*Database, *http.Response, error) {
 	return r.ApiService.GetDatabaseExecute(r)
+}
+
+func (r GetDatabaseApiRequest) ExecuteWithParams(params *GetDatabaseApiParams) (*Database, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.databaseName = params.DatabaseName 
+	r.processId = params.ProcessId 
+	return r.Execute()
 }
 
 /*
@@ -557,6 +570,14 @@ func (r GetDatabaseMeasurementsApiRequest) M(m []string) GetDatabaseMeasurements
 
 func (r GetDatabaseMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	return r.ApiService.GetDatabaseMeasurementsExecute(r)
+}
+
+func (r GetDatabaseMeasurementsApiRequest) ExecuteWithParams(params *GetDatabaseMeasurementsApiParams) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.databaseName = params.DatabaseName 
+	r.processId = params.ProcessId 
+	r.m = params.M 
+	return r.Execute()
 }
 
 /*
@@ -707,6 +728,14 @@ func (r GetDiskMeasurementsApiRequest) M(m []string) GetDiskMeasurementsApiReque
 
 func (r GetDiskMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	return r.ApiService.GetDiskMeasurementsExecute(r)
+}
+
+func (r GetDiskMeasurementsApiRequest) ExecuteWithParams(params *GetDiskMeasurementsApiParams) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.partitionName = params.PartitionName 
+	r.processId = params.ProcessId 
+	r.m = params.M 
+	return r.Execute()
 }
 
 /*
@@ -873,6 +902,15 @@ func (r GetHostLogsApiRequest) Execute() (*os.File, *http.Response, error) {
 	return r.ApiService.GetHostLogsExecute(r)
 }
 
+func (r GetHostLogsApiRequest) ExecuteWithParams(params *GetHostLogsApiParams) (*os.File, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.hostName = params.HostName 
+	r.logName = params.LogName 
+	r.endDate = params.EndDate 
+	r.startDate = params.StartDate 
+	return r.Execute()
+}
+
 /*
 GetHostLogs Download Logs for One Multi-Cloud Cluster Host in One Project
 
@@ -1022,6 +1060,14 @@ func (r GetHostMeasurementsApiRequest) Period(period time.Time) GetHostMeasureme
 
 func (r GetHostMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	return r.ApiService.GetHostMeasurementsExecute(r)
+}
+
+func (r GetHostMeasurementsApiRequest) ExecuteWithParams(params *GetHostMeasurementsApiParams) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	r.m = params.M 
+	r.period = params.Period 
+	return r.Execute()
 }
 
 /*
@@ -1214,6 +1260,20 @@ func (r GetIndexMetricsApiRequest) End(end time.Time) GetIndexMetricsApiRequest 
 
 func (r GetIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
 	return r.ApiService.GetIndexMetricsExecute(r)
+}
+
+func (r GetIndexMetricsApiRequest) ExecuteWithParams(params *GetIndexMetricsApiParams) (*MeasurementsIndexes, *http.Response, error) {
+	r.processId = params.ProcessId 
+	r.indexName = params.IndexName 
+	r.databaseName = params.DatabaseName 
+	r.collectionName = params.CollectionName 
+	r.groupId = params.GroupId 
+	r.granularity = params.Granularity 
+	r.metrics = params.Metrics 
+	r.period = params.Period 
+	r.start = params.Start 
+	r.end = params.End 
+	return r.Execute()
 }
 
 /*
@@ -1421,6 +1481,17 @@ func (r GetMeasurementsApiRequest) Execute() (*MeasurementsNonIndex, *http.Respo
 	return r.ApiService.GetMeasurementsExecute(r)
 }
 
+func (r GetMeasurementsApiRequest) ExecuteWithParams(params *GetMeasurementsApiParams) (*MeasurementsNonIndex, *http.Response, error) {
+	r.processId = params.ProcessId 
+	r.groupId = params.GroupId 
+	r.granularity = params.Granularity 
+	r.metrics = params.Metrics 
+	r.period = params.Period 
+	r.start = params.Start 
+	r.end = params.End 
+	return r.Execute()
+}
+
 /*
 GetMeasurements Return Atlas Search Hardware and Status Metrics
 
@@ -1599,6 +1670,14 @@ func (r ListAtlasProcessesApiRequest) Execute() (*PaginatedHostViewAtlas, *http.
 	return r.ApiService.ListAtlasProcessesExecute(r)
 }
 
+func (r ListAtlasProcessesApiRequest) ExecuteWithParams(params *ListAtlasProcessesApiParams) (*PaginatedHostViewAtlas, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListAtlasProcesses Return All MongoDB Processes in One Project
 
@@ -1767,6 +1846,15 @@ func (r ListDatabasesApiRequest) Execute() (*PaginatedDatabase, *http.Response, 
 	return r.ApiService.ListDatabasesExecute(r)
 }
 
+func (r ListDatabasesApiRequest) ExecuteWithParams(params *ListDatabasesApiParams) (*PaginatedDatabase, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListDatabases Return Available Databases for One MongoDB Process
 
@@ -1914,6 +2002,13 @@ type ListDiskMeasurementsApiParams struct {
 
 func (r ListDiskMeasurementsApiRequest) Execute() (*DiskPartition, *http.Response, error) {
 	return r.ApiService.ListDiskMeasurementsExecute(r)
+}
+
+func (r ListDiskMeasurementsApiRequest) ExecuteWithParams(params *ListDiskMeasurementsApiParams) (*DiskPartition, *http.Response, error) {
+	r.partitionName = params.PartitionName 
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	return r.Execute()
 }
 
 /*
@@ -2073,6 +2168,15 @@ func (r ListDiskPartitionsApiRequest) PageNum(pageNum int32) ListDiskPartitionsA
 
 func (r ListDiskPartitionsApiRequest) Execute() (*PaginatedDiskPartition, *http.Response, error) {
 	return r.ApiService.ListDiskPartitionsExecute(r)
+}
+
+func (r ListDiskPartitionsApiRequest) ExecuteWithParams(params *ListDiskPartitionsApiParams) (*PaginatedDiskPartition, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -2266,6 +2370,19 @@ func (r ListIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Respo
 	return r.ApiService.ListIndexMetricsExecute(r)
 }
 
+func (r ListIndexMetricsApiRequest) ExecuteWithParams(params *ListIndexMetricsApiParams) (*MeasurementsIndexes, *http.Response, error) {
+	r.processId = params.ProcessId 
+	r.databaseName = params.DatabaseName 
+	r.collectionName = params.CollectionName 
+	r.groupId = params.GroupId 
+	r.granularity = params.Granularity 
+	r.metrics = params.Metrics 
+	r.period = params.Period 
+	r.start = params.Start 
+	r.end = params.End 
+	return r.Execute()
+}
+
 /*
 ListIndexMetrics Return All Atlas Search Index Metrics for One Namespace
 
@@ -2426,6 +2543,12 @@ type ListMetricTypesApiParams struct {
 
 func (r ListMetricTypesApiRequest) Execute() (*FTSMetrics, *http.Response, error) {
 	return r.ApiService.ListMetricTypesExecute(r)
+}
+
+func (r ListMetricTypesApiRequest) ExecuteWithParams(params *ListMetricTypesApiParams) (*FTSMetrics, *http.Response, error) {
+	r.processId = params.ProcessId 
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_monitoring_and_logs.go
+++ b/mongodbatlasv2/api_monitoring_and_logs.go
@@ -32,10 +32,18 @@ type MonitoringAndLogsApi interface {
 	@return GetAtlasProcessApiRequest
 	*/
 	GetAtlasProcess(ctx context.Context, groupId string, processId string) GetAtlasProcessApiRequest
+	/*
+	GetAtlasProcess Return One MongoDB Process by ID
 
-	// GetAtlasProcessExecute executes the request
-	//  @return HostViewAtlas
-	GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*HostViewAtlas, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetAtlasProcessApiParams - Parameters for the request
+	@return GetAtlasProcessApiRequest}}
+	*/
+	GetAtlasProcessWithParams(ctx context.Context, args *GetAtlasProcessApiParams) GetAtlasProcessApiRequest
+
+	// Interface only available internally
+	getAtlasProcessExecute(r GetAtlasProcessApiRequest) (*HostViewAtlas, *http.Response, error)
 
 	/*
 	GetDatabase Return One Database for a MongoDB Process
@@ -49,10 +57,18 @@ type MonitoringAndLogsApi interface {
 	@return GetDatabaseApiRequest
 	*/
 	GetDatabase(ctx context.Context, groupId string, databaseName string, processId string) GetDatabaseApiRequest
+	/*
+	GetDatabase Return One Database for a MongoDB Process
 
-	// GetDatabaseExecute executes the request
-	//  @return Database
-	GetDatabaseExecute(r GetDatabaseApiRequest) (*Database, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetDatabaseApiParams - Parameters for the request
+	@return GetDatabaseApiRequest}}
+	*/
+	GetDatabaseWithParams(ctx context.Context, args *GetDatabaseApiParams) GetDatabaseApiRequest
+
+	// Interface only available internally
+	getDatabaseExecute(r GetDatabaseApiRequest) (*Database, *http.Response, error)
 
 	/*
 	GetDatabaseMeasurements Return Measurements of One Database for One MongoDB Process
@@ -66,10 +82,18 @@ type MonitoringAndLogsApi interface {
 	@return GetDatabaseMeasurementsApiRequest
 	*/
 	GetDatabaseMeasurements(ctx context.Context, groupId string, databaseName string, processId string) GetDatabaseMeasurementsApiRequest
+	/*
+	GetDatabaseMeasurements Return Measurements of One Database for One MongoDB Process
 
-	// GetDatabaseMeasurementsExecute executes the request
-	//  @return MeasurementsGeneralViewAtlas
-	GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetDatabaseMeasurementsApiParams - Parameters for the request
+	@return GetDatabaseMeasurementsApiRequest}}
+	*/
+	GetDatabaseMeasurementsWithParams(ctx context.Context, args *GetDatabaseMeasurementsApiParams) GetDatabaseMeasurementsApiRequest
+
+	// Interface only available internally
+	getDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 	GetDiskMeasurements Return Measurements of One Disk for One MongoDB Process
@@ -89,10 +113,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return GetDiskMeasurementsApiRequest
 	*/
 	GetDiskMeasurements(ctx context.Context, groupId string, partitionName string, processId string) GetDiskMeasurementsApiRequest
+	/*
+	GetDiskMeasurements Return Measurements of One Disk for One MongoDB Process
 
-	// GetDiskMeasurementsExecute executes the request
-	//  @return MeasurementsGeneralViewAtlas
-	GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetDiskMeasurementsApiParams - Parameters for the request
+	@return GetDiskMeasurementsApiRequest}}
+	*/
+	GetDiskMeasurementsWithParams(ctx context.Context, args *GetDiskMeasurementsApiParams) GetDiskMeasurementsApiRequest
+
+	// Interface only available internally
+	getDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 	GetHostLogs Download Logs for One Multi-Cloud Cluster Host in One Project
@@ -106,10 +138,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return GetHostLogsApiRequest
 	*/
 	GetHostLogs(ctx context.Context, groupId string, hostName string, logName string) GetHostLogsApiRequest
+	/*
+	GetHostLogs Download Logs for One Multi-Cloud Cluster Host in One Project
 
-	// GetHostLogsExecute executes the request
-	//  @return *os.File
-	GetHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetHostLogsApiParams - Parameters for the request
+	@return GetHostLogsApiRequest}}
+	*/
+	GetHostLogsWithParams(ctx context.Context, args *GetHostLogsApiParams) GetHostLogsApiRequest
+
+	// Interface only available internally
+	getHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error)
 
 	/*
 	GetHostMeasurements Return Measurements for One MongoDB Process
@@ -128,10 +168,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return GetHostMeasurementsApiRequest
 	*/
 	GetHostMeasurements(ctx context.Context, groupId string, processId string) GetHostMeasurementsApiRequest
+	/*
+	GetHostMeasurements Return Measurements for One MongoDB Process
 
-	// GetHostMeasurementsExecute executes the request
-	//  @return MeasurementsGeneralViewAtlas
-	GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetHostMeasurementsApiParams - Parameters for the request
+	@return GetHostMeasurementsApiRequest}}
+	*/
+	GetHostMeasurementsWithParams(ctx context.Context, args *GetHostMeasurementsApiParams) GetHostMeasurementsApiRequest
+
+	// Interface only available internally
+	getHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error)
 
 	/*
 	GetIndexMetrics Return Atlas Search Metrics for One Index in One Specified Namespace
@@ -147,10 +195,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return GetIndexMetricsApiRequest
 	*/
 	GetIndexMetrics(ctx context.Context, processId string, indexName string, databaseName string, collectionName string, groupId string) GetIndexMetricsApiRequest
+	/*
+	GetIndexMetrics Return Atlas Search Metrics for One Index in One Specified Namespace
 
-	// GetIndexMetricsExecute executes the request
-	//  @return MeasurementsIndexes
-	GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetIndexMetricsApiParams - Parameters for the request
+	@return GetIndexMetricsApiRequest}}
+	*/
+	GetIndexMetricsWithParams(ctx context.Context, args *GetIndexMetricsApiParams) GetIndexMetricsApiRequest
+
+	// Interface only available internally
+	getIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
 	GetMeasurements Return Atlas Search Hardware and Status Metrics
@@ -163,10 +219,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return GetMeasurementsApiRequest
 	*/
 	GetMeasurements(ctx context.Context, processId string, groupId string) GetMeasurementsApiRequest
+	/*
+	GetMeasurements Return Atlas Search Hardware and Status Metrics
 
-	// GetMeasurementsExecute executes the request
-	//  @return MeasurementsNonIndex
-	GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetMeasurementsApiParams - Parameters for the request
+	@return GetMeasurementsApiRequest}}
+	*/
+	GetMeasurementsWithParams(ctx context.Context, args *GetMeasurementsApiParams) GetMeasurementsApiRequest
+
+	// Interface only available internally
+	getMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error)
 
 	/*
 	ListAtlasProcesses Return All MongoDB Processes in One Project
@@ -178,10 +242,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return ListAtlasProcessesApiRequest
 	*/
 	ListAtlasProcesses(ctx context.Context, groupId string) ListAtlasProcessesApiRequest
+	/*
+	ListAtlasProcesses Return All MongoDB Processes in One Project
 
-	// ListAtlasProcessesExecute executes the request
-	//  @return PaginatedHostViewAtlas
-	ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListAtlasProcessesApiParams - Parameters for the request
+	@return ListAtlasProcessesApiRequest}}
+	*/
+	ListAtlasProcessesWithParams(ctx context.Context, args *ListAtlasProcessesApiParams) ListAtlasProcessesApiRequest
+
+	// Interface only available internally
+	listAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error)
 
 	/*
 	ListDatabases Return Available Databases for One MongoDB Process
@@ -194,10 +266,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return ListDatabasesApiRequest
 	*/
 	ListDatabases(ctx context.Context, groupId string, processId string) ListDatabasesApiRequest
+	/*
+	ListDatabases Return Available Databases for One MongoDB Process
 
-	// ListDatabasesExecute executes the request
-	//  @return PaginatedDatabase
-	ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListDatabasesApiParams - Parameters for the request
+	@return ListDatabasesApiRequest}}
+	*/
+	ListDatabasesWithParams(ctx context.Context, args *ListDatabasesApiParams) ListDatabasesApiRequest
+
+	// Interface only available internally
+	listDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error)
 
 	/*
 	ListDiskMeasurements Return Measurements of One Disk
@@ -217,10 +297,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return ListDiskMeasurementsApiRequest
 	*/
 	ListDiskMeasurements(ctx context.Context, partitionName string, groupId string, processId string) ListDiskMeasurementsApiRequest
+	/*
+	ListDiskMeasurements Return Measurements of One Disk
 
-	// ListDiskMeasurementsExecute executes the request
-	//  @return DiskPartition
-	ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*DiskPartition, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListDiskMeasurementsApiParams - Parameters for the request
+	@return ListDiskMeasurementsApiRequest}}
+	*/
+	ListDiskMeasurementsWithParams(ctx context.Context, args *ListDiskMeasurementsApiParams) ListDiskMeasurementsApiRequest
+
+	// Interface only available internally
+	listDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*DiskPartition, *http.Response, error)
 
 	/*
 	ListDiskPartitions Return Available Disks for One MongoDB Process
@@ -233,10 +321,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return ListDiskPartitionsApiRequest
 	*/
 	ListDiskPartitions(ctx context.Context, groupId string, processId string) ListDiskPartitionsApiRequest
+	/*
+	ListDiskPartitions Return Available Disks for One MongoDB Process
 
-	// ListDiskPartitionsExecute executes the request
-	//  @return PaginatedDiskPartition
-	ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListDiskPartitionsApiParams - Parameters for the request
+	@return ListDiskPartitionsApiRequest}}
+	*/
+	ListDiskPartitionsWithParams(ctx context.Context, args *ListDiskPartitionsApiParams) ListDiskPartitionsApiRequest
+
+	// Interface only available internally
+	listDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error)
 
 	/*
 	ListIndexMetrics Return All Atlas Search Index Metrics for One Namespace
@@ -251,10 +347,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return ListIndexMetricsApiRequest
 	*/
 	ListIndexMetrics(ctx context.Context, processId string, databaseName string, collectionName string, groupId string) ListIndexMetricsApiRequest
+	/*
+	ListIndexMetrics Return All Atlas Search Index Metrics for One Namespace
 
-	// ListIndexMetricsExecute executes the request
-	//  @return MeasurementsIndexes
-	ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListIndexMetricsApiParams - Parameters for the request
+	@return ListIndexMetricsApiRequest}}
+	*/
+	ListIndexMetricsWithParams(ctx context.Context, args *ListIndexMetricsApiParams) ListIndexMetricsApiRequest
+
+	// Interface only available internally
+	listIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error)
 
 	/*
 	ListMetricTypes Return All Atlas Search Metric Types for One Process
@@ -267,10 +371,18 @@ To use this resource, the requesting API Key must have the Project Read Only rol
 	@return ListMetricTypesApiRequest
 	*/
 	ListMetricTypes(ctx context.Context, processId string, groupId string) ListMetricTypesApiRequest
+	/*
+	ListMetricTypes Return All Atlas Search Metric Types for One Process
 
-	// ListMetricTypesExecute executes the request
-	//  @return FTSMetrics
-	ListMetricTypesExecute(r ListMetricTypesApiRequest) (*FTSMetrics, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListMetricTypesApiParams - Parameters for the request
+	@return ListMetricTypesApiRequest}}
+	*/
+	ListMetricTypesWithParams(ctx context.Context, args *ListMetricTypesApiParams) ListMetricTypesApiRequest
+
+	// Interface only available internally
+	listMetricTypesExecute(r ListMetricTypesApiRequest) (*FTSMetrics, *http.Response, error)
 }
 
 // MonitoringAndLogsApiService MonitoringAndLogsApi service
@@ -288,14 +400,17 @@ type GetAtlasProcessApiParams struct {
 		ProcessId string
 }
 
-func (r GetAtlasProcessApiRequest) Execute() (*HostViewAtlas, *http.Response, error) {
-	return r.ApiService.GetAtlasProcessExecute(r)
+func (a *MonitoringAndLogsApiService) GetAtlasProcessWithParams(ctx context.Context, args *GetAtlasProcessApiParams) GetAtlasProcessApiRequest {
+	return GetAtlasProcessApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+	}
 }
 
-func (r GetAtlasProcessApiRequest) ExecuteWithParams(params *GetAtlasProcessApiParams) (*HostViewAtlas, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	return r.Execute()
+func (r GetAtlasProcessApiRequest) Execute() (*HostViewAtlas, *http.Response, error) {
+	return r.ApiService.getAtlasProcessExecute(r)
 }
 
 /*
@@ -319,7 +434,7 @@ func (a *MonitoringAndLogsApiService) GetAtlasProcess(ctx context.Context, group
 
 // Execute executes the request
 //  @return HostViewAtlas
-func (a *MonitoringAndLogsApiService) GetAtlasProcessExecute(r GetAtlasProcessApiRequest) (*HostViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getAtlasProcessExecute(r GetAtlasProcessApiRequest) (*HostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -422,15 +537,18 @@ type GetDatabaseApiParams struct {
 		ProcessId string
 }
 
-func (r GetDatabaseApiRequest) Execute() (*Database, *http.Response, error) {
-	return r.ApiService.GetDatabaseExecute(r)
+func (a *MonitoringAndLogsApiService) GetDatabaseWithParams(ctx context.Context, args *GetDatabaseApiParams) GetDatabaseApiRequest {
+	return GetDatabaseApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		databaseName: args.DatabaseName,
+		processId: args.ProcessId,
+	}
 }
 
-func (r GetDatabaseApiRequest) ExecuteWithParams(params *GetDatabaseApiParams) (*Database, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.databaseName = params.DatabaseName 
-	r.processId = params.ProcessId 
-	return r.Execute()
+func (r GetDatabaseApiRequest) Execute() (*Database, *http.Response, error) {
+	return r.ApiService.getDatabaseExecute(r)
 }
 
 /*
@@ -456,7 +574,7 @@ func (a *MonitoringAndLogsApiService) GetDatabase(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return Database
-func (a *MonitoringAndLogsApiService) GetDatabaseExecute(r GetDatabaseApiRequest) (*Database, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getDatabaseExecute(r GetDatabaseApiRequest) (*Database, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -562,6 +680,17 @@ type GetDatabaseMeasurementsApiParams struct {
 		M *[]string
 }
 
+func (a *MonitoringAndLogsApiService) GetDatabaseMeasurementsWithParams(ctx context.Context, args *GetDatabaseMeasurementsApiParams) GetDatabaseMeasurementsApiRequest {
+	return GetDatabaseMeasurementsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		databaseName: args.DatabaseName,
+		processId: args.ProcessId,
+		m: args.M,
+	}
+}
+
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
 func (r GetDatabaseMeasurementsApiRequest) M(m []string) GetDatabaseMeasurementsApiRequest {
 	r.m = &m
@@ -569,15 +698,7 @@ func (r GetDatabaseMeasurementsApiRequest) M(m []string) GetDatabaseMeasurements
 }
 
 func (r GetDatabaseMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
-	return r.ApiService.GetDatabaseMeasurementsExecute(r)
-}
-
-func (r GetDatabaseMeasurementsApiRequest) ExecuteWithParams(params *GetDatabaseMeasurementsApiParams) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.databaseName = params.DatabaseName 
-	r.processId = params.ProcessId 
-	r.m = params.M 
-	return r.Execute()
+	return r.ApiService.getDatabaseMeasurementsExecute(r)
 }
 
 /*
@@ -603,7 +724,7 @@ func (a *MonitoringAndLogsApiService) GetDatabaseMeasurements(ctx context.Contex
 
 // Execute executes the request
 //  @return MeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) GetDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getDatabaseMeasurementsExecute(r GetDatabaseMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -720,6 +841,17 @@ type GetDiskMeasurementsApiParams struct {
 		M *[]string
 }
 
+func (a *MonitoringAndLogsApiService) GetDiskMeasurementsWithParams(ctx context.Context, args *GetDiskMeasurementsApiParams) GetDiskMeasurementsApiRequest {
+	return GetDiskMeasurementsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		partitionName: args.PartitionName,
+		processId: args.ProcessId,
+		m: args.M,
+	}
+}
+
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
 func (r GetDiskMeasurementsApiRequest) M(m []string) GetDiskMeasurementsApiRequest {
 	r.m = &m
@@ -727,15 +859,7 @@ func (r GetDiskMeasurementsApiRequest) M(m []string) GetDiskMeasurementsApiReque
 }
 
 func (r GetDiskMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
-	return r.ApiService.GetDiskMeasurementsExecute(r)
-}
-
-func (r GetDiskMeasurementsApiRequest) ExecuteWithParams(params *GetDiskMeasurementsApiParams) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.partitionName = params.PartitionName 
-	r.processId = params.ProcessId 
-	r.m = params.M 
-	return r.Execute()
+	return r.ApiService.getDiskMeasurementsExecute(r)
 }
 
 /*
@@ -767,7 +891,7 @@ func (a *MonitoringAndLogsApiService) GetDiskMeasurements(ctx context.Context, g
 
 // Execute executes the request
 //  @return MeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) GetDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getDiskMeasurementsExecute(r GetDiskMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -886,6 +1010,18 @@ type GetHostLogsApiParams struct {
 		StartDate *int64
 }
 
+func (a *MonitoringAndLogsApiService) GetHostLogsWithParams(ctx context.Context, args *GetHostLogsApiParams) GetHostLogsApiRequest {
+	return GetHostLogsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		hostName: args.HostName,
+		logName: args.LogName,
+		endDate: args.EndDate,
+		startDate: args.StartDate,
+	}
+}
+
 // Date and time when the period specifies the inclusive ending point for the range of log messages to retrieve. This parameter expresses its value in the number of seconds that have elapsed since the UNIX epoch.
 func (r GetHostLogsApiRequest) EndDate(endDate int64) GetHostLogsApiRequest {
 	r.endDate = &endDate
@@ -899,16 +1035,7 @@ func (r GetHostLogsApiRequest) StartDate(startDate int64) GetHostLogsApiRequest 
 }
 
 func (r GetHostLogsApiRequest) Execute() (*os.File, *http.Response, error) {
-	return r.ApiService.GetHostLogsExecute(r)
-}
-
-func (r GetHostLogsApiRequest) ExecuteWithParams(params *GetHostLogsApiParams) (*os.File, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.hostName = params.HostName 
-	r.logName = params.LogName 
-	r.endDate = params.EndDate 
-	r.startDate = params.StartDate 
-	return r.Execute()
+	return r.ApiService.getHostLogsExecute(r)
 }
 
 /*
@@ -934,7 +1061,7 @@ func (a *MonitoringAndLogsApiService) GetHostLogs(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return *os.File
-func (a *MonitoringAndLogsApiService) GetHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getHostLogsExecute(r GetHostLogsApiRequest) (*os.File, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1046,6 +1173,17 @@ type GetHostMeasurementsApiParams struct {
 		Period *time.Time
 }
 
+func (a *MonitoringAndLogsApiService) GetHostMeasurementsWithParams(ctx context.Context, args *GetHostMeasurementsApiParams) GetHostMeasurementsApiRequest {
+	return GetHostMeasurementsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+		m: args.M,
+		period: args.Period,
+	}
+}
+
 // One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for &#x60;m&#x60;, repeat the &#x60;m&#x60; parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
 func (r GetHostMeasurementsApiRequest) M(m []string) GetHostMeasurementsApiRequest {
 	r.m = &m
@@ -1059,15 +1197,7 @@ func (r GetHostMeasurementsApiRequest) Period(period time.Time) GetHostMeasureme
 }
 
 func (r GetHostMeasurementsApiRequest) Execute() (*MeasurementsGeneralViewAtlas, *http.Response, error) {
-	return r.ApiService.GetHostMeasurementsExecute(r)
-}
-
-func (r GetHostMeasurementsApiRequest) ExecuteWithParams(params *GetHostMeasurementsApiParams) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	r.m = params.M 
-	r.period = params.Period 
-	return r.Execute()
+	return r.ApiService.getHostMeasurementsExecute(r)
 }
 
 /*
@@ -1097,7 +1227,7 @@ func (a *MonitoringAndLogsApiService) GetHostMeasurements(ctx context.Context, g
 
 // Execute executes the request
 //  @return MeasurementsGeneralViewAtlas
-func (a *MonitoringAndLogsApiService) GetHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getHostMeasurementsExecute(r GetHostMeasurementsApiRequest) (*MeasurementsGeneralViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1228,6 +1358,23 @@ type GetIndexMetricsApiParams struct {
 		End *time.Time
 }
 
+func (a *MonitoringAndLogsApiService) GetIndexMetricsWithParams(ctx context.Context, args *GetIndexMetricsApiParams) GetIndexMetricsApiRequest {
+	return GetIndexMetricsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		processId: args.ProcessId,
+		indexName: args.IndexName,
+		databaseName: args.DatabaseName,
+		collectionName: args.CollectionName,
+		groupId: args.GroupId,
+		granularity: args.Granularity,
+		metrics: args.Metrics,
+		period: args.Period,
+		start: args.Start,
+		end: args.End,
+	}
+}
+
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
 func (r GetIndexMetricsApiRequest) Granularity(granularity string) GetIndexMetricsApiRequest {
 	r.granularity = &granularity
@@ -1259,21 +1406,7 @@ func (r GetIndexMetricsApiRequest) End(end time.Time) GetIndexMetricsApiRequest 
 }
 
 func (r GetIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
-	return r.ApiService.GetIndexMetricsExecute(r)
-}
-
-func (r GetIndexMetricsApiRequest) ExecuteWithParams(params *GetIndexMetricsApiParams) (*MeasurementsIndexes, *http.Response, error) {
-	r.processId = params.ProcessId 
-	r.indexName = params.IndexName 
-	r.databaseName = params.DatabaseName 
-	r.collectionName = params.CollectionName 
-	r.groupId = params.GroupId 
-	r.granularity = params.Granularity 
-	r.metrics = params.Metrics 
-	r.period = params.Period 
-	r.start = params.Start 
-	r.end = params.End 
-	return r.Execute()
+	return r.ApiService.getIndexMetricsExecute(r)
 }
 
 /*
@@ -1303,7 +1436,7 @@ func (a *MonitoringAndLogsApiService) GetIndexMetrics(ctx context.Context, proce
 
 // Execute executes the request
 //  @return MeasurementsIndexes
-func (a *MonitoringAndLogsApiService) GetIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getIndexMetricsExecute(r GetIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1447,6 +1580,20 @@ type GetMeasurementsApiParams struct {
 		End *time.Time
 }
 
+func (a *MonitoringAndLogsApiService) GetMeasurementsWithParams(ctx context.Context, args *GetMeasurementsApiParams) GetMeasurementsApiRequest {
+	return GetMeasurementsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		processId: args.ProcessId,
+		groupId: args.GroupId,
+		granularity: args.Granularity,
+		metrics: args.Metrics,
+		period: args.Period,
+		start: args.Start,
+		end: args.End,
+	}
+}
+
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
 func (r GetMeasurementsApiRequest) Granularity(granularity string) GetMeasurementsApiRequest {
 	r.granularity = &granularity
@@ -1478,18 +1625,7 @@ func (r GetMeasurementsApiRequest) End(end time.Time) GetMeasurementsApiRequest 
 }
 
 func (r GetMeasurementsApiRequest) Execute() (*MeasurementsNonIndex, *http.Response, error) {
-	return r.ApiService.GetMeasurementsExecute(r)
-}
-
-func (r GetMeasurementsApiRequest) ExecuteWithParams(params *GetMeasurementsApiParams) (*MeasurementsNonIndex, *http.Response, error) {
-	r.processId = params.ProcessId 
-	r.groupId = params.GroupId 
-	r.granularity = params.Granularity 
-	r.metrics = params.Metrics 
-	r.period = params.Period 
-	r.start = params.Start 
-	r.end = params.End 
-	return r.Execute()
+	return r.ApiService.getMeasurementsExecute(r)
 }
 
 /*
@@ -1513,7 +1649,7 @@ func (a *MonitoringAndLogsApiService) GetMeasurements(ctx context.Context, proce
 
 // Execute executes the request
 //  @return MeasurementsNonIndex
-func (a *MonitoringAndLogsApiService) GetMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) getMeasurementsExecute(r GetMeasurementsApiRequest) (*MeasurementsNonIndex, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1648,6 +1784,17 @@ type ListAtlasProcessesApiParams struct {
 		PageNum *int32
 }
 
+func (a *MonitoringAndLogsApiService) ListAtlasProcessesWithParams(ctx context.Context, args *ListAtlasProcessesApiParams) ListAtlasProcessesApiRequest {
+	return ListAtlasProcessesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListAtlasProcessesApiRequest) IncludeCount(includeCount bool) ListAtlasProcessesApiRequest {
 	r.includeCount = &includeCount
@@ -1667,15 +1814,7 @@ func (r ListAtlasProcessesApiRequest) PageNum(pageNum int32) ListAtlasProcessesA
 }
 
 func (r ListAtlasProcessesApiRequest) Execute() (*PaginatedHostViewAtlas, *http.Response, error) {
-	return r.ApiService.ListAtlasProcessesExecute(r)
-}
-
-func (r ListAtlasProcessesApiRequest) ExecuteWithParams(params *ListAtlasProcessesApiParams) (*PaginatedHostViewAtlas, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listAtlasProcessesExecute(r)
 }
 
 /*
@@ -1697,7 +1836,7 @@ func (a *MonitoringAndLogsApiService) ListAtlasProcesses(ctx context.Context, gr
 
 // Execute executes the request
 //  @return PaginatedHostViewAtlas
-func (a *MonitoringAndLogsApiService) ListAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) listAtlasProcessesExecute(r ListAtlasProcessesApiRequest) (*PaginatedHostViewAtlas, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1824,6 +1963,18 @@ type ListDatabasesApiParams struct {
 		PageNum *int32
 }
 
+func (a *MonitoringAndLogsApiService) ListDatabasesWithParams(ctx context.Context, args *ListDatabasesApiParams) ListDatabasesApiRequest {
+	return ListDatabasesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListDatabasesApiRequest) IncludeCount(includeCount bool) ListDatabasesApiRequest {
 	r.includeCount = &includeCount
@@ -1843,16 +1994,7 @@ func (r ListDatabasesApiRequest) PageNum(pageNum int32) ListDatabasesApiRequest 
 }
 
 func (r ListDatabasesApiRequest) Execute() (*PaginatedDatabase, *http.Response, error) {
-	return r.ApiService.ListDatabasesExecute(r)
-}
-
-func (r ListDatabasesApiRequest) ExecuteWithParams(params *ListDatabasesApiParams) (*PaginatedDatabase, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listDatabasesExecute(r)
 }
 
 /*
@@ -1876,7 +2018,7 @@ func (a *MonitoringAndLogsApiService) ListDatabases(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return PaginatedDatabase
-func (a *MonitoringAndLogsApiService) ListDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) listDatabasesExecute(r ListDatabasesApiRequest) (*PaginatedDatabase, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2000,15 +2142,18 @@ type ListDiskMeasurementsApiParams struct {
 		ProcessId string
 }
 
-func (r ListDiskMeasurementsApiRequest) Execute() (*DiskPartition, *http.Response, error) {
-	return r.ApiService.ListDiskMeasurementsExecute(r)
+func (a *MonitoringAndLogsApiService) ListDiskMeasurementsWithParams(ctx context.Context, args *ListDiskMeasurementsApiParams) ListDiskMeasurementsApiRequest {
+	return ListDiskMeasurementsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		partitionName: args.PartitionName,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+	}
 }
 
-func (r ListDiskMeasurementsApiRequest) ExecuteWithParams(params *ListDiskMeasurementsApiParams) (*DiskPartition, *http.Response, error) {
-	r.partitionName = params.PartitionName 
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	return r.Execute()
+func (r ListDiskMeasurementsApiRequest) Execute() (*DiskPartition, *http.Response, error) {
+	return r.ApiService.listDiskMeasurementsExecute(r)
 }
 
 /*
@@ -2040,7 +2185,7 @@ func (a *MonitoringAndLogsApiService) ListDiskMeasurements(ctx context.Context, 
 
 // Execute executes the request
 //  @return DiskPartition
-func (a *MonitoringAndLogsApiService) ListDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*DiskPartition, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) listDiskMeasurementsExecute(r ListDiskMeasurementsApiRequest) (*DiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2148,6 +2293,18 @@ type ListDiskPartitionsApiParams struct {
 		PageNum *int32
 }
 
+func (a *MonitoringAndLogsApiService) ListDiskPartitionsWithParams(ctx context.Context, args *ListDiskPartitionsApiParams) ListDiskPartitionsApiRequest {
+	return ListDiskPartitionsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListDiskPartitionsApiRequest) IncludeCount(includeCount bool) ListDiskPartitionsApiRequest {
 	r.includeCount = &includeCount
@@ -2167,16 +2324,7 @@ func (r ListDiskPartitionsApiRequest) PageNum(pageNum int32) ListDiskPartitionsA
 }
 
 func (r ListDiskPartitionsApiRequest) Execute() (*PaginatedDiskPartition, *http.Response, error) {
-	return r.ApiService.ListDiskPartitionsExecute(r)
-}
-
-func (r ListDiskPartitionsApiRequest) ExecuteWithParams(params *ListDiskPartitionsApiParams) (*PaginatedDiskPartition, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listDiskPartitionsExecute(r)
 }
 
 /*
@@ -2200,7 +2348,7 @@ func (a *MonitoringAndLogsApiService) ListDiskPartitions(ctx context.Context, gr
 
 // Execute executes the request
 //  @return PaginatedDiskPartition
-func (a *MonitoringAndLogsApiService) ListDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) listDiskPartitionsExecute(r ListDiskPartitionsApiRequest) (*PaginatedDiskPartition, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2336,6 +2484,22 @@ type ListIndexMetricsApiParams struct {
 		End *time.Time
 }
 
+func (a *MonitoringAndLogsApiService) ListIndexMetricsWithParams(ctx context.Context, args *ListIndexMetricsApiParams) ListIndexMetricsApiRequest {
+	return ListIndexMetricsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		processId: args.ProcessId,
+		databaseName: args.DatabaseName,
+		collectionName: args.CollectionName,
+		groupId: args.GroupId,
+		granularity: args.Granularity,
+		metrics: args.Metrics,
+		period: args.Period,
+		start: args.Start,
+		end: args.End,
+	}
+}
+
 // Duration that specifies the interval at which Atlas reports the metrics. This parameter expresses its value in the ISO 8601 duration format in UTC.
 func (r ListIndexMetricsApiRequest) Granularity(granularity string) ListIndexMetricsApiRequest {
 	r.granularity = &granularity
@@ -2367,20 +2531,7 @@ func (r ListIndexMetricsApiRequest) End(end time.Time) ListIndexMetricsApiReques
 }
 
 func (r ListIndexMetricsApiRequest) Execute() (*MeasurementsIndexes, *http.Response, error) {
-	return r.ApiService.ListIndexMetricsExecute(r)
-}
-
-func (r ListIndexMetricsApiRequest) ExecuteWithParams(params *ListIndexMetricsApiParams) (*MeasurementsIndexes, *http.Response, error) {
-	r.processId = params.ProcessId 
-	r.databaseName = params.DatabaseName 
-	r.collectionName = params.CollectionName 
-	r.groupId = params.GroupId 
-	r.granularity = params.Granularity 
-	r.metrics = params.Metrics 
-	r.period = params.Period 
-	r.start = params.Start 
-	r.end = params.End 
-	return r.Execute()
+	return r.ApiService.listIndexMetricsExecute(r)
 }
 
 /*
@@ -2408,7 +2559,7 @@ func (a *MonitoringAndLogsApiService) ListIndexMetrics(ctx context.Context, proc
 
 // Execute executes the request
 //  @return MeasurementsIndexes
-func (a *MonitoringAndLogsApiService) ListIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) listIndexMetricsExecute(r ListIndexMetricsApiRequest) (*MeasurementsIndexes, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2541,14 +2692,17 @@ type ListMetricTypesApiParams struct {
 		GroupId string
 }
 
-func (r ListMetricTypesApiRequest) Execute() (*FTSMetrics, *http.Response, error) {
-	return r.ApiService.ListMetricTypesExecute(r)
+func (a *MonitoringAndLogsApiService) ListMetricTypesWithParams(ctx context.Context, args *ListMetricTypesApiParams) ListMetricTypesApiRequest {
+	return ListMetricTypesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		processId: args.ProcessId,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ListMetricTypesApiRequest) ExecuteWithParams(params *ListMetricTypesApiParams) (*FTSMetrics, *http.Response, error) {
-	r.processId = params.ProcessId 
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ListMetricTypesApiRequest) Execute() (*FTSMetrics, *http.Response, error) {
+	return r.ApiService.listMetricTypesExecute(r)
 }
 
 /*
@@ -2572,7 +2726,7 @@ func (a *MonitoringAndLogsApiService) ListMetricTypes(ctx context.Context, proce
 
 // Execute executes the request
 //  @return FTSMetrics
-func (a *MonitoringAndLogsApiService) ListMetricTypesExecute(r ListMetricTypesApiRequest) (*FTSMetrics, *http.Response, error) {
+func (a *MonitoringAndLogsApiService) listMetricTypesExecute(r ListMetricTypesApiRequest) (*FTSMetrics, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -28,10 +28,18 @@ type MultiCloudClustersApi interface {
 	@return CreateClusterApiRequest
 	*/
 	CreateCluster(ctx context.Context, groupId string) CreateClusterApiRequest
+	/*
+	CreateCluster Create One Multi-Cloud Cluster from One Project
 
-	// CreateClusterExecute executes the request
-	//  @return ClusterDescriptionV15
-	CreateClusterExecute(r CreateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateClusterApiParams - Parameters for the request
+	@return CreateClusterApiRequest}}
+	*/
+	CreateClusterWithParams(ctx context.Context, args *CreateClusterApiParams) CreateClusterApiRequest
+
+	// Interface only available internally
+	createClusterExecute(r CreateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
 
 	/*
 	DeleteCluster Remove One Multi-Cloud Cluster from One Project
@@ -44,9 +52,18 @@ type MultiCloudClustersApi interface {
 	@return DeleteClusterApiRequest
 	*/
 	DeleteCluster(ctx context.Context, groupId string, clusterName string) DeleteClusterApiRequest
+	/*
+	DeleteCluster Remove One Multi-Cloud Cluster from One Project
 
-	// DeleteClusterExecute executes the request
-	DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteClusterApiParams - Parameters for the request
+	@return DeleteClusterApiRequest}}
+	*/
+	DeleteClusterWithParams(ctx context.Context, args *DeleteClusterApiParams) DeleteClusterApiRequest
+
+	// Interface only available internally
+	deleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error)
 
 	/*
 	GetCluster Return One Multi-Cloud Cluster from One Project
@@ -59,10 +76,18 @@ type MultiCloudClustersApi interface {
 	@return GetClusterApiRequest
 	*/
 	GetCluster(ctx context.Context, groupId string, clusterName string) GetClusterApiRequest
+	/*
+	GetCluster Return One Multi-Cloud Cluster from One Project
 
-	// GetClusterExecute executes the request
-	//  @return ClusterDescriptionV15
-	GetClusterExecute(r GetClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetClusterApiParams - Parameters for the request
+	@return GetClusterApiRequest}}
+	*/
+	GetClusterWithParams(ctx context.Context, args *GetClusterApiParams) GetClusterApiRequest
+
+	// Interface only available internally
+	getClusterExecute(r GetClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
 
 	/*
 	ListClusters Return All Multi-Cloud Clusters from One Project
@@ -74,10 +99,18 @@ type MultiCloudClustersApi interface {
 	@return ListClustersApiRequest
 	*/
 	ListClusters(ctx context.Context, groupId string) ListClustersApiRequest
+	/*
+	ListClusters Return All Multi-Cloud Clusters from One Project
 
-	// ListClustersExecute executes the request
-	//  @return PaginatedClusterDescriptionV15
-	ListClustersExecute(r ListClustersApiRequest) (*PaginatedClusterDescriptionV15, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListClustersApiParams - Parameters for the request
+	@return ListClustersApiRequest}}
+	*/
+	ListClustersWithParams(ctx context.Context, args *ListClustersApiParams) ListClustersApiRequest
+
+	// Interface only available internally
+	listClustersExecute(r ListClustersApiRequest) (*PaginatedClusterDescriptionV15, *http.Response, error)
 
 	/*
 	TestFailover Test Failover for One Multi-Cloud Cluster
@@ -90,9 +123,18 @@ type MultiCloudClustersApi interface {
 	@return TestFailoverApiRequest
 	*/
 	TestFailover(ctx context.Context, groupId string, clusterName string) TestFailoverApiRequest
+	/*
+	TestFailover Test Failover for One Multi-Cloud Cluster
 
-	// TestFailoverExecute executes the request
-	TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param TestFailoverApiParams - Parameters for the request
+	@return TestFailoverApiRequest}}
+	*/
+	TestFailoverWithParams(ctx context.Context, args *TestFailoverApiParams) TestFailoverApiRequest
+
+	// Interface only available internally
+	testFailoverExecute(r TestFailoverApiRequest) (*http.Response, error)
 
 	/*
 	UpdateCluster Modify One Multi-Cloud Cluster from One Project
@@ -105,10 +147,18 @@ type MultiCloudClustersApi interface {
 	@return UpdateClusterApiRequest
 	*/
 	UpdateCluster(ctx context.Context, groupId string, clusterName string) UpdateClusterApiRequest
+	/*
+	UpdateCluster Modify One Multi-Cloud Cluster from One Project
 
-	// UpdateClusterExecute executes the request
-	//  @return ClusterDescriptionV15
-	UpdateClusterExecute(r UpdateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateClusterApiParams - Parameters for the request
+	@return UpdateClusterApiRequest}}
+	*/
+	UpdateClusterWithParams(ctx context.Context, args *UpdateClusterApiParams) UpdateClusterApiRequest
+
+	// Interface only available internally
+	updateClusterExecute(r UpdateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error)
 }
 
 // MultiCloudClustersApiService MultiCloudClustersApi service
@@ -126,6 +176,15 @@ type CreateClusterApiParams struct {
 		ClusterDescriptionV15 *ClusterDescriptionV15
 }
 
+func (a *MultiCloudClustersApiService) CreateClusterWithParams(ctx context.Context, args *CreateClusterApiParams) CreateClusterApiRequest {
+	return CreateClusterApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterDescriptionV15: args.ClusterDescriptionV15,
+	}
+}
+
 // Cluster to create in the specific project.
 func (r CreateClusterApiRequest) ClusterDescriptionV15(clusterDescriptionV15 ClusterDescriptionV15) CreateClusterApiRequest {
 	r.clusterDescriptionV15 = &clusterDescriptionV15
@@ -133,13 +192,7 @@ func (r CreateClusterApiRequest) ClusterDescriptionV15(clusterDescriptionV15 Clu
 }
 
 func (r CreateClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
-	return r.ApiService.CreateClusterExecute(r)
-}
-
-func (r CreateClusterApiRequest) ExecuteWithParams(params *CreateClusterApiParams) (*ClusterDescriptionV15, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterDescriptionV15 = params.ClusterDescriptionV15 
-	return r.Execute()
+	return r.ApiService.createClusterExecute(r)
 }
 
 /*
@@ -161,7 +214,7 @@ func (a *MultiCloudClustersApiService) CreateCluster(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return ClusterDescriptionV15
-func (a *MultiCloudClustersApiService) CreateClusterExecute(r CreateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) createClusterExecute(r CreateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -268,6 +321,16 @@ type DeleteClusterApiParams struct {
 		RetainBackups *bool
 }
 
+func (a *MultiCloudClustersApiService) DeleteClusterWithParams(ctx context.Context, args *DeleteClusterApiParams) DeleteClusterApiRequest {
+	return DeleteClusterApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		retainBackups: args.RetainBackups,
+	}
+}
+
 // Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.
 func (r DeleteClusterApiRequest) RetainBackups(retainBackups bool) DeleteClusterApiRequest {
 	r.retainBackups = &retainBackups
@@ -275,14 +338,7 @@ func (r DeleteClusterApiRequest) RetainBackups(retainBackups bool) DeleteCluster
 }
 
 func (r DeleteClusterApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteClusterExecute(r)
-}
-
-func (r DeleteClusterApiRequest) ExecuteWithParams(params *DeleteClusterApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.retainBackups = params.RetainBackups 
-	return r.Execute()
+	return r.ApiService.deleteClusterExecute(r)
 }
 
 /*
@@ -305,7 +361,7 @@ func (a *MultiCloudClustersApiService) DeleteCluster(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *MultiCloudClustersApiService) DeleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error) {
+func (a *MultiCloudClustersApiService) deleteClusterExecute(r DeleteClusterApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -405,14 +461,17 @@ type GetClusterApiParams struct {
 		ClusterName string
 }
 
-func (r GetClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
-	return r.ApiService.GetClusterExecute(r)
+func (a *MultiCloudClustersApiService) GetClusterWithParams(ctx context.Context, args *GetClusterApiParams) GetClusterApiRequest {
+	return GetClusterApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetClusterApiRequest) ExecuteWithParams(params *GetClusterApiParams) (*ClusterDescriptionV15, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
+	return r.ApiService.getClusterExecute(r)
 }
 
 /*
@@ -436,7 +495,7 @@ func (a *MultiCloudClustersApiService) GetCluster(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return ClusterDescriptionV15
-func (a *MultiCloudClustersApiService) GetClusterExecute(r GetClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) getClusterExecute(r GetClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -547,6 +606,17 @@ type ListClustersApiParams struct {
 		PageNum *int32
 }
 
+func (a *MultiCloudClustersApiService) ListClustersWithParams(ctx context.Context, args *ListClustersApiParams) ListClustersApiRequest {
+	return ListClustersApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListClustersApiRequest) IncludeCount(includeCount bool) ListClustersApiRequest {
 	r.includeCount = &includeCount
@@ -566,15 +636,7 @@ func (r ListClustersApiRequest) PageNum(pageNum int32) ListClustersApiRequest {
 }
 
 func (r ListClustersApiRequest) Execute() (*PaginatedClusterDescriptionV15, *http.Response, error) {
-	return r.ApiService.ListClustersExecute(r)
-}
-
-func (r ListClustersApiRequest) ExecuteWithParams(params *ListClustersApiParams) (*PaginatedClusterDescriptionV15, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listClustersExecute(r)
 }
 
 /*
@@ -596,7 +658,7 @@ func (a *MultiCloudClustersApiService) ListClusters(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return PaginatedClusterDescriptionV15
-func (a *MultiCloudClustersApiService) ListClustersExecute(r ListClustersApiRequest) (*PaginatedClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) listClustersExecute(r ListClustersApiRequest) (*PaginatedClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -717,14 +779,17 @@ type TestFailoverApiParams struct {
 		ClusterName string
 }
 
-func (r TestFailoverApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.TestFailoverExecute(r)
+func (a *MultiCloudClustersApiService) TestFailoverWithParams(ctx context.Context, args *TestFailoverApiParams) TestFailoverApiRequest {
+	return TestFailoverApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r TestFailoverApiRequest) ExecuteWithParams(params *TestFailoverApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r TestFailoverApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.testFailoverExecute(r)
 }
 
 /*
@@ -747,7 +812,7 @@ func (a *MultiCloudClustersApiService) TestFailover(ctx context.Context, groupId
 }
 
 // Execute executes the request
-func (a *MultiCloudClustersApiService) TestFailoverExecute(r TestFailoverApiRequest) (*http.Response, error) {
+func (a *MultiCloudClustersApiService) testFailoverExecute(r TestFailoverApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -846,6 +911,16 @@ type UpdateClusterApiParams struct {
 		ClusterDescriptionV15 *ClusterDescriptionV15
 }
 
+func (a *MultiCloudClustersApiService) UpdateClusterWithParams(ctx context.Context, args *UpdateClusterApiParams) UpdateClusterApiRequest {
+	return UpdateClusterApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		clusterDescriptionV15: args.ClusterDescriptionV15,
+	}
+}
+
 // Cluster to update in the specified project.
 func (r UpdateClusterApiRequest) ClusterDescriptionV15(clusterDescriptionV15 ClusterDescriptionV15) UpdateClusterApiRequest {
 	r.clusterDescriptionV15 = &clusterDescriptionV15
@@ -853,14 +928,7 @@ func (r UpdateClusterApiRequest) ClusterDescriptionV15(clusterDescriptionV15 Clu
 }
 
 func (r UpdateClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
-	return r.ApiService.UpdateClusterExecute(r)
-}
-
-func (r UpdateClusterApiRequest) ExecuteWithParams(params *UpdateClusterApiParams) (*ClusterDescriptionV15, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.clusterDescriptionV15 = params.ClusterDescriptionV15 
-	return r.Execute()
+	return r.ApiService.updateClusterExecute(r)
 }
 
 /*
@@ -884,7 +952,7 @@ func (a *MultiCloudClustersApiService) UpdateCluster(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return ClusterDescriptionV15
-func (a *MultiCloudClustersApiService) UpdateClusterExecute(r UpdateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
+func (a *MultiCloudClustersApiService) updateClusterExecute(r UpdateClusterApiRequest) (*ClusterDescriptionV15, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -34,7 +34,7 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateClusterApiParams - Parameters for the request
-	@return CreateClusterApiRequest}}
+	@return CreateClusterApiRequest
 	*/
 	CreateClusterWithParams(ctx context.Context, args *CreateClusterApiParams) CreateClusterApiRequest
 
@@ -58,7 +58,7 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteClusterApiParams - Parameters for the request
-	@return DeleteClusterApiRequest}}
+	@return DeleteClusterApiRequest
 	*/
 	DeleteClusterWithParams(ctx context.Context, args *DeleteClusterApiParams) DeleteClusterApiRequest
 
@@ -82,7 +82,7 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetClusterApiParams - Parameters for the request
-	@return GetClusterApiRequest}}
+	@return GetClusterApiRequest
 	*/
 	GetClusterWithParams(ctx context.Context, args *GetClusterApiParams) GetClusterApiRequest
 
@@ -105,7 +105,7 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListClustersApiParams - Parameters for the request
-	@return ListClustersApiRequest}}
+	@return ListClustersApiRequest
 	*/
 	ListClustersWithParams(ctx context.Context, args *ListClustersApiParams) ListClustersApiRequest
 
@@ -129,7 +129,7 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param TestFailoverApiParams - Parameters for the request
-	@return TestFailoverApiRequest}}
+	@return TestFailoverApiRequest
 	*/
 	TestFailoverWithParams(ctx context.Context, args *TestFailoverApiParams) TestFailoverApiRequest
 
@@ -153,7 +153,7 @@ type MultiCloudClustersApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateClusterApiParams - Parameters for the request
-	@return UpdateClusterApiRequest}}
+	@return UpdateClusterApiRequest
 	*/
 	UpdateClusterWithParams(ctx context.Context, args *UpdateClusterApiParams) UpdateClusterApiRequest
 

--- a/mongodbatlasv2/api_multi_cloud_clusters.go
+++ b/mongodbatlasv2/api_multi_cloud_clusters.go
@@ -136,6 +136,12 @@ func (r CreateClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Respon
 	return r.ApiService.CreateClusterExecute(r)
 }
 
+func (r CreateClusterApiRequest) ExecuteWithParams(params *CreateClusterApiParams) (*ClusterDescriptionV15, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterDescriptionV15 = params.ClusterDescriptionV15 
+	return r.Execute()
+}
+
 /*
 CreateCluster Create One Multi-Cloud Cluster from One Project
 
@@ -272,6 +278,13 @@ func (r DeleteClusterApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteClusterExecute(r)
 }
 
+func (r DeleteClusterApiRequest) ExecuteWithParams(params *DeleteClusterApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.retainBackups = params.RetainBackups 
+	return r.Execute()
+}
+
 /*
 DeleteCluster Remove One Multi-Cloud Cluster from One Project
 
@@ -394,6 +407,12 @@ type GetClusterApiParams struct {
 
 func (r GetClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
 	return r.ApiService.GetClusterExecute(r)
+}
+
+func (r GetClusterApiRequest) ExecuteWithParams(params *GetClusterApiParams) (*ClusterDescriptionV15, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*
@@ -550,6 +569,14 @@ func (r ListClustersApiRequest) Execute() (*PaginatedClusterDescriptionV15, *htt
 	return r.ApiService.ListClustersExecute(r)
 }
 
+func (r ListClustersApiRequest) ExecuteWithParams(params *ListClustersApiParams) (*PaginatedClusterDescriptionV15, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListClusters Return All Multi-Cloud Clusters from One Project
 
@@ -694,6 +721,12 @@ func (r TestFailoverApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.TestFailoverExecute(r)
 }
 
+func (r TestFailoverApiRequest) ExecuteWithParams(params *TestFailoverApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
+}
+
 /*
 TestFailover Test Failover for One Multi-Cloud Cluster
 
@@ -821,6 +854,13 @@ func (r UpdateClusterApiRequest) ClusterDescriptionV15(clusterDescriptionV15 Clu
 
 func (r UpdateClusterApiRequest) Execute() (*ClusterDescriptionV15, *http.Response, error) {
 	return r.ApiService.UpdateClusterExecute(r)
+}
+
+func (r UpdateClusterApiRequest) ExecuteWithParams(params *UpdateClusterApiParams) (*ClusterDescriptionV15, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.clusterDescriptionV15 = params.ClusterDescriptionV15 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -249,6 +249,12 @@ func (r CreatePeeringConnectionApiRequest) Execute() (*CreatePeeringConnection20
 	return r.ApiService.CreatePeeringConnectionExecute(r)
 }
 
+func (r CreatePeeringConnectionApiRequest) ExecuteWithParams(params *CreatePeeringConnectionApiParams) (*CreatePeeringConnection200Response, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.containerPeerViewRequest = params.ContainerPeerViewRequest 
+	return r.Execute()
+}
+
 /*
 CreatePeeringConnection Create One New Network Peering Connection
 
@@ -383,6 +389,12 @@ func (r CreatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *h
 	return r.ApiService.CreatePeeringContainerExecute(r)
 }
 
+func (r CreatePeeringContainerApiRequest) ExecuteWithParams(params *CreatePeeringContainerApiParams) (*CloudProviderContainer, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProviderContainer = params.CloudProviderContainer 
+	return r.Execute()
+}
+
 /*
 CreatePeeringContainer Create One New Network Peering Container
 
@@ -511,6 +523,12 @@ func (r DeletePeeringConnectionApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePeeringConnectionExecute(r)
 }
 
+func (r DeletePeeringConnectionApiRequest) ExecuteWithParams(params *DeletePeeringConnectionApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.peerId = params.PeerId 
+	return r.Execute()
+}
+
 /*
 DeletePeeringConnection Remove One Existing Network Peering Connection
 
@@ -630,6 +648,12 @@ type DeletePeeringContainerApiParams struct {
 
 func (r DeletePeeringContainerApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePeeringContainerExecute(r)
+}
+
+func (r DeletePeeringContainerApiRequest) ExecuteWithParams(params *DeletePeeringContainerApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.containerId = params.ContainerId 
+	return r.Execute()
 }
 
 /*
@@ -757,6 +781,12 @@ func (r DisablePeeringApiRequest) PrivateIPMode(privateIPMode PrivateIPMode) Dis
 
 func (r DisablePeeringApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
 	return r.ApiService.DisablePeeringExecute(r)
+}
+
+func (r DisablePeeringApiRequest) ExecuteWithParams(params *DisablePeeringApiParams) (*PrivateIPMode, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.privateIPMode = params.PrivateIPMode 
+	return r.Execute()
 }
 
 /*
@@ -890,6 +920,12 @@ func (r GetPeeringConnectionApiRequest) Execute() (*GetPeeringConnection200Respo
 	return r.ApiService.GetPeeringConnectionExecute(r)
 }
 
+func (r GetPeeringConnectionApiRequest) ExecuteWithParams(params *GetPeeringConnectionApiParams) (*GetPeeringConnection200Response, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.peerId = params.PeerId 
+	return r.Execute()
+}
+
 /*
 GetPeeringConnection Return One Network Peering Connection in One Project
 
@@ -1020,6 +1056,12 @@ type GetPeeringContainerApiParams struct {
 
 func (r GetPeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
 	return r.ApiService.GetPeeringContainerExecute(r)
+}
+
+func (r GetPeeringContainerApiRequest) ExecuteWithParams(params *GetPeeringContainerApiParams) (*CloudProviderContainer, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.containerId = params.ContainerId 
+	return r.Execute()
 }
 
 /*
@@ -1182,6 +1224,15 @@ func (r ListPeeringConnectionsApiRequest) ProviderName(providerName string) List
 
 func (r ListPeeringConnectionsApiRequest) Execute() (*ListPeeringConnections200Response, *http.Response, error) {
 	return r.ApiService.ListPeeringConnectionsExecute(r)
+}
+
+func (r ListPeeringConnectionsApiRequest) ExecuteWithParams(params *ListPeeringConnectionsApiParams) (*ListPeeringConnections200Response, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.providerName = params.ProviderName 
+	return r.Execute()
 }
 
 /*
@@ -1365,6 +1416,15 @@ func (r ListPeeringContainerByCloudProviderApiRequest) Execute() (*PaginatedClou
 	return r.ApiService.ListPeeringContainerByCloudProviderExecute(r)
 }
 
+func (r ListPeeringContainerByCloudProviderApiRequest) ExecuteWithParams(params *ListPeeringContainerByCloudProviderApiParams) (*PaginatedCloudProviderContainer, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.providerName = params.ProviderName 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListPeeringContainerByCloudProvider Return All Network Peering Containers in One Project for One Cloud Provider
 
@@ -1535,6 +1595,14 @@ func (r ListPeeringContainersApiRequest) Execute() (*PaginatedCloudProviderConta
 	return r.ApiService.ListPeeringContainersExecute(r)
 }
 
+func (r ListPeeringContainersApiRequest) ExecuteWithParams(params *ListPeeringContainersApiParams) (*PaginatedCloudProviderContainer, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListPeeringContainers Return All Network Peering Containers in One Project
 
@@ -1687,6 +1755,13 @@ func (r UpdatePeeringConnectionApiRequest) Execute() (*GetPeeringConnection200Re
 	return r.ApiService.UpdatePeeringConnectionExecute(r)
 }
 
+func (r UpdatePeeringConnectionApiRequest) ExecuteWithParams(params *UpdatePeeringConnectionApiParams) (*GetPeeringConnection200Response, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.peerId = params.PeerId 
+	r.containerPeerViewRequest = params.ContainerPeerViewRequest 
+	return r.Execute()
+}
+
 /*
 UpdatePeeringConnection Update One New Network Peering Connection
 
@@ -1832,6 +1907,13 @@ func (r UpdatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *h
 	return r.ApiService.UpdatePeeringContainerExecute(r)
 }
 
+func (r UpdatePeeringContainerApiRequest) ExecuteWithParams(params *UpdatePeeringContainerApiParams) (*CloudProviderContainer, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.containerId = params.ContainerId 
+	r.cloudProviderContainer = params.CloudProviderContainer 
+	return r.Execute()
+}
+
 /*
 UpdatePeeringContainer Update One Network Peering Container
 
@@ -1965,6 +2047,11 @@ type VerifyConnectViaPeeringOnlyModeForOneProjectApiParams struct {
 
 func (r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
 	return r.ApiService.VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r)
+}
+
+func (r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) ExecuteWithParams(params *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) (*PrivateIPMode, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -34,7 +34,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreatePeeringConnectionApiParams - Parameters for the request
-	@return CreatePeeringConnectionApiRequest}}
+	@return CreatePeeringConnectionApiRequest
 	*/
 	CreatePeeringConnectionWithParams(ctx context.Context, args *CreatePeeringConnectionApiParams) CreatePeeringConnectionApiRequest
 
@@ -57,7 +57,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreatePeeringContainerApiParams - Parameters for the request
-	@return CreatePeeringContainerApiRequest}}
+	@return CreatePeeringContainerApiRequest
 	*/
 	CreatePeeringContainerWithParams(ctx context.Context, args *CreatePeeringContainerApiParams) CreatePeeringContainerApiRequest
 
@@ -81,7 +81,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeletePeeringConnectionApiParams - Parameters for the request
-	@return DeletePeeringConnectionApiRequest}}
+	@return DeletePeeringConnectionApiRequest
 	*/
 	DeletePeeringConnectionWithParams(ctx context.Context, args *DeletePeeringConnectionApiParams) DeletePeeringConnectionApiRequest
 
@@ -105,7 +105,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeletePeeringContainerApiParams - Parameters for the request
-	@return DeletePeeringContainerApiRequest}}
+	@return DeletePeeringContainerApiRequest
 	*/
 	DeletePeeringContainerWithParams(ctx context.Context, args *DeletePeeringContainerApiParams) DeletePeeringContainerApiRequest
 
@@ -121,7 +121,7 @@ type NetworkPeeringApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@return DisablePeeringApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	DisablePeering(ctx context.Context, groupId string) DisablePeeringApiRequest
 	/*
@@ -130,9 +130,9 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DisablePeeringApiParams - Parameters for the request
-	@return DisablePeeringApiRequest}}
+	@return DisablePeeringApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	DisablePeeringWithParams(ctx context.Context, args *DisablePeeringApiParams) DisablePeeringApiRequest
 
@@ -156,7 +156,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetPeeringConnectionApiParams - Parameters for the request
-	@return GetPeeringConnectionApiRequest}}
+	@return GetPeeringConnectionApiRequest
 	*/
 	GetPeeringConnectionWithParams(ctx context.Context, args *GetPeeringConnectionApiParams) GetPeeringConnectionApiRequest
 
@@ -180,7 +180,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetPeeringContainerApiParams - Parameters for the request
-	@return GetPeeringContainerApiRequest}}
+	@return GetPeeringContainerApiRequest
 	*/
 	GetPeeringContainerWithParams(ctx context.Context, args *GetPeeringContainerApiParams) GetPeeringContainerApiRequest
 
@@ -203,7 +203,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPeeringConnectionsApiParams - Parameters for the request
-	@return ListPeeringConnectionsApiRequest}}
+	@return ListPeeringConnectionsApiRequest
 	*/
 	ListPeeringConnectionsWithParams(ctx context.Context, args *ListPeeringConnectionsApiParams) ListPeeringConnectionsApiRequest
 
@@ -226,7 +226,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPeeringContainerByCloudProviderApiParams - Parameters for the request
-	@return ListPeeringContainerByCloudProviderApiRequest}}
+	@return ListPeeringContainerByCloudProviderApiRequest
 	*/
 	ListPeeringContainerByCloudProviderWithParams(ctx context.Context, args *ListPeeringContainerByCloudProviderApiParams) ListPeeringContainerByCloudProviderApiRequest
 
@@ -249,7 +249,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPeeringContainersApiParams - Parameters for the request
-	@return ListPeeringContainersApiRequest}}
+	@return ListPeeringContainersApiRequest
 	*/
 	ListPeeringContainersWithParams(ctx context.Context, args *ListPeeringContainersApiParams) ListPeeringContainersApiRequest
 
@@ -273,7 +273,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdatePeeringConnectionApiParams - Parameters for the request
-	@return UpdatePeeringConnectionApiRequest}}
+	@return UpdatePeeringConnectionApiRequest
 	*/
 	UpdatePeeringConnectionWithParams(ctx context.Context, args *UpdatePeeringConnectionApiParams) UpdatePeeringConnectionApiRequest
 
@@ -297,7 +297,7 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdatePeeringContainerApiParams - Parameters for the request
-	@return UpdatePeeringContainerApiRequest}}
+	@return UpdatePeeringContainerApiRequest
 	*/
 	UpdatePeeringContainerWithParams(ctx context.Context, args *UpdatePeeringContainerApiParams) UpdatePeeringContainerApiRequest
 
@@ -313,7 +313,7 @@ type NetworkPeeringApi interface {
 	@param groupId Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 	@return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	VerifyConnectViaPeeringOnlyModeForOneProject(ctx context.Context, groupId string) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 	/*
@@ -322,9 +322,9 @@ type NetworkPeeringApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param VerifyConnectViaPeeringOnlyModeForOneProjectApiParams - Parameters for the request
-	@return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest}}
+	@return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
+	Deprecated: this method has been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx context.Context, args *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -28,10 +28,18 @@ type NetworkPeeringApi interface {
 	@return CreatePeeringConnectionApiRequest
 	*/
 	CreatePeeringConnection(ctx context.Context, groupId string) CreatePeeringConnectionApiRequest
+	/*
+	CreatePeeringConnection Create One New Network Peering Connection
 
-	// CreatePeeringConnectionExecute executes the request
-	//  @return CreatePeeringConnection200Response
-	CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*CreatePeeringConnection200Response, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreatePeeringConnectionApiParams - Parameters for the request
+	@return CreatePeeringConnectionApiRequest}}
+	*/
+	CreatePeeringConnectionWithParams(ctx context.Context, args *CreatePeeringConnectionApiParams) CreatePeeringConnectionApiRequest
+
+	// Interface only available internally
+	createPeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*CreatePeeringConnection200Response, *http.Response, error)
 
 	/*
 	CreatePeeringContainer Create One New Network Peering Container
@@ -43,10 +51,18 @@ type NetworkPeeringApi interface {
 	@return CreatePeeringContainerApiRequest
 	*/
 	CreatePeeringContainer(ctx context.Context, groupId string) CreatePeeringContainerApiRequest
+	/*
+	CreatePeeringContainer Create One New Network Peering Container
 
-	// CreatePeeringContainerExecute executes the request
-	//  @return CloudProviderContainer
-	CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreatePeeringContainerApiParams - Parameters for the request
+	@return CreatePeeringContainerApiRequest}}
+	*/
+	CreatePeeringContainerWithParams(ctx context.Context, args *CreatePeeringContainerApiParams) CreatePeeringContainerApiRequest
+
+	// Interface only available internally
+	createPeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 	DeletePeeringConnection Remove One Existing Network Peering Connection
@@ -59,9 +75,18 @@ type NetworkPeeringApi interface {
 	@return DeletePeeringConnectionApiRequest
 	*/
 	DeletePeeringConnection(ctx context.Context, groupId string, peerId string) DeletePeeringConnectionApiRequest
+	/*
+	DeletePeeringConnection Remove One Existing Network Peering Connection
 
-	// DeletePeeringConnectionExecute executes the request
-	DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeletePeeringConnectionApiParams - Parameters for the request
+	@return DeletePeeringConnectionApiRequest}}
+	*/
+	DeletePeeringConnectionWithParams(ctx context.Context, args *DeletePeeringConnectionApiParams) DeletePeeringConnectionApiRequest
+
+	// Interface only available internally
+	deletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (*http.Response, error)
 
 	/*
 	DeletePeeringContainer Remove One Network Peering Container
@@ -74,9 +99,18 @@ type NetworkPeeringApi interface {
 	@return DeletePeeringContainerApiRequest
 	*/
 	DeletePeeringContainer(ctx context.Context, groupId string, containerId string) DeletePeeringContainerApiRequest
+	/*
+	DeletePeeringContainer Remove One Network Peering Container
 
-	// DeletePeeringContainerExecute executes the request
-	DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeletePeeringContainerApiParams - Parameters for the request
+	@return DeletePeeringContainerApiRequest}}
+	*/
+	DeletePeeringContainerWithParams(ctx context.Context, args *DeletePeeringContainerApiParams) DeletePeeringContainerApiRequest
+
+	// Interface only available internally
+	deletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (*http.Response, error)
 
 	/*
 	DisablePeering Disable Connect via Peering Only Mode for One Project
@@ -90,11 +124,20 @@ type NetworkPeeringApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	DisablePeering(ctx context.Context, groupId string) DisablePeeringApiRequest
+	/*
+	DisablePeering Disable Connect via Peering Only Mode for One Project
 
-	// DisablePeeringExecute executes the request
-	//  @return PrivateIPMode
-	// Deprecated
-	DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DisablePeeringApiParams - Parameters for the request
+	@return DisablePeeringApiRequest}}
+
+	Deprecated
+	*/
+	DisablePeeringWithParams(ctx context.Context, args *DisablePeeringApiParams) DisablePeeringApiRequest
+
+	// Interface only available internally
+	disablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error)
 
 	/*
 	GetPeeringConnection Return One Network Peering Connection in One Project
@@ -107,10 +150,18 @@ type NetworkPeeringApi interface {
 	@return GetPeeringConnectionApiRequest
 	*/
 	GetPeeringConnection(ctx context.Context, groupId string, peerId string) GetPeeringConnectionApiRequest
+	/*
+	GetPeeringConnection Return One Network Peering Connection in One Project
 
-	// GetPeeringConnectionExecute executes the request
-	//  @return GetPeeringConnection200Response
-	GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetPeeringConnectionApiParams - Parameters for the request
+	@return GetPeeringConnectionApiRequest}}
+	*/
+	GetPeeringConnectionWithParams(ctx context.Context, args *GetPeeringConnectionApiParams) GetPeeringConnectionApiRequest
+
+	// Interface only available internally
+	getPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error)
 
 	/*
 	GetPeeringContainer Return One Network Peering Container
@@ -123,10 +174,18 @@ type NetworkPeeringApi interface {
 	@return GetPeeringContainerApiRequest
 	*/
 	GetPeeringContainer(ctx context.Context, groupId string, containerId string) GetPeeringContainerApiRequest
+	/*
+	GetPeeringContainer Return One Network Peering Container
 
-	// GetPeeringContainerExecute executes the request
-	//  @return CloudProviderContainer
-	GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetPeeringContainerApiParams - Parameters for the request
+	@return GetPeeringContainerApiRequest}}
+	*/
+	GetPeeringContainerWithParams(ctx context.Context, args *GetPeeringContainerApiParams) GetPeeringContainerApiRequest
+
+	// Interface only available internally
+	getPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 	ListPeeringConnections Return All Network Peering Connections in One Project
@@ -138,10 +197,18 @@ type NetworkPeeringApi interface {
 	@return ListPeeringConnectionsApiRequest
 	*/
 	ListPeeringConnections(ctx context.Context, groupId string) ListPeeringConnectionsApiRequest
+	/*
+	ListPeeringConnections Return All Network Peering Connections in One Project
 
-	// ListPeeringConnectionsExecute executes the request
-	//  @return ListPeeringConnections200Response
-	ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*ListPeeringConnections200Response, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPeeringConnectionsApiParams - Parameters for the request
+	@return ListPeeringConnectionsApiRequest}}
+	*/
+	ListPeeringConnectionsWithParams(ctx context.Context, args *ListPeeringConnectionsApiParams) ListPeeringConnectionsApiRequest
+
+	// Interface only available internally
+	listPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*ListPeeringConnections200Response, *http.Response, error)
 
 	/*
 	ListPeeringContainerByCloudProvider Return All Network Peering Containers in One Project for One Cloud Provider
@@ -153,10 +220,18 @@ type NetworkPeeringApi interface {
 	@return ListPeeringContainerByCloudProviderApiRequest
 	*/
 	ListPeeringContainerByCloudProvider(ctx context.Context, groupId string) ListPeeringContainerByCloudProviderApiRequest
+	/*
+	ListPeeringContainerByCloudProvider Return All Network Peering Containers in One Project for One Cloud Provider
 
-	// ListPeeringContainerByCloudProviderExecute executes the request
-	//  @return PaginatedCloudProviderContainer
-	ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPeeringContainerByCloudProviderApiParams - Parameters for the request
+	@return ListPeeringContainerByCloudProviderApiRequest}}
+	*/
+	ListPeeringContainerByCloudProviderWithParams(ctx context.Context, args *ListPeeringContainerByCloudProviderApiParams) ListPeeringContainerByCloudProviderApiRequest
+
+	// Interface only available internally
+	listPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
 	ListPeeringContainers Return All Network Peering Containers in One Project
@@ -168,10 +243,18 @@ type NetworkPeeringApi interface {
 	@return ListPeeringContainersApiRequest
 	*/
 	ListPeeringContainers(ctx context.Context, groupId string) ListPeeringContainersApiRequest
+	/*
+	ListPeeringContainers Return All Network Peering Containers in One Project
 
-	// ListPeeringContainersExecute executes the request
-	//  @return PaginatedCloudProviderContainer
-	ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPeeringContainersApiParams - Parameters for the request
+	@return ListPeeringContainersApiRequest}}
+	*/
+	ListPeeringContainersWithParams(ctx context.Context, args *ListPeeringContainersApiParams) ListPeeringContainersApiRequest
+
+	// Interface only available internally
+	listPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error)
 
 	/*
 	UpdatePeeringConnection Update One New Network Peering Connection
@@ -184,10 +267,18 @@ type NetworkPeeringApi interface {
 	@return UpdatePeeringConnectionApiRequest
 	*/
 	UpdatePeeringConnection(ctx context.Context, groupId string, peerId string) UpdatePeeringConnectionApiRequest
+	/*
+	UpdatePeeringConnection Update One New Network Peering Connection
 
-	// UpdatePeeringConnectionExecute executes the request
-	//  @return GetPeeringConnection200Response
-	UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdatePeeringConnectionApiParams - Parameters for the request
+	@return UpdatePeeringConnectionApiRequest}}
+	*/
+	UpdatePeeringConnectionWithParams(ctx context.Context, args *UpdatePeeringConnectionApiParams) UpdatePeeringConnectionApiRequest
+
+	// Interface only available internally
+	updatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error)
 
 	/*
 	UpdatePeeringContainer Update One Network Peering Container
@@ -200,10 +291,18 @@ type NetworkPeeringApi interface {
 	@return UpdatePeeringContainerApiRequest
 	*/
 	UpdatePeeringContainer(ctx context.Context, groupId string, containerId string) UpdatePeeringContainerApiRequest
+	/*
+	UpdatePeeringContainer Update One Network Peering Container
 
-	// UpdatePeeringContainerExecute executes the request
-	//  @return CloudProviderContainer
-	UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdatePeeringContainerApiParams - Parameters for the request
+	@return UpdatePeeringContainerApiRequest}}
+	*/
+	UpdatePeeringContainerWithParams(ctx context.Context, args *UpdatePeeringContainerApiParams) UpdatePeeringContainerApiRequest
+
+	// Interface only available internally
+	updatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error)
 
 	/*
 	VerifyConnectViaPeeringOnlyModeForOneProject Verify Connect via Peering Only Mode for One Project
@@ -217,11 +316,20 @@ type NetworkPeeringApi interface {
 	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	VerifyConnectViaPeeringOnlyModeForOneProject(ctx context.Context, groupId string) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
+	/*
+	VerifyConnectViaPeeringOnlyModeForOneProject Verify Connect via Peering Only Mode for One Project
 
-	// VerifyConnectViaPeeringOnlyModeForOneProjectExecute executes the request
-	//  @return PrivateIPMode
-	// Deprecated
-	VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param VerifyConnectViaPeeringOnlyModeForOneProjectApiParams - Parameters for the request
+	@return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest}}
+
+	Deprecated
+	*/
+	VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx context.Context, args *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
+
+	// Interface only available internally
+	verifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error)
 }
 
 // NetworkPeeringApiService NetworkPeeringApi service
@@ -239,6 +347,15 @@ type CreatePeeringConnectionApiParams struct {
 		ContainerPeerViewRequest *ContainerPeerViewRequest
 }
 
+func (a *NetworkPeeringApiService) CreatePeeringConnectionWithParams(ctx context.Context, args *CreatePeeringConnectionApiParams) CreatePeeringConnectionApiRequest {
+	return CreatePeeringConnectionApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		containerPeerViewRequest: args.ContainerPeerViewRequest,
+	}
+}
+
 // Create one network peering connection.
 func (r CreatePeeringConnectionApiRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) CreatePeeringConnectionApiRequest {
 	r.containerPeerViewRequest = &containerPeerViewRequest
@@ -246,13 +363,7 @@ func (r CreatePeeringConnectionApiRequest) ContainerPeerViewRequest(containerPee
 }
 
 func (r CreatePeeringConnectionApiRequest) Execute() (*CreatePeeringConnection200Response, *http.Response, error) {
-	return r.ApiService.CreatePeeringConnectionExecute(r)
-}
-
-func (r CreatePeeringConnectionApiRequest) ExecuteWithParams(params *CreatePeeringConnectionApiParams) (*CreatePeeringConnection200Response, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.containerPeerViewRequest = params.ContainerPeerViewRequest 
-	return r.Execute()
+	return r.ApiService.createPeeringConnectionExecute(r)
 }
 
 /*
@@ -274,7 +385,7 @@ func (a *NetworkPeeringApiService) CreatePeeringConnection(ctx context.Context, 
 
 // Execute executes the request
 //  @return CreatePeeringConnection200Response
-func (a *NetworkPeeringApiService) CreatePeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*CreatePeeringConnection200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) createPeeringConnectionExecute(r CreatePeeringConnectionApiRequest) (*CreatePeeringConnection200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -379,6 +490,15 @@ type CreatePeeringContainerApiParams struct {
 		CloudProviderContainer *CloudProviderContainer
 }
 
+func (a *NetworkPeeringApiService) CreatePeeringContainerWithParams(ctx context.Context, args *CreatePeeringContainerApiParams) CreatePeeringContainerApiRequest {
+	return CreatePeeringContainerApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProviderContainer: args.CloudProviderContainer,
+	}
+}
+
 // Creates one new network peering container in the specified project.
 func (r CreatePeeringContainerApiRequest) CloudProviderContainer(cloudProviderContainer CloudProviderContainer) CreatePeeringContainerApiRequest {
 	r.cloudProviderContainer = &cloudProviderContainer
@@ -386,13 +506,7 @@ func (r CreatePeeringContainerApiRequest) CloudProviderContainer(cloudProviderCo
 }
 
 func (r CreatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
-	return r.ApiService.CreatePeeringContainerExecute(r)
-}
-
-func (r CreatePeeringContainerApiRequest) ExecuteWithParams(params *CreatePeeringContainerApiParams) (*CloudProviderContainer, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProviderContainer = params.CloudProviderContainer 
-	return r.Execute()
+	return r.ApiService.createPeeringContainerExecute(r)
 }
 
 /*
@@ -414,7 +528,7 @@ func (a *NetworkPeeringApiService) CreatePeeringContainer(ctx context.Context, g
 
 // Execute executes the request
 //  @return CloudProviderContainer
-func (a *NetworkPeeringApiService) CreatePeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) createPeeringContainerExecute(r CreatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -519,14 +633,17 @@ type DeletePeeringConnectionApiParams struct {
 		PeerId string
 }
 
-func (r DeletePeeringConnectionApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeletePeeringConnectionExecute(r)
+func (a *NetworkPeeringApiService) DeletePeeringConnectionWithParams(ctx context.Context, args *DeletePeeringConnectionApiParams) DeletePeeringConnectionApiRequest {
+	return DeletePeeringConnectionApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		peerId: args.PeerId,
+	}
 }
 
-func (r DeletePeeringConnectionApiRequest) ExecuteWithParams(params *DeletePeeringConnectionApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.peerId = params.PeerId 
-	return r.Execute()
+func (r DeletePeeringConnectionApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deletePeeringConnectionExecute(r)
 }
 
 /*
@@ -549,7 +666,7 @@ func (a *NetworkPeeringApiService) DeletePeeringConnection(ctx context.Context, 
 }
 
 // Execute executes the request
-func (a *NetworkPeeringApiService) DeletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (*http.Response, error) {
+func (a *NetworkPeeringApiService) deletePeeringConnectionExecute(r DeletePeeringConnectionApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -646,14 +763,17 @@ type DeletePeeringContainerApiParams struct {
 		ContainerId string
 }
 
-func (r DeletePeeringContainerApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeletePeeringContainerExecute(r)
+func (a *NetworkPeeringApiService) DeletePeeringContainerWithParams(ctx context.Context, args *DeletePeeringContainerApiParams) DeletePeeringContainerApiRequest {
+	return DeletePeeringContainerApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		containerId: args.ContainerId,
+	}
 }
 
-func (r DeletePeeringContainerApiRequest) ExecuteWithParams(params *DeletePeeringContainerApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.containerId = params.ContainerId 
-	return r.Execute()
+func (r DeletePeeringContainerApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deletePeeringContainerExecute(r)
 }
 
 /*
@@ -676,7 +796,7 @@ func (a *NetworkPeeringApiService) DeletePeeringContainer(ctx context.Context, g
 }
 
 // Execute executes the request
-func (a *NetworkPeeringApiService) DeletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (*http.Response, error) {
+func (a *NetworkPeeringApiService) deletePeeringContainerExecute(r DeletePeeringContainerApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -773,6 +893,15 @@ type DisablePeeringApiParams struct {
 		PrivateIPMode *PrivateIPMode
 }
 
+func (a *NetworkPeeringApiService) DisablePeeringWithParams(ctx context.Context, args *DisablePeeringApiParams) DisablePeeringApiRequest {
+	return DisablePeeringApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		privateIPMode: args.PrivateIPMode,
+	}
+}
+
 // Disables Connect via Peering Only mode for the specified project.
 func (r DisablePeeringApiRequest) PrivateIPMode(privateIPMode PrivateIPMode) DisablePeeringApiRequest {
 	r.privateIPMode = &privateIPMode
@@ -780,13 +909,7 @@ func (r DisablePeeringApiRequest) PrivateIPMode(privateIPMode PrivateIPMode) Dis
 }
 
 func (r DisablePeeringApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
-	return r.ApiService.DisablePeeringExecute(r)
-}
-
-func (r DisablePeeringApiRequest) ExecuteWithParams(params *DisablePeeringApiParams) (*PrivateIPMode, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.privateIPMode = params.PrivateIPMode 
-	return r.Execute()
+	return r.ApiService.disablePeeringExecute(r)
 }
 
 /*
@@ -811,7 +934,7 @@ func (a *NetworkPeeringApiService) DisablePeering(ctx context.Context, groupId s
 // Execute executes the request
 //  @return PrivateIPMode
 // Deprecated
-func (a *NetworkPeeringApiService) DisablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error) {
+func (a *NetworkPeeringApiService) disablePeeringExecute(r DisablePeeringApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -916,14 +1039,17 @@ type GetPeeringConnectionApiParams struct {
 		PeerId string
 }
 
-func (r GetPeeringConnectionApiRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
-	return r.ApiService.GetPeeringConnectionExecute(r)
+func (a *NetworkPeeringApiService) GetPeeringConnectionWithParams(ctx context.Context, args *GetPeeringConnectionApiParams) GetPeeringConnectionApiRequest {
+	return GetPeeringConnectionApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		peerId: args.PeerId,
+	}
 }
 
-func (r GetPeeringConnectionApiRequest) ExecuteWithParams(params *GetPeeringConnectionApiParams) (*GetPeeringConnection200Response, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.peerId = params.PeerId 
-	return r.Execute()
+func (r GetPeeringConnectionApiRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
+	return r.ApiService.getPeeringConnectionExecute(r)
 }
 
 /*
@@ -947,7 +1073,7 @@ func (a *NetworkPeeringApiService) GetPeeringConnection(ctx context.Context, gro
 
 // Execute executes the request
 //  @return GetPeeringConnection200Response
-func (a *NetworkPeeringApiService) GetPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) getPeeringConnectionExecute(r GetPeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1054,14 +1180,17 @@ type GetPeeringContainerApiParams struct {
 		ContainerId string
 }
 
-func (r GetPeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
-	return r.ApiService.GetPeeringContainerExecute(r)
+func (a *NetworkPeeringApiService) GetPeeringContainerWithParams(ctx context.Context, args *GetPeeringContainerApiParams) GetPeeringContainerApiRequest {
+	return GetPeeringContainerApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		containerId: args.ContainerId,
+	}
 }
 
-func (r GetPeeringContainerApiRequest) ExecuteWithParams(params *GetPeeringContainerApiParams) (*CloudProviderContainer, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.containerId = params.ContainerId 
-	return r.Execute()
+func (r GetPeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
+	return r.ApiService.getPeeringContainerExecute(r)
 }
 
 /*
@@ -1085,7 +1214,7 @@ func (a *NetworkPeeringApiService) GetPeeringContainer(ctx context.Context, grou
 
 // Execute executes the request
 //  @return CloudProviderContainer
-func (a *NetworkPeeringApiService) GetPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) getPeeringContainerExecute(r GetPeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1198,6 +1327,18 @@ type ListPeeringConnectionsApiParams struct {
 		ProviderName *string
 }
 
+func (a *NetworkPeeringApiService) ListPeeringConnectionsWithParams(ctx context.Context, args *ListPeeringConnectionsApiParams) ListPeeringConnectionsApiRequest {
+	return ListPeeringConnectionsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		providerName: args.ProviderName,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListPeeringConnectionsApiRequest) IncludeCount(includeCount bool) ListPeeringConnectionsApiRequest {
 	r.includeCount = &includeCount
@@ -1223,16 +1364,7 @@ func (r ListPeeringConnectionsApiRequest) ProviderName(providerName string) List
 }
 
 func (r ListPeeringConnectionsApiRequest) Execute() (*ListPeeringConnections200Response, *http.Response, error) {
-	return r.ApiService.ListPeeringConnectionsExecute(r)
-}
-
-func (r ListPeeringConnectionsApiRequest) ExecuteWithParams(params *ListPeeringConnectionsApiParams) (*ListPeeringConnections200Response, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.providerName = params.ProviderName 
-	return r.Execute()
+	return r.ApiService.listPeeringConnectionsExecute(r)
 }
 
 /*
@@ -1254,7 +1386,7 @@ func (a *NetworkPeeringApiService) ListPeeringConnections(ctx context.Context, g
 
 // Execute executes the request
 //  @return ListPeeringConnections200Response
-func (a *NetworkPeeringApiService) ListPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*ListPeeringConnections200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) listPeeringConnectionsExecute(r ListPeeringConnectionsApiRequest) (*ListPeeringConnections200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1388,6 +1520,18 @@ type ListPeeringContainerByCloudProviderApiParams struct {
 		PageNum *int32
 }
 
+func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProviderWithParams(ctx context.Context, args *ListPeeringContainerByCloudProviderApiParams) ListPeeringContainerByCloudProviderApiRequest {
+	return ListPeeringContainerByCloudProviderApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		providerName: args.ProviderName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Cloud service provider that serves the desired network peering containers.
 func (r ListPeeringContainerByCloudProviderApiRequest) ProviderName(providerName string) ListPeeringContainerByCloudProviderApiRequest {
 	r.providerName = &providerName
@@ -1413,16 +1557,7 @@ func (r ListPeeringContainerByCloudProviderApiRequest) PageNum(pageNum int32) Li
 }
 
 func (r ListPeeringContainerByCloudProviderApiRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
-	return r.ApiService.ListPeeringContainerByCloudProviderExecute(r)
-}
-
-func (r ListPeeringContainerByCloudProviderApiRequest) ExecuteWithParams(params *ListPeeringContainerByCloudProviderApiParams) (*PaginatedCloudProviderContainer, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.providerName = params.ProviderName 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listPeeringContainerByCloudProviderExecute(r)
 }
 
 /*
@@ -1444,7 +1579,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProvider(ctx conte
 
 // Execute executes the request
 //  @return PaginatedCloudProviderContainer
-func (a *NetworkPeeringApiService) ListPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) listPeeringContainerByCloudProviderExecute(r ListPeeringContainerByCloudProviderApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1573,6 +1708,17 @@ type ListPeeringContainersApiParams struct {
 		PageNum *int32
 }
 
+func (a *NetworkPeeringApiService) ListPeeringContainersWithParams(ctx context.Context, args *ListPeeringContainersApiParams) ListPeeringContainersApiRequest {
+	return ListPeeringContainersApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListPeeringContainersApiRequest) IncludeCount(includeCount bool) ListPeeringContainersApiRequest {
 	r.includeCount = &includeCount
@@ -1592,15 +1738,7 @@ func (r ListPeeringContainersApiRequest) PageNum(pageNum int32) ListPeeringConta
 }
 
 func (r ListPeeringContainersApiRequest) Execute() (*PaginatedCloudProviderContainer, *http.Response, error) {
-	return r.ApiService.ListPeeringContainersExecute(r)
-}
-
-func (r ListPeeringContainersApiRequest) ExecuteWithParams(params *ListPeeringContainersApiParams) (*PaginatedCloudProviderContainer, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listPeeringContainersExecute(r)
 }
 
 /*
@@ -1622,7 +1760,7 @@ func (a *NetworkPeeringApiService) ListPeeringContainers(ctx context.Context, gr
 
 // Execute executes the request
 //  @return PaginatedCloudProviderContainer
-func (a *NetworkPeeringApiService) ListPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) listPeeringContainersExecute(r ListPeeringContainersApiRequest) (*PaginatedCloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1745,6 +1883,16 @@ type UpdatePeeringConnectionApiParams struct {
 		ContainerPeerViewRequest *ContainerPeerViewRequest
 }
 
+func (a *NetworkPeeringApiService) UpdatePeeringConnectionWithParams(ctx context.Context, args *UpdatePeeringConnectionApiParams) UpdatePeeringConnectionApiRequest {
+	return UpdatePeeringConnectionApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		peerId: args.PeerId,
+		containerPeerViewRequest: args.ContainerPeerViewRequest,
+	}
+}
+
 // Modify one network peering connection.
 func (r UpdatePeeringConnectionApiRequest) ContainerPeerViewRequest(containerPeerViewRequest ContainerPeerViewRequest) UpdatePeeringConnectionApiRequest {
 	r.containerPeerViewRequest = &containerPeerViewRequest
@@ -1752,14 +1900,7 @@ func (r UpdatePeeringConnectionApiRequest) ContainerPeerViewRequest(containerPee
 }
 
 func (r UpdatePeeringConnectionApiRequest) Execute() (*GetPeeringConnection200Response, *http.Response, error) {
-	return r.ApiService.UpdatePeeringConnectionExecute(r)
-}
-
-func (r UpdatePeeringConnectionApiRequest) ExecuteWithParams(params *UpdatePeeringConnectionApiParams) (*GetPeeringConnection200Response, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.peerId = params.PeerId 
-	r.containerPeerViewRequest = params.ContainerPeerViewRequest 
-	return r.Execute()
+	return r.ApiService.updatePeeringConnectionExecute(r)
 }
 
 /*
@@ -1783,7 +1924,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringConnection(ctx context.Context, 
 
 // Execute executes the request
 //  @return GetPeeringConnection200Response
-func (a *NetworkPeeringApiService) UpdatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error) {
+func (a *NetworkPeeringApiService) updatePeeringConnectionExecute(r UpdatePeeringConnectionApiRequest) (*GetPeeringConnection200Response, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1897,6 +2038,16 @@ type UpdatePeeringContainerApiParams struct {
 		CloudProviderContainer *CloudProviderContainer
 }
 
+func (a *NetworkPeeringApiService) UpdatePeeringContainerWithParams(ctx context.Context, args *UpdatePeeringContainerApiParams) UpdatePeeringContainerApiRequest {
+	return UpdatePeeringContainerApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		containerId: args.ContainerId,
+		cloudProviderContainer: args.CloudProviderContainer,
+	}
+}
+
 // Updates the network details and labels of one specified network peering container in the specified project.
 func (r UpdatePeeringContainerApiRequest) CloudProviderContainer(cloudProviderContainer CloudProviderContainer) UpdatePeeringContainerApiRequest {
 	r.cloudProviderContainer = &cloudProviderContainer
@@ -1904,14 +2055,7 @@ func (r UpdatePeeringContainerApiRequest) CloudProviderContainer(cloudProviderCo
 }
 
 func (r UpdatePeeringContainerApiRequest) Execute() (*CloudProviderContainer, *http.Response, error) {
-	return r.ApiService.UpdatePeeringContainerExecute(r)
-}
-
-func (r UpdatePeeringContainerApiRequest) ExecuteWithParams(params *UpdatePeeringContainerApiParams) (*CloudProviderContainer, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.containerId = params.ContainerId 
-	r.cloudProviderContainer = params.CloudProviderContainer 
-	return r.Execute()
+	return r.ApiService.updatePeeringContainerExecute(r)
 }
 
 /*
@@ -1935,7 +2079,7 @@ func (a *NetworkPeeringApiService) UpdatePeeringContainer(ctx context.Context, g
 
 // Execute executes the request
 //  @return CloudProviderContainer
-func (a *NetworkPeeringApiService) UpdatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
+func (a *NetworkPeeringApiService) updatePeeringContainerExecute(r UpdatePeeringContainerApiRequest) (*CloudProviderContainer, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2045,13 +2189,16 @@ type VerifyConnectViaPeeringOnlyModeForOneProjectApiParams struct {
 		GroupId string
 }
 
-func (r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
-	return r.ApiService.VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r)
+func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx context.Context, args *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest {
+	return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) ExecuteWithParams(params *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) (*PrivateIPMode, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) Execute() (*PrivateIPMode, *http.Response, error) {
+	return r.ApiService.verifyConnectViaPeeringOnlyModeForOneProjectExecute(r)
 }
 
 /*
@@ -2076,7 +2223,7 @@ func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProject(
 // Execute executes the request
 //  @return PrivateIPMode
 // Deprecated
-func (a *NetworkPeeringApiService) VerifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error) {
+func (a *NetworkPeeringApiService) verifyConnectViaPeeringOnlyModeForOneProjectExecute(r VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest) (*PrivateIPMode, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_network_peering.go
+++ b/mongodbatlasv2/api_network_peering.go
@@ -132,7 +132,7 @@ type NetworkPeeringApi interface {
 	@param DisablePeeringApiParams - Parameters for the request
 	@return DisablePeeringApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	DisablePeeringWithParams(ctx context.Context, args *DisablePeeringApiParams) DisablePeeringApiRequest
 
@@ -324,7 +324,7 @@ type NetworkPeeringApi interface {
 	@param VerifyConnectViaPeeringOnlyModeForOneProjectApiParams - Parameters for the request
 	@return VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for NetworkPeeringApi
 	*/
 	VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx context.Context, args *VerifyConnectViaPeeringOnlyModeForOneProjectApiParams) VerifyConnectViaPeeringOnlyModeForOneProjectApiRequest
 

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -145,6 +145,13 @@ func (r CreateOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response
 	return r.ApiService.CreateOnlineArchiveExecute(r)
 }
 
+func (r CreateOnlineArchiveApiRequest) ExecuteWithParams(params *CreateOnlineArchiveApiParams) (*OnlineArchive, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.onlineArchive = params.OnlineArchive 
+	return r.Execute()
+}
+
 /*
 CreateOnlineArchive Create One Online Archive
 
@@ -282,6 +289,13 @@ type DeleteOnlineArchiveApiParams struct {
 
 func (r DeleteOnlineArchiveApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOnlineArchiveExecute(r)
+}
+
+func (r DeleteOnlineArchiveApiRequest) ExecuteWithParams(params *DeleteOnlineArchiveApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.archiveId = params.ArchiveId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*
@@ -438,6 +452,15 @@ func (r DownloadOnlineArchiveQueryLogsApiRequest) Execute() (*os.File, *http.Res
 	return r.ApiService.DownloadOnlineArchiveQueryLogsExecute(r)
 }
 
+func (r DownloadOnlineArchiveQueryLogsApiRequest) ExecuteWithParams(params *DownloadOnlineArchiveQueryLogsApiParams) (*os.File, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.startDate = params.StartDate 
+	r.endDate = params.EndDate 
+	r.archiveOnly = params.ArchiveOnly 
+	return r.Execute()
+}
+
 /*
 DownloadOnlineArchiveQueryLogs Download Online Archive Query Logs
 
@@ -583,6 +606,13 @@ type GetOnlineArchiveApiParams struct {
 
 func (r GetOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
 	return r.ApiService.GetOnlineArchiveExecute(r)
+}
+
+func (r GetOnlineArchiveApiRequest) ExecuteWithParams(params *GetOnlineArchiveApiParams) (*OnlineArchive, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.archiveId = params.ArchiveId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*
@@ -750,6 +780,15 @@ func (r ListOnlineArchivesApiRequest) Execute() (*PaginatedOnlineArchive, *http.
 	return r.ApiService.ListOnlineArchivesExecute(r)
 }
 
+func (r ListOnlineArchivesApiRequest) ExecuteWithParams(params *ListOnlineArchivesApiParams) (*PaginatedOnlineArchive, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListOnlineArchives Return All Online Archives for One Cluster
 
@@ -911,6 +950,14 @@ func (r UpdateOnlineArchiveApiRequest) OnlineArchive(onlineArchive OnlineArchive
 
 func (r UpdateOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
 	return r.ApiService.UpdateOnlineArchiveExecute(r)
+}
+
+func (r UpdateOnlineArchiveApiRequest) ExecuteWithParams(params *UpdateOnlineArchiveApiParams) (*OnlineArchive, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.archiveId = params.ArchiveId 
+	r.clusterName = params.ClusterName 
+	r.onlineArchive = params.OnlineArchive 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -30,10 +30,18 @@ type OnlineArchiveApi interface {
 	@return CreateOnlineArchiveApiRequest
 	*/
 	CreateOnlineArchive(ctx context.Context, groupId string, clusterName string) CreateOnlineArchiveApiRequest
+	/*
+	CreateOnlineArchive Create One Online Archive
 
-	// CreateOnlineArchiveExecute executes the request
-	//  @return OnlineArchive
-	CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateOnlineArchiveApiParams - Parameters for the request
+	@return CreateOnlineArchiveApiRequest}}
+	*/
+	CreateOnlineArchiveWithParams(ctx context.Context, args *CreateOnlineArchiveApiParams) CreateOnlineArchiveApiRequest
+
+	// Interface only available internally
+	createOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
 
 	/*
 	DeleteOnlineArchive Remove One Online Archive
@@ -47,9 +55,18 @@ type OnlineArchiveApi interface {
 	@return DeleteOnlineArchiveApiRequest
 	*/
 	DeleteOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) DeleteOnlineArchiveApiRequest
+	/*
+	DeleteOnlineArchive Remove One Online Archive
 
-	// DeleteOnlineArchiveExecute executes the request
-	DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteOnlineArchiveApiParams - Parameters for the request
+	@return DeleteOnlineArchiveApiRequest}}
+	*/
+	DeleteOnlineArchiveWithParams(ctx context.Context, args *DeleteOnlineArchiveApiParams) DeleteOnlineArchiveApiRequest
+
+	// Interface only available internally
+	deleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (*http.Response, error)
 
 	/*
 	DownloadOnlineArchiveQueryLogs Download Online Archive Query Logs
@@ -62,10 +79,18 @@ type OnlineArchiveApi interface {
 	@return DownloadOnlineArchiveQueryLogsApiRequest
 	*/
 	DownloadOnlineArchiveQueryLogs(ctx context.Context, groupId string, clusterName string) DownloadOnlineArchiveQueryLogsApiRequest
+	/*
+	DownloadOnlineArchiveQueryLogs Download Online Archive Query Logs
 
-	// DownloadOnlineArchiveQueryLogsExecute executes the request
-	//  @return *os.File
-	DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DownloadOnlineArchiveQueryLogsApiParams - Parameters for the request
+	@return DownloadOnlineArchiveQueryLogsApiRequest}}
+	*/
+	DownloadOnlineArchiveQueryLogsWithParams(ctx context.Context, args *DownloadOnlineArchiveQueryLogsApiParams) DownloadOnlineArchiveQueryLogsApiRequest
+
+	// Interface only available internally
+	downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error)
 
 	/*
 	GetOnlineArchive Return One Online Archive
@@ -79,10 +104,18 @@ type OnlineArchiveApi interface {
 	@return GetOnlineArchiveApiRequest
 	*/
 	GetOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) GetOnlineArchiveApiRequest
+	/*
+	GetOnlineArchive Return One Online Archive
 
-	// GetOnlineArchiveExecute executes the request
-	//  @return OnlineArchive
-	GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetOnlineArchiveApiParams - Parameters for the request
+	@return GetOnlineArchiveApiRequest}}
+	*/
+	GetOnlineArchiveWithParams(ctx context.Context, args *GetOnlineArchiveApiParams) GetOnlineArchiveApiRequest
+
+	// Interface only available internally
+	getOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
 
 	/*
 	ListOnlineArchives Return All Online Archives for One Cluster
@@ -95,10 +128,18 @@ type OnlineArchiveApi interface {
 	@return ListOnlineArchivesApiRequest
 	*/
 	ListOnlineArchives(ctx context.Context, groupId string, clusterName string) ListOnlineArchivesApiRequest
+	/*
+	ListOnlineArchives Return All Online Archives for One Cluster
 
-	// ListOnlineArchivesExecute executes the request
-	//  @return PaginatedOnlineArchive
-	ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListOnlineArchivesApiParams - Parameters for the request
+	@return ListOnlineArchivesApiRequest}}
+	*/
+	ListOnlineArchivesWithParams(ctx context.Context, args *ListOnlineArchivesApiParams) ListOnlineArchivesApiRequest
+
+	// Interface only available internally
+	listOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error)
 
 	/*
 	UpdateOnlineArchive Update One Online Archive
@@ -112,10 +153,18 @@ type OnlineArchiveApi interface {
 	@return UpdateOnlineArchiveApiRequest
 	*/
 	UpdateOnlineArchive(ctx context.Context, groupId string, archiveId string, clusterName string) UpdateOnlineArchiveApiRequest
+	/*
+	UpdateOnlineArchive Update One Online Archive
 
-	// UpdateOnlineArchiveExecute executes the request
-	//  @return OnlineArchive
-	UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateOnlineArchiveApiParams - Parameters for the request
+	@return UpdateOnlineArchiveApiRequest}}
+	*/
+	UpdateOnlineArchiveWithParams(ctx context.Context, args *UpdateOnlineArchiveApiParams) UpdateOnlineArchiveApiRequest
+
+	// Interface only available internally
+	updateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error)
 }
 
 // OnlineArchiveApiService OnlineArchiveApi service
@@ -135,6 +184,16 @@ type CreateOnlineArchiveApiParams struct {
 		OnlineArchive *OnlineArchive
 }
 
+func (a *OnlineArchiveApiService) CreateOnlineArchiveWithParams(ctx context.Context, args *CreateOnlineArchiveApiParams) CreateOnlineArchiveApiRequest {
+	return CreateOnlineArchiveApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		onlineArchive: args.OnlineArchive,
+	}
+}
+
 // Creates one online archive.
 func (r CreateOnlineArchiveApiRequest) OnlineArchive(onlineArchive OnlineArchive) CreateOnlineArchiveApiRequest {
 	r.onlineArchive = &onlineArchive
@@ -142,14 +201,7 @@ func (r CreateOnlineArchiveApiRequest) OnlineArchive(onlineArchive OnlineArchive
 }
 
 func (r CreateOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
-	return r.ApiService.CreateOnlineArchiveExecute(r)
-}
-
-func (r CreateOnlineArchiveApiRequest) ExecuteWithParams(params *CreateOnlineArchiveApiParams) (*OnlineArchive, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.onlineArchive = params.OnlineArchive 
-	return r.Execute()
+	return r.ApiService.createOnlineArchiveExecute(r)
 }
 
 /*
@@ -173,7 +225,7 @@ func (a *OnlineArchiveApiService) CreateOnlineArchive(ctx context.Context, group
 
 // Execute executes the request
 //  @return OnlineArchive
-func (a *OnlineArchiveApiService) CreateOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) createOnlineArchiveExecute(r CreateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -287,15 +339,18 @@ type DeleteOnlineArchiveApiParams struct {
 		ClusterName string
 }
 
-func (r DeleteOnlineArchiveApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteOnlineArchiveExecute(r)
+func (a *OnlineArchiveApiService) DeleteOnlineArchiveWithParams(ctx context.Context, args *DeleteOnlineArchiveApiParams) DeleteOnlineArchiveApiRequest {
+	return DeleteOnlineArchiveApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		archiveId: args.ArchiveId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r DeleteOnlineArchiveApiRequest) ExecuteWithParams(params *DeleteOnlineArchiveApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.archiveId = params.ArchiveId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r DeleteOnlineArchiveApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteOnlineArchiveExecute(r)
 }
 
 /*
@@ -320,7 +375,7 @@ func (a *OnlineArchiveApiService) DeleteOnlineArchive(ctx context.Context, group
 }
 
 // Execute executes the request
-func (a *OnlineArchiveApiService) DeleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (*http.Response, error) {
+func (a *OnlineArchiveApiService) deleteOnlineArchiveExecute(r DeleteOnlineArchiveApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -430,6 +485,18 @@ type DownloadOnlineArchiveQueryLogsApiParams struct {
 		ArchiveOnly *bool
 }
 
+func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogsWithParams(ctx context.Context, args *DownloadOnlineArchiveQueryLogsApiParams) DownloadOnlineArchiveQueryLogsApiRequest {
+	return DownloadOnlineArchiveQueryLogsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		startDate: args.StartDate,
+		endDate: args.EndDate,
+		archiveOnly: args.ArchiveOnly,
+	}
+}
+
 // Date and time that specifies the starting point for the range of log messages to return. This resource expresses this value in the number of seconds that have elapsed since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time).
 func (r DownloadOnlineArchiveQueryLogsApiRequest) StartDate(startDate int64) DownloadOnlineArchiveQueryLogsApiRequest {
 	r.startDate = &startDate
@@ -449,16 +516,7 @@ func (r DownloadOnlineArchiveQueryLogsApiRequest) ArchiveOnly(archiveOnly bool) 
 }
 
 func (r DownloadOnlineArchiveQueryLogsApiRequest) Execute() (*os.File, *http.Response, error) {
-	return r.ApiService.DownloadOnlineArchiveQueryLogsExecute(r)
-}
-
-func (r DownloadOnlineArchiveQueryLogsApiRequest) ExecuteWithParams(params *DownloadOnlineArchiveQueryLogsApiParams) (*os.File, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.startDate = params.StartDate 
-	r.endDate = params.EndDate 
-	r.archiveOnly = params.ArchiveOnly 
-	return r.Execute()
+	return r.ApiService.downloadOnlineArchiveQueryLogsExecute(r)
 }
 
 /*
@@ -482,7 +540,7 @@ func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogs(ctx context.Con
 
 // Execute executes the request
 //  @return *os.File
-func (a *OnlineArchiveApiService) DownloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error) {
+func (a *OnlineArchiveApiService) downloadOnlineArchiveQueryLogsExecute(r DownloadOnlineArchiveQueryLogsApiRequest) (*os.File, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -604,15 +662,18 @@ type GetOnlineArchiveApiParams struct {
 		ClusterName string
 }
 
-func (r GetOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
-	return r.ApiService.GetOnlineArchiveExecute(r)
+func (a *OnlineArchiveApiService) GetOnlineArchiveWithParams(ctx context.Context, args *GetOnlineArchiveApiParams) GetOnlineArchiveApiRequest {
+	return GetOnlineArchiveApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		archiveId: args.ArchiveId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r GetOnlineArchiveApiRequest) ExecuteWithParams(params *GetOnlineArchiveApiParams) (*OnlineArchive, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.archiveId = params.ArchiveId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r GetOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
+	return r.ApiService.getOnlineArchiveExecute(r)
 }
 
 /*
@@ -638,7 +699,7 @@ func (a *OnlineArchiveApiService) GetOnlineArchive(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return OnlineArchive
-func (a *OnlineArchiveApiService) GetOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) getOnlineArchiveExecute(r GetOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -758,6 +819,18 @@ type ListOnlineArchivesApiParams struct {
 		PageNum *int32
 }
 
+func (a *OnlineArchiveApiService) ListOnlineArchivesWithParams(ctx context.Context, args *ListOnlineArchivesApiParams) ListOnlineArchivesApiRequest {
+	return ListOnlineArchivesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListOnlineArchivesApiRequest) IncludeCount(includeCount bool) ListOnlineArchivesApiRequest {
 	r.includeCount = &includeCount
@@ -777,16 +850,7 @@ func (r ListOnlineArchivesApiRequest) PageNum(pageNum int32) ListOnlineArchivesA
 }
 
 func (r ListOnlineArchivesApiRequest) Execute() (*PaginatedOnlineArchive, *http.Response, error) {
-	return r.ApiService.ListOnlineArchivesExecute(r)
-}
-
-func (r ListOnlineArchivesApiRequest) ExecuteWithParams(params *ListOnlineArchivesApiParams) (*PaginatedOnlineArchive, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listOnlineArchivesExecute(r)
 }
 
 /*
@@ -810,7 +874,7 @@ func (a *OnlineArchiveApiService) ListOnlineArchives(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return PaginatedOnlineArchive
-func (a *OnlineArchiveApiService) ListOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) listOnlineArchivesExecute(r ListOnlineArchivesApiRequest) (*PaginatedOnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -942,6 +1006,17 @@ type UpdateOnlineArchiveApiParams struct {
 		OnlineArchive *OnlineArchive
 }
 
+func (a *OnlineArchiveApiService) UpdateOnlineArchiveWithParams(ctx context.Context, args *UpdateOnlineArchiveApiParams) UpdateOnlineArchiveApiRequest {
+	return UpdateOnlineArchiveApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		archiveId: args.ArchiveId,
+		clusterName: args.ClusterName,
+		onlineArchive: args.OnlineArchive,
+	}
+}
+
 // Updates, pauses, or resumes one online archive.
 func (r UpdateOnlineArchiveApiRequest) OnlineArchive(onlineArchive OnlineArchive) UpdateOnlineArchiveApiRequest {
 	r.onlineArchive = &onlineArchive
@@ -949,15 +1024,7 @@ func (r UpdateOnlineArchiveApiRequest) OnlineArchive(onlineArchive OnlineArchive
 }
 
 func (r UpdateOnlineArchiveApiRequest) Execute() (*OnlineArchive, *http.Response, error) {
-	return r.ApiService.UpdateOnlineArchiveExecute(r)
-}
-
-func (r UpdateOnlineArchiveApiRequest) ExecuteWithParams(params *UpdateOnlineArchiveApiParams) (*OnlineArchive, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.archiveId = params.ArchiveId 
-	r.clusterName = params.ClusterName 
-	r.onlineArchive = params.OnlineArchive 
-	return r.Execute()
+	return r.ApiService.updateOnlineArchiveExecute(r)
 }
 
 /*
@@ -983,7 +1050,7 @@ func (a *OnlineArchiveApiService) UpdateOnlineArchive(ctx context.Context, group
 
 // Execute executes the request
 //  @return OnlineArchive
-func (a *OnlineArchiveApiService) UpdateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
+func (a *OnlineArchiveApiService) updateOnlineArchiveExecute(r UpdateOnlineArchiveApiRequest) (*OnlineArchive, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_online_archive.go
+++ b/mongodbatlasv2/api_online_archive.go
@@ -36,7 +36,7 @@ type OnlineArchiveApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateOnlineArchiveApiParams - Parameters for the request
-	@return CreateOnlineArchiveApiRequest}}
+	@return CreateOnlineArchiveApiRequest
 	*/
 	CreateOnlineArchiveWithParams(ctx context.Context, args *CreateOnlineArchiveApiParams) CreateOnlineArchiveApiRequest
 
@@ -61,7 +61,7 @@ type OnlineArchiveApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteOnlineArchiveApiParams - Parameters for the request
-	@return DeleteOnlineArchiveApiRequest}}
+	@return DeleteOnlineArchiveApiRequest
 	*/
 	DeleteOnlineArchiveWithParams(ctx context.Context, args *DeleteOnlineArchiveApiParams) DeleteOnlineArchiveApiRequest
 
@@ -85,7 +85,7 @@ type OnlineArchiveApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DownloadOnlineArchiveQueryLogsApiParams - Parameters for the request
-	@return DownloadOnlineArchiveQueryLogsApiRequest}}
+	@return DownloadOnlineArchiveQueryLogsApiRequest
 	*/
 	DownloadOnlineArchiveQueryLogsWithParams(ctx context.Context, args *DownloadOnlineArchiveQueryLogsApiParams) DownloadOnlineArchiveQueryLogsApiRequest
 
@@ -110,7 +110,7 @@ type OnlineArchiveApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetOnlineArchiveApiParams - Parameters for the request
-	@return GetOnlineArchiveApiRequest}}
+	@return GetOnlineArchiveApiRequest
 	*/
 	GetOnlineArchiveWithParams(ctx context.Context, args *GetOnlineArchiveApiParams) GetOnlineArchiveApiRequest
 
@@ -134,7 +134,7 @@ type OnlineArchiveApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListOnlineArchivesApiParams - Parameters for the request
-	@return ListOnlineArchivesApiRequest}}
+	@return ListOnlineArchivesApiRequest
 	*/
 	ListOnlineArchivesWithParams(ctx context.Context, args *ListOnlineArchivesApiParams) ListOnlineArchivesApiRequest
 
@@ -159,7 +159,7 @@ type OnlineArchiveApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateOnlineArchiveApiParams - Parameters for the request
-	@return UpdateOnlineArchiveApiRequest}}
+	@return UpdateOnlineArchiveApiRequest
 	*/
 	UpdateOnlineArchiveWithParams(ctx context.Context, args *UpdateOnlineArchiveApiParams) UpdateOnlineArchiveApiRequest
 

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -33,7 +33,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateOrganizationApiParams - Parameters for the request
-	@return CreateOrganizationApiRequest}}
+	@return CreateOrganizationApiRequest
 	*/
 	CreateOrganizationWithParams(ctx context.Context, args *CreateOrganizationApiParams) CreateOrganizationApiRequest
 
@@ -56,7 +56,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateOrganizationInvitationApiParams - Parameters for the request
-	@return CreateOrganizationInvitationApiRequest}}
+	@return CreateOrganizationInvitationApiRequest
 	*/
 	CreateOrganizationInvitationWithParams(ctx context.Context, args *CreateOrganizationInvitationApiParams) CreateOrganizationInvitationApiRequest
 
@@ -83,7 +83,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteOrganizationApiParams - Parameters for the request
-	@return DeleteOrganizationApiRequest}}
+	@return DeleteOrganizationApiRequest
 	*/
 	DeleteOrganizationWithParams(ctx context.Context, args *DeleteOrganizationApiParams) DeleteOrganizationApiRequest
 
@@ -107,7 +107,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteOrganizationInvitationApiParams - Parameters for the request
-	@return DeleteOrganizationInvitationApiRequest}}
+	@return DeleteOrganizationInvitationApiRequest
 	*/
 	DeleteOrganizationInvitationWithParams(ctx context.Context, args *DeleteOrganizationInvitationApiParams) DeleteOrganizationInvitationApiRequest
 
@@ -130,7 +130,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetOrganizationApiParams - Parameters for the request
-	@return GetOrganizationApiRequest}}
+	@return GetOrganizationApiRequest
 	*/
 	GetOrganizationWithParams(ctx context.Context, args *GetOrganizationApiParams) GetOrganizationApiRequest
 
@@ -154,7 +154,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetOrganizationInvitationApiParams - Parameters for the request
-	@return GetOrganizationInvitationApiRequest}}
+	@return GetOrganizationInvitationApiRequest
 	*/
 	GetOrganizationInvitationWithParams(ctx context.Context, args *GetOrganizationInvitationApiParams) GetOrganizationInvitationApiRequest
 
@@ -177,7 +177,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetOrganizationSettingsApiParams - Parameters for the request
-	@return GetOrganizationSettingsApiRequest}}
+	@return GetOrganizationSettingsApiRequest
 	*/
 	GetOrganizationSettingsWithParams(ctx context.Context, args *GetOrganizationSettingsApiParams) GetOrganizationSettingsApiRequest
 
@@ -200,7 +200,7 @@ type OrganizationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListOrganizationInvitationsApiParams - Parameters for the request
-	@return ListOrganizationInvitationsApiRequest}}
+	@return ListOrganizationInvitationsApiRequest
 	*/
 	ListOrganizationInvitationsWithParams(ctx context.Context, args *ListOrganizationInvitationsApiParams) ListOrganizationInvitationsApiRequest
 
@@ -230,7 +230,7 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListOrganizationProjectsApiParams - Parameters for the request
-	@return ListOrganizationProjectsApiRequest}}
+	@return ListOrganizationProjectsApiRequest
 	*/
 	ListOrganizationProjectsWithParams(ctx context.Context, args *ListOrganizationProjectsApiParams) ListOrganizationProjectsApiRequest
 
@@ -253,7 +253,7 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListOrganizationUsersApiParams - Parameters for the request
-	@return ListOrganizationUsersApiRequest}}
+	@return ListOrganizationUsersApiRequest
 	*/
 	ListOrganizationUsersWithParams(ctx context.Context, args *ListOrganizationUsersApiParams) ListOrganizationUsersApiRequest
 
@@ -275,7 +275,7 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListOrganizationsApiParams - Parameters for the request
-	@return ListOrganizationsApiRequest}}
+	@return ListOrganizationsApiRequest
 	*/
 	ListOrganizationsWithParams(ctx context.Context, args *ListOrganizationsApiParams) ListOrganizationsApiRequest
 
@@ -298,7 +298,7 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param RenameOrganizationApiParams - Parameters for the request
-	@return RenameOrganizationApiRequest}}
+	@return RenameOrganizationApiRequest
 	*/
 	RenameOrganizationWithParams(ctx context.Context, args *RenameOrganizationApiParams) RenameOrganizationApiRequest
 
@@ -321,7 +321,7 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateOrganizationInvitationApiParams - Parameters for the request
-	@return UpdateOrganizationInvitationApiRequest}}
+	@return UpdateOrganizationInvitationApiRequest
 	*/
 	UpdateOrganizationInvitationWithParams(ctx context.Context, args *UpdateOrganizationInvitationApiParams) UpdateOrganizationInvitationApiRequest
 
@@ -345,7 +345,7 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateOrganizationInvitationByIdApiParams - Parameters for the request
-	@return UpdateOrganizationInvitationByIdApiRequest}}
+	@return UpdateOrganizationInvitationByIdApiRequest
 	*/
 	UpdateOrganizationInvitationByIdWithParams(ctx context.Context, args *UpdateOrganizationInvitationByIdApiParams) UpdateOrganizationInvitationByIdApiRequest
 
@@ -368,7 +368,7 @@ To use this resource, the requesting API Key must have the Organization Member r
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateOrganizationSettingsApiParams - Parameters for the request
-	@return UpdateOrganizationSettingsApiRequest}}
+	@return UpdateOrganizationSettingsApiRequest
 	*/
 	UpdateOrganizationSettingsWithParams(ctx context.Context, args *UpdateOrganizationSettingsApiParams) UpdateOrganizationSettingsApiRequest
 

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -27,10 +27,18 @@ type OrganizationsApi interface {
 	@return CreateOrganizationApiRequest
 	*/
 	CreateOrganization(ctx context.Context) CreateOrganizationApiRequest
+	/*
+	CreateOrganization Create One Organization
 
-	// CreateOrganizationExecute executes the request
-	//  @return CreateOrganizationResponse
-	CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateOrganizationApiParams - Parameters for the request
+	@return CreateOrganizationApiRequest}}
+	*/
+	CreateOrganizationWithParams(ctx context.Context, args *CreateOrganizationApiParams) CreateOrganizationApiRequest
+
+	// Interface only available internally
+	createOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error)
 
 	/*
 	CreateOrganizationInvitation Invite One MongoDB Cloud User to Join One Atlas Organization
@@ -42,10 +50,18 @@ type OrganizationsApi interface {
 	@return CreateOrganizationInvitationApiRequest
 	*/
 	CreateOrganizationInvitation(ctx context.Context, orgId string) CreateOrganizationInvitationApiRequest
+	/*
+	CreateOrganizationInvitation Invite One MongoDB Cloud User to Join One Atlas Organization
 
-	// CreateOrganizationInvitationExecute executes the request
-	//  @return OrganizationInvitation
-	CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateOrganizationInvitationApiParams - Parameters for the request
+	@return CreateOrganizationInvitationApiRequest}}
+	*/
+	CreateOrganizationInvitationWithParams(ctx context.Context, args *CreateOrganizationInvitationApiParams) CreateOrganizationInvitationApiRequest
+
+	// Interface only available internally
+	createOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	DeleteOrganization Remove One Organization
@@ -61,9 +77,18 @@ type OrganizationsApi interface {
 	@return DeleteOrganizationApiRequest
 	*/
 	DeleteOrganization(ctx context.Context, orgId string) DeleteOrganizationApiRequest
+	/*
+	DeleteOrganization Remove One Organization
 
-	// DeleteOrganizationExecute executes the request
-	DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteOrganizationApiParams - Parameters for the request
+	@return DeleteOrganizationApiRequest}}
+	*/
+	DeleteOrganizationWithParams(ctx context.Context, args *DeleteOrganizationApiParams) DeleteOrganizationApiRequest
+
+	// Interface only available internally
+	deleteOrganizationExecute(r DeleteOrganizationApiRequest) (*http.Response, error)
 
 	/*
 	DeleteOrganizationInvitation Cancel One Organization Invitation
@@ -76,9 +101,18 @@ type OrganizationsApi interface {
 	@return DeleteOrganizationInvitationApiRequest
 	*/
 	DeleteOrganizationInvitation(ctx context.Context, orgId string, invitationId string) DeleteOrganizationInvitationApiRequest
+	/*
+	DeleteOrganizationInvitation Cancel One Organization Invitation
 
-	// DeleteOrganizationInvitationExecute executes the request
-	DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteOrganizationInvitationApiParams - Parameters for the request
+	@return DeleteOrganizationInvitationApiRequest}}
+	*/
+	DeleteOrganizationInvitationWithParams(ctx context.Context, args *DeleteOrganizationInvitationApiParams) DeleteOrganizationInvitationApiRequest
+
+	// Interface only available internally
+	deleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (*http.Response, error)
 
 	/*
 	GetOrganization Return One Organization
@@ -90,10 +124,18 @@ type OrganizationsApi interface {
 	@return GetOrganizationApiRequest
 	*/
 	GetOrganization(ctx context.Context, orgId string) GetOrganizationApiRequest
+	/*
+	GetOrganization Return One Organization
 
-	// GetOrganizationExecute executes the request
-	//  @return Organization
-	GetOrganizationExecute(r GetOrganizationApiRequest) (*Organization, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetOrganizationApiParams - Parameters for the request
+	@return GetOrganizationApiRequest}}
+	*/
+	GetOrganizationWithParams(ctx context.Context, args *GetOrganizationApiParams) GetOrganizationApiRequest
+
+	// Interface only available internally
+	getOrganizationExecute(r GetOrganizationApiRequest) (*Organization, *http.Response, error)
 
 	/*
 	GetOrganizationInvitation Return One Organization Invitation
@@ -106,10 +148,18 @@ type OrganizationsApi interface {
 	@return GetOrganizationInvitationApiRequest
 	*/
 	GetOrganizationInvitation(ctx context.Context, orgId string, invitationId string) GetOrganizationInvitationApiRequest
+	/*
+	GetOrganizationInvitation Return One Organization Invitation
 
-	// GetOrganizationInvitationExecute executes the request
-	//  @return OrganizationInvitation
-	GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetOrganizationInvitationApiParams - Parameters for the request
+	@return GetOrganizationInvitationApiRequest}}
+	*/
+	GetOrganizationInvitationWithParams(ctx context.Context, args *GetOrganizationInvitationApiParams) GetOrganizationInvitationApiRequest
+
+	// Interface only available internally
+	getOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	GetOrganizationSettings Return Settings for One Organization
@@ -121,10 +171,18 @@ type OrganizationsApi interface {
 	@return GetOrganizationSettingsApiRequest
 	*/
 	GetOrganizationSettings(ctx context.Context, orgId string) GetOrganizationSettingsApiRequest
+	/*
+	GetOrganizationSettings Return Settings for One Organization
 
-	// GetOrganizationSettingsExecute executes the request
-	//  @return OrganizationSettings
-	GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetOrganizationSettingsApiParams - Parameters for the request
+	@return GetOrganizationSettingsApiRequest}}
+	*/
+	GetOrganizationSettingsWithParams(ctx context.Context, args *GetOrganizationSettingsApiParams) GetOrganizationSettingsApiRequest
+
+	// Interface only available internally
+	getOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 
 	/*
 	ListOrganizationInvitations Return All Organization Invitations
@@ -136,10 +194,18 @@ type OrganizationsApi interface {
 	@return ListOrganizationInvitationsApiRequest
 	*/
 	ListOrganizationInvitations(ctx context.Context, orgId string) ListOrganizationInvitationsApiRequest
+	/*
+	ListOrganizationInvitations Return All Organization Invitations
 
-	// ListOrganizationInvitationsExecute executes the request
-	//  @return []OrganizationInvitation
-	ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListOrganizationInvitationsApiParams - Parameters for the request
+	@return ListOrganizationInvitationsApiRequest}}
+	*/
+	ListOrganizationInvitationsWithParams(ctx context.Context, args *ListOrganizationInvitationsApiParams) ListOrganizationInvitationsApiRequest
+
+	// Interface only available internally
+	listOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error)
 
 	/*
 	ListOrganizationProjects Return One or More Projects in One Organization
@@ -158,10 +224,18 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@return ListOrganizationProjectsApiRequest
 	*/
 	ListOrganizationProjects(ctx context.Context, orgId string) ListOrganizationProjectsApiRequest
+	/*
+	ListOrganizationProjects Return One or More Projects in One Organization
 
-	// ListOrganizationProjectsExecute executes the request
-	//  @return PaginatedAtlasGroup
-	ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListOrganizationProjectsApiParams - Parameters for the request
+	@return ListOrganizationProjectsApiRequest}}
+	*/
+	ListOrganizationProjectsWithParams(ctx context.Context, args *ListOrganizationProjectsApiParams) ListOrganizationProjectsApiRequest
+
+	// Interface only available internally
+	listOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
 	ListOrganizationUsers Return All MongoDB Cloud Users in One Organization
@@ -173,10 +247,18 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@return ListOrganizationUsersApiRequest
 	*/
 	ListOrganizationUsers(ctx context.Context, orgId string) ListOrganizationUsersApiRequest
+	/*
+	ListOrganizationUsers Return All MongoDB Cloud Users in One Organization
 
-	// ListOrganizationUsersExecute executes the request
-	//  @return PaginatedAppUser
-	ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListOrganizationUsersApiParams - Parameters for the request
+	@return ListOrganizationUsersApiRequest}}
+	*/
+	ListOrganizationUsersWithParams(ctx context.Context, args *ListOrganizationUsersApiParams) ListOrganizationUsersApiRequest
+
+	// Interface only available internally
+	listOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error)
 
 	/*
 	ListOrganizations Return All Organizations
@@ -187,10 +269,18 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@return ListOrganizationsApiRequest
 	*/
 	ListOrganizations(ctx context.Context) ListOrganizationsApiRequest
+	/*
+	ListOrganizations Return All Organizations
 
-	// ListOrganizationsExecute executes the request
-	//  @return PaginatedOrganization
-	ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListOrganizationsApiParams - Parameters for the request
+	@return ListOrganizationsApiRequest}}
+	*/
+	ListOrganizationsWithParams(ctx context.Context, args *ListOrganizationsApiParams) ListOrganizationsApiRequest
+
+	// Interface only available internally
+	listOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error)
 
 	/*
 	RenameOrganization Rename One Organization
@@ -202,10 +292,18 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@return RenameOrganizationApiRequest
 	*/
 	RenameOrganization(ctx context.Context, orgId string) RenameOrganizationApiRequest
+	/*
+	RenameOrganization Rename One Organization
 
-	// RenameOrganizationExecute executes the request
-	//  @return Organization
-	RenameOrganizationExecute(r RenameOrganizationApiRequest) (*Organization, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param RenameOrganizationApiParams - Parameters for the request
+	@return RenameOrganizationApiRequest}}
+	*/
+	RenameOrganizationWithParams(ctx context.Context, args *RenameOrganizationApiParams) RenameOrganizationApiRequest
+
+	// Interface only available internally
+	renameOrganizationExecute(r RenameOrganizationApiRequest) (*Organization, *http.Response, error)
 
 	/*
 	UpdateOrganizationInvitation Update One Organization Invitation
@@ -217,10 +315,18 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@return UpdateOrganizationInvitationApiRequest
 	*/
 	UpdateOrganizationInvitation(ctx context.Context, orgId string) UpdateOrganizationInvitationApiRequest
+	/*
+	UpdateOrganizationInvitation Update One Organization Invitation
 
-	// UpdateOrganizationInvitationExecute executes the request
-	//  @return OrganizationInvitation
-	UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateOrganizationInvitationApiParams - Parameters for the request
+	@return UpdateOrganizationInvitationApiRequest}}
+	*/
+	UpdateOrganizationInvitationWithParams(ctx context.Context, args *UpdateOrganizationInvitationApiParams) UpdateOrganizationInvitationApiRequest
+
+	// Interface only available internally
+	updateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	UpdateOrganizationInvitationById Update One Organization Invitation by Invitation ID
@@ -233,10 +339,18 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@return UpdateOrganizationInvitationByIdApiRequest
 	*/
 	UpdateOrganizationInvitationById(ctx context.Context, orgId string, invitationId string) UpdateOrganizationInvitationByIdApiRequest
+	/*
+	UpdateOrganizationInvitationById Update One Organization Invitation by Invitation ID
 
-	// UpdateOrganizationInvitationByIdExecute executes the request
-	//  @return OrganizationInvitation
-	UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateOrganizationInvitationByIdApiParams - Parameters for the request
+	@return UpdateOrganizationInvitationByIdApiRequest}}
+	*/
+	UpdateOrganizationInvitationByIdWithParams(ctx context.Context, args *UpdateOrganizationInvitationByIdApiParams) UpdateOrganizationInvitationByIdApiRequest
+
+	// Interface only available internally
+	updateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error)
 
 	/*
 	UpdateOrganizationSettings Update Settings for One Organization
@@ -248,10 +362,18 @@ To use this resource, the requesting API Key must have the Organization Member r
 	@return UpdateOrganizationSettingsApiRequest
 	*/
 	UpdateOrganizationSettings(ctx context.Context, orgId string) UpdateOrganizationSettingsApiRequest
+	/*
+	UpdateOrganizationSettings Update Settings for One Organization
 
-	// UpdateOrganizationSettingsExecute executes the request
-	//  @return OrganizationSettings
-	UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateOrganizationSettingsApiParams - Parameters for the request
+	@return UpdateOrganizationSettingsApiRequest}}
+	*/
+	UpdateOrganizationSettingsWithParams(ctx context.Context, args *UpdateOrganizationSettingsApiParams) UpdateOrganizationSettingsApiRequest
+
+	// Interface only available internally
+	updateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error)
 }
 
 // OrganizationsApiService OrganizationsApi service
@@ -267,6 +389,14 @@ type CreateOrganizationApiParams struct {
 		CreateOrganizationRequest *CreateOrganizationRequest
 }
 
+func (a *OrganizationsApiService) CreateOrganizationWithParams(ctx context.Context, args *CreateOrganizationApiParams) CreateOrganizationApiRequest {
+	return CreateOrganizationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		createOrganizationRequest: args.CreateOrganizationRequest,
+	}
+}
+
 // Organization that you want to create.
 func (r CreateOrganizationApiRequest) CreateOrganizationRequest(createOrganizationRequest CreateOrganizationRequest) CreateOrganizationApiRequest {
 	r.createOrganizationRequest = &createOrganizationRequest
@@ -274,12 +404,7 @@ func (r CreateOrganizationApiRequest) CreateOrganizationRequest(createOrganizati
 }
 
 func (r CreateOrganizationApiRequest) Execute() (*CreateOrganizationResponse, *http.Response, error) {
-	return r.ApiService.CreateOrganizationExecute(r)
-}
-
-func (r CreateOrganizationApiRequest) ExecuteWithParams(params *CreateOrganizationApiParams) (*CreateOrganizationResponse, *http.Response, error) {
-	r.createOrganizationRequest = params.CreateOrganizationRequest 
-	return r.Execute()
+	return r.ApiService.createOrganizationExecute(r)
 }
 
 /*
@@ -299,7 +424,7 @@ func (a *OrganizationsApiService) CreateOrganization(ctx context.Context) Create
 
 // Execute executes the request
 //  @return CreateOrganizationResponse
-func (a *OrganizationsApiService) CreateOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error) {
+func (a *OrganizationsApiService) createOrganizationExecute(r CreateOrganizationApiRequest) (*CreateOrganizationResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -397,6 +522,15 @@ type CreateOrganizationInvitationApiParams struct {
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
 
+func (a *OrganizationsApiService) CreateOrganizationInvitationWithParams(ctx context.Context, args *CreateOrganizationInvitationApiParams) CreateOrganizationInvitationApiRequest {
+	return CreateOrganizationInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		organizationInvitationRequest: args.OrganizationInvitationRequest,
+	}
+}
+
 // Invites one MongoDB Cloud user to join the specified organization.
 func (r CreateOrganizationInvitationApiRequest) OrganizationInvitationRequest(organizationInvitationRequest OrganizationInvitationRequest) CreateOrganizationInvitationApiRequest {
 	r.organizationInvitationRequest = &organizationInvitationRequest
@@ -404,13 +538,7 @@ func (r CreateOrganizationInvitationApiRequest) OrganizationInvitationRequest(or
 }
 
 func (r CreateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.CreateOrganizationInvitationExecute(r)
-}
-
-func (r CreateOrganizationInvitationApiRequest) ExecuteWithParams(params *CreateOrganizationInvitationApiParams) (*OrganizationInvitation, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.organizationInvitationRequest = params.OrganizationInvitationRequest 
-	return r.Execute()
+	return r.ApiService.createOrganizationInvitationExecute(r)
 }
 
 /*
@@ -432,7 +560,7 @@ func (a *OrganizationsApiService) CreateOrganizationInvitation(ctx context.Conte
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) CreateOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) createOrganizationInvitationExecute(r CreateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -535,13 +663,16 @@ type DeleteOrganizationApiParams struct {
 		OrgId string
 }
 
-func (r DeleteOrganizationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteOrganizationExecute(r)
+func (a *OrganizationsApiService) DeleteOrganizationWithParams(ctx context.Context, args *DeleteOrganizationApiParams) DeleteOrganizationApiRequest {
+	return DeleteOrganizationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+	}
 }
 
-func (r DeleteOrganizationApiRequest) ExecuteWithParams(params *DeleteOrganizationApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r DeleteOrganizationApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteOrganizationExecute(r)
 }
 
 /*
@@ -566,7 +697,7 @@ func (a *OrganizationsApiService) DeleteOrganization(ctx context.Context, orgId 
 }
 
 // Execute executes the request
-func (a *OrganizationsApiService) DeleteOrganizationExecute(r DeleteOrganizationApiRequest) (*http.Response, error) {
+func (a *OrganizationsApiService) deleteOrganizationExecute(r DeleteOrganizationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -656,14 +787,17 @@ type DeleteOrganizationInvitationApiParams struct {
 		InvitationId string
 }
 
-func (r DeleteOrganizationInvitationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteOrganizationInvitationExecute(r)
+func (a *OrganizationsApiService) DeleteOrganizationInvitationWithParams(ctx context.Context, args *DeleteOrganizationInvitationApiParams) DeleteOrganizationInvitationApiRequest {
+	return DeleteOrganizationInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		invitationId: args.InvitationId,
+	}
 }
 
-func (r DeleteOrganizationInvitationApiRequest) ExecuteWithParams(params *DeleteOrganizationInvitationApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	r.invitationId = params.InvitationId 
-	return r.Execute()
+func (r DeleteOrganizationInvitationApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteOrganizationInvitationExecute(r)
 }
 
 /*
@@ -686,7 +820,7 @@ func (a *OrganizationsApiService) DeleteOrganizationInvitation(ctx context.Conte
 }
 
 // Execute executes the request
-func (a *OrganizationsApiService) DeleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (*http.Response, error) {
+func (a *OrganizationsApiService) deleteOrganizationInvitationExecute(r DeleteOrganizationInvitationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -775,13 +909,16 @@ type GetOrganizationApiParams struct {
 		OrgId string
 }
 
-func (r GetOrganizationApiRequest) Execute() (*Organization, *http.Response, error) {
-	return r.ApiService.GetOrganizationExecute(r)
+func (a *OrganizationsApiService) GetOrganizationWithParams(ctx context.Context, args *GetOrganizationApiParams) GetOrganizationApiRequest {
+	return GetOrganizationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+	}
 }
 
-func (r GetOrganizationApiRequest) ExecuteWithParams(params *GetOrganizationApiParams) (*Organization, *http.Response, error) {
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r GetOrganizationApiRequest) Execute() (*Organization, *http.Response, error) {
+	return r.ApiService.getOrganizationExecute(r)
 }
 
 /*
@@ -803,7 +940,7 @@ func (a *OrganizationsApiService) GetOrganization(ctx context.Context, orgId str
 
 // Execute executes the request
 //  @return Organization
-func (a *OrganizationsApiService) GetOrganizationExecute(r GetOrganizationApiRequest) (*Organization, *http.Response, error) {
+func (a *OrganizationsApiService) getOrganizationExecute(r GetOrganizationApiRequest) (*Organization, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -903,14 +1040,17 @@ type GetOrganizationInvitationApiParams struct {
 		InvitationId string
 }
 
-func (r GetOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.GetOrganizationInvitationExecute(r)
+func (a *OrganizationsApiService) GetOrganizationInvitationWithParams(ctx context.Context, args *GetOrganizationInvitationApiParams) GetOrganizationInvitationApiRequest {
+	return GetOrganizationInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		invitationId: args.InvitationId,
+	}
 }
 
-func (r GetOrganizationInvitationApiRequest) ExecuteWithParams(params *GetOrganizationInvitationApiParams) (*OrganizationInvitation, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.invitationId = params.InvitationId 
-	return r.Execute()
+func (r GetOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
+	return r.ApiService.getOrganizationInvitationExecute(r)
 }
 
 /*
@@ -934,7 +1074,7 @@ func (a *OrganizationsApiService) GetOrganizationInvitation(ctx context.Context,
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) GetOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) getOrganizationInvitationExecute(r GetOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1039,13 +1179,16 @@ type GetOrganizationSettingsApiParams struct {
 		OrgId string
 }
 
-func (r GetOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
-	return r.ApiService.GetOrganizationSettingsExecute(r)
+func (a *OrganizationsApiService) GetOrganizationSettingsWithParams(ctx context.Context, args *GetOrganizationSettingsApiParams) GetOrganizationSettingsApiRequest {
+	return GetOrganizationSettingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+	}
 }
 
-func (r GetOrganizationSettingsApiRequest) ExecuteWithParams(params *GetOrganizationSettingsApiParams) (*OrganizationSettings, *http.Response, error) {
-	r.orgId = params.OrgId 
-	return r.Execute()
+func (r GetOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
+	return r.ApiService.getOrganizationSettingsExecute(r)
 }
 
 /*
@@ -1067,7 +1210,7 @@ func (a *OrganizationsApiService) GetOrganizationSettings(ctx context.Context, o
 
 // Execute executes the request
 //  @return OrganizationSettings
-func (a *OrganizationsApiService) GetOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
+func (a *OrganizationsApiService) getOrganizationSettingsExecute(r GetOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1167,6 +1310,15 @@ type ListOrganizationInvitationsApiParams struct {
 		Username *string
 }
 
+func (a *OrganizationsApiService) ListOrganizationInvitationsWithParams(ctx context.Context, args *ListOrganizationInvitationsApiParams) ListOrganizationInvitationsApiRequest {
+	return ListOrganizationInvitationsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		username: args.Username,
+	}
+}
+
 // Email address of the user account invited to this organization. If you exclude this parameter, this resource returns all pending invitations.
 func (r ListOrganizationInvitationsApiRequest) Username(username string) ListOrganizationInvitationsApiRequest {
 	r.username = &username
@@ -1174,13 +1326,7 @@ func (r ListOrganizationInvitationsApiRequest) Username(username string) ListOrg
 }
 
 func (r ListOrganizationInvitationsApiRequest) Execute() ([]OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.ListOrganizationInvitationsExecute(r)
-}
-
-func (r ListOrganizationInvitationsApiRequest) ExecuteWithParams(params *ListOrganizationInvitationsApiParams) ([]OrganizationInvitation, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.username = params.Username 
-	return r.Execute()
+	return r.ApiService.listOrganizationInvitationsExecute(r)
 }
 
 /*
@@ -1202,7 +1348,7 @@ func (a *OrganizationsApiService) ListOrganizationInvitations(ctx context.Contex
 
 // Execute executes the request
 //  @return []OrganizationInvitation
-func (a *OrganizationsApiService) ListOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) listOrganizationInvitationsExecute(r ListOrganizationInvitationsApiRequest) ([]OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1311,6 +1457,18 @@ type ListOrganizationProjectsApiParams struct {
 		Name *string
 }
 
+func (a *OrganizationsApiService) ListOrganizationProjectsWithParams(ctx context.Context, args *ListOrganizationProjectsApiParams) ListOrganizationProjectsApiRequest {
+	return ListOrganizationProjectsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		name: args.Name,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListOrganizationProjectsApiRequest) IncludeCount(includeCount bool) ListOrganizationProjectsApiRequest {
 	r.includeCount = &includeCount
@@ -1336,16 +1494,7 @@ func (r ListOrganizationProjectsApiRequest) Name(name string) ListOrganizationPr
 }
 
 func (r ListOrganizationProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
-	return r.ApiService.ListOrganizationProjectsExecute(r)
-}
-
-func (r ListOrganizationProjectsApiRequest) ExecuteWithParams(params *ListOrganizationProjectsApiParams) (*PaginatedAtlasGroup, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.name = params.Name 
-	return r.Execute()
+	return r.ApiService.listOrganizationProjectsExecute(r)
 }
 
 /*
@@ -1374,7 +1523,7 @@ func (a *OrganizationsApiService) ListOrganizationProjects(ctx context.Context, 
 
 // Execute executes the request
 //  @return PaginatedAtlasGroup
-func (a *OrganizationsApiService) ListOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
+func (a *OrganizationsApiService) listOrganizationProjectsExecute(r ListOrganizationProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1502,6 +1651,17 @@ type ListOrganizationUsersApiParams struct {
 		PageNum *int32
 }
 
+func (a *OrganizationsApiService) ListOrganizationUsersWithParams(ctx context.Context, args *ListOrganizationUsersApiParams) ListOrganizationUsersApiRequest {
+	return ListOrganizationUsersApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListOrganizationUsersApiRequest) IncludeCount(includeCount bool) ListOrganizationUsersApiRequest {
 	r.includeCount = &includeCount
@@ -1521,15 +1681,7 @@ func (r ListOrganizationUsersApiRequest) PageNum(pageNum int32) ListOrganization
 }
 
 func (r ListOrganizationUsersApiRequest) Execute() (*PaginatedAppUser, *http.Response, error) {
-	return r.ApiService.ListOrganizationUsersExecute(r)
-}
-
-func (r ListOrganizationUsersApiRequest) ExecuteWithParams(params *ListOrganizationUsersApiParams) (*PaginatedAppUser, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listOrganizationUsersExecute(r)
 }
 
 /*
@@ -1551,7 +1703,7 @@ func (a *OrganizationsApiService) ListOrganizationUsers(ctx context.Context, org
 
 // Execute executes the request
 //  @return PaginatedAppUser
-func (a *OrganizationsApiService) ListOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
+func (a *OrganizationsApiService) listOrganizationUsersExecute(r ListOrganizationUsersApiRequest) (*PaginatedAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1676,6 +1828,17 @@ type ListOrganizationsApiParams struct {
 		Name *string
 }
 
+func (a *OrganizationsApiService) ListOrganizationsWithParams(ctx context.Context, args *ListOrganizationsApiParams) ListOrganizationsApiRequest {
+	return ListOrganizationsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		name: args.Name,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListOrganizationsApiRequest) IncludeCount(includeCount bool) ListOrganizationsApiRequest {
 	r.includeCount = &includeCount
@@ -1701,15 +1864,7 @@ func (r ListOrganizationsApiRequest) Name(name string) ListOrganizationsApiReque
 }
 
 func (r ListOrganizationsApiRequest) Execute() (*PaginatedOrganization, *http.Response, error) {
-	return r.ApiService.ListOrganizationsExecute(r)
-}
-
-func (r ListOrganizationsApiRequest) ExecuteWithParams(params *ListOrganizationsApiParams) (*PaginatedOrganization, *http.Response, error) {
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.name = params.Name 
-	return r.Execute()
+	return r.ApiService.listOrganizationsExecute(r)
 }
 
 /*
@@ -1729,7 +1884,7 @@ func (a *OrganizationsApiService) ListOrganizations(ctx context.Context) ListOrg
 
 // Execute executes the request
 //  @return PaginatedOrganization
-func (a *OrganizationsApiService) ListOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error) {
+func (a *OrganizationsApiService) listOrganizationsExecute(r ListOrganizationsApiRequest) (*PaginatedOrganization, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1846,6 +2001,15 @@ type RenameOrganizationApiParams struct {
 		Organization *Organization
 }
 
+func (a *OrganizationsApiService) RenameOrganizationWithParams(ctx context.Context, args *RenameOrganizationApiParams) RenameOrganizationApiRequest {
+	return RenameOrganizationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		organization: args.Organization,
+	}
+}
+
 // Details to update on the specified organization.
 func (r RenameOrganizationApiRequest) Organization(organization Organization) RenameOrganizationApiRequest {
 	r.organization = &organization
@@ -1853,13 +2017,7 @@ func (r RenameOrganizationApiRequest) Organization(organization Organization) Re
 }
 
 func (r RenameOrganizationApiRequest) Execute() (*Organization, *http.Response, error) {
-	return r.ApiService.RenameOrganizationExecute(r)
-}
-
-func (r RenameOrganizationApiRequest) ExecuteWithParams(params *RenameOrganizationApiParams) (*Organization, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.organization = params.Organization 
-	return r.Execute()
+	return r.ApiService.renameOrganizationExecute(r)
 }
 
 /*
@@ -1881,7 +2039,7 @@ func (a *OrganizationsApiService) RenameOrganization(ctx context.Context, orgId 
 
 // Execute executes the request
 //  @return Organization
-func (a *OrganizationsApiService) RenameOrganizationExecute(r RenameOrganizationApiRequest) (*Organization, *http.Response, error) {
+func (a *OrganizationsApiService) renameOrganizationExecute(r RenameOrganizationApiRequest) (*Organization, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -1986,6 +2144,15 @@ type UpdateOrganizationInvitationApiParams struct {
 		OrganizationInvitationRequest *OrganizationInvitationRequest
 }
 
+func (a *OrganizationsApiService) UpdateOrganizationInvitationWithParams(ctx context.Context, args *UpdateOrganizationInvitationApiParams) UpdateOrganizationInvitationApiRequest {
+	return UpdateOrganizationInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		organizationInvitationRequest: args.OrganizationInvitationRequest,
+	}
+}
+
 // Updates the details of one pending invitation to the specified organization.
 func (r UpdateOrganizationInvitationApiRequest) OrganizationInvitationRequest(organizationInvitationRequest OrganizationInvitationRequest) UpdateOrganizationInvitationApiRequest {
 	r.organizationInvitationRequest = &organizationInvitationRequest
@@ -1993,13 +2160,7 @@ func (r UpdateOrganizationInvitationApiRequest) OrganizationInvitationRequest(or
 }
 
 func (r UpdateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.UpdateOrganizationInvitationExecute(r)
-}
-
-func (r UpdateOrganizationInvitationApiRequest) ExecuteWithParams(params *UpdateOrganizationInvitationApiParams) (*OrganizationInvitation, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.organizationInvitationRequest = params.OrganizationInvitationRequest 
-	return r.Execute()
+	return r.ApiService.updateOrganizationInvitationExecute(r)
 }
 
 /*
@@ -2021,7 +2182,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitation(ctx context.Conte
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) UpdateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) updateOrganizationInvitationExecute(r UpdateOrganizationInvitationApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2128,6 +2289,16 @@ type UpdateOrganizationInvitationByIdApiParams struct {
 		OrganizationInvitationUpdateRequest *OrganizationInvitationUpdateRequest
 }
 
+func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdWithParams(ctx context.Context, args *UpdateOrganizationInvitationByIdApiParams) UpdateOrganizationInvitationByIdApiRequest {
+	return UpdateOrganizationInvitationByIdApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		invitationId: args.InvitationId,
+		organizationInvitationUpdateRequest: args.OrganizationInvitationUpdateRequest,
+	}
+}
+
 // Updates the details of one pending invitation to the specified organization.
 func (r UpdateOrganizationInvitationByIdApiRequest) OrganizationInvitationUpdateRequest(organizationInvitationUpdateRequest OrganizationInvitationUpdateRequest) UpdateOrganizationInvitationByIdApiRequest {
 	r.organizationInvitationUpdateRequest = &organizationInvitationUpdateRequest
@@ -2135,14 +2306,7 @@ func (r UpdateOrganizationInvitationByIdApiRequest) OrganizationInvitationUpdate
 }
 
 func (r UpdateOrganizationInvitationByIdApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
-	return r.ApiService.UpdateOrganizationInvitationByIdExecute(r)
-}
-
-func (r UpdateOrganizationInvitationByIdApiRequest) ExecuteWithParams(params *UpdateOrganizationInvitationByIdApiParams) (*OrganizationInvitation, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.invitationId = params.InvitationId 
-	r.organizationInvitationUpdateRequest = params.OrganizationInvitationUpdateRequest 
-	return r.Execute()
+	return r.ApiService.updateOrganizationInvitationByIdExecute(r)
 }
 
 /*
@@ -2166,7 +2330,7 @@ func (a *OrganizationsApiService) UpdateOrganizationInvitationById(ctx context.C
 
 // Execute executes the request
 //  @return OrganizationInvitation
-func (a *OrganizationsApiService) UpdateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error) {
+func (a *OrganizationsApiService) updateOrganizationInvitationByIdExecute(r UpdateOrganizationInvitationByIdApiRequest) (*OrganizationInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2278,6 +2442,15 @@ type UpdateOrganizationSettingsApiParams struct {
 		OrganizationSettings *OrganizationSettings
 }
 
+func (a *OrganizationsApiService) UpdateOrganizationSettingsWithParams(ctx context.Context, args *UpdateOrganizationSettingsApiParams) UpdateOrganizationSettingsApiRequest {
+	return UpdateOrganizationSettingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		organizationSettings: args.OrganizationSettings,
+	}
+}
+
 // Details to update on the specified organization&#39;s settings.
 func (r UpdateOrganizationSettingsApiRequest) OrganizationSettings(organizationSettings OrganizationSettings) UpdateOrganizationSettingsApiRequest {
 	r.organizationSettings = &organizationSettings
@@ -2285,13 +2458,7 @@ func (r UpdateOrganizationSettingsApiRequest) OrganizationSettings(organizationS
 }
 
 func (r UpdateOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
-	return r.ApiService.UpdateOrganizationSettingsExecute(r)
-}
-
-func (r UpdateOrganizationSettingsApiRequest) ExecuteWithParams(params *UpdateOrganizationSettingsApiParams) (*OrganizationSettings, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.organizationSettings = params.OrganizationSettings 
-	return r.Execute()
+	return r.ApiService.updateOrganizationSettingsExecute(r)
 }
 
 /*
@@ -2313,7 +2480,7 @@ func (a *OrganizationsApiService) UpdateOrganizationSettings(ctx context.Context
 
 // Execute executes the request
 //  @return OrganizationSettings
-func (a *OrganizationsApiService) UpdateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
+func (a *OrganizationsApiService) updateOrganizationSettingsExecute(r UpdateOrganizationSettingsApiRequest) (*OrganizationSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_organizations.go
+++ b/mongodbatlasv2/api_organizations.go
@@ -277,6 +277,11 @@ func (r CreateOrganizationApiRequest) Execute() (*CreateOrganizationResponse, *h
 	return r.ApiService.CreateOrganizationExecute(r)
 }
 
+func (r CreateOrganizationApiRequest) ExecuteWithParams(params *CreateOrganizationApiParams) (*CreateOrganizationResponse, *http.Response, error) {
+	r.createOrganizationRequest = params.CreateOrganizationRequest 
+	return r.Execute()
+}
+
 /*
 CreateOrganization Create One Organization
 
@@ -400,6 +405,12 @@ func (r CreateOrganizationInvitationApiRequest) OrganizationInvitationRequest(or
 
 func (r CreateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.CreateOrganizationInvitationExecute(r)
+}
+
+func (r CreateOrganizationInvitationApiRequest) ExecuteWithParams(params *CreateOrganizationInvitationApiParams) (*OrganizationInvitation, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.organizationInvitationRequest = params.OrganizationInvitationRequest 
+	return r.Execute()
 }
 
 /*
@@ -528,6 +539,11 @@ func (r DeleteOrganizationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteOrganizationExecute(r)
 }
 
+func (r DeleteOrganizationApiRequest) ExecuteWithParams(params *DeleteOrganizationApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	return r.Execute()
+}
+
 /*
 DeleteOrganization Remove One Organization
 
@@ -644,6 +660,12 @@ func (r DeleteOrganizationInvitationApiRequest) Execute() (*http.Response, error
 	return r.ApiService.DeleteOrganizationInvitationExecute(r)
 }
 
+func (r DeleteOrganizationInvitationApiRequest) ExecuteWithParams(params *DeleteOrganizationInvitationApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	r.invitationId = params.InvitationId 
+	return r.Execute()
+}
+
 /*
 DeleteOrganizationInvitation Cancel One Organization Invitation
 
@@ -755,6 +777,11 @@ type GetOrganizationApiParams struct {
 
 func (r GetOrganizationApiRequest) Execute() (*Organization, *http.Response, error) {
 	return r.ApiService.GetOrganizationExecute(r)
+}
+
+func (r GetOrganizationApiRequest) ExecuteWithParams(params *GetOrganizationApiParams) (*Organization, *http.Response, error) {
+	r.orgId = params.OrgId 
+	return r.Execute()
 }
 
 /*
@@ -878,6 +905,12 @@ type GetOrganizationInvitationApiParams struct {
 
 func (r GetOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.GetOrganizationInvitationExecute(r)
+}
+
+func (r GetOrganizationInvitationApiRequest) ExecuteWithParams(params *GetOrganizationInvitationApiParams) (*OrganizationInvitation, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.invitationId = params.InvitationId 
+	return r.Execute()
 }
 
 /*
@@ -1010,6 +1043,11 @@ func (r GetOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *ht
 	return r.ApiService.GetOrganizationSettingsExecute(r)
 }
 
+func (r GetOrganizationSettingsApiRequest) ExecuteWithParams(params *GetOrganizationSettingsApiParams) (*OrganizationSettings, *http.Response, error) {
+	r.orgId = params.OrgId 
+	return r.Execute()
+}
+
 /*
 GetOrganizationSettings Return Settings for One Organization
 
@@ -1137,6 +1175,12 @@ func (r ListOrganizationInvitationsApiRequest) Username(username string) ListOrg
 
 func (r ListOrganizationInvitationsApiRequest) Execute() ([]OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.ListOrganizationInvitationsExecute(r)
+}
+
+func (r ListOrganizationInvitationsApiRequest) ExecuteWithParams(params *ListOrganizationInvitationsApiParams) ([]OrganizationInvitation, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.username = params.Username 
+	return r.Execute()
 }
 
 /*
@@ -1293,6 +1337,15 @@ func (r ListOrganizationProjectsApiRequest) Name(name string) ListOrganizationPr
 
 func (r ListOrganizationProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
 	return r.ApiService.ListOrganizationProjectsExecute(r)
+}
+
+func (r ListOrganizationProjectsApiRequest) ExecuteWithParams(params *ListOrganizationProjectsApiParams) (*PaginatedAtlasGroup, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.name = params.Name 
+	return r.Execute()
 }
 
 /*
@@ -1471,6 +1524,14 @@ func (r ListOrganizationUsersApiRequest) Execute() (*PaginatedAppUser, *http.Res
 	return r.ApiService.ListOrganizationUsersExecute(r)
 }
 
+func (r ListOrganizationUsersApiRequest) ExecuteWithParams(params *ListOrganizationUsersApiParams) (*PaginatedAppUser, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListOrganizationUsers Return All MongoDB Cloud Users in One Organization
 
@@ -1643,6 +1704,14 @@ func (r ListOrganizationsApiRequest) Execute() (*PaginatedOrganization, *http.Re
 	return r.ApiService.ListOrganizationsExecute(r)
 }
 
+func (r ListOrganizationsApiRequest) ExecuteWithParams(params *ListOrganizationsApiParams) (*PaginatedOrganization, *http.Response, error) {
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.name = params.Name 
+	return r.Execute()
+}
+
 /*
 ListOrganizations Return All Organizations
 
@@ -1787,6 +1856,12 @@ func (r RenameOrganizationApiRequest) Execute() (*Organization, *http.Response, 
 	return r.ApiService.RenameOrganizationExecute(r)
 }
 
+func (r RenameOrganizationApiRequest) ExecuteWithParams(params *RenameOrganizationApiParams) (*Organization, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.organization = params.Organization 
+	return r.Execute()
+}
+
 /*
 RenameOrganization Rename One Organization
 
@@ -1919,6 +1994,12 @@ func (r UpdateOrganizationInvitationApiRequest) OrganizationInvitationRequest(or
 
 func (r UpdateOrganizationInvitationApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.UpdateOrganizationInvitationExecute(r)
+}
+
+func (r UpdateOrganizationInvitationApiRequest) ExecuteWithParams(params *UpdateOrganizationInvitationApiParams) (*OrganizationInvitation, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.organizationInvitationRequest = params.OrganizationInvitationRequest 
+	return r.Execute()
 }
 
 /*
@@ -2055,6 +2136,13 @@ func (r UpdateOrganizationInvitationByIdApiRequest) OrganizationInvitationUpdate
 
 func (r UpdateOrganizationInvitationByIdApiRequest) Execute() (*OrganizationInvitation, *http.Response, error) {
 	return r.ApiService.UpdateOrganizationInvitationByIdExecute(r)
+}
+
+func (r UpdateOrganizationInvitationByIdApiRequest) ExecuteWithParams(params *UpdateOrganizationInvitationByIdApiParams) (*OrganizationInvitation, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.invitationId = params.InvitationId 
+	r.organizationInvitationUpdateRequest = params.OrganizationInvitationUpdateRequest 
+	return r.Execute()
 }
 
 /*
@@ -2198,6 +2286,12 @@ func (r UpdateOrganizationSettingsApiRequest) OrganizationSettings(organizationS
 
 func (r UpdateOrganizationSettingsApiRequest) Execute() (*OrganizationSettings, *http.Response, error) {
 	return r.ApiService.UpdateOrganizationSettingsExecute(r)
+}
+
+func (r UpdateOrganizationSettingsApiRequest) ExecuteWithParams(params *UpdateOrganizationSettingsApiParams) (*OrganizationSettings, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.organizationSettings = params.OrganizationSettings 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -35,7 +35,7 @@ type PerformanceAdvisorApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DisableSlowOperationThresholdingApiParams - Parameters for the request
-	@return DisableSlowOperationThresholdingApiRequest}}
+	@return DisableSlowOperationThresholdingApiRequest
 	*/
 	DisableSlowOperationThresholdingWithParams(ctx context.Context, args *DisableSlowOperationThresholdingApiParams) DisableSlowOperationThresholdingApiRequest
 
@@ -58,7 +58,7 @@ type PerformanceAdvisorApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param EnableSlowOperationThresholdingApiParams - Parameters for the request
-	@return EnableSlowOperationThresholdingApiRequest}}
+	@return EnableSlowOperationThresholdingApiRequest
 	*/
 	EnableSlowOperationThresholdingWithParams(ctx context.Context, args *EnableSlowOperationThresholdingApiParams) EnableSlowOperationThresholdingApiRequest
 
@@ -82,7 +82,7 @@ type PerformanceAdvisorApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListSlowQueriesApiParams - Parameters for the request
-	@return ListSlowQueriesApiRequest}}
+	@return ListSlowQueriesApiRequest
 	*/
 	ListSlowQueriesWithParams(ctx context.Context, args *ListSlowQueriesApiParams) ListSlowQueriesApiRequest
 
@@ -106,7 +106,7 @@ type PerformanceAdvisorApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListSlowQueryNamespacesApiParams - Parameters for the request
-	@return ListSlowQueryNamespacesApiRequest}}
+	@return ListSlowQueryNamespacesApiRequest
 	*/
 	ListSlowQueryNamespacesWithParams(ctx context.Context, args *ListSlowQueryNamespacesApiParams) ListSlowQueryNamespacesApiRequest
 
@@ -130,7 +130,7 @@ type PerformanceAdvisorApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListSuggestedIndexesApiParams - Parameters for the request
-	@return ListSuggestedIndexesApiRequest}}
+	@return ListSuggestedIndexesApiRequest
 	*/
 	ListSuggestedIndexesWithParams(ctx context.Context, args *ListSuggestedIndexesApiParams) ListSuggestedIndexesApiRequest
 

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -29,9 +29,18 @@ type PerformanceAdvisorApi interface {
 	@return DisableSlowOperationThresholdingApiRequest
 	*/
 	DisableSlowOperationThresholding(ctx context.Context, groupId string) DisableSlowOperationThresholdingApiRequest
+	/*
+	DisableSlowOperationThresholding Disable Managed Slow Operation Threshold
 
-	// DisableSlowOperationThresholdingExecute executes the request
-	DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DisableSlowOperationThresholdingApiParams - Parameters for the request
+	@return DisableSlowOperationThresholdingApiRequest}}
+	*/
+	DisableSlowOperationThresholdingWithParams(ctx context.Context, args *DisableSlowOperationThresholdingApiParams) DisableSlowOperationThresholdingApiRequest
+
+	// Interface only available internally
+	disableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
 	EnableSlowOperationThresholding Enable Managed Slow Operation Threshold
@@ -43,9 +52,18 @@ type PerformanceAdvisorApi interface {
 	@return EnableSlowOperationThresholdingApiRequest
 	*/
 	EnableSlowOperationThresholding(ctx context.Context, groupId string) EnableSlowOperationThresholdingApiRequest
+	/*
+	EnableSlowOperationThresholding Enable Managed Slow Operation Threshold
 
-	// EnableSlowOperationThresholdingExecute executes the request
-	EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param EnableSlowOperationThresholdingApiParams - Parameters for the request
+	@return EnableSlowOperationThresholdingApiRequest}}
+	*/
+	EnableSlowOperationThresholdingWithParams(ctx context.Context, args *EnableSlowOperationThresholdingApiParams) EnableSlowOperationThresholdingApiRequest
+
+	// Interface only available internally
+	enableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error)
 
 	/*
 	ListSlowQueries Return Slow Queries
@@ -58,10 +76,18 @@ type PerformanceAdvisorApi interface {
 	@return ListSlowQueriesApiRequest
 	*/
 	ListSlowQueries(ctx context.Context, groupId string, processId string) ListSlowQueriesApiRequest
+	/*
+	ListSlowQueries Return Slow Queries
 
-	// ListSlowQueriesExecute executes the request
-	//  @return PerformanceAdvisorSlowQueryList
-	ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListSlowQueriesApiParams - Parameters for the request
+	@return ListSlowQueriesApiRequest}}
+	*/
+	ListSlowQueriesWithParams(ctx context.Context, args *ListSlowQueriesApiParams) ListSlowQueriesApiRequest
+
+	// Interface only available internally
+	listSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error)
 
 	/*
 	ListSlowQueryNamespaces Return All Namespaces for One Host
@@ -74,10 +100,18 @@ type PerformanceAdvisorApi interface {
 	@return ListSlowQueryNamespacesApiRequest
 	*/
 	ListSlowQueryNamespaces(ctx context.Context, groupId string, processId string) ListSlowQueryNamespacesApiRequest
+	/*
+	ListSlowQueryNamespaces Return All Namespaces for One Host
 
-	// ListSlowQueryNamespacesExecute executes the request
-	//  @return Namespaces
-	ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListSlowQueryNamespacesApiParams - Parameters for the request
+	@return ListSlowQueryNamespacesApiRequest}}
+	*/
+	ListSlowQueryNamespacesWithParams(ctx context.Context, args *ListSlowQueryNamespacesApiParams) ListSlowQueryNamespacesApiRequest
+
+	// Interface only available internally
+	listSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error)
 
 	/*
 	ListSuggestedIndexes Return Suggested Indexes
@@ -90,10 +124,18 @@ type PerformanceAdvisorApi interface {
 	@return ListSuggestedIndexesApiRequest
 	*/
 	ListSuggestedIndexes(ctx context.Context, groupId string, processId string) ListSuggestedIndexesApiRequest
+	/*
+	ListSuggestedIndexes Return Suggested Indexes
 
-	// ListSuggestedIndexesExecute executes the request
-	//  @return PerformanceAdvisorResponse
-	ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListSuggestedIndexesApiParams - Parameters for the request
+	@return ListSuggestedIndexesApiRequest}}
+	*/
+	ListSuggestedIndexesWithParams(ctx context.Context, args *ListSuggestedIndexesApiParams) ListSuggestedIndexesApiRequest
+
+	// Interface only available internally
+	listSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error)
 }
 
 // PerformanceAdvisorApiService PerformanceAdvisorApi service
@@ -109,13 +151,16 @@ type DisableSlowOperationThresholdingApiParams struct {
 		GroupId string
 }
 
-func (r DisableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DisableSlowOperationThresholdingExecute(r)
+func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingWithParams(ctx context.Context, args *DisableSlowOperationThresholdingApiParams) DisableSlowOperationThresholdingApiRequest {
+	return DisableSlowOperationThresholdingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r DisableSlowOperationThresholdingApiRequest) ExecuteWithParams(params *DisableSlowOperationThresholdingApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r DisableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.disableSlowOperationThresholdingExecute(r)
 }
 
 /*
@@ -136,7 +181,7 @@ func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholding(ctx cont
 }
 
 // Execute executes the request
-func (a *PerformanceAdvisorApiService) DisableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error) {
+func (a *PerformanceAdvisorApiService) disableSlowOperationThresholdingExecute(r DisableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -224,13 +269,16 @@ type EnableSlowOperationThresholdingApiParams struct {
 		GroupId string
 }
 
-func (r EnableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.EnableSlowOperationThresholdingExecute(r)
+func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingWithParams(ctx context.Context, args *EnableSlowOperationThresholdingApiParams) EnableSlowOperationThresholdingApiRequest {
+	return EnableSlowOperationThresholdingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r EnableSlowOperationThresholdingApiRequest) ExecuteWithParams(params *EnableSlowOperationThresholdingApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r EnableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.enableSlowOperationThresholdingExecute(r)
 }
 
 /*
@@ -251,7 +299,7 @@ func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholding(ctx conte
 }
 
 // Execute executes the request
-func (a *PerformanceAdvisorApiService) EnableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error) {
+func (a *PerformanceAdvisorApiService) enableSlowOperationThresholdingExecute(r EnableSlowOperationThresholdingApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -349,6 +397,19 @@ type ListSlowQueriesApiParams struct {
 		Since *int64
 }
 
+func (a *PerformanceAdvisorApiService) ListSlowQueriesWithParams(ctx context.Context, args *ListSlowQueriesApiParams) ListSlowQueriesApiRequest {
+	return ListSlowQueriesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+		duration: args.Duration,
+		namespaces: args.Namespaces,
+		nLogs: args.NLogs,
+		since: args.Since,
+	}
+}
+
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
 func (r ListSlowQueriesApiRequest) Duration(duration int64) ListSlowQueriesApiRequest {
 	r.duration = &duration
@@ -374,17 +435,7 @@ func (r ListSlowQueriesApiRequest) Since(since int64) ListSlowQueriesApiRequest 
 }
 
 func (r ListSlowQueriesApiRequest) Execute() (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
-	return r.ApiService.ListSlowQueriesExecute(r)
-}
-
-func (r ListSlowQueriesApiRequest) ExecuteWithParams(params *ListSlowQueriesApiParams) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	r.duration = params.Duration 
-	r.namespaces = params.Namespaces 
-	r.nLogs = params.NLogs 
-	r.since = params.Since 
-	return r.Execute()
+	return r.ApiService.listSlowQueriesExecute(r)
 }
 
 /*
@@ -408,7 +459,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueries(ctx context.Context, grou
 
 // Execute executes the request
 //  @return PerformanceAdvisorSlowQueryList
-func (a *PerformanceAdvisorApiService) ListSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) listSlowQueriesExecute(r ListSlowQueriesApiRequest) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -537,6 +588,17 @@ type ListSlowQueryNamespacesApiParams struct {
 		Since *int64
 }
 
+func (a *PerformanceAdvisorApiService) ListSlowQueryNamespacesWithParams(ctx context.Context, args *ListSlowQueryNamespacesApiParams) ListSlowQueryNamespacesApiRequest {
+	return ListSlowQueryNamespacesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+		duration: args.Duration,
+		since: args.Since,
+	}
+}
+
 // Length of time expressed during which the query finds suggested indexes among the managed namespaces in the cluster. This parameter expresses its value in milliseconds.  - If you don&#39;t specify the **since** parameter, the endpoint returns data covering the duration before the current time. - If you specify neither the **duration** nor **since** parameters, the endpoint returns data from the previous 24 hours.
 func (r ListSlowQueryNamespacesApiRequest) Duration(duration int64) ListSlowQueryNamespacesApiRequest {
 	r.duration = &duration
@@ -550,15 +612,7 @@ func (r ListSlowQueryNamespacesApiRequest) Since(since int64) ListSlowQueryNames
 }
 
 func (r ListSlowQueryNamespacesApiRequest) Execute() (*Namespaces, *http.Response, error) {
-	return r.ApiService.ListSlowQueryNamespacesExecute(r)
-}
-
-func (r ListSlowQueryNamespacesApiRequest) ExecuteWithParams(params *ListSlowQueryNamespacesApiParams) (*Namespaces, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	r.duration = params.Duration 
-	r.since = params.Since 
-	return r.Execute()
+	return r.ApiService.listSlowQueryNamespacesExecute(r)
 }
 
 /*
@@ -582,7 +636,7 @@ func (a *PerformanceAdvisorApiService) ListSlowQueryNamespaces(ctx context.Conte
 
 // Execute executes the request
 //  @return Namespaces
-func (a *PerformanceAdvisorApiService) ListSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) listSlowQueryNamespacesExecute(r ListSlowQueryNamespacesApiRequest) (*Namespaces, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -705,6 +759,23 @@ type ListSuggestedIndexesApiParams struct {
 		Since *float32
 }
 
+func (a *PerformanceAdvisorApiService) ListSuggestedIndexesWithParams(ctx context.Context, args *ListSuggestedIndexesApiParams) ListSuggestedIndexesApiRequest {
+	return ListSuggestedIndexesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		processId: args.ProcessId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		duration: args.Duration,
+		namespaces: args.Namespaces,
+		nExamples: args.NExamples,
+		nIndexes: args.NIndexes,
+		since: args.Since,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListSuggestedIndexesApiRequest) IncludeCount(includeCount bool) ListSuggestedIndexesApiRequest {
 	r.includeCount = &includeCount
@@ -754,21 +825,7 @@ func (r ListSuggestedIndexesApiRequest) Since(since float32) ListSuggestedIndexe
 }
 
 func (r ListSuggestedIndexesApiRequest) Execute() (*PerformanceAdvisorResponse, *http.Response, error) {
-	return r.ApiService.ListSuggestedIndexesExecute(r)
-}
-
-func (r ListSuggestedIndexesApiRequest) ExecuteWithParams(params *ListSuggestedIndexesApiParams) (*PerformanceAdvisorResponse, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.processId = params.ProcessId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.duration = params.Duration 
-	r.namespaces = params.Namespaces 
-	r.nExamples = params.NExamples 
-	r.nIndexes = params.NIndexes 
-	r.since = params.Since 
-	return r.Execute()
+	return r.ApiService.listSuggestedIndexesExecute(r)
 }
 
 /*
@@ -792,7 +849,7 @@ func (a *PerformanceAdvisorApiService) ListSuggestedIndexes(ctx context.Context,
 
 // Execute executes the request
 //  @return PerformanceAdvisorResponse
-func (a *PerformanceAdvisorApiService) ListSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error) {
+func (a *PerformanceAdvisorApiService) listSuggestedIndexesExecute(r ListSuggestedIndexesApiRequest) (*PerformanceAdvisorResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_performance_advisor.go
+++ b/mongodbatlasv2/api_performance_advisor.go
@@ -113,6 +113,11 @@ func (r DisableSlowOperationThresholdingApiRequest) Execute() (*http.Response, e
 	return r.ApiService.DisableSlowOperationThresholdingExecute(r)
 }
 
+func (r DisableSlowOperationThresholdingApiRequest) ExecuteWithParams(params *DisableSlowOperationThresholdingApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 DisableSlowOperationThresholding Disable Managed Slow Operation Threshold
 
@@ -221,6 +226,11 @@ type EnableSlowOperationThresholdingApiParams struct {
 
 func (r EnableSlowOperationThresholdingApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.EnableSlowOperationThresholdingExecute(r)
+}
+
+func (r EnableSlowOperationThresholdingApiRequest) ExecuteWithParams(params *EnableSlowOperationThresholdingApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -365,6 +375,16 @@ func (r ListSlowQueriesApiRequest) Since(since int64) ListSlowQueriesApiRequest 
 
 func (r ListSlowQueriesApiRequest) Execute() (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
 	return r.ApiService.ListSlowQueriesExecute(r)
+}
+
+func (r ListSlowQueriesApiRequest) ExecuteWithParams(params *ListSlowQueriesApiParams) (*PerformanceAdvisorSlowQueryList, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	r.duration = params.Duration 
+	r.namespaces = params.Namespaces 
+	r.nLogs = params.NLogs 
+	r.since = params.Since 
+	return r.Execute()
 }
 
 /*
@@ -531,6 +551,14 @@ func (r ListSlowQueryNamespacesApiRequest) Since(since int64) ListSlowQueryNames
 
 func (r ListSlowQueryNamespacesApiRequest) Execute() (*Namespaces, *http.Response, error) {
 	return r.ApiService.ListSlowQueryNamespacesExecute(r)
+}
+
+func (r ListSlowQueryNamespacesApiRequest) ExecuteWithParams(params *ListSlowQueryNamespacesApiParams) (*Namespaces, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	r.duration = params.Duration 
+	r.since = params.Since 
+	return r.Execute()
 }
 
 /*
@@ -727,6 +755,20 @@ func (r ListSuggestedIndexesApiRequest) Since(since float32) ListSuggestedIndexe
 
 func (r ListSuggestedIndexesApiRequest) Execute() (*PerformanceAdvisorResponse, *http.Response, error) {
 	return r.ApiService.ListSuggestedIndexesExecute(r)
+}
+
+func (r ListSuggestedIndexesApiRequest) ExecuteWithParams(params *ListSuggestedIndexesApiParams) (*PerformanceAdvisorResponse, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.processId = params.ProcessId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.duration = params.Duration 
+	r.namespaces = params.Namespaces 
+	r.nExamples = params.NExamples 
+	r.nIndexes = params.NIndexes 
+	r.since = params.Since 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -194,6 +194,14 @@ func (r CreatePrivateEndpointApiRequest) Execute() (*Endpoint, *http.Response, e
 	return r.ApiService.CreatePrivateEndpointExecute(r)
 }
 
+func (r CreatePrivateEndpointApiRequest) ExecuteWithParams(params *CreatePrivateEndpointApiParams) (*Endpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProvider = params.CloudProvider 
+	r.endpointServiceId = params.EndpointServiceId 
+	r.createPrivateEndpointRequest = params.CreatePrivateEndpointRequest 
+	return r.Execute()
+}
+
 /*
 CreatePrivateEndpoint Create One Private Endpoint for One Provider
 
@@ -340,6 +348,12 @@ func (r CreatePrivateEndpointServiceApiRequest) Execute() (*EndpointService, *ht
 	return r.ApiService.CreatePrivateEndpointServiceExecute(r)
 }
 
+func (r CreatePrivateEndpointServiceApiRequest) ExecuteWithParams(params *CreatePrivateEndpointServiceApiParams) (*EndpointService, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.createEndpointServiceRequest = params.CreateEndpointServiceRequest 
+	return r.Execute()
+}
+
 /*
 CreatePrivateEndpointService Create One Private Endpoint Service for One Provider
 
@@ -472,6 +486,14 @@ func (r DeletePrivateEndpointApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeletePrivateEndpointExecute(r)
 }
 
+func (r DeletePrivateEndpointApiRequest) ExecuteWithParams(params *DeletePrivateEndpointApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProvider = params.CloudProvider 
+	r.endpointId = params.EndpointId 
+	r.endpointServiceId = params.EndpointServiceId 
+	return r.Execute()
+}
+
 /*
 DeletePrivateEndpoint Remove One Private Endpoint for One Provider
 
@@ -601,6 +623,13 @@ func (r DeletePrivateEndpointServiceApiRequest) Execute() (*http.Response, error
 	return r.ApiService.DeletePrivateEndpointServiceExecute(r)
 }
 
+func (r DeletePrivateEndpointServiceApiRequest) ExecuteWithParams(params *DeletePrivateEndpointServiceApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProvider = params.CloudProvider 
+	r.endpointServiceId = params.EndpointServiceId 
+	return r.Execute()
+}
+
 /*
 DeletePrivateEndpointService Remove One Private Endpoint Service for One Provider
 
@@ -727,6 +756,14 @@ type GetPrivateEndpointApiParams struct {
 
 func (r GetPrivateEndpointApiRequest) Execute() (*Endpoint, *http.Response, error) {
 	return r.ApiService.GetPrivateEndpointExecute(r)
+}
+
+func (r GetPrivateEndpointApiRequest) ExecuteWithParams(params *GetPrivateEndpointApiParams) (*Endpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProvider = params.CloudProvider 
+	r.endpointId = params.EndpointId 
+	r.endpointServiceId = params.EndpointServiceId 
+	return r.Execute()
 }
 
 /*
@@ -869,6 +906,13 @@ func (r GetPrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.
 	return r.ApiService.GetPrivateEndpointServiceExecute(r)
 }
 
+func (r GetPrivateEndpointServiceApiRequest) ExecuteWithParams(params *GetPrivateEndpointServiceApiParams) (*EndpointService, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProvider = params.CloudProvider 
+	r.endpointServiceId = params.EndpointServiceId 
+	return r.Execute()
+}
+
 /*
 GetPrivateEndpointService Return One Private Endpoint Service for One Provider
 
@@ -1002,6 +1046,11 @@ func (r GetRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSett
 	return r.ApiService.GetRegionalizedPrivateEndpointSettingExecute(r)
 }
 
+func (r GetRegionalizedPrivateEndpointSettingApiRequest) ExecuteWithParams(params *GetRegionalizedPrivateEndpointSettingApiParams) (*ProjectSettingItem, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 GetRegionalizedPrivateEndpointSetting Return Regionalized Private Endpoint Status
 
@@ -1123,6 +1172,12 @@ type ListPrivateEndpointServicesApiParams struct {
 
 func (r ListPrivateEndpointServicesApiRequest) Execute() (*PaginatedPrivateLinkConnection, *http.Response, error) {
 	return r.ApiService.ListPrivateEndpointServicesExecute(r)
+}
+
+func (r ListPrivateEndpointServicesApiRequest) ExecuteWithParams(params *ListPrivateEndpointServicesApiParams) (*PaginatedPrivateLinkConnection, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.cloudProvider = params.CloudProvider 
+	return r.Execute()
 }
 
 /*
@@ -1255,6 +1310,12 @@ func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) ProjectSettingItem(p
 
 func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
 	return r.ApiService.ToggleRegionalizedPrivateEndpointSettingExecute(r)
+}
+
+func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) ExecuteWithParams(params *ToggleRegionalizedPrivateEndpointSettingApiParams) (*ProjectSettingItem, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.projectSettingItem = params.ProjectSettingItem 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -30,10 +30,18 @@ type PrivateEndpointServicesApi interface {
 	@return CreatePrivateEndpointApiRequest
 	*/
 	CreatePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) CreatePrivateEndpointApiRequest
+	/*
+	CreatePrivateEndpoint Create One Private Endpoint for One Provider
 
-	// CreatePrivateEndpointExecute executes the request
-	//  @return Endpoint
-	CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*Endpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreatePrivateEndpointApiParams - Parameters for the request
+	@return CreatePrivateEndpointApiRequest}}
+	*/
+	CreatePrivateEndpointWithParams(ctx context.Context, args *CreatePrivateEndpointApiParams) CreatePrivateEndpointApiRequest
+
+	// Interface only available internally
+	createPrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*Endpoint, *http.Response, error)
 
 	/*
 	CreatePrivateEndpointService Create One Private Endpoint Service for One Provider
@@ -45,10 +53,18 @@ type PrivateEndpointServicesApi interface {
 	@return CreatePrivateEndpointServiceApiRequest
 	*/
 	CreatePrivateEndpointService(ctx context.Context, groupId string) CreatePrivateEndpointServiceApiRequest
+	/*
+	CreatePrivateEndpointService Create One Private Endpoint Service for One Provider
 
-	// CreatePrivateEndpointServiceExecute executes the request
-	//  @return EndpointService
-	CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreatePrivateEndpointServiceApiParams - Parameters for the request
+	@return CreatePrivateEndpointServiceApiRequest}}
+	*/
+	CreatePrivateEndpointServiceWithParams(ctx context.Context, args *CreatePrivateEndpointServiceApiParams) CreatePrivateEndpointServiceApiRequest
+
+	// Interface only available internally
+	createPrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
 	DeletePrivateEndpoint Remove One Private Endpoint for One Provider
@@ -63,9 +79,18 @@ type PrivateEndpointServicesApi interface {
 	@return DeletePrivateEndpointApiRequest
 	*/
 	DeletePrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) DeletePrivateEndpointApiRequest
+	/*
+	DeletePrivateEndpoint Remove One Private Endpoint for One Provider
 
-	// DeletePrivateEndpointExecute executes the request
-	DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeletePrivateEndpointApiParams - Parameters for the request
+	@return DeletePrivateEndpointApiRequest}}
+	*/
+	DeletePrivateEndpointWithParams(ctx context.Context, args *DeletePrivateEndpointApiParams) DeletePrivateEndpointApiRequest
+
+	// Interface only available internally
+	deletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (*http.Response, error)
 
 	/*
 	DeletePrivateEndpointService Remove One Private Endpoint Service for One Provider
@@ -79,9 +104,18 @@ type PrivateEndpointServicesApi interface {
 	@return DeletePrivateEndpointServiceApiRequest
 	*/
 	DeletePrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) DeletePrivateEndpointServiceApiRequest
+	/*
+	DeletePrivateEndpointService Remove One Private Endpoint Service for One Provider
 
-	// DeletePrivateEndpointServiceExecute executes the request
-	DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeletePrivateEndpointServiceApiParams - Parameters for the request
+	@return DeletePrivateEndpointServiceApiRequest}}
+	*/
+	DeletePrivateEndpointServiceWithParams(ctx context.Context, args *DeletePrivateEndpointServiceApiParams) DeletePrivateEndpointServiceApiRequest
+
+	// Interface only available internally
+	deletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (*http.Response, error)
 
 	/*
 	GetPrivateEndpoint Return One Private Endpoint for One Provider
@@ -96,10 +130,18 @@ type PrivateEndpointServicesApi interface {
 	@return GetPrivateEndpointApiRequest
 	*/
 	GetPrivateEndpoint(ctx context.Context, groupId string, cloudProvider string, endpointId string, endpointServiceId string) GetPrivateEndpointApiRequest
+	/*
+	GetPrivateEndpoint Return One Private Endpoint for One Provider
 
-	// GetPrivateEndpointExecute executes the request
-	//  @return Endpoint
-	GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*Endpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetPrivateEndpointApiParams - Parameters for the request
+	@return GetPrivateEndpointApiRequest}}
+	*/
+	GetPrivateEndpointWithParams(ctx context.Context, args *GetPrivateEndpointApiParams) GetPrivateEndpointApiRequest
+
+	// Interface only available internally
+	getPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*Endpoint, *http.Response, error)
 
 	/*
 	GetPrivateEndpointService Return One Private Endpoint Service for One Provider
@@ -113,10 +155,18 @@ type PrivateEndpointServicesApi interface {
 	@return GetPrivateEndpointServiceApiRequest
 	*/
 	GetPrivateEndpointService(ctx context.Context, groupId string, cloudProvider string, endpointServiceId string) GetPrivateEndpointServiceApiRequest
+	/*
+	GetPrivateEndpointService Return One Private Endpoint Service for One Provider
 
-	// GetPrivateEndpointServiceExecute executes the request
-	//  @return EndpointService
-	GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetPrivateEndpointServiceApiParams - Parameters for the request
+	@return GetPrivateEndpointServiceApiRequest}}
+	*/
+	GetPrivateEndpointServiceWithParams(ctx context.Context, args *GetPrivateEndpointServiceApiParams) GetPrivateEndpointServiceApiRequest
+
+	// Interface only available internally
+	getPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error)
 
 	/*
 	GetRegionalizedPrivateEndpointSetting Return Regionalized Private Endpoint Status
@@ -128,10 +178,18 @@ type PrivateEndpointServicesApi interface {
 	@return GetRegionalizedPrivateEndpointSettingApiRequest
 	*/
 	GetRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) GetRegionalizedPrivateEndpointSettingApiRequest
+	/*
+	GetRegionalizedPrivateEndpointSetting Return Regionalized Private Endpoint Status
 
-	// GetRegionalizedPrivateEndpointSettingExecute executes the request
-	//  @return ProjectSettingItem
-	GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetRegionalizedPrivateEndpointSettingApiParams - Parameters for the request
+	@return GetRegionalizedPrivateEndpointSettingApiRequest}}
+	*/
+	GetRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *GetRegionalizedPrivateEndpointSettingApiParams) GetRegionalizedPrivateEndpointSettingApiRequest
+
+	// Interface only available internally
+	getRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 
 	/*
 	ListPrivateEndpointServices Return All Private Endpoint Services for One Provider
@@ -144,10 +202,18 @@ type PrivateEndpointServicesApi interface {
 	@return ListPrivateEndpointServicesApiRequest
 	*/
 	ListPrivateEndpointServices(ctx context.Context, groupId string, cloudProvider string) ListPrivateEndpointServicesApiRequest
+	/*
+	ListPrivateEndpointServices Return All Private Endpoint Services for One Provider
 
-	// ListPrivateEndpointServicesExecute executes the request
-	//  @return PaginatedPrivateLinkConnection
-	ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) (*PaginatedPrivateLinkConnection, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListPrivateEndpointServicesApiParams - Parameters for the request
+	@return ListPrivateEndpointServicesApiRequest}}
+	*/
+	ListPrivateEndpointServicesWithParams(ctx context.Context, args *ListPrivateEndpointServicesApiParams) ListPrivateEndpointServicesApiRequest
+
+	// Interface only available internally
+	listPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) (*PaginatedPrivateLinkConnection, *http.Response, error)
 
 	/*
 	ToggleRegionalizedPrivateEndpointSetting Toggle Regionalized Private Endpoint Status
@@ -159,10 +225,18 @@ type PrivateEndpointServicesApi interface {
 	@return ToggleRegionalizedPrivateEndpointSettingApiRequest
 	*/
 	ToggleRegionalizedPrivateEndpointSetting(ctx context.Context, groupId string) ToggleRegionalizedPrivateEndpointSettingApiRequest
+	/*
+	ToggleRegionalizedPrivateEndpointSetting Toggle Regionalized Private Endpoint Status
 
-	// ToggleRegionalizedPrivateEndpointSettingExecute executes the request
-	//  @return ProjectSettingItem
-	ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ToggleRegionalizedPrivateEndpointSettingApiParams - Parameters for the request
+	@return ToggleRegionalizedPrivateEndpointSettingApiRequest}}
+	*/
+	ToggleRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *ToggleRegionalizedPrivateEndpointSettingApiParams) ToggleRegionalizedPrivateEndpointSettingApiRequest
+
+	// Interface only available internally
+	toggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error)
 }
 
 // PrivateEndpointServicesApiService PrivateEndpointServicesApi service
@@ -184,6 +258,17 @@ type CreatePrivateEndpointApiParams struct {
 		CreatePrivateEndpointRequest *CreatePrivateEndpointRequest
 }
 
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointWithParams(ctx context.Context, args *CreatePrivateEndpointApiParams) CreatePrivateEndpointApiRequest {
+	return CreatePrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProvider: args.CloudProvider,
+		endpointServiceId: args.EndpointServiceId,
+		createPrivateEndpointRequest: args.CreatePrivateEndpointRequest,
+	}
+}
+
 // Creates one private endpoint for the specified cloud service provider.
 func (r CreatePrivateEndpointApiRequest) CreatePrivateEndpointRequest(createPrivateEndpointRequest CreatePrivateEndpointRequest) CreatePrivateEndpointApiRequest {
 	r.createPrivateEndpointRequest = &createPrivateEndpointRequest
@@ -191,15 +276,7 @@ func (r CreatePrivateEndpointApiRequest) CreatePrivateEndpointRequest(createPriv
 }
 
 func (r CreatePrivateEndpointApiRequest) Execute() (*Endpoint, *http.Response, error) {
-	return r.ApiService.CreatePrivateEndpointExecute(r)
-}
-
-func (r CreatePrivateEndpointApiRequest) ExecuteWithParams(params *CreatePrivateEndpointApiParams) (*Endpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProvider = params.CloudProvider 
-	r.endpointServiceId = params.EndpointServiceId 
-	r.createPrivateEndpointRequest = params.CreatePrivateEndpointRequest 
-	return r.Execute()
+	return r.ApiService.createPrivateEndpointExecute(r)
 }
 
 /*
@@ -225,7 +302,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpoint(ctx context.Co
 
 // Execute executes the request
 //  @return Endpoint
-func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*Endpoint, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) createPrivateEndpointExecute(r CreatePrivateEndpointApiRequest) (*Endpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -338,6 +415,15 @@ type CreatePrivateEndpointServiceApiParams struct {
 		CreateEndpointServiceRequest *CreateEndpointServiceRequest
 }
 
+func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceWithParams(ctx context.Context, args *CreatePrivateEndpointServiceApiParams) CreatePrivateEndpointServiceApiRequest {
+	return CreatePrivateEndpointServiceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		createEndpointServiceRequest: args.CreateEndpointServiceRequest,
+	}
+}
+
 // Creates one private endpoint for the specified cloud service provider.
 func (r CreatePrivateEndpointServiceApiRequest) CreateEndpointServiceRequest(createEndpointServiceRequest CreateEndpointServiceRequest) CreatePrivateEndpointServiceApiRequest {
 	r.createEndpointServiceRequest = &createEndpointServiceRequest
@@ -345,13 +431,7 @@ func (r CreatePrivateEndpointServiceApiRequest) CreateEndpointServiceRequest(cre
 }
 
 func (r CreatePrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.Response, error) {
-	return r.ApiService.CreatePrivateEndpointServiceExecute(r)
-}
-
-func (r CreatePrivateEndpointServiceApiRequest) ExecuteWithParams(params *CreatePrivateEndpointServiceApiParams) (*EndpointService, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.createEndpointServiceRequest = params.CreateEndpointServiceRequest 
-	return r.Execute()
+	return r.ApiService.createPrivateEndpointServiceExecute(r)
 }
 
 /*
@@ -373,7 +453,7 @@ func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointService(ctx con
 
 // Execute executes the request
 //  @return EndpointService
-func (a *PrivateEndpointServicesApiService) CreatePrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) createPrivateEndpointServiceExecute(r CreatePrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -482,16 +562,19 @@ type DeletePrivateEndpointApiParams struct {
 		EndpointServiceId string
 }
 
-func (r DeletePrivateEndpointApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeletePrivateEndpointExecute(r)
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointWithParams(ctx context.Context, args *DeletePrivateEndpointApiParams) DeletePrivateEndpointApiRequest {
+	return DeletePrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProvider: args.CloudProvider,
+		endpointId: args.EndpointId,
+		endpointServiceId: args.EndpointServiceId,
+	}
 }
 
-func (r DeletePrivateEndpointApiRequest) ExecuteWithParams(params *DeletePrivateEndpointApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProvider = params.CloudProvider 
-	r.endpointId = params.EndpointId 
-	r.endpointServiceId = params.EndpointServiceId 
-	return r.Execute()
+func (r DeletePrivateEndpointApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deletePrivateEndpointExecute(r)
 }
 
 /*
@@ -518,7 +601,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpoint(ctx context.Co
 }
 
 // Execute executes the request
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (*http.Response, error) {
+func (a *PrivateEndpointServicesApiService) deletePrivateEndpointExecute(r DeletePrivateEndpointApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -619,15 +702,18 @@ type DeletePrivateEndpointServiceApiParams struct {
 		EndpointServiceId string
 }
 
-func (r DeletePrivateEndpointServiceApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeletePrivateEndpointServiceExecute(r)
+func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceWithParams(ctx context.Context, args *DeletePrivateEndpointServiceApiParams) DeletePrivateEndpointServiceApiRequest {
+	return DeletePrivateEndpointServiceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProvider: args.CloudProvider,
+		endpointServiceId: args.EndpointServiceId,
+	}
 }
 
-func (r DeletePrivateEndpointServiceApiRequest) ExecuteWithParams(params *DeletePrivateEndpointServiceApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProvider = params.CloudProvider 
-	r.endpointServiceId = params.EndpointServiceId 
-	return r.Execute()
+func (r DeletePrivateEndpointServiceApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deletePrivateEndpointServiceExecute(r)
 }
 
 /*
@@ -652,7 +738,7 @@ func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointService(ctx con
 }
 
 // Execute executes the request
-func (a *PrivateEndpointServicesApiService) DeletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (*http.Response, error) {
+func (a *PrivateEndpointServicesApiService) deletePrivateEndpointServiceExecute(r DeletePrivateEndpointServiceApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -754,16 +840,19 @@ type GetPrivateEndpointApiParams struct {
 		EndpointServiceId string
 }
 
-func (r GetPrivateEndpointApiRequest) Execute() (*Endpoint, *http.Response, error) {
-	return r.ApiService.GetPrivateEndpointExecute(r)
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpointWithParams(ctx context.Context, args *GetPrivateEndpointApiParams) GetPrivateEndpointApiRequest {
+	return GetPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProvider: args.CloudProvider,
+		endpointId: args.EndpointId,
+		endpointServiceId: args.EndpointServiceId,
+	}
 }
 
-func (r GetPrivateEndpointApiRequest) ExecuteWithParams(params *GetPrivateEndpointApiParams) (*Endpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProvider = params.CloudProvider 
-	r.endpointId = params.EndpointId 
-	r.endpointServiceId = params.EndpointServiceId 
-	return r.Execute()
+func (r GetPrivateEndpointApiRequest) Execute() (*Endpoint, *http.Response, error) {
+	return r.ApiService.getPrivateEndpointExecute(r)
 }
 
 /*
@@ -791,7 +880,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpoint(ctx context.Conte
 
 // Execute executes the request
 //  @return Endpoint
-func (a *PrivateEndpointServicesApiService) GetPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*Endpoint, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) getPrivateEndpointExecute(r GetPrivateEndpointApiRequest) (*Endpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -902,15 +991,18 @@ type GetPrivateEndpointServiceApiParams struct {
 		EndpointServiceId string
 }
 
-func (r GetPrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.Response, error) {
-	return r.ApiService.GetPrivateEndpointServiceExecute(r)
+func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceWithParams(ctx context.Context, args *GetPrivateEndpointServiceApiParams) GetPrivateEndpointServiceApiRequest {
+	return GetPrivateEndpointServiceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProvider: args.CloudProvider,
+		endpointServiceId: args.EndpointServiceId,
+	}
 }
 
-func (r GetPrivateEndpointServiceApiRequest) ExecuteWithParams(params *GetPrivateEndpointServiceApiParams) (*EndpointService, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProvider = params.CloudProvider 
-	r.endpointServiceId = params.EndpointServiceId 
-	return r.Execute()
+func (r GetPrivateEndpointServiceApiRequest) Execute() (*EndpointService, *http.Response, error) {
+	return r.ApiService.getPrivateEndpointServiceExecute(r)
 }
 
 /*
@@ -936,7 +1028,7 @@ func (a *PrivateEndpointServicesApiService) GetPrivateEndpointService(ctx contex
 
 // Execute executes the request
 //  @return EndpointService
-func (a *PrivateEndpointServicesApiService) GetPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) getPrivateEndpointServiceExecute(r GetPrivateEndpointServiceApiRequest) (*EndpointService, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1042,13 +1134,16 @@ type GetRegionalizedPrivateEndpointSettingApiParams struct {
 		GroupId string
 }
 
-func (r GetRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
-	return r.ApiService.GetRegionalizedPrivateEndpointSettingExecute(r)
+func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *GetRegionalizedPrivateEndpointSettingApiParams) GetRegionalizedPrivateEndpointSettingApiRequest {
+	return GetRegionalizedPrivateEndpointSettingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetRegionalizedPrivateEndpointSettingApiRequest) ExecuteWithParams(params *GetRegionalizedPrivateEndpointSettingApiParams) (*ProjectSettingItem, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
+	return r.ApiService.getRegionalizedPrivateEndpointSettingExecute(r)
 }
 
 /*
@@ -1070,7 +1165,7 @@ func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettin
 
 // Execute executes the request
 //  @return ProjectSettingItem
-func (a *PrivateEndpointServicesApiService) GetRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) getRegionalizedPrivateEndpointSettingExecute(r GetRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1170,14 +1265,17 @@ type ListPrivateEndpointServicesApiParams struct {
 		CloudProvider string
 }
 
-func (r ListPrivateEndpointServicesApiRequest) Execute() (*PaginatedPrivateLinkConnection, *http.Response, error) {
-	return r.ApiService.ListPrivateEndpointServicesExecute(r)
+func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesWithParams(ctx context.Context, args *ListPrivateEndpointServicesApiParams) ListPrivateEndpointServicesApiRequest {
+	return ListPrivateEndpointServicesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		cloudProvider: args.CloudProvider,
+	}
 }
 
-func (r ListPrivateEndpointServicesApiRequest) ExecuteWithParams(params *ListPrivateEndpointServicesApiParams) (*PaginatedPrivateLinkConnection, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.cloudProvider = params.CloudProvider 
-	return r.Execute()
+func (r ListPrivateEndpointServicesApiRequest) Execute() (*PaginatedPrivateLinkConnection, *http.Response, error) {
+	return r.ApiService.listPrivateEndpointServicesExecute(r)
 }
 
 /*
@@ -1201,7 +1299,7 @@ func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServices(ctx cont
 
 // Execute executes the request
 //  @return PaginatedPrivateLinkConnection
-func (a *PrivateEndpointServicesApiService) ListPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) (*PaginatedPrivateLinkConnection, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) listPrivateEndpointServicesExecute(r ListPrivateEndpointServicesApiRequest) (*PaginatedPrivateLinkConnection, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1302,6 +1400,15 @@ type ToggleRegionalizedPrivateEndpointSettingApiParams struct {
 		ProjectSettingItem *ProjectSettingItem
 }
 
+func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *ToggleRegionalizedPrivateEndpointSettingApiParams) ToggleRegionalizedPrivateEndpointSettingApiRequest {
+	return ToggleRegionalizedPrivateEndpointSettingApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		projectSettingItem: args.ProjectSettingItem,
+	}
+}
+
 // Enables or disables the ability to create multiple private endpoints per region in all cloud service providers in one project.
 func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) ProjectSettingItem(projectSettingItem ProjectSettingItem) ToggleRegionalizedPrivateEndpointSettingApiRequest {
 	r.projectSettingItem = &projectSettingItem
@@ -1309,13 +1416,7 @@ func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) ProjectSettingItem(p
 }
 
 func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) Execute() (*ProjectSettingItem, *http.Response, error) {
-	return r.ApiService.ToggleRegionalizedPrivateEndpointSettingExecute(r)
-}
-
-func (r ToggleRegionalizedPrivateEndpointSettingApiRequest) ExecuteWithParams(params *ToggleRegionalizedPrivateEndpointSettingApiParams) (*ProjectSettingItem, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.projectSettingItem = params.ProjectSettingItem 
-	return r.Execute()
+	return r.ApiService.toggleRegionalizedPrivateEndpointSettingExecute(r)
 }
 
 /*
@@ -1337,7 +1438,7 @@ func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSet
 
 // Execute executes the request
 //  @return ProjectSettingItem
-func (a *PrivateEndpointServicesApiService) ToggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
+func (a *PrivateEndpointServicesApiService) toggleRegionalizedPrivateEndpointSettingExecute(r ToggleRegionalizedPrivateEndpointSettingApiRequest) (*ProjectSettingItem, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_private_endpoint_services.go
+++ b/mongodbatlasv2/api_private_endpoint_services.go
@@ -36,7 +36,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreatePrivateEndpointApiParams - Parameters for the request
-	@return CreatePrivateEndpointApiRequest}}
+	@return CreatePrivateEndpointApiRequest
 	*/
 	CreatePrivateEndpointWithParams(ctx context.Context, args *CreatePrivateEndpointApiParams) CreatePrivateEndpointApiRequest
 
@@ -59,7 +59,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreatePrivateEndpointServiceApiParams - Parameters for the request
-	@return CreatePrivateEndpointServiceApiRequest}}
+	@return CreatePrivateEndpointServiceApiRequest
 	*/
 	CreatePrivateEndpointServiceWithParams(ctx context.Context, args *CreatePrivateEndpointServiceApiParams) CreatePrivateEndpointServiceApiRequest
 
@@ -85,7 +85,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeletePrivateEndpointApiParams - Parameters for the request
-	@return DeletePrivateEndpointApiRequest}}
+	@return DeletePrivateEndpointApiRequest
 	*/
 	DeletePrivateEndpointWithParams(ctx context.Context, args *DeletePrivateEndpointApiParams) DeletePrivateEndpointApiRequest
 
@@ -110,7 +110,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeletePrivateEndpointServiceApiParams - Parameters for the request
-	@return DeletePrivateEndpointServiceApiRequest}}
+	@return DeletePrivateEndpointServiceApiRequest
 	*/
 	DeletePrivateEndpointServiceWithParams(ctx context.Context, args *DeletePrivateEndpointServiceApiParams) DeletePrivateEndpointServiceApiRequest
 
@@ -136,7 +136,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetPrivateEndpointApiParams - Parameters for the request
-	@return GetPrivateEndpointApiRequest}}
+	@return GetPrivateEndpointApiRequest
 	*/
 	GetPrivateEndpointWithParams(ctx context.Context, args *GetPrivateEndpointApiParams) GetPrivateEndpointApiRequest
 
@@ -161,7 +161,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetPrivateEndpointServiceApiParams - Parameters for the request
-	@return GetPrivateEndpointServiceApiRequest}}
+	@return GetPrivateEndpointServiceApiRequest
 	*/
 	GetPrivateEndpointServiceWithParams(ctx context.Context, args *GetPrivateEndpointServiceApiParams) GetPrivateEndpointServiceApiRequest
 
@@ -184,7 +184,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetRegionalizedPrivateEndpointSettingApiParams - Parameters for the request
-	@return GetRegionalizedPrivateEndpointSettingApiRequest}}
+	@return GetRegionalizedPrivateEndpointSettingApiRequest
 	*/
 	GetRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *GetRegionalizedPrivateEndpointSettingApiParams) GetRegionalizedPrivateEndpointSettingApiRequest
 
@@ -208,7 +208,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListPrivateEndpointServicesApiParams - Parameters for the request
-	@return ListPrivateEndpointServicesApiRequest}}
+	@return ListPrivateEndpointServicesApiRequest
 	*/
 	ListPrivateEndpointServicesWithParams(ctx context.Context, args *ListPrivateEndpointServicesApiParams) ListPrivateEndpointServicesApiRequest
 
@@ -231,7 +231,7 @@ type PrivateEndpointServicesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ToggleRegionalizedPrivateEndpointSettingApiParams - Parameters for the request
-	@return ToggleRegionalizedPrivateEndpointSettingApiRequest}}
+	@return ToggleRegionalizedPrivateEndpointSettingApiRequest
 	*/
 	ToggleRegionalizedPrivateEndpointSettingWithParams(ctx context.Context, args *ToggleRegionalizedPrivateEndpointSettingApiParams) ToggleRegionalizedPrivateEndpointSettingApiRequest
 

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -35,7 +35,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param AddProjectApiKeyApiParams - Parameters for the request
-	@return AddProjectApiKeyApiRequest}}
+	@return AddProjectApiKeyApiRequest
 	*/
 	AddProjectApiKeyWithParams(ctx context.Context, args *AddProjectApiKeyApiParams) AddProjectApiKeyApiRequest
 
@@ -58,7 +58,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateApiKeyApiParams - Parameters for the request
-	@return CreateApiKeyApiRequest}}
+	@return CreateApiKeyApiRequest
 	*/
 	CreateApiKeyWithParams(ctx context.Context, args *CreateApiKeyApiParams) CreateApiKeyApiRequest
 
@@ -82,7 +82,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateApiKeyAccessListApiParams - Parameters for the request
-	@return CreateApiKeyAccessListApiRequest}}
+	@return CreateApiKeyAccessListApiRequest
 	*/
 	CreateApiKeyAccessListWithParams(ctx context.Context, args *CreateApiKeyAccessListApiParams) CreateApiKeyAccessListApiRequest
 
@@ -105,7 +105,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateProjectApiKeyApiParams - Parameters for the request
-	@return CreateProjectApiKeyApiRequest}}
+	@return CreateProjectApiKeyApiRequest
 	*/
 	CreateProjectApiKeyWithParams(ctx context.Context, args *CreateProjectApiKeyApiParams) CreateProjectApiKeyApiRequest
 
@@ -129,7 +129,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteApiKeyApiParams - Parameters for the request
-	@return DeleteApiKeyApiRequest}}
+	@return DeleteApiKeyApiRequest
 	*/
 	DeleteApiKeyWithParams(ctx context.Context, args *DeleteApiKeyApiParams) DeleteApiKeyApiRequest
 
@@ -154,7 +154,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteApiKeyAccessListEntryApiParams - Parameters for the request
-	@return DeleteApiKeyAccessListEntryApiRequest}}
+	@return DeleteApiKeyAccessListEntryApiRequest
 	*/
 	DeleteApiKeyAccessListEntryWithParams(ctx context.Context, args *DeleteApiKeyAccessListEntryApiParams) DeleteApiKeyAccessListEntryApiRequest
 
@@ -178,7 +178,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetApiKeyApiParams - Parameters for the request
-	@return GetApiKeyApiRequest}}
+	@return GetApiKeyApiRequest
 	*/
 	GetApiKeyWithParams(ctx context.Context, args *GetApiKeyApiParams) GetApiKeyApiRequest
 
@@ -203,7 +203,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetApiKeyAccessListApiParams - Parameters for the request
-	@return GetApiKeyAccessListApiRequest}}
+	@return GetApiKeyAccessListApiRequest
 	*/
 	GetApiKeyAccessListWithParams(ctx context.Context, args *GetApiKeyAccessListApiParams) GetApiKeyAccessListApiRequest
 
@@ -227,7 +227,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListApiKeyAccessListsEntriesApiParams - Parameters for the request
-	@return ListApiKeyAccessListsEntriesApiRequest}}
+	@return ListApiKeyAccessListsEntriesApiRequest
 	*/
 	ListApiKeyAccessListsEntriesWithParams(ctx context.Context, args *ListApiKeyAccessListsEntriesApiParams) ListApiKeyAccessListsEntriesApiRequest
 
@@ -250,7 +250,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListApiKeysApiParams - Parameters for the request
-	@return ListApiKeysApiRequest}}
+	@return ListApiKeysApiRequest
 	*/
 	ListApiKeysWithParams(ctx context.Context, args *ListApiKeysApiParams) ListApiKeysApiRequest
 
@@ -273,7 +273,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectApiKeysApiParams - Parameters for the request
-	@return ListProjectApiKeysApiRequest}}
+	@return ListProjectApiKeysApiRequest
 	*/
 	ListProjectApiKeysWithParams(ctx context.Context, args *ListProjectApiKeysApiParams) ListProjectApiKeysApiRequest
 
@@ -297,7 +297,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param RemoveProjectApiKeyApiParams - Parameters for the request
-	@return RemoveProjectApiKeyApiRequest}}
+	@return RemoveProjectApiKeyApiRequest
 	*/
 	RemoveProjectApiKeyWithParams(ctx context.Context, args *RemoveProjectApiKeyApiParams) RemoveProjectApiKeyApiRequest
 
@@ -321,7 +321,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateApiKeyApiParams - Parameters for the request
-	@return UpdateApiKeyApiRequest}}
+	@return UpdateApiKeyApiRequest
 	*/
 	UpdateApiKeyWithParams(ctx context.Context, args *UpdateApiKeyApiParams) UpdateApiKeyApiRequest
 
@@ -345,7 +345,7 @@ type ProgrammaticAPIKeysApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateApiKeyRolesApiParams - Parameters for the request
-	@return UpdateApiKeyRolesApiRequest}}
+	@return UpdateApiKeyRolesApiRequest
 	*/
 	UpdateApiKeyRolesWithParams(ctx context.Context, args *UpdateApiKeyRolesApiParams) UpdateApiKeyRolesApiRequest
 

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -265,6 +265,13 @@ func (r AddProjectApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) 
 	return r.ApiService.AddProjectApiKeyExecute(r)
 }
 
+func (r AddProjectApiKeyApiRequest) ExecuteWithParams(params *AddProjectApiKeyApiParams) (*ApiUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.apiUserId = params.ApiUserId 
+	r.userRoleAssignment = params.UserRoleAssignment 
+	return r.Execute()
+}
+
 /*
 AddProjectApiKey Assign One Organization API Key to One Project
 
@@ -406,6 +413,12 @@ func (r CreateApiKeyApiRequest) CreateApiKey(createApiKey CreateApiKey) CreateAp
 
 func (r CreateApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.CreateApiKeyExecute(r)
+}
+
+func (r CreateApiKeyApiRequest) ExecuteWithParams(params *CreateApiKeyApiParams) (*ApiUser, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.createApiKey = params.CreateApiKey 
+	return r.Execute()
 }
 
 /*
@@ -566,6 +579,16 @@ func (r CreateApiKeyAccessListApiRequest) PageNum(pageNum int32) CreateApiKeyAcc
 
 func (r CreateApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
 	return r.ApiService.CreateApiKeyAccessListExecute(r)
+}
+
+func (r CreateApiKeyAccessListApiRequest) ExecuteWithParams(params *CreateApiKeyAccessListApiParams) (*UserAccessList, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.apiUserId = params.ApiUserId 
+	r.userAccessList = params.UserAccessList 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -732,6 +755,12 @@ func (r CreateProjectApiKeyApiRequest) Execute() (*ApiUser, *http.Response, erro
 	return r.ApiService.CreateProjectApiKeyExecute(r)
 }
 
+func (r CreateProjectApiKeyApiRequest) ExecuteWithParams(params *CreateProjectApiKeyApiParams) (*ApiUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.createApiKey = params.CreateApiKey 
+	return r.Execute()
+}
+
 /*
 CreateProjectApiKey Create and Assign One Organization API Key to One Project
 
@@ -860,6 +889,12 @@ func (r DeleteApiKeyApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteApiKeyExecute(r)
 }
 
+func (r DeleteApiKeyApiRequest) ExecuteWithParams(params *DeleteApiKeyApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	r.apiUserId = params.ApiUserId 
+	return r.Execute()
+}
+
 /*
 DeleteApiKey Remove One Organization API Key
 
@@ -981,6 +1016,13 @@ type DeleteApiKeyAccessListEntryApiParams struct {
 
 func (r DeleteApiKeyAccessListEntryApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteApiKeyAccessListEntryExecute(r)
+}
+
+func (r DeleteApiKeyAccessListEntryApiRequest) ExecuteWithParams(params *DeleteApiKeyAccessListEntryApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	r.apiUserId = params.ApiUserId 
+	r.ipAddress = params.IpAddress 
+	return r.Execute()
 }
 
 /*
@@ -1105,6 +1147,12 @@ type GetApiKeyApiParams struct {
 
 func (r GetApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.GetApiKeyExecute(r)
+}
+
+func (r GetApiKeyApiRequest) ExecuteWithParams(params *GetApiKeyApiParams) (*ApiUser, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.apiUserId = params.ApiUserId 
+	return r.Execute()
 }
 
 /*
@@ -1239,6 +1287,13 @@ type GetApiKeyAccessListApiParams struct {
 
 func (r GetApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
 	return r.ApiService.GetApiKeyAccessListExecute(r)
+}
+
+func (r GetApiKeyAccessListApiRequest) ExecuteWithParams(params *GetApiKeyAccessListApiParams) (*UserAccessList, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.ipAddress = params.IpAddress 
+	r.apiUserId = params.ApiUserId 
+	return r.Execute()
 }
 
 /*
@@ -1398,6 +1453,15 @@ func (r ListApiKeyAccessListsEntriesApiRequest) PageNum(pageNum int32) ListApiKe
 
 func (r ListApiKeyAccessListsEntriesApiRequest) Execute() (*PaginatedApiUserAccessList, *http.Response, error) {
 	return r.ApiService.ListApiKeyAccessListsEntriesExecute(r)
+}
+
+func (r ListApiKeyAccessListsEntriesApiRequest) ExecuteWithParams(params *ListApiKeyAccessListsEntriesApiParams) (*PaginatedApiUserAccessList, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.apiUserId = params.ApiUserId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -1575,6 +1639,14 @@ func (r ListApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Response, 
 	return r.ApiService.ListApiKeysExecute(r)
 }
 
+func (r ListApiKeysApiRequest) ExecuteWithParams(params *ListApiKeysApiParams) (*PaginatedApiApiUser, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListApiKeys Return All Organization API Keys
 
@@ -1741,6 +1813,14 @@ func (r ListProjectApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Res
 	return r.ApiService.ListProjectApiKeysExecute(r)
 }
 
+func (r ListProjectApiKeysApiRequest) ExecuteWithParams(params *ListProjectApiKeysApiParams) (*PaginatedApiApiUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListProjectApiKeys Return All Organization API Keys Assigned to One Project
 
@@ -1885,6 +1965,12 @@ func (r RemoveProjectApiKeyApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectApiKeyExecute(r)
 }
 
+func (r RemoveProjectApiKeyApiRequest) ExecuteWithParams(params *RemoveProjectApiKeyApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.apiUserId = params.ApiUserId 
+	return r.Execute()
+}
+
 /*
 RemoveProjectApiKey Unassign One Organization API Key from One Project
 
@@ -2012,6 +2098,13 @@ func (r UpdateApiKeyApiRequest) ApiUser(apiUser ApiUser) UpdateApiKeyApiRequest 
 
 func (r UpdateApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.UpdateApiKeyExecute(r)
+}
+
+func (r UpdateApiKeyApiRequest) ExecuteWithParams(params *UpdateApiKeyApiParams) (*ApiUser, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.apiUserId = params.ApiUserId 
+	r.apiUser = params.ApiUser 
+	return r.Execute()
 }
 
 /*
@@ -2181,6 +2274,16 @@ func (r UpdateApiKeyRolesApiRequest) IncludeCount(includeCount bool) UpdateApiKe
 
 func (r UpdateApiKeyRolesApiRequest) Execute() (*ApiUser, *http.Response, error) {
 	return r.ApiService.UpdateApiKeyRolesExecute(r)
+}
+
+func (r UpdateApiKeyRolesApiRequest) ExecuteWithParams(params *UpdateApiKeyRolesApiParams) (*ApiUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.apiUserId = params.ApiUserId 
+	r.createApiKey = params.CreateApiKey 
+	r.pageNum = params.PageNum 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.includeCount = params.IncludeCount 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_programmatic_api_keys.go
+++ b/mongodbatlasv2/api_programmatic_api_keys.go
@@ -29,10 +29,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return AddProjectApiKeyApiRequest
 	*/
 	AddProjectApiKey(ctx context.Context, groupId string, apiUserId string) AddProjectApiKeyApiRequest
+	/*
+	AddProjectApiKey Assign One Organization API Key to One Project
 
-	// AddProjectApiKeyExecute executes the request
-	//  @return ApiUser
-	AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param AddProjectApiKeyApiParams - Parameters for the request
+	@return AddProjectApiKeyApiRequest}}
+	*/
+	AddProjectApiKeyWithParams(ctx context.Context, args *AddProjectApiKeyApiParams) AddProjectApiKeyApiRequest
+
+	// Interface only available internally
+	addProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	CreateApiKey Create One Organization API Key
@@ -44,10 +52,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return CreateApiKeyApiRequest
 	*/
 	CreateApiKey(ctx context.Context, orgId string) CreateApiKeyApiRequest
+	/*
+	CreateApiKey Create One Organization API Key
 
-	// CreateApiKeyExecute executes the request
-	//  @return ApiUser
-	CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateApiKeyApiParams - Parameters for the request
+	@return CreateApiKeyApiRequest}}
+	*/
+	CreateApiKeyWithParams(ctx context.Context, args *CreateApiKeyApiParams) CreateApiKeyApiRequest
+
+	// Interface only available internally
+	createApiKeyExecute(r CreateApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	CreateApiKeyAccessList Create Access List Entries for One Organization API Key
@@ -60,10 +76,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return CreateApiKeyAccessListApiRequest
 	*/
 	CreateApiKeyAccessList(ctx context.Context, orgId string, apiUserId string) CreateApiKeyAccessListApiRequest
+	/*
+	CreateApiKeyAccessList Create Access List Entries for One Organization API Key
 
-	// CreateApiKeyAccessListExecute executes the request
-	//  @return UserAccessList
-	CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateApiKeyAccessListApiParams - Parameters for the request
+	@return CreateApiKeyAccessListApiRequest}}
+	*/
+	CreateApiKeyAccessListWithParams(ctx context.Context, args *CreateApiKeyAccessListApiParams) CreateApiKeyAccessListApiRequest
+
+	// Interface only available internally
+	createApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
 
 	/*
 	CreateProjectApiKey Create and Assign One Organization API Key to One Project
@@ -75,10 +99,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return CreateProjectApiKeyApiRequest
 	*/
 	CreateProjectApiKey(ctx context.Context, groupId string) CreateProjectApiKeyApiRequest
+	/*
+	CreateProjectApiKey Create and Assign One Organization API Key to One Project
 
-	// CreateProjectApiKeyExecute executes the request
-	//  @return ApiUser
-	CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateProjectApiKeyApiParams - Parameters for the request
+	@return CreateProjectApiKeyApiRequest}}
+	*/
+	CreateProjectApiKeyWithParams(ctx context.Context, args *CreateProjectApiKeyApiParams) CreateProjectApiKeyApiRequest
+
+	// Interface only available internally
+	createProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	DeleteApiKey Remove One Organization API Key
@@ -91,9 +123,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return DeleteApiKeyApiRequest
 	*/
 	DeleteApiKey(ctx context.Context, orgId string, apiUserId string) DeleteApiKeyApiRequest
+	/*
+	DeleteApiKey Remove One Organization API Key
 
-	// DeleteApiKeyExecute executes the request
-	DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteApiKeyApiParams - Parameters for the request
+	@return DeleteApiKeyApiRequest}}
+	*/
+	DeleteApiKeyWithParams(ctx context.Context, args *DeleteApiKeyApiParams) DeleteApiKeyApiRequest
+
+	// Interface only available internally
+	deleteApiKeyExecute(r DeleteApiKeyApiRequest) (*http.Response, error)
 
 	/*
 	DeleteApiKeyAccessListEntry Remove One Access List Entry for One Organization API Key
@@ -107,9 +148,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return DeleteApiKeyAccessListEntryApiRequest
 	*/
 	DeleteApiKeyAccessListEntry(ctx context.Context, orgId string, apiUserId string, ipAddress string) DeleteApiKeyAccessListEntryApiRequest
+	/*
+	DeleteApiKeyAccessListEntry Remove One Access List Entry for One Organization API Key
 
-	// DeleteApiKeyAccessListEntryExecute executes the request
-	DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteApiKeyAccessListEntryApiParams - Parameters for the request
+	@return DeleteApiKeyAccessListEntryApiRequest}}
+	*/
+	DeleteApiKeyAccessListEntryWithParams(ctx context.Context, args *DeleteApiKeyAccessListEntryApiParams) DeleteApiKeyAccessListEntryApiRequest
+
+	// Interface only available internally
+	deleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (*http.Response, error)
 
 	/*
 	GetApiKey Return One Organization API Key
@@ -122,10 +172,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return GetApiKeyApiRequest
 	*/
 	GetApiKey(ctx context.Context, orgId string, apiUserId string) GetApiKeyApiRequest
+	/*
+	GetApiKey Return One Organization API Key
 
-	// GetApiKeyExecute executes the request
-	//  @return ApiUser
-	GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetApiKeyApiParams - Parameters for the request
+	@return GetApiKeyApiRequest}}
+	*/
+	GetApiKeyWithParams(ctx context.Context, args *GetApiKeyApiParams) GetApiKeyApiRequest
+
+	// Interface only available internally
+	getApiKeyExecute(r GetApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	GetApiKeyAccessList Return One Access List Entry for One Organization API Key
@@ -139,10 +197,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return GetApiKeyAccessListApiRequest
 	*/
 	GetApiKeyAccessList(ctx context.Context, orgId string, ipAddress string, apiUserId string) GetApiKeyAccessListApiRequest
+	/*
+	GetApiKeyAccessList Return One Access List Entry for One Organization API Key
 
-	// GetApiKeyAccessListExecute executes the request
-	//  @return UserAccessList
-	GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetApiKeyAccessListApiParams - Parameters for the request
+	@return GetApiKeyAccessListApiRequest}}
+	*/
+	GetApiKeyAccessListWithParams(ctx context.Context, args *GetApiKeyAccessListApiParams) GetApiKeyAccessListApiRequest
+
+	// Interface only available internally
+	getApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error)
 
 	/*
 	ListApiKeyAccessListsEntries Return All Access List Entries for One Organization API Key
@@ -155,10 +221,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return ListApiKeyAccessListsEntriesApiRequest
 	*/
 	ListApiKeyAccessListsEntries(ctx context.Context, orgId string, apiUserId string) ListApiKeyAccessListsEntriesApiRequest
+	/*
+	ListApiKeyAccessListsEntries Return All Access List Entries for One Organization API Key
 
-	// ListApiKeyAccessListsEntriesExecute executes the request
-	//  @return PaginatedApiUserAccessList
-	ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListApiKeyAccessListsEntriesApiParams - Parameters for the request
+	@return ListApiKeyAccessListsEntriesApiRequest}}
+	*/
+	ListApiKeyAccessListsEntriesWithParams(ctx context.Context, args *ListApiKeyAccessListsEntriesApiParams) ListApiKeyAccessListsEntriesApiRequest
+
+	// Interface only available internally
+	listApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error)
 
 	/*
 	ListApiKeys Return All Organization API Keys
@@ -170,10 +244,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return ListApiKeysApiRequest
 	*/
 	ListApiKeys(ctx context.Context, orgId string) ListApiKeysApiRequest
+	/*
+	ListApiKeys Return All Organization API Keys
 
-	// ListApiKeysExecute executes the request
-	//  @return PaginatedApiApiUser
-	ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListApiKeysApiParams - Parameters for the request
+	@return ListApiKeysApiRequest}}
+	*/
+	ListApiKeysWithParams(ctx context.Context, args *ListApiKeysApiParams) ListApiKeysApiRequest
+
+	// Interface only available internally
+	listApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
 	ListProjectApiKeys Return All Organization API Keys Assigned to One Project
@@ -185,10 +267,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return ListProjectApiKeysApiRequest
 	*/
 	ListProjectApiKeys(ctx context.Context, groupId string) ListProjectApiKeysApiRequest
+	/*
+	ListProjectApiKeys Return All Organization API Keys Assigned to One Project
 
-	// ListProjectApiKeysExecute executes the request
-	//  @return PaginatedApiApiUser
-	ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectApiKeysApiParams - Parameters for the request
+	@return ListProjectApiKeysApiRequest}}
+	*/
+	ListProjectApiKeysWithParams(ctx context.Context, args *ListProjectApiKeysApiParams) ListProjectApiKeysApiRequest
+
+	// Interface only available internally
+	listProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error)
 
 	/*
 	RemoveProjectApiKey Unassign One Organization API Key from One Project
@@ -201,9 +291,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return RemoveProjectApiKeyApiRequest
 	*/
 	RemoveProjectApiKey(ctx context.Context, groupId string, apiUserId string) RemoveProjectApiKeyApiRequest
+	/*
+	RemoveProjectApiKey Unassign One Organization API Key from One Project
 
-	// RemoveProjectApiKeyExecute executes the request
-	RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param RemoveProjectApiKeyApiParams - Parameters for the request
+	@return RemoveProjectApiKeyApiRequest}}
+	*/
+	RemoveProjectApiKeyWithParams(ctx context.Context, args *RemoveProjectApiKeyApiParams) RemoveProjectApiKeyApiRequest
+
+	// Interface only available internally
+	removeProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (*http.Response, error)
 
 	/*
 	UpdateApiKey Update One Organization API Key
@@ -216,10 +315,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return UpdateApiKeyApiRequest
 	*/
 	UpdateApiKey(ctx context.Context, orgId string, apiUserId string) UpdateApiKeyApiRequest
+	/*
+	UpdateApiKey Update One Organization API Key
 
-	// UpdateApiKeyExecute executes the request
-	//  @return ApiUser
-	UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateApiKeyApiParams - Parameters for the request
+	@return UpdateApiKeyApiRequest}}
+	*/
+	UpdateApiKeyWithParams(ctx context.Context, args *UpdateApiKeyApiParams) UpdateApiKeyApiRequest
+
+	// Interface only available internally
+	updateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiUser, *http.Response, error)
 
 	/*
 	UpdateApiKeyRoles Update Roles of One Organization API Key to One Project
@@ -232,10 +339,18 @@ type ProgrammaticAPIKeysApi interface {
 	@return UpdateApiKeyRolesApiRequest
 	*/
 	UpdateApiKeyRoles(ctx context.Context, groupId string, apiUserId string) UpdateApiKeyRolesApiRequest
+	/*
+	UpdateApiKeyRoles Update Roles of One Organization API Key to One Project
 
-	// UpdateApiKeyRolesExecute executes the request
-	//  @return ApiUser
-	UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateApiKeyRolesApiParams - Parameters for the request
+	@return UpdateApiKeyRolesApiRequest}}
+	*/
+	UpdateApiKeyRolesWithParams(ctx context.Context, args *UpdateApiKeyRolesApiParams) UpdateApiKeyRolesApiRequest
+
+	// Interface only available internally
+	updateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiUser, *http.Response, error)
 }
 
 // ProgrammaticAPIKeysApiService ProgrammaticAPIKeysApi service
@@ -255,6 +370,16 @@ type AddProjectApiKeyApiParams struct {
 		UserRoleAssignment *[]UserRoleAssignment
 }
 
+func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyWithParams(ctx context.Context, args *AddProjectApiKeyApiParams) AddProjectApiKeyApiRequest {
+	return AddProjectApiKeyApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		apiUserId: args.ApiUserId,
+		userRoleAssignment: args.UserRoleAssignment,
+	}
+}
+
 // Organization API key to be assigned to the specified project.
 func (r AddProjectApiKeyApiRequest) UserRoleAssignment(userRoleAssignment []UserRoleAssignment) AddProjectApiKeyApiRequest {
 	r.userRoleAssignment = &userRoleAssignment
@@ -262,14 +387,7 @@ func (r AddProjectApiKeyApiRequest) UserRoleAssignment(userRoleAssignment []User
 }
 
 func (r AddProjectApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
-	return r.ApiService.AddProjectApiKeyExecute(r)
-}
-
-func (r AddProjectApiKeyApiRequest) ExecuteWithParams(params *AddProjectApiKeyApiParams) (*ApiUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.apiUserId = params.ApiUserId 
-	r.userRoleAssignment = params.UserRoleAssignment 
-	return r.Execute()
+	return r.ApiService.addProjectApiKeyExecute(r)
 }
 
 /*
@@ -293,7 +411,7 @@ func (a *ProgrammaticAPIKeysApiService) AddProjectApiKey(ctx context.Context, gr
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) AddProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) addProjectApiKeyExecute(r AddProjectApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -405,6 +523,15 @@ type CreateApiKeyApiParams struct {
 		CreateApiKey *CreateApiKey
 }
 
+func (a *ProgrammaticAPIKeysApiService) CreateApiKeyWithParams(ctx context.Context, args *CreateApiKeyApiParams) CreateApiKeyApiRequest {
+	return CreateApiKeyApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		createApiKey: args.CreateApiKey,
+	}
+}
+
 // Organization API Key to be created. This request requires a minimum of one of the two body parameters.
 func (r CreateApiKeyApiRequest) CreateApiKey(createApiKey CreateApiKey) CreateApiKeyApiRequest {
 	r.createApiKey = &createApiKey
@@ -412,13 +539,7 @@ func (r CreateApiKeyApiRequest) CreateApiKey(createApiKey CreateApiKey) CreateAp
 }
 
 func (r CreateApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
-	return r.ApiService.CreateApiKeyExecute(r)
-}
-
-func (r CreateApiKeyApiRequest) ExecuteWithParams(params *CreateApiKeyApiParams) (*ApiUser, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.createApiKey = params.CreateApiKey 
-	return r.Execute()
+	return r.ApiService.createApiKeyExecute(r)
 }
 
 /*
@@ -440,7 +561,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKey(ctx context.Context, orgId 
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) CreateApiKeyExecute(r CreateApiKeyApiRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) createApiKeyExecute(r CreateApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -553,6 +674,19 @@ type CreateApiKeyAccessListApiParams struct {
 		PageNum *int32
 }
 
+func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessListWithParams(ctx context.Context, args *CreateApiKeyAccessListApiParams) CreateApiKeyAccessListApiRequest {
+	return CreateApiKeyAccessListApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		apiUserId: args.ApiUserId,
+		userAccessList: args.UserAccessList,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Access list entries to be created for the specified organization API key.
 func (r CreateApiKeyAccessListApiRequest) UserAccessList(userAccessList []UserAccessList) CreateApiKeyAccessListApiRequest {
 	r.userAccessList = &userAccessList
@@ -578,17 +712,7 @@ func (r CreateApiKeyAccessListApiRequest) PageNum(pageNum int32) CreateApiKeyAcc
 }
 
 func (r CreateApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
-	return r.ApiService.CreateApiKeyAccessListExecute(r)
-}
-
-func (r CreateApiKeyAccessListApiRequest) ExecuteWithParams(params *CreateApiKeyAccessListApiParams) (*UserAccessList, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.apiUserId = params.ApiUserId 
-	r.userAccessList = params.UserAccessList 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.createApiKeyAccessListExecute(r)
 }
 
 /*
@@ -612,7 +736,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessList(ctx context.Conte
 
 // Execute executes the request
 //  @return UserAccessList
-func (a *ProgrammaticAPIKeysApiService) CreateApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) createApiKeyAccessListExecute(r CreateApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -745,6 +869,15 @@ type CreateProjectApiKeyApiParams struct {
 		CreateApiKey *CreateApiKey
 }
 
+func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyWithParams(ctx context.Context, args *CreateProjectApiKeyApiParams) CreateProjectApiKeyApiRequest {
+	return CreateProjectApiKeyApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		createApiKey: args.CreateApiKey,
+	}
+}
+
 // Organization API key to be created and assigned to the specified project. This request requires a minimum of one of the two body parameters.
 func (r CreateProjectApiKeyApiRequest) CreateApiKey(createApiKey CreateApiKey) CreateProjectApiKeyApiRequest {
 	r.createApiKey = &createApiKey
@@ -752,13 +885,7 @@ func (r CreateProjectApiKeyApiRequest) CreateApiKey(createApiKey CreateApiKey) C
 }
 
 func (r CreateProjectApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
-	return r.ApiService.CreateProjectApiKeyExecute(r)
-}
-
-func (r CreateProjectApiKeyApiRequest) ExecuteWithParams(params *CreateProjectApiKeyApiParams) (*ApiUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.createApiKey = params.CreateApiKey 
-	return r.Execute()
+	return r.ApiService.createProjectApiKeyExecute(r)
 }
 
 /*
@@ -780,7 +907,7 @@ func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKey(ctx context.Context,
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) CreateProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) createProjectApiKeyExecute(r CreateProjectApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -885,14 +1012,17 @@ type DeleteApiKeyApiParams struct {
 		ApiUserId string
 }
 
-func (r DeleteApiKeyApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteApiKeyExecute(r)
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyWithParams(ctx context.Context, args *DeleteApiKeyApiParams) DeleteApiKeyApiRequest {
+	return DeleteApiKeyApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		apiUserId: args.ApiUserId,
+	}
 }
 
-func (r DeleteApiKeyApiRequest) ExecuteWithParams(params *DeleteApiKeyApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	r.apiUserId = params.ApiUserId 
-	return r.Execute()
+func (r DeleteApiKeyApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteApiKeyExecute(r)
 }
 
 /*
@@ -915,7 +1045,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKey(ctx context.Context, orgId 
 }
 
 // Execute executes the request
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyExecute(r DeleteApiKeyApiRequest) (*http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) deleteApiKeyExecute(r DeleteApiKeyApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1014,15 +1144,18 @@ type DeleteApiKeyAccessListEntryApiParams struct {
 		IpAddress string
 }
 
-func (r DeleteApiKeyAccessListEntryApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteApiKeyAccessListEntryExecute(r)
+func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryWithParams(ctx context.Context, args *DeleteApiKeyAccessListEntryApiParams) DeleteApiKeyAccessListEntryApiRequest {
+	return DeleteApiKeyAccessListEntryApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		apiUserId: args.ApiUserId,
+		ipAddress: args.IpAddress,
+	}
 }
 
-func (r DeleteApiKeyAccessListEntryApiRequest) ExecuteWithParams(params *DeleteApiKeyAccessListEntryApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	r.apiUserId = params.ApiUserId 
-	r.ipAddress = params.IpAddress 
-	return r.Execute()
+func (r DeleteApiKeyAccessListEntryApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteApiKeyAccessListEntryExecute(r)
 }
 
 /*
@@ -1047,7 +1180,7 @@ func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntry(ctx context.
 }
 
 // Execute executes the request
-func (a *ProgrammaticAPIKeysApiService) DeleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (*http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) deleteApiKeyAccessListEntryExecute(r DeleteApiKeyAccessListEntryApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1145,14 +1278,17 @@ type GetApiKeyApiParams struct {
 		ApiUserId string
 }
 
-func (r GetApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
-	return r.ApiService.GetApiKeyExecute(r)
+func (a *ProgrammaticAPIKeysApiService) GetApiKeyWithParams(ctx context.Context, args *GetApiKeyApiParams) GetApiKeyApiRequest {
+	return GetApiKeyApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		apiUserId: args.ApiUserId,
+	}
 }
 
-func (r GetApiKeyApiRequest) ExecuteWithParams(params *GetApiKeyApiParams) (*ApiUser, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.apiUserId = params.ApiUserId 
-	return r.Execute()
+func (r GetApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
+	return r.ApiService.getApiKeyExecute(r)
 }
 
 /*
@@ -1176,7 +1312,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKey(ctx context.Context, orgId str
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) GetApiKeyExecute(r GetApiKeyApiRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) getApiKeyExecute(r GetApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1285,15 +1421,18 @@ type GetApiKeyAccessListApiParams struct {
 		ApiUserId string
 }
 
-func (r GetApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
-	return r.ApiService.GetApiKeyAccessListExecute(r)
+func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListWithParams(ctx context.Context, args *GetApiKeyAccessListApiParams) GetApiKeyAccessListApiRequest {
+	return GetApiKeyAccessListApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		ipAddress: args.IpAddress,
+		apiUserId: args.ApiUserId,
+	}
 }
 
-func (r GetApiKeyAccessListApiRequest) ExecuteWithParams(params *GetApiKeyAccessListApiParams) (*UserAccessList, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.ipAddress = params.IpAddress 
-	r.apiUserId = params.ApiUserId 
-	return r.Execute()
+func (r GetApiKeyAccessListApiRequest) Execute() (*UserAccessList, *http.Response, error) {
+	return r.ApiService.getApiKeyAccessListExecute(r)
 }
 
 /*
@@ -1319,7 +1458,7 @@ func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessList(ctx context.Context,
 
 // Execute executes the request
 //  @return UserAccessList
-func (a *ProgrammaticAPIKeysApiService) GetApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) getApiKeyAccessListExecute(r GetApiKeyAccessListApiRequest) (*UserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1433,6 +1572,18 @@ type ListApiKeyAccessListsEntriesApiParams struct {
 		PageNum *int32
 }
 
+func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntriesWithParams(ctx context.Context, args *ListApiKeyAccessListsEntriesApiParams) ListApiKeyAccessListsEntriesApiRequest {
+	return ListApiKeyAccessListsEntriesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		apiUserId: args.ApiUserId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListApiKeyAccessListsEntriesApiRequest) IncludeCount(includeCount bool) ListApiKeyAccessListsEntriesApiRequest {
 	r.includeCount = &includeCount
@@ -1452,16 +1603,7 @@ func (r ListApiKeyAccessListsEntriesApiRequest) PageNum(pageNum int32) ListApiKe
 }
 
 func (r ListApiKeyAccessListsEntriesApiRequest) Execute() (*PaginatedApiUserAccessList, *http.Response, error) {
-	return r.ApiService.ListApiKeyAccessListsEntriesExecute(r)
-}
-
-func (r ListApiKeyAccessListsEntriesApiRequest) ExecuteWithParams(params *ListApiKeyAccessListsEntriesApiParams) (*PaginatedApiUserAccessList, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.apiUserId = params.ApiUserId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listApiKeyAccessListsEntriesExecute(r)
 }
 
 /*
@@ -1485,7 +1627,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntries(ctx context
 
 // Execute executes the request
 //  @return PaginatedApiUserAccessList
-func (a *ProgrammaticAPIKeysApiService) ListApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) listApiKeyAccessListsEntriesExecute(r ListApiKeyAccessListsEntriesApiRequest) (*PaginatedApiUserAccessList, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1617,6 +1759,17 @@ type ListApiKeysApiParams struct {
 		PageNum *int32
 }
 
+func (a *ProgrammaticAPIKeysApiService) ListApiKeysWithParams(ctx context.Context, args *ListApiKeysApiParams) ListApiKeysApiRequest {
+	return ListApiKeysApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListApiKeysApiRequest) IncludeCount(includeCount bool) ListApiKeysApiRequest {
 	r.includeCount = &includeCount
@@ -1636,15 +1789,7 @@ func (r ListApiKeysApiRequest) PageNum(pageNum int32) ListApiKeysApiRequest {
 }
 
 func (r ListApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
-	return r.ApiService.ListApiKeysExecute(r)
-}
-
-func (r ListApiKeysApiRequest) ExecuteWithParams(params *ListApiKeysApiParams) (*PaginatedApiApiUser, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listApiKeysExecute(r)
 }
 
 /*
@@ -1666,7 +1811,7 @@ func (a *ProgrammaticAPIKeysApiService) ListApiKeys(ctx context.Context, orgId s
 
 // Execute executes the request
 //  @return PaginatedApiApiUser
-func (a *ProgrammaticAPIKeysApiService) ListApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) listApiKeysExecute(r ListApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1791,6 +1936,17 @@ type ListProjectApiKeysApiParams struct {
 		PageNum *int32
 }
 
+func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeysWithParams(ctx context.Context, args *ListProjectApiKeysApiParams) ListProjectApiKeysApiRequest {
+	return ListProjectApiKeysApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListProjectApiKeysApiRequest) IncludeCount(includeCount bool) ListProjectApiKeysApiRequest {
 	r.includeCount = &includeCount
@@ -1810,15 +1966,7 @@ func (r ListProjectApiKeysApiRequest) PageNum(pageNum int32) ListProjectApiKeysA
 }
 
 func (r ListProjectApiKeysApiRequest) Execute() (*PaginatedApiApiUser, *http.Response, error) {
-	return r.ApiService.ListProjectApiKeysExecute(r)
-}
-
-func (r ListProjectApiKeysApiRequest) ExecuteWithParams(params *ListProjectApiKeysApiParams) (*PaginatedApiApiUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listProjectApiKeysExecute(r)
 }
 
 /*
@@ -1840,7 +1988,7 @@ func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeys(ctx context.Context, 
 
 // Execute executes the request
 //  @return PaginatedApiApiUser
-func (a *ProgrammaticAPIKeysApiService) ListProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) listProjectApiKeysExecute(r ListProjectApiKeysApiRequest) (*PaginatedApiApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1961,14 +2109,17 @@ type RemoveProjectApiKeyApiParams struct {
 		ApiUserId string
 }
 
-func (r RemoveProjectApiKeyApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.RemoveProjectApiKeyExecute(r)
+func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyWithParams(ctx context.Context, args *RemoveProjectApiKeyApiParams) RemoveProjectApiKeyApiRequest {
+	return RemoveProjectApiKeyApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		apiUserId: args.ApiUserId,
+	}
 }
 
-func (r RemoveProjectApiKeyApiRequest) ExecuteWithParams(params *RemoveProjectApiKeyApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.apiUserId = params.ApiUserId 
-	return r.Execute()
+func (r RemoveProjectApiKeyApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.removeProjectApiKeyExecute(r)
 }
 
 /*
@@ -1991,7 +2142,7 @@ func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKey(ctx context.Context,
 }
 
 // Execute executes the request
-func (a *ProgrammaticAPIKeysApiService) RemoveProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (*http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) removeProjectApiKeyExecute(r RemoveProjectApiKeyApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -2090,6 +2241,16 @@ type UpdateApiKeyApiParams struct {
 		ApiUser *ApiUser
 }
 
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyWithParams(ctx context.Context, args *UpdateApiKeyApiParams) UpdateApiKeyApiRequest {
+	return UpdateApiKeyApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		apiUserId: args.ApiUserId,
+		apiUser: args.ApiUser,
+	}
+}
+
 // Organization API key to be updated. This request requires a minimum of one of the two body parameters.
 func (r UpdateApiKeyApiRequest) ApiUser(apiUser ApiUser) UpdateApiKeyApiRequest {
 	r.apiUser = &apiUser
@@ -2097,14 +2258,7 @@ func (r UpdateApiKeyApiRequest) ApiUser(apiUser ApiUser) UpdateApiKeyApiRequest 
 }
 
 func (r UpdateApiKeyApiRequest) Execute() (*ApiUser, *http.Response, error) {
-	return r.ApiService.UpdateApiKeyExecute(r)
-}
-
-func (r UpdateApiKeyApiRequest) ExecuteWithParams(params *UpdateApiKeyApiParams) (*ApiUser, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.apiUserId = params.ApiUserId 
-	r.apiUser = params.ApiUser 
-	return r.Execute()
+	return r.ApiService.updateApiKeyExecute(r)
 }
 
 /*
@@ -2128,7 +2282,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKey(ctx context.Context, orgId 
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) updateApiKeyExecute(r UpdateApiKeyApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2248,6 +2402,19 @@ type UpdateApiKeyRolesApiParams struct {
 		IncludeCount *bool
 }
 
+func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRolesWithParams(ctx context.Context, args *UpdateApiKeyRolesApiParams) UpdateApiKeyRolesApiRequest {
+	return UpdateApiKeyRolesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		apiUserId: args.ApiUserId,
+		createApiKey: args.CreateApiKey,
+		pageNum: args.PageNum,
+		itemsPerPage: args.ItemsPerPage,
+		includeCount: args.IncludeCount,
+	}
+}
+
 // Organization API Key to be updated. This request requires a minimum of one of the two body parameters.
 func (r UpdateApiKeyRolesApiRequest) CreateApiKey(createApiKey CreateApiKey) UpdateApiKeyRolesApiRequest {
 	r.createApiKey = &createApiKey
@@ -2273,17 +2440,7 @@ func (r UpdateApiKeyRolesApiRequest) IncludeCount(includeCount bool) UpdateApiKe
 }
 
 func (r UpdateApiKeyRolesApiRequest) Execute() (*ApiUser, *http.Response, error) {
-	return r.ApiService.UpdateApiKeyRolesExecute(r)
-}
-
-func (r UpdateApiKeyRolesApiRequest) ExecuteWithParams(params *UpdateApiKeyRolesApiParams) (*ApiUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.apiUserId = params.ApiUserId 
-	r.createApiKey = params.CreateApiKey 
-	r.pageNum = params.PageNum 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.includeCount = params.IncludeCount 
-	return r.Execute()
+	return r.ApiService.updateApiKeyRolesExecute(r)
 }
 
 /*
@@ -2307,7 +2464,7 @@ func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRoles(ctx context.Context, g
 
 // Execute executes the request
 //  @return ApiUser
-func (a *ProgrammaticAPIKeysApiService) UpdateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiUser, *http.Response, error) {
+func (a *ProgrammaticAPIKeysApiService) updateApiKeyRolesExecute(r UpdateApiKeyRolesApiRequest) (*ApiUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -34,7 +34,7 @@ type ProjectIPAccessListApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateProjectIpAccessListApiParams - Parameters for the request
-	@return CreateProjectIpAccessListApiRequest}}
+	@return CreateProjectIpAccessListApiRequest
 	*/
 	CreateProjectIpAccessListWithParams(ctx context.Context, args *CreateProjectIpAccessListApiParams) CreateProjectIpAccessListApiRequest
 
@@ -58,7 +58,7 @@ type ProjectIPAccessListApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteProjectIpAccessListApiParams - Parameters for the request
-	@return DeleteProjectIpAccessListApiRequest}}
+	@return DeleteProjectIpAccessListApiRequest
 	*/
 	DeleteProjectIpAccessListWithParams(ctx context.Context, args *DeleteProjectIpAccessListApiParams) DeleteProjectIpAccessListApiRequest
 
@@ -82,7 +82,7 @@ type ProjectIPAccessListApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectIpAccessListStatusApiParams - Parameters for the request
-	@return GetProjectIpAccessListStatusApiRequest}}
+	@return GetProjectIpAccessListStatusApiRequest
 	*/
 	GetProjectIpAccessListStatusWithParams(ctx context.Context, args *GetProjectIpAccessListStatusApiParams) GetProjectIpAccessListStatusApiRequest
 
@@ -106,7 +106,7 @@ type ProjectIPAccessListApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectIpListApiParams - Parameters for the request
-	@return GetProjectIpListApiRequest}}
+	@return GetProjectIpListApiRequest
 	*/
 	GetProjectIpListWithParams(ctx context.Context, args *GetProjectIpListApiParams) GetProjectIpListApiRequest
 
@@ -129,7 +129,7 @@ type ProjectIPAccessListApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectIpAccessListsApiParams - Parameters for the request
-	@return ListProjectIpAccessListsApiRequest}}
+	@return ListProjectIpAccessListsApiRequest
 	*/
 	ListProjectIpAccessListsWithParams(ctx context.Context, args *ListProjectIpAccessListsApiParams) ListProjectIpAccessListsApiRequest
 

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -145,6 +145,15 @@ func (r CreateProjectIpAccessListApiRequest) Execute() (*PaginatedNetworkAccess,
 	return r.ApiService.CreateProjectIpAccessListExecute(r)
 }
 
+func (r CreateProjectIpAccessListApiRequest) ExecuteWithParams(params *CreateProjectIpAccessListApiParams) (*PaginatedNetworkAccess, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.networkPermissionEntry = params.NetworkPermissionEntry 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 CreateProjectIpAccessList Add Entries to Project IP Access List
 
@@ -294,6 +303,12 @@ func (r DeleteProjectIpAccessListApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectIpAccessListExecute(r)
 }
 
+func (r DeleteProjectIpAccessListApiRequest) ExecuteWithParams(params *DeleteProjectIpAccessListApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.entryValue = params.EntryValue 
+	return r.Execute()
+}
+
 /*
 DeleteProjectIpAccessList Remove One Entry from One Project IP Access List
 
@@ -407,6 +422,12 @@ type GetProjectIpAccessListStatusApiParams struct {
 
 func (r GetProjectIpAccessListStatusApiRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
 	return r.ApiService.GetProjectIpAccessListStatusExecute(r)
+}
+
+func (r GetProjectIpAccessListStatusApiRequest) ExecuteWithParams(params *GetProjectIpAccessListStatusApiParams) (*NetworkPermissionEntryStatus, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.entryValue = params.EntryValue 
+	return r.Execute()
 }
 
 /*
@@ -533,6 +554,12 @@ type GetProjectIpListApiParams struct {
 
 func (r GetProjectIpListApiRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
 	return r.ApiService.GetProjectIpListExecute(r)
+}
+
+func (r GetProjectIpListApiRequest) ExecuteWithParams(params *GetProjectIpListApiParams) (*NetworkPermissionEntry, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.entryValue = params.EntryValue 
+	return r.Execute()
 }
 
 /*
@@ -681,6 +708,14 @@ func (r ListProjectIpAccessListsApiRequest) PageNum(pageNum int32) ListProjectIp
 
 func (r ListProjectIpAccessListsApiRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
 	return r.ApiService.ListProjectIpAccessListsExecute(r)
+}
+
+func (r ListProjectIpAccessListsApiRequest) ExecuteWithParams(params *ListProjectIpAccessListsApiParams) (*PaginatedNetworkAccess, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_project_ip_access_list.go
+++ b/mongodbatlasv2/api_project_ip_access_list.go
@@ -28,10 +28,18 @@ type ProjectIPAccessListApi interface {
 	@return CreateProjectIpAccessListApiRequest
 	*/
 	CreateProjectIpAccessList(ctx context.Context, groupId string) CreateProjectIpAccessListApiRequest
+	/*
+	CreateProjectIpAccessList Add Entries to Project IP Access List
 
-	// CreateProjectIpAccessListExecute executes the request
-	//  @return PaginatedNetworkAccess
-	CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateProjectIpAccessListApiParams - Parameters for the request
+	@return CreateProjectIpAccessListApiRequest}}
+	*/
+	CreateProjectIpAccessListWithParams(ctx context.Context, args *CreateProjectIpAccessListApiParams) CreateProjectIpAccessListApiRequest
+
+	// Interface only available internally
+	createProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 
 	/*
 	DeleteProjectIpAccessList Remove One Entry from One Project IP Access List
@@ -44,9 +52,18 @@ type ProjectIPAccessListApi interface {
 	@return DeleteProjectIpAccessListApiRequest
 	*/
 	DeleteProjectIpAccessList(ctx context.Context, groupId string, entryValue string) DeleteProjectIpAccessListApiRequest
+	/*
+	DeleteProjectIpAccessList Remove One Entry from One Project IP Access List
 
-	// DeleteProjectIpAccessListExecute executes the request
-	DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteProjectIpAccessListApiParams - Parameters for the request
+	@return DeleteProjectIpAccessListApiRequest}}
+	*/
+	DeleteProjectIpAccessListWithParams(ctx context.Context, args *DeleteProjectIpAccessListApiParams) DeleteProjectIpAccessListApiRequest
+
+	// Interface only available internally
+	deleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (*http.Response, error)
 
 	/*
 	GetProjectIpAccessListStatus Return Status of One Project IP Access List Entry
@@ -59,10 +76,18 @@ type ProjectIPAccessListApi interface {
 	@return GetProjectIpAccessListStatusApiRequest
 	*/
 	GetProjectIpAccessListStatus(ctx context.Context, groupId string, entryValue string) GetProjectIpAccessListStatusApiRequest
+	/*
+	GetProjectIpAccessListStatus Return Status of One Project IP Access List Entry
 
-	// GetProjectIpAccessListStatusExecute executes the request
-	//  @return NetworkPermissionEntryStatus
-	GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectIpAccessListStatusApiParams - Parameters for the request
+	@return GetProjectIpAccessListStatusApiRequest}}
+	*/
+	GetProjectIpAccessListStatusWithParams(ctx context.Context, args *GetProjectIpAccessListStatusApiParams) GetProjectIpAccessListStatusApiRequest
+
+	// Interface only available internally
+	getProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error)
 
 	/*
 	GetProjectIpList Return One Project IP Access List Entry
@@ -75,10 +100,18 @@ type ProjectIPAccessListApi interface {
 	@return GetProjectIpListApiRequest
 	*/
 	GetProjectIpList(ctx context.Context, groupId string, entryValue string) GetProjectIpListApiRequest
+	/*
+	GetProjectIpList Return One Project IP Access List Entry
 
-	// GetProjectIpListExecute executes the request
-	//  @return NetworkPermissionEntry
-	GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectIpListApiParams - Parameters for the request
+	@return GetProjectIpListApiRequest}}
+	*/
+	GetProjectIpListWithParams(ctx context.Context, args *GetProjectIpListApiParams) GetProjectIpListApiRequest
+
+	// Interface only available internally
+	getProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error)
 
 	/*
 	ListProjectIpAccessLists Return Project IP Access List
@@ -90,10 +123,18 @@ type ProjectIPAccessListApi interface {
 	@return ListProjectIpAccessListsApiRequest
 	*/
 	ListProjectIpAccessLists(ctx context.Context, groupId string) ListProjectIpAccessListsApiRequest
+	/*
+	ListProjectIpAccessLists Return Project IP Access List
 
-	// ListProjectIpAccessListsExecute executes the request
-	//  @return PaginatedNetworkAccess
-	ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectIpAccessListsApiParams - Parameters for the request
+	@return ListProjectIpAccessListsApiRequest}}
+	*/
+	ListProjectIpAccessListsWithParams(ctx context.Context, args *ListProjectIpAccessListsApiParams) ListProjectIpAccessListsApiRequest
+
+	// Interface only available internally
+	listProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error)
 }
 
 // ProjectIPAccessListApiService ProjectIPAccessListApi service
@@ -115,6 +156,18 @@ type CreateProjectIpAccessListApiParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
+}
+
+func (a *ProjectIPAccessListApiService) CreateProjectIpAccessListWithParams(ctx context.Context, args *CreateProjectIpAccessListApiParams) CreateProjectIpAccessListApiRequest {
+	return CreateProjectIpAccessListApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		networkPermissionEntry: args.NetworkPermissionEntry,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
 }
 
 // One or more access list entries to add to the specified project.
@@ -142,16 +195,7 @@ func (r CreateProjectIpAccessListApiRequest) PageNum(pageNum int32) CreateProjec
 }
 
 func (r CreateProjectIpAccessListApiRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
-	return r.ApiService.CreateProjectIpAccessListExecute(r)
-}
-
-func (r CreateProjectIpAccessListApiRequest) ExecuteWithParams(params *CreateProjectIpAccessListApiParams) (*PaginatedNetworkAccess, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.networkPermissionEntry = params.NetworkPermissionEntry 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.createProjectIpAccessListExecute(r)
 }
 
 /*
@@ -173,7 +217,7 @@ func (a *ProjectIPAccessListApiService) CreateProjectIpAccessList(ctx context.Co
 
 // Execute executes the request
 //  @return PaginatedNetworkAccess
-func (a *ProjectIPAccessListApiService) CreateProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) createProjectIpAccessListExecute(r CreateProjectIpAccessListApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -299,14 +343,17 @@ type DeleteProjectIpAccessListApiParams struct {
 		EntryValue string
 }
 
-func (r DeleteProjectIpAccessListApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteProjectIpAccessListExecute(r)
+func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListWithParams(ctx context.Context, args *DeleteProjectIpAccessListApiParams) DeleteProjectIpAccessListApiRequest {
+	return DeleteProjectIpAccessListApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		entryValue: args.EntryValue,
+	}
 }
 
-func (r DeleteProjectIpAccessListApiRequest) ExecuteWithParams(params *DeleteProjectIpAccessListApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.entryValue = params.EntryValue 
-	return r.Execute()
+func (r DeleteProjectIpAccessListApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteProjectIpAccessListExecute(r)
 }
 
 /*
@@ -329,7 +376,7 @@ func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessList(ctx context.Co
 }
 
 // Execute executes the request
-func (a *ProjectIPAccessListApiService) DeleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (*http.Response, error) {
+func (a *ProjectIPAccessListApiService) deleteProjectIpAccessListExecute(r DeleteProjectIpAccessListApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -420,14 +467,17 @@ type GetProjectIpAccessListStatusApiParams struct {
 		EntryValue string
 }
 
-func (r GetProjectIpAccessListStatusApiRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
-	return r.ApiService.GetProjectIpAccessListStatusExecute(r)
+func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusWithParams(ctx context.Context, args *GetProjectIpAccessListStatusApiParams) GetProjectIpAccessListStatusApiRequest {
+	return GetProjectIpAccessListStatusApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		entryValue: args.EntryValue,
+	}
 }
 
-func (r GetProjectIpAccessListStatusApiRequest) ExecuteWithParams(params *GetProjectIpAccessListStatusApiParams) (*NetworkPermissionEntryStatus, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.entryValue = params.EntryValue 
-	return r.Execute()
+func (r GetProjectIpAccessListStatusApiRequest) Execute() (*NetworkPermissionEntryStatus, *http.Response, error) {
+	return r.ApiService.getProjectIpAccessListStatusExecute(r)
 }
 
 /*
@@ -451,7 +501,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatus(ctx context
 
 // Execute executes the request
 //  @return NetworkPermissionEntryStatus
-func (a *ProjectIPAccessListApiService) GetProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) getProjectIpAccessListStatusExecute(r GetProjectIpAccessListStatusApiRequest) (*NetworkPermissionEntryStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -552,14 +602,17 @@ type GetProjectIpListApiParams struct {
 		EntryValue string
 }
 
-func (r GetProjectIpListApiRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
-	return r.ApiService.GetProjectIpListExecute(r)
+func (a *ProjectIPAccessListApiService) GetProjectIpListWithParams(ctx context.Context, args *GetProjectIpListApiParams) GetProjectIpListApiRequest {
+	return GetProjectIpListApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		entryValue: args.EntryValue,
+	}
 }
 
-func (r GetProjectIpListApiRequest) ExecuteWithParams(params *GetProjectIpListApiParams) (*NetworkPermissionEntry, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.entryValue = params.EntryValue 
-	return r.Execute()
+func (r GetProjectIpListApiRequest) Execute() (*NetworkPermissionEntry, *http.Response, error) {
+	return r.ApiService.getProjectIpListExecute(r)
 }
 
 /*
@@ -583,7 +636,7 @@ func (a *ProjectIPAccessListApiService) GetProjectIpList(ctx context.Context, gr
 
 // Execute executes the request
 //  @return NetworkPermissionEntry
-func (a *ProjectIPAccessListApiService) GetProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) getProjectIpListExecute(r GetProjectIpListApiRequest) (*NetworkPermissionEntry, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -688,6 +741,17 @@ type ListProjectIpAccessListsApiParams struct {
 		PageNum *int32
 }
 
+func (a *ProjectIPAccessListApiService) ListProjectIpAccessListsWithParams(ctx context.Context, args *ListProjectIpAccessListsApiParams) ListProjectIpAccessListsApiRequest {
+	return ListProjectIpAccessListsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListProjectIpAccessListsApiRequest) IncludeCount(includeCount bool) ListProjectIpAccessListsApiRequest {
 	r.includeCount = &includeCount
@@ -707,15 +771,7 @@ func (r ListProjectIpAccessListsApiRequest) PageNum(pageNum int32) ListProjectIp
 }
 
 func (r ListProjectIpAccessListsApiRequest) Execute() (*PaginatedNetworkAccess, *http.Response, error) {
-	return r.ApiService.ListProjectIpAccessListsExecute(r)
-}
-
-func (r ListProjectIpAccessListsApiRequest) ExecuteWithParams(params *ListProjectIpAccessListsApiParams) (*PaginatedNetworkAccess, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listProjectIpAccessListsExecute(r)
 }
 
 /*
@@ -737,7 +793,7 @@ func (a *ProjectIPAccessListApiService) ListProjectIpAccessLists(ctx context.Con
 
 // Execute executes the request
 //  @return PaginatedNetworkAccess
-func (a *ProjectIPAccessListApiService) ListProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
+func (a *ProjectIPAccessListApiService) listProjectIpAccessListsExecute(r ListProjectIpAccessListsApiRequest) (*PaginatedNetworkAccess, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -353,6 +353,12 @@ func (r CreateProjectApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.CreateProjectExecute(r)
 }
 
+func (r CreateProjectApiRequest) ExecuteWithParams(params *CreateProjectApiParams) (*Group, *http.Response, error) {
+	r.group = params.Group 
+	r.projectOwnerId = params.ProjectOwnerId 
+	return r.Execute()
+}
+
 /*
 CreateProject Create One Project
 
@@ -481,6 +487,12 @@ func (r CreateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Re
 	return r.ApiService.CreateProjectInvitationExecute(r)
 }
 
+func (r CreateProjectInvitationApiRequest) ExecuteWithParams(params *CreateProjectInvitationApiParams) (*GroupInvitation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.groupInvitationRequest = params.GroupInvitationRequest 
+	return r.Execute()
+}
+
 /*
 CreateProjectInvitation Invite One MongoDB Cloud User to Join One Project
 
@@ -607,6 +619,11 @@ func (r DeleteProjectApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectExecute(r)
 }
 
+func (r DeleteProjectApiRequest) ExecuteWithParams(params *DeleteProjectApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 DeleteProject Remove One Project
 
@@ -717,6 +734,12 @@ type DeleteProjectInvitationApiParams struct {
 
 func (r DeleteProjectInvitationApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectInvitationExecute(r)
+}
+
+func (r DeleteProjectInvitationApiRequest) ExecuteWithParams(params *DeleteProjectInvitationApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.invitationId = params.InvitationId 
+	return r.Execute()
 }
 
 /*
@@ -840,6 +863,12 @@ func (r DeleteProjectLimitApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteProjectLimitExecute(r)
 }
 
+func (r DeleteProjectLimitApiRequest) ExecuteWithParams(params *DeleteProjectLimitApiParams) (*http.Response, error) {
+	r.limitName = params.LimitName 
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 DeleteProjectLimit Remove One Project Limit
 
@@ -951,6 +980,11 @@ type GetProjectApiParams struct {
 
 func (r GetProjectApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.GetProjectExecute(r)
+}
+
+func (r GetProjectApiRequest) ExecuteWithParams(params *GetProjectApiParams) (*Group, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -1074,6 +1108,11 @@ func (r GetProjectByNameApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.GetProjectByNameExecute(r)
 }
 
+func (r GetProjectByNameApiRequest) ExecuteWithParams(params *GetProjectByNameApiParams) (*Group, *http.Response, error) {
+	r.groupName = params.GroupName 
+	return r.Execute()
+}
+
 /*
 GetProjectByName Return One Project using Its Name
 
@@ -1195,6 +1234,12 @@ type GetProjectInvitationApiParams struct {
 
 func (r GetProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
 	return r.ApiService.GetProjectInvitationExecute(r)
+}
+
+func (r GetProjectInvitationApiRequest) ExecuteWithParams(params *GetProjectInvitationApiParams) (*GroupInvitation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.invitationId = params.InvitationId 
+	return r.Execute()
 }
 
 /*
@@ -1329,6 +1374,12 @@ func (r GetProjectLimitApiRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.GetProjectLimitExecute(r)
 }
 
+func (r GetProjectLimitApiRequest) ExecuteWithParams(params *GetProjectLimitApiParams) (*Limit, *http.Response, error) {
+	r.limitName = params.LimitName 
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 GetProjectLimit Return One Limit for One Project
 
@@ -1451,6 +1502,11 @@ type GetProjectSettingsApiParams struct {
 
 func (r GetProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
 	return r.ApiService.GetProjectSettingsExecute(r)
+}
+
+func (r GetProjectSettingsApiRequest) ExecuteWithParams(params *GetProjectSettingsApiParams) (*GroupSettings, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -1582,6 +1638,12 @@ func (r ListProjectInvitationsApiRequest) Execute() ([]GroupInvitation, *http.Re
 	return r.ApiService.ListProjectInvitationsExecute(r)
 }
 
+func (r ListProjectInvitationsApiRequest) ExecuteWithParams(params *ListProjectInvitationsApiParams) ([]GroupInvitation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.username = params.Username 
+	return r.Execute()
+}
+
 /*
 ListProjectInvitations Return All Project Invitations
 
@@ -1704,6 +1766,11 @@ type ListProjectLimitsApiParams struct {
 
 func (r ListProjectLimitsApiRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.ListProjectLimitsExecute(r)
+}
+
+func (r ListProjectLimitsApiRequest) ExecuteWithParams(params *ListProjectLimitsApiParams) (*Limit, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -1865,6 +1932,16 @@ func (r ListProjectUsersApiRequest) IncludeOrgUsers(includeOrgUsers bool) ListPr
 
 func (r ListProjectUsersApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
 	return r.ApiService.ListProjectUsersExecute(r)
+}
+
+func (r ListProjectUsersApiRequest) ExecuteWithParams(params *ListProjectUsersApiParams) (*PaginatedApiAppUser, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	r.flattenTeams = params.FlattenTeams 
+	r.includeOrgUsers = params.IncludeOrgUsers 
+	return r.Execute()
 }
 
 /*
@@ -2045,6 +2122,13 @@ func (r ListProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response,
 	return r.ApiService.ListProjectsExecute(r)
 }
 
+func (r ListProjectsApiRequest) ExecuteWithParams(params *ListProjectsApiParams) (*PaginatedAtlasGroup, *http.Response, error) {
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListProjects Return All Projects
 
@@ -2180,6 +2264,12 @@ func (r RemoveProjectUserApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectUserExecute(r)
 }
 
+func (r RemoveProjectUserApiRequest) ExecuteWithParams(params *RemoveProjectUserApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.userId = params.UserId 
+	return r.Execute()
+}
+
 /*
 RemoveProjectUser Remove One User from One Project
 
@@ -2306,6 +2396,13 @@ func (r SetProjectLimitApiRequest) Limit(limit Limit) SetProjectLimitApiRequest 
 
 func (r SetProjectLimitApiRequest) Execute() (*Limit, *http.Response, error) {
 	return r.ApiService.SetProjectLimitExecute(r)
+}
+
+func (r SetProjectLimitApiRequest) ExecuteWithParams(params *SetProjectLimitApiParams) (*Limit, *http.Response, error) {
+	r.limitName = params.LimitName 
+	r.groupId = params.GroupId 
+	r.limit = params.Limit 
+	return r.Execute()
 }
 
 /*
@@ -2443,6 +2540,12 @@ func (r UpdateProjectApiRequest) Execute() (*Group, *http.Response, error) {
 	return r.ApiService.UpdateProjectExecute(r)
 }
 
+func (r UpdateProjectApiRequest) ExecuteWithParams(params *UpdateProjectApiParams) (*Group, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.groupName = params.GroupName 
+	return r.Execute()
+}
+
 /*
 UpdateProject Update One Project Name
 
@@ -2572,6 +2675,12 @@ func (r UpdateProjectInvitationApiRequest) GroupInvitationRequest(groupInvitatio
 
 func (r UpdateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
 	return r.ApiService.UpdateProjectInvitationExecute(r)
+}
+
+func (r UpdateProjectInvitationApiRequest) ExecuteWithParams(params *UpdateProjectInvitationApiParams) (*GroupInvitation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.groupInvitationRequest = params.GroupInvitationRequest 
+	return r.Execute()
 }
 
 /*
@@ -2708,6 +2817,13 @@ func (r UpdateProjectInvitationByIdApiRequest) GroupInvitationUpdateRequest(grou
 
 func (r UpdateProjectInvitationByIdApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
 	return r.ApiService.UpdateProjectInvitationByIdExecute(r)
+}
+
+func (r UpdateProjectInvitationByIdApiRequest) ExecuteWithParams(params *UpdateProjectInvitationByIdApiParams) (*GroupInvitation, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.invitationId = params.InvitationId 
+	r.groupInvitationUpdateRequest = params.GroupInvitationUpdateRequest 
+	return r.Execute()
 }
 
 /*
@@ -2850,6 +2966,12 @@ func (r UpdateProjectSettingsApiRequest) GroupSettings(groupSettings GroupSettin
 
 func (r UpdateProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
 	return r.ApiService.UpdateProjectSettingsExecute(r)
+}
+
+func (r UpdateProjectSettingsApiRequest) ExecuteWithParams(params *UpdateProjectSettingsApiParams) (*GroupSettings, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.groupSettings = params.GroupSettings 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -27,10 +27,18 @@ type ProjectsApi interface {
 	@return CreateProjectApiRequest
 	*/
 	CreateProject(ctx context.Context) CreateProjectApiRequest
+	/*
+	CreateProject Create One Project
 
-	// CreateProjectExecute executes the request
-	//  @return Group
-	CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateProjectApiParams - Parameters for the request
+	@return CreateProjectApiRequest}}
+	*/
+	CreateProjectWithParams(ctx context.Context, args *CreateProjectApiParams) CreateProjectApiRequest
+
+	// Interface only available internally
+	createProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 	CreateProjectInvitation Invite One MongoDB Cloud User to Join One Project
@@ -42,10 +50,18 @@ type ProjectsApi interface {
 	@return CreateProjectInvitationApiRequest
 	*/
 	CreateProjectInvitation(ctx context.Context, groupId string) CreateProjectInvitationApiRequest
+	/*
+	CreateProjectInvitation Invite One MongoDB Cloud User to Join One Project
 
-	// CreateProjectInvitationExecute executes the request
-	//  @return GroupInvitation
-	CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateProjectInvitationApiParams - Parameters for the request
+	@return CreateProjectInvitationApiRequest}}
+	*/
+	CreateProjectInvitationWithParams(ctx context.Context, args *CreateProjectInvitationApiParams) CreateProjectInvitationApiRequest
+
+	// Interface only available internally
+	createProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	DeleteProject Remove One Project
@@ -57,9 +73,18 @@ type ProjectsApi interface {
 	@return DeleteProjectApiRequest
 	*/
 	DeleteProject(ctx context.Context, groupId string) DeleteProjectApiRequest
+	/*
+	DeleteProject Remove One Project
 
-	// DeleteProjectExecute executes the request
-	DeleteProjectExecute(r DeleteProjectApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteProjectApiParams - Parameters for the request
+	@return DeleteProjectApiRequest}}
+	*/
+	DeleteProjectWithParams(ctx context.Context, args *DeleteProjectApiParams) DeleteProjectApiRequest
+
+	// Interface only available internally
+	deleteProjectExecute(r DeleteProjectApiRequest) (*http.Response, error)
 
 	/*
 	DeleteProjectInvitation Cancel One Project Invitation
@@ -72,9 +97,18 @@ type ProjectsApi interface {
 	@return DeleteProjectInvitationApiRequest
 	*/
 	DeleteProjectInvitation(ctx context.Context, groupId string, invitationId string) DeleteProjectInvitationApiRequest
+	/*
+	DeleteProjectInvitation Cancel One Project Invitation
 
-	// DeleteProjectInvitationExecute executes the request
-	DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteProjectInvitationApiParams - Parameters for the request
+	@return DeleteProjectInvitationApiRequest}}
+	*/
+	DeleteProjectInvitationWithParams(ctx context.Context, args *DeleteProjectInvitationApiParams) DeleteProjectInvitationApiRequest
+
+	// Interface only available internally
+	deleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (*http.Response, error)
 
 	/*
 	DeleteProjectLimit Remove One Project Limit
@@ -87,9 +121,18 @@ type ProjectsApi interface {
 	@return DeleteProjectLimitApiRequest
 	*/
 	DeleteProjectLimit(ctx context.Context, limitName string, groupId string) DeleteProjectLimitApiRequest
+	/*
+	DeleteProjectLimit Remove One Project Limit
 
-	// DeleteProjectLimitExecute executes the request
-	DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteProjectLimitApiParams - Parameters for the request
+	@return DeleteProjectLimitApiRequest}}
+	*/
+	DeleteProjectLimitWithParams(ctx context.Context, args *DeleteProjectLimitApiParams) DeleteProjectLimitApiRequest
+
+	// Interface only available internally
+	deleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (*http.Response, error)
 
 	/*
 	GetProject Return One Project
@@ -101,10 +144,18 @@ type ProjectsApi interface {
 	@return GetProjectApiRequest
 	*/
 	GetProject(ctx context.Context, groupId string) GetProjectApiRequest
+	/*
+	GetProject Return One Project
 
-	// GetProjectExecute executes the request
-	//  @return Group
-	GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectApiParams - Parameters for the request
+	@return GetProjectApiRequest}}
+	*/
+	GetProjectWithParams(ctx context.Context, args *GetProjectApiParams) GetProjectApiRequest
+
+	// Interface only available internally
+	getProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 	GetProjectByName Return One Project using Its Name
@@ -116,10 +167,18 @@ type ProjectsApi interface {
 	@return GetProjectByNameApiRequest
 	*/
 	GetProjectByName(ctx context.Context, groupName string) GetProjectByNameApiRequest
+	/*
+	GetProjectByName Return One Project using Its Name
 
-	// GetProjectByNameExecute executes the request
-	//  @return Group
-	GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectByNameApiParams - Parameters for the request
+	@return GetProjectByNameApiRequest}}
+	*/
+	GetProjectByNameWithParams(ctx context.Context, args *GetProjectByNameApiParams) GetProjectByNameApiRequest
+
+	// Interface only available internally
+	getProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error)
 
 	/*
 	GetProjectInvitation Return One Project Invitation
@@ -132,10 +191,18 @@ type ProjectsApi interface {
 	@return GetProjectInvitationApiRequest
 	*/
 	GetProjectInvitation(ctx context.Context, groupId string, invitationId string) GetProjectInvitationApiRequest
+	/*
+	GetProjectInvitation Return One Project Invitation
 
-	// GetProjectInvitationExecute executes the request
-	//  @return GroupInvitation
-	GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectInvitationApiParams - Parameters for the request
+	@return GetProjectInvitationApiRequest}}
+	*/
+	GetProjectInvitationWithParams(ctx context.Context, args *GetProjectInvitationApiParams) GetProjectInvitationApiRequest
+
+	// Interface only available internally
+	getProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	GetProjectLimit Return One Limit for One Project
@@ -148,10 +215,18 @@ type ProjectsApi interface {
 	@return GetProjectLimitApiRequest
 	*/
 	GetProjectLimit(ctx context.Context, limitName string, groupId string) GetProjectLimitApiRequest
+	/*
+	GetProjectLimit Return One Limit for One Project
 
-	// GetProjectLimitExecute executes the request
-	//  @return Limit
-	GetProjectLimitExecute(r GetProjectLimitApiRequest) (*Limit, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectLimitApiParams - Parameters for the request
+	@return GetProjectLimitApiRequest}}
+	*/
+	GetProjectLimitWithParams(ctx context.Context, args *GetProjectLimitApiParams) GetProjectLimitApiRequest
+
+	// Interface only available internally
+	getProjectLimitExecute(r GetProjectLimitApiRequest) (*Limit, *http.Response, error)
 
 	/*
 	GetProjectSettings Return One Project Settings
@@ -163,10 +238,18 @@ type ProjectsApi interface {
 	@return GetProjectSettingsApiRequest
 	*/
 	GetProjectSettings(ctx context.Context, groupId string) GetProjectSettingsApiRequest
+	/*
+	GetProjectSettings Return One Project Settings
 
-	// GetProjectSettingsExecute executes the request
-	//  @return GroupSettings
-	GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetProjectSettingsApiParams - Parameters for the request
+	@return GetProjectSettingsApiRequest}}
+	*/
+	GetProjectSettingsWithParams(ctx context.Context, args *GetProjectSettingsApiParams) GetProjectSettingsApiRequest
+
+	// Interface only available internally
+	getProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 
 	/*
 	ListProjectInvitations Return All Project Invitations
@@ -178,10 +261,18 @@ type ProjectsApi interface {
 	@return ListProjectInvitationsApiRequest
 	*/
 	ListProjectInvitations(ctx context.Context, groupId string) ListProjectInvitationsApiRequest
+	/*
+	ListProjectInvitations Return All Project Invitations
 
-	// ListProjectInvitationsExecute executes the request
-	//  @return []GroupInvitation
-	ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectInvitationsApiParams - Parameters for the request
+	@return ListProjectInvitationsApiRequest}}
+	*/
+	ListProjectInvitationsWithParams(ctx context.Context, args *ListProjectInvitationsApiParams) ListProjectInvitationsApiRequest
+
+	// Interface only available internally
+	listProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error)
 
 	/*
 	ListProjectLimits Return All Limits for One Project
@@ -193,10 +284,18 @@ type ProjectsApi interface {
 	@return ListProjectLimitsApiRequest
 	*/
 	ListProjectLimits(ctx context.Context, groupId string) ListProjectLimitsApiRequest
+	/*
+	ListProjectLimits Return All Limits for One Project
 
-	// ListProjectLimitsExecute executes the request
-	//  @return Limit
-	ListProjectLimitsExecute(r ListProjectLimitsApiRequest) (*Limit, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectLimitsApiParams - Parameters for the request
+	@return ListProjectLimitsApiRequest}}
+	*/
+	ListProjectLimitsWithParams(ctx context.Context, args *ListProjectLimitsApiParams) ListProjectLimitsApiRequest
+
+	// Interface only available internally
+	listProjectLimitsExecute(r ListProjectLimitsApiRequest) (*Limit, *http.Response, error)
 
 	/*
 	ListProjectUsers Return All Users in One Project
@@ -208,10 +307,18 @@ type ProjectsApi interface {
 	@return ListProjectUsersApiRequest
 	*/
 	ListProjectUsers(ctx context.Context, groupId string) ListProjectUsersApiRequest
+	/*
+	ListProjectUsers Return All Users in One Project
 
-	// ListProjectUsersExecute executes the request
-	//  @return PaginatedApiAppUser
-	ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectUsersApiParams - Parameters for the request
+	@return ListProjectUsersApiRequest}}
+	*/
+	ListProjectUsersWithParams(ctx context.Context, args *ListProjectUsersApiParams) ListProjectUsersApiRequest
+
+	// Interface only available internally
+	listProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 	ListProjects Return All Projects
@@ -222,10 +329,18 @@ type ProjectsApi interface {
 	@return ListProjectsApiRequest
 	*/
 	ListProjects(ctx context.Context) ListProjectsApiRequest
+	/*
+	ListProjects Return All Projects
 
-	// ListProjectsExecute executes the request
-	//  @return PaginatedAtlasGroup
-	ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectsApiParams - Parameters for the request
+	@return ListProjectsApiRequest}}
+	*/
+	ListProjectsWithParams(ctx context.Context, args *ListProjectsApiParams) ListProjectsApiRequest
+
+	// Interface only available internally
+	listProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error)
 
 	/*
 	RemoveProjectUser Remove One User from One Project
@@ -238,9 +353,18 @@ type ProjectsApi interface {
 	@return RemoveProjectUserApiRequest
 	*/
 	RemoveProjectUser(ctx context.Context, groupId string, userId string) RemoveProjectUserApiRequest
+	/*
+	RemoveProjectUser Remove One User from One Project
 
-	// RemoveProjectUserExecute executes the request
-	RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param RemoveProjectUserApiParams - Parameters for the request
+	@return RemoveProjectUserApiRequest}}
+	*/
+	RemoveProjectUserWithParams(ctx context.Context, args *RemoveProjectUserApiParams) RemoveProjectUserApiRequest
+
+	// Interface only available internally
+	removeProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error)
 
 	/*
 	SetProjectLimit Set One Project Limit
@@ -255,10 +379,18 @@ type ProjectsApi interface {
 	@return SetProjectLimitApiRequest
 	*/
 	SetProjectLimit(ctx context.Context, limitName string, groupId string) SetProjectLimitApiRequest
+	/*
+	SetProjectLimit Set One Project Limit
 
-	// SetProjectLimitExecute executes the request
-	//  @return Limit
-	SetProjectLimitExecute(r SetProjectLimitApiRequest) (*Limit, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param SetProjectLimitApiParams - Parameters for the request
+	@return SetProjectLimitApiRequest}}
+	*/
+	SetProjectLimitWithParams(ctx context.Context, args *SetProjectLimitApiParams) SetProjectLimitApiRequest
+
+	// Interface only available internally
+	setProjectLimitExecute(r SetProjectLimitApiRequest) (*Limit, *http.Response, error)
 
 	/*
 	UpdateProject Update One Project Name
@@ -270,10 +402,18 @@ type ProjectsApi interface {
 	@return UpdateProjectApiRequest
 	*/
 	UpdateProject(ctx context.Context, groupId string) UpdateProjectApiRequest
+	/*
+	UpdateProject Update One Project Name
 
-	// UpdateProjectExecute executes the request
-	//  @return Group
-	UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateProjectApiParams - Parameters for the request
+	@return UpdateProjectApiRequest}}
+	*/
+	UpdateProjectWithParams(ctx context.Context, args *UpdateProjectApiParams) UpdateProjectApiRequest
+
+	// Interface only available internally
+	updateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error)
 
 	/*
 	UpdateProjectInvitation Update One Project Invitation
@@ -285,10 +425,18 @@ type ProjectsApi interface {
 	@return UpdateProjectInvitationApiRequest
 	*/
 	UpdateProjectInvitation(ctx context.Context, groupId string) UpdateProjectInvitationApiRequest
+	/*
+	UpdateProjectInvitation Update One Project Invitation
 
-	// UpdateProjectInvitationExecute executes the request
-	//  @return GroupInvitation
-	UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateProjectInvitationApiParams - Parameters for the request
+	@return UpdateProjectInvitationApiRequest}}
+	*/
+	UpdateProjectInvitationWithParams(ctx context.Context, args *UpdateProjectInvitationApiParams) UpdateProjectInvitationApiRequest
+
+	// Interface only available internally
+	updateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	UpdateProjectInvitationById Update One Project Invitation by Invitation ID
@@ -301,10 +449,18 @@ type ProjectsApi interface {
 	@return UpdateProjectInvitationByIdApiRequest
 	*/
 	UpdateProjectInvitationById(ctx context.Context, groupId string, invitationId string) UpdateProjectInvitationByIdApiRequest
+	/*
+	UpdateProjectInvitationById Update One Project Invitation by Invitation ID
 
-	// UpdateProjectInvitationByIdExecute executes the request
-	//  @return GroupInvitation
-	UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateProjectInvitationByIdApiParams - Parameters for the request
+	@return UpdateProjectInvitationByIdApiRequest}}
+	*/
+	UpdateProjectInvitationByIdWithParams(ctx context.Context, args *UpdateProjectInvitationByIdApiParams) UpdateProjectInvitationByIdApiRequest
+
+	// Interface only available internally
+	updateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error)
 
 	/*
 	UpdateProjectSettings Update One Project Settings
@@ -316,10 +472,18 @@ type ProjectsApi interface {
 	@return UpdateProjectSettingsApiRequest
 	*/
 	UpdateProjectSettings(ctx context.Context, groupId string) UpdateProjectSettingsApiRequest
+	/*
+	UpdateProjectSettings Update One Project Settings
 
-	// UpdateProjectSettingsExecute executes the request
-	//  @return GroupSettings
-	UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateProjectSettingsApiParams - Parameters for the request
+	@return UpdateProjectSettingsApiRequest}}
+	*/
+	UpdateProjectSettingsWithParams(ctx context.Context, args *UpdateProjectSettingsApiParams) UpdateProjectSettingsApiRequest
+
+	// Interface only available internally
+	updateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error)
 }
 
 // ProjectsApiService ProjectsApi service
@@ -337,6 +501,15 @@ type CreateProjectApiParams struct {
 		ProjectOwnerId *string
 }
 
+func (a *ProjectsApiService) CreateProjectWithParams(ctx context.Context, args *CreateProjectApiParams) CreateProjectApiRequest {
+	return CreateProjectApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		group: args.Group,
+		projectOwnerId: args.ProjectOwnerId,
+	}
+}
+
 // Creates one project.
 func (r CreateProjectApiRequest) Group(group Group) CreateProjectApiRequest {
 	r.group = &group
@@ -350,13 +523,7 @@ func (r CreateProjectApiRequest) ProjectOwnerId(projectOwnerId string) CreatePro
 }
 
 func (r CreateProjectApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.CreateProjectExecute(r)
-}
-
-func (r CreateProjectApiRequest) ExecuteWithParams(params *CreateProjectApiParams) (*Group, *http.Response, error) {
-	r.group = params.Group 
-	r.projectOwnerId = params.ProjectOwnerId 
-	return r.Execute()
+	return r.ApiService.createProjectExecute(r)
 }
 
 /*
@@ -376,7 +543,7 @@ func (a *ProjectsApiService) CreateProject(ctx context.Context) CreateProjectApi
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) CreateProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) createProjectExecute(r CreateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -477,6 +644,15 @@ type CreateProjectInvitationApiParams struct {
 		GroupInvitationRequest *GroupInvitationRequest
 }
 
+func (a *ProjectsApiService) CreateProjectInvitationWithParams(ctx context.Context, args *CreateProjectInvitationApiParams) CreateProjectInvitationApiRequest {
+	return CreateProjectInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		groupInvitationRequest: args.GroupInvitationRequest,
+	}
+}
+
 // Invites one MongoDB Cloud user to join the specified project.
 func (r CreateProjectInvitationApiRequest) GroupInvitationRequest(groupInvitationRequest GroupInvitationRequest) CreateProjectInvitationApiRequest {
 	r.groupInvitationRequest = &groupInvitationRequest
@@ -484,13 +660,7 @@ func (r CreateProjectInvitationApiRequest) GroupInvitationRequest(groupInvitatio
 }
 
 func (r CreateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.CreateProjectInvitationExecute(r)
-}
-
-func (r CreateProjectInvitationApiRequest) ExecuteWithParams(params *CreateProjectInvitationApiParams) (*GroupInvitation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.groupInvitationRequest = params.GroupInvitationRequest 
-	return r.Execute()
+	return r.ApiService.createProjectInvitationExecute(r)
 }
 
 /*
@@ -512,7 +682,7 @@ func (a *ProjectsApiService) CreateProjectInvitation(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) CreateProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) createProjectInvitationExecute(r CreateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -615,13 +785,16 @@ type DeleteProjectApiParams struct {
 		GroupId string
 }
 
-func (r DeleteProjectApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteProjectExecute(r)
+func (a *ProjectsApiService) DeleteProjectWithParams(ctx context.Context, args *DeleteProjectApiParams) DeleteProjectApiRequest {
+	return DeleteProjectApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r DeleteProjectApiRequest) ExecuteWithParams(params *DeleteProjectApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r DeleteProjectApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteProjectExecute(r)
 }
 
 /*
@@ -642,7 +815,7 @@ func (a *ProjectsApiService) DeleteProject(ctx context.Context, groupId string) 
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) DeleteProjectExecute(r DeleteProjectApiRequest) (*http.Response, error) {
+func (a *ProjectsApiService) deleteProjectExecute(r DeleteProjectApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -732,14 +905,17 @@ type DeleteProjectInvitationApiParams struct {
 		InvitationId string
 }
 
-func (r DeleteProjectInvitationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteProjectInvitationExecute(r)
+func (a *ProjectsApiService) DeleteProjectInvitationWithParams(ctx context.Context, args *DeleteProjectInvitationApiParams) DeleteProjectInvitationApiRequest {
+	return DeleteProjectInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		invitationId: args.InvitationId,
+	}
 }
 
-func (r DeleteProjectInvitationApiRequest) ExecuteWithParams(params *DeleteProjectInvitationApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.invitationId = params.InvitationId 
-	return r.Execute()
+func (r DeleteProjectInvitationApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteProjectInvitationExecute(r)
 }
 
 /*
@@ -762,7 +938,7 @@ func (a *ProjectsApiService) DeleteProjectInvitation(ctx context.Context, groupI
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) DeleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (*http.Response, error) {
+func (a *ProjectsApiService) deleteProjectInvitationExecute(r DeleteProjectInvitationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -859,14 +1035,17 @@ type DeleteProjectLimitApiParams struct {
 		GroupId string
 }
 
-func (r DeleteProjectLimitApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteProjectLimitExecute(r)
+func (a *ProjectsApiService) DeleteProjectLimitWithParams(ctx context.Context, args *DeleteProjectLimitApiParams) DeleteProjectLimitApiRequest {
+	return DeleteProjectLimitApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		limitName: args.LimitName,
+		groupId: args.GroupId,
+	}
 }
 
-func (r DeleteProjectLimitApiRequest) ExecuteWithParams(params *DeleteProjectLimitApiParams) (*http.Response, error) {
-	r.limitName = params.LimitName 
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r DeleteProjectLimitApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteProjectLimitExecute(r)
 }
 
 /*
@@ -889,7 +1068,7 @@ func (a *ProjectsApiService) DeleteProjectLimit(ctx context.Context, limitName s
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) DeleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (*http.Response, error) {
+func (a *ProjectsApiService) deleteProjectLimitExecute(r DeleteProjectLimitApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -978,13 +1157,16 @@ type GetProjectApiParams struct {
 		GroupId string
 }
 
-func (r GetProjectApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.GetProjectExecute(r)
+func (a *ProjectsApiService) GetProjectWithParams(ctx context.Context, args *GetProjectApiParams) GetProjectApiRequest {
+	return GetProjectApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetProjectApiRequest) ExecuteWithParams(params *GetProjectApiParams) (*Group, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetProjectApiRequest) Execute() (*Group, *http.Response, error) {
+	return r.ApiService.getProjectExecute(r)
 }
 
 /*
@@ -1006,7 +1188,7 @@ func (a *ProjectsApiService) GetProject(ctx context.Context, groupId string) Get
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) GetProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) getProjectExecute(r GetProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1104,13 +1286,16 @@ type GetProjectByNameApiParams struct {
 		GroupName string
 }
 
-func (r GetProjectByNameApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.GetProjectByNameExecute(r)
+func (a *ProjectsApiService) GetProjectByNameWithParams(ctx context.Context, args *GetProjectByNameApiParams) GetProjectByNameApiRequest {
+	return GetProjectByNameApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupName: args.GroupName,
+	}
 }
 
-func (r GetProjectByNameApiRequest) ExecuteWithParams(params *GetProjectByNameApiParams) (*Group, *http.Response, error) {
-	r.groupName = params.GroupName 
-	return r.Execute()
+func (r GetProjectByNameApiRequest) Execute() (*Group, *http.Response, error) {
+	return r.ApiService.getProjectByNameExecute(r)
 }
 
 /*
@@ -1132,7 +1317,7 @@ func (a *ProjectsApiService) GetProjectByName(ctx context.Context, groupName str
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) GetProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) getProjectByNameExecute(r GetProjectByNameApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1232,14 +1417,17 @@ type GetProjectInvitationApiParams struct {
 		InvitationId string
 }
 
-func (r GetProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.GetProjectInvitationExecute(r)
+func (a *ProjectsApiService) GetProjectInvitationWithParams(ctx context.Context, args *GetProjectInvitationApiParams) GetProjectInvitationApiRequest {
+	return GetProjectInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		invitationId: args.InvitationId,
+	}
 }
 
-func (r GetProjectInvitationApiRequest) ExecuteWithParams(params *GetProjectInvitationApiParams) (*GroupInvitation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.invitationId = params.InvitationId 
-	return r.Execute()
+func (r GetProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
+	return r.ApiService.getProjectInvitationExecute(r)
 }
 
 /*
@@ -1263,7 +1451,7 @@ func (a *ProjectsApiService) GetProjectInvitation(ctx context.Context, groupId s
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) GetProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) getProjectInvitationExecute(r GetProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1370,14 +1558,17 @@ type GetProjectLimitApiParams struct {
 		GroupId string
 }
 
-func (r GetProjectLimitApiRequest) Execute() (*Limit, *http.Response, error) {
-	return r.ApiService.GetProjectLimitExecute(r)
+func (a *ProjectsApiService) GetProjectLimitWithParams(ctx context.Context, args *GetProjectLimitApiParams) GetProjectLimitApiRequest {
+	return GetProjectLimitApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		limitName: args.LimitName,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetProjectLimitApiRequest) ExecuteWithParams(params *GetProjectLimitApiParams) (*Limit, *http.Response, error) {
-	r.limitName = params.LimitName 
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetProjectLimitApiRequest) Execute() (*Limit, *http.Response, error) {
+	return r.ApiService.getProjectLimitExecute(r)
 }
 
 /*
@@ -1401,7 +1592,7 @@ func (a *ProjectsApiService) GetProjectLimit(ctx context.Context, limitName stri
 
 // Execute executes the request
 //  @return Limit
-func (a *ProjectsApiService) GetProjectLimitExecute(r GetProjectLimitApiRequest) (*Limit, *http.Response, error) {
+func (a *ProjectsApiService) getProjectLimitExecute(r GetProjectLimitApiRequest) (*Limit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1500,13 +1691,16 @@ type GetProjectSettingsApiParams struct {
 		GroupId string
 }
 
-func (r GetProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
-	return r.ApiService.GetProjectSettingsExecute(r)
+func (a *ProjectsApiService) GetProjectSettingsWithParams(ctx context.Context, args *GetProjectSettingsApiParams) GetProjectSettingsApiRequest {
+	return GetProjectSettingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r GetProjectSettingsApiRequest) ExecuteWithParams(params *GetProjectSettingsApiParams) (*GroupSettings, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r GetProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
+	return r.ApiService.getProjectSettingsExecute(r)
 }
 
 /*
@@ -1528,7 +1722,7 @@ func (a *ProjectsApiService) GetProjectSettings(ctx context.Context, groupId str
 
 // Execute executes the request
 //  @return GroupSettings
-func (a *ProjectsApiService) GetProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
+func (a *ProjectsApiService) getProjectSettingsExecute(r GetProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1628,6 +1822,15 @@ type ListProjectInvitationsApiParams struct {
 		Username *string
 }
 
+func (a *ProjectsApiService) ListProjectInvitationsWithParams(ctx context.Context, args *ListProjectInvitationsApiParams) ListProjectInvitationsApiRequest {
+	return ListProjectInvitationsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		username: args.Username,
+	}
+}
+
 // Email address of the user account invited to this project.
 func (r ListProjectInvitationsApiRequest) Username(username string) ListProjectInvitationsApiRequest {
 	r.username = &username
@@ -1635,13 +1838,7 @@ func (r ListProjectInvitationsApiRequest) Username(username string) ListProjectI
 }
 
 func (r ListProjectInvitationsApiRequest) Execute() ([]GroupInvitation, *http.Response, error) {
-	return r.ApiService.ListProjectInvitationsExecute(r)
-}
-
-func (r ListProjectInvitationsApiRequest) ExecuteWithParams(params *ListProjectInvitationsApiParams) ([]GroupInvitation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.username = params.Username 
-	return r.Execute()
+	return r.ApiService.listProjectInvitationsExecute(r)
 }
 
 /*
@@ -1663,7 +1860,7 @@ func (a *ProjectsApiService) ListProjectInvitations(ctx context.Context, groupId
 
 // Execute executes the request
 //  @return []GroupInvitation
-func (a *ProjectsApiService) ListProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) listProjectInvitationsExecute(r ListProjectInvitationsApiRequest) ([]GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1764,13 +1961,16 @@ type ListProjectLimitsApiParams struct {
 		GroupId string
 }
 
-func (r ListProjectLimitsApiRequest) Execute() (*Limit, *http.Response, error) {
-	return r.ApiService.ListProjectLimitsExecute(r)
+func (a *ProjectsApiService) ListProjectLimitsWithParams(ctx context.Context, args *ListProjectLimitsApiParams) ListProjectLimitsApiRequest {
+	return ListProjectLimitsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ListProjectLimitsApiRequest) ExecuteWithParams(params *ListProjectLimitsApiParams) (*Limit, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ListProjectLimitsApiRequest) Execute() (*Limit, *http.Response, error) {
+	return r.ApiService.listProjectLimitsExecute(r)
 }
 
 /*
@@ -1792,7 +1992,7 @@ func (a *ProjectsApiService) ListProjectLimits(ctx context.Context, groupId stri
 
 // Execute executes the request
 //  @return Limit
-func (a *ProjectsApiService) ListProjectLimitsExecute(r ListProjectLimitsApiRequest) (*Limit, *http.Response, error) {
+func (a *ProjectsApiService) listProjectLimitsExecute(r ListProjectLimitsApiRequest) (*Limit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1900,6 +2100,19 @@ type ListProjectUsersApiParams struct {
 		IncludeOrgUsers *bool
 }
 
+func (a *ProjectsApiService) ListProjectUsersWithParams(ctx context.Context, args *ListProjectUsersApiParams) ListProjectUsersApiRequest {
+	return ListProjectUsersApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+		flattenTeams: args.FlattenTeams,
+		includeOrgUsers: args.IncludeOrgUsers,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListProjectUsersApiRequest) IncludeCount(includeCount bool) ListProjectUsersApiRequest {
 	r.includeCount = &includeCount
@@ -1931,17 +2144,7 @@ func (r ListProjectUsersApiRequest) IncludeOrgUsers(includeOrgUsers bool) ListPr
 }
 
 func (r ListProjectUsersApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
-	return r.ApiService.ListProjectUsersExecute(r)
-}
-
-func (r ListProjectUsersApiRequest) ExecuteWithParams(params *ListProjectUsersApiParams) (*PaginatedApiAppUser, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	r.flattenTeams = params.FlattenTeams 
-	r.includeOrgUsers = params.IncludeOrgUsers 
-	return r.Execute()
+	return r.ApiService.listProjectUsersExecute(r)
 }
 
 /*
@@ -1963,7 +2166,7 @@ func (a *ProjectsApiService) ListProjectUsers(ctx context.Context, groupId strin
 
 // Execute executes the request
 //  @return PaginatedApiAppUser
-func (a *ProjectsApiService) ListProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *ProjectsApiService) listProjectUsersExecute(r ListProjectUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2100,6 +2303,16 @@ type ListProjectsApiParams struct {
 		PageNum *int32
 }
 
+func (a *ProjectsApiService) ListProjectsWithParams(ctx context.Context, args *ListProjectsApiParams) ListProjectsApiRequest {
+	return ListProjectsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListProjectsApiRequest) IncludeCount(includeCount bool) ListProjectsApiRequest {
 	r.includeCount = &includeCount
@@ -2119,14 +2332,7 @@ func (r ListProjectsApiRequest) PageNum(pageNum int32) ListProjectsApiRequest {
 }
 
 func (r ListProjectsApiRequest) Execute() (*PaginatedAtlasGroup, *http.Response, error) {
-	return r.ApiService.ListProjectsExecute(r)
-}
-
-func (r ListProjectsApiRequest) ExecuteWithParams(params *ListProjectsApiParams) (*PaginatedAtlasGroup, *http.Response, error) {
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listProjectsExecute(r)
 }
 
 /*
@@ -2146,7 +2352,7 @@ func (a *ProjectsApiService) ListProjects(ctx context.Context) ListProjectsApiRe
 
 // Execute executes the request
 //  @return PaginatedAtlasGroup
-func (a *ProjectsApiService) ListProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
+func (a *ProjectsApiService) listProjectsExecute(r ListProjectsApiRequest) (*PaginatedAtlasGroup, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -2260,14 +2466,17 @@ type RemoveProjectUserApiParams struct {
 		UserId string
 }
 
-func (r RemoveProjectUserApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.RemoveProjectUserExecute(r)
+func (a *ProjectsApiService) RemoveProjectUserWithParams(ctx context.Context, args *RemoveProjectUserApiParams) RemoveProjectUserApiRequest {
+	return RemoveProjectUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		userId: args.UserId,
+	}
 }
 
-func (r RemoveProjectUserApiRequest) ExecuteWithParams(params *RemoveProjectUserApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.userId = params.UserId 
-	return r.Execute()
+func (r RemoveProjectUserApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.removeProjectUserExecute(r)
 }
 
 /*
@@ -2290,7 +2499,7 @@ func (a *ProjectsApiService) RemoveProjectUser(ctx context.Context, groupId stri
 }
 
 // Execute executes the request
-func (a *ProjectsApiService) RemoveProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error) {
+func (a *ProjectsApiService) removeProjectUserExecute(r RemoveProjectUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -2389,20 +2598,23 @@ type SetProjectLimitApiParams struct {
 		Limit *Limit
 }
 
+func (a *ProjectsApiService) SetProjectLimitWithParams(ctx context.Context, args *SetProjectLimitApiParams) SetProjectLimitApiRequest {
+	return SetProjectLimitApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		limitName: args.LimitName,
+		groupId: args.GroupId,
+		limit: args.Limit,
+	}
+}
+
 func (r SetProjectLimitApiRequest) Limit(limit Limit) SetProjectLimitApiRequest {
 	r.limit = &limit
 	return r
 }
 
 func (r SetProjectLimitApiRequest) Execute() (*Limit, *http.Response, error) {
-	return r.ApiService.SetProjectLimitExecute(r)
-}
-
-func (r SetProjectLimitApiRequest) ExecuteWithParams(params *SetProjectLimitApiParams) (*Limit, *http.Response, error) {
-	r.limitName = params.LimitName 
-	r.groupId = params.GroupId 
-	r.limit = params.Limit 
-	return r.Execute()
+	return r.ApiService.setProjectLimitExecute(r)
 }
 
 /*
@@ -2428,7 +2640,7 @@ func (a *ProjectsApiService) SetProjectLimit(ctx context.Context, limitName stri
 
 // Execute executes the request
 //  @return Limit
-func (a *ProjectsApiService) SetProjectLimitExecute(r SetProjectLimitApiRequest) (*Limit, *http.Response, error) {
+func (a *ProjectsApiService) setProjectLimitExecute(r SetProjectLimitApiRequest) (*Limit, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2531,19 +2743,22 @@ type UpdateProjectApiParams struct {
 		GroupName *GroupName
 }
 
+func (a *ProjectsApiService) UpdateProjectWithParams(ctx context.Context, args *UpdateProjectApiParams) UpdateProjectApiRequest {
+	return UpdateProjectApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		groupName: args.GroupName,
+	}
+}
+
 func (r UpdateProjectApiRequest) GroupName(groupName GroupName) UpdateProjectApiRequest {
 	r.groupName = &groupName
 	return r
 }
 
 func (r UpdateProjectApiRequest) Execute() (*Group, *http.Response, error) {
-	return r.ApiService.UpdateProjectExecute(r)
-}
-
-func (r UpdateProjectApiRequest) ExecuteWithParams(params *UpdateProjectApiParams) (*Group, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.groupName = params.GroupName 
-	return r.Execute()
+	return r.ApiService.updateProjectExecute(r)
 }
 
 /*
@@ -2565,7 +2780,7 @@ func (a *ProjectsApiService) UpdateProject(ctx context.Context, groupId string) 
 
 // Execute executes the request
 //  @return Group
-func (a *ProjectsApiService) UpdateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error) {
+func (a *ProjectsApiService) updateProjectExecute(r UpdateProjectApiRequest) (*Group, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2667,6 +2882,15 @@ type UpdateProjectInvitationApiParams struct {
 		GroupInvitationRequest *GroupInvitationRequest
 }
 
+func (a *ProjectsApiService) UpdateProjectInvitationWithParams(ctx context.Context, args *UpdateProjectInvitationApiParams) UpdateProjectInvitationApiRequest {
+	return UpdateProjectInvitationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		groupInvitationRequest: args.GroupInvitationRequest,
+	}
+}
+
 // Updates the details of one pending invitation to the specified project.
 func (r UpdateProjectInvitationApiRequest) GroupInvitationRequest(groupInvitationRequest GroupInvitationRequest) UpdateProjectInvitationApiRequest {
 	r.groupInvitationRequest = &groupInvitationRequest
@@ -2674,13 +2898,7 @@ func (r UpdateProjectInvitationApiRequest) GroupInvitationRequest(groupInvitatio
 }
 
 func (r UpdateProjectInvitationApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.UpdateProjectInvitationExecute(r)
-}
-
-func (r UpdateProjectInvitationApiRequest) ExecuteWithParams(params *UpdateProjectInvitationApiParams) (*GroupInvitation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.groupInvitationRequest = params.GroupInvitationRequest 
-	return r.Execute()
+	return r.ApiService.updateProjectInvitationExecute(r)
 }
 
 /*
@@ -2702,7 +2920,7 @@ func (a *ProjectsApiService) UpdateProjectInvitation(ctx context.Context, groupI
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) UpdateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) updateProjectInvitationExecute(r UpdateProjectInvitationApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2809,6 +3027,16 @@ type UpdateProjectInvitationByIdApiParams struct {
 		GroupInvitationUpdateRequest *GroupInvitationUpdateRequest
 }
 
+func (a *ProjectsApiService) UpdateProjectInvitationByIdWithParams(ctx context.Context, args *UpdateProjectInvitationByIdApiParams) UpdateProjectInvitationByIdApiRequest {
+	return UpdateProjectInvitationByIdApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		invitationId: args.InvitationId,
+		groupInvitationUpdateRequest: args.GroupInvitationUpdateRequest,
+	}
+}
+
 // Updates the details of one pending invitation to the specified project.
 func (r UpdateProjectInvitationByIdApiRequest) GroupInvitationUpdateRequest(groupInvitationUpdateRequest GroupInvitationUpdateRequest) UpdateProjectInvitationByIdApiRequest {
 	r.groupInvitationUpdateRequest = &groupInvitationUpdateRequest
@@ -2816,14 +3044,7 @@ func (r UpdateProjectInvitationByIdApiRequest) GroupInvitationUpdateRequest(grou
 }
 
 func (r UpdateProjectInvitationByIdApiRequest) Execute() (*GroupInvitation, *http.Response, error) {
-	return r.ApiService.UpdateProjectInvitationByIdExecute(r)
-}
-
-func (r UpdateProjectInvitationByIdApiRequest) ExecuteWithParams(params *UpdateProjectInvitationByIdApiParams) (*GroupInvitation, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.invitationId = params.InvitationId 
-	r.groupInvitationUpdateRequest = params.GroupInvitationUpdateRequest 
-	return r.Execute()
+	return r.ApiService.updateProjectInvitationByIdExecute(r)
 }
 
 /*
@@ -2847,7 +3068,7 @@ func (a *ProjectsApiService) UpdateProjectInvitationById(ctx context.Context, gr
 
 // Execute executes the request
 //  @return GroupInvitation
-func (a *ProjectsApiService) UpdateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error) {
+func (a *ProjectsApiService) updateProjectInvitationByIdExecute(r UpdateProjectInvitationByIdApiRequest) (*GroupInvitation, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2959,19 +3180,22 @@ type UpdateProjectSettingsApiParams struct {
 		GroupSettings *GroupSettings
 }
 
+func (a *ProjectsApiService) UpdateProjectSettingsWithParams(ctx context.Context, args *UpdateProjectSettingsApiParams) UpdateProjectSettingsApiRequest {
+	return UpdateProjectSettingsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		groupSettings: args.GroupSettings,
+	}
+}
+
 func (r UpdateProjectSettingsApiRequest) GroupSettings(groupSettings GroupSettings) UpdateProjectSettingsApiRequest {
 	r.groupSettings = &groupSettings
 	return r
 }
 
 func (r UpdateProjectSettingsApiRequest) Execute() (*GroupSettings, *http.Response, error) {
-	return r.ApiService.UpdateProjectSettingsExecute(r)
-}
-
-func (r UpdateProjectSettingsApiRequest) ExecuteWithParams(params *UpdateProjectSettingsApiParams) (*GroupSettings, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.groupSettings = params.GroupSettings 
-	return r.Execute()
+	return r.ApiService.updateProjectSettingsExecute(r)
 }
 
 /*
@@ -2993,7 +3217,7 @@ func (a *ProjectsApiService) UpdateProjectSettings(ctx context.Context, groupId 
 
 // Execute executes the request
 //  @return GroupSettings
-func (a *ProjectsApiService) UpdateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
+func (a *ProjectsApiService) updateProjectSettingsExecute(r UpdateProjectSettingsApiRequest) (*GroupSettings, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_projects.go
+++ b/mongodbatlasv2/api_projects.go
@@ -33,7 +33,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateProjectApiParams - Parameters for the request
-	@return CreateProjectApiRequest}}
+	@return CreateProjectApiRequest
 	*/
 	CreateProjectWithParams(ctx context.Context, args *CreateProjectApiParams) CreateProjectApiRequest
 
@@ -56,7 +56,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateProjectInvitationApiParams - Parameters for the request
-	@return CreateProjectInvitationApiRequest}}
+	@return CreateProjectInvitationApiRequest
 	*/
 	CreateProjectInvitationWithParams(ctx context.Context, args *CreateProjectInvitationApiParams) CreateProjectInvitationApiRequest
 
@@ -79,7 +79,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteProjectApiParams - Parameters for the request
-	@return DeleteProjectApiRequest}}
+	@return DeleteProjectApiRequest
 	*/
 	DeleteProjectWithParams(ctx context.Context, args *DeleteProjectApiParams) DeleteProjectApiRequest
 
@@ -103,7 +103,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteProjectInvitationApiParams - Parameters for the request
-	@return DeleteProjectInvitationApiRequest}}
+	@return DeleteProjectInvitationApiRequest
 	*/
 	DeleteProjectInvitationWithParams(ctx context.Context, args *DeleteProjectInvitationApiParams) DeleteProjectInvitationApiRequest
 
@@ -127,7 +127,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteProjectLimitApiParams - Parameters for the request
-	@return DeleteProjectLimitApiRequest}}
+	@return DeleteProjectLimitApiRequest
 	*/
 	DeleteProjectLimitWithParams(ctx context.Context, args *DeleteProjectLimitApiParams) DeleteProjectLimitApiRequest
 
@@ -150,7 +150,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectApiParams - Parameters for the request
-	@return GetProjectApiRequest}}
+	@return GetProjectApiRequest
 	*/
 	GetProjectWithParams(ctx context.Context, args *GetProjectApiParams) GetProjectApiRequest
 
@@ -173,7 +173,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectByNameApiParams - Parameters for the request
-	@return GetProjectByNameApiRequest}}
+	@return GetProjectByNameApiRequest
 	*/
 	GetProjectByNameWithParams(ctx context.Context, args *GetProjectByNameApiParams) GetProjectByNameApiRequest
 
@@ -197,7 +197,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectInvitationApiParams - Parameters for the request
-	@return GetProjectInvitationApiRequest}}
+	@return GetProjectInvitationApiRequest
 	*/
 	GetProjectInvitationWithParams(ctx context.Context, args *GetProjectInvitationApiParams) GetProjectInvitationApiRequest
 
@@ -221,7 +221,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectLimitApiParams - Parameters for the request
-	@return GetProjectLimitApiRequest}}
+	@return GetProjectLimitApiRequest
 	*/
 	GetProjectLimitWithParams(ctx context.Context, args *GetProjectLimitApiParams) GetProjectLimitApiRequest
 
@@ -244,7 +244,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetProjectSettingsApiParams - Parameters for the request
-	@return GetProjectSettingsApiRequest}}
+	@return GetProjectSettingsApiRequest
 	*/
 	GetProjectSettingsWithParams(ctx context.Context, args *GetProjectSettingsApiParams) GetProjectSettingsApiRequest
 
@@ -267,7 +267,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectInvitationsApiParams - Parameters for the request
-	@return ListProjectInvitationsApiRequest}}
+	@return ListProjectInvitationsApiRequest
 	*/
 	ListProjectInvitationsWithParams(ctx context.Context, args *ListProjectInvitationsApiParams) ListProjectInvitationsApiRequest
 
@@ -290,7 +290,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectLimitsApiParams - Parameters for the request
-	@return ListProjectLimitsApiRequest}}
+	@return ListProjectLimitsApiRequest
 	*/
 	ListProjectLimitsWithParams(ctx context.Context, args *ListProjectLimitsApiParams) ListProjectLimitsApiRequest
 
@@ -313,7 +313,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectUsersApiParams - Parameters for the request
-	@return ListProjectUsersApiRequest}}
+	@return ListProjectUsersApiRequest
 	*/
 	ListProjectUsersWithParams(ctx context.Context, args *ListProjectUsersApiParams) ListProjectUsersApiRequest
 
@@ -335,7 +335,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectsApiParams - Parameters for the request
-	@return ListProjectsApiRequest}}
+	@return ListProjectsApiRequest
 	*/
 	ListProjectsWithParams(ctx context.Context, args *ListProjectsApiParams) ListProjectsApiRequest
 
@@ -359,7 +359,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param RemoveProjectUserApiParams - Parameters for the request
-	@return RemoveProjectUserApiRequest}}
+	@return RemoveProjectUserApiRequest
 	*/
 	RemoveProjectUserWithParams(ctx context.Context, args *RemoveProjectUserApiParams) RemoveProjectUserApiRequest
 
@@ -385,7 +385,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param SetProjectLimitApiParams - Parameters for the request
-	@return SetProjectLimitApiRequest}}
+	@return SetProjectLimitApiRequest
 	*/
 	SetProjectLimitWithParams(ctx context.Context, args *SetProjectLimitApiParams) SetProjectLimitApiRequest
 
@@ -408,7 +408,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateProjectApiParams - Parameters for the request
-	@return UpdateProjectApiRequest}}
+	@return UpdateProjectApiRequest
 	*/
 	UpdateProjectWithParams(ctx context.Context, args *UpdateProjectApiParams) UpdateProjectApiRequest
 
@@ -431,7 +431,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateProjectInvitationApiParams - Parameters for the request
-	@return UpdateProjectInvitationApiRequest}}
+	@return UpdateProjectInvitationApiRequest
 	*/
 	UpdateProjectInvitationWithParams(ctx context.Context, args *UpdateProjectInvitationApiParams) UpdateProjectInvitationApiRequest
 
@@ -455,7 +455,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateProjectInvitationByIdApiParams - Parameters for the request
-	@return UpdateProjectInvitationByIdApiRequest}}
+	@return UpdateProjectInvitationByIdApiRequest
 	*/
 	UpdateProjectInvitationByIdWithParams(ctx context.Context, args *UpdateProjectInvitationByIdApiParams) UpdateProjectInvitationByIdApiRequest
 
@@ -478,7 +478,7 @@ type ProjectsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateProjectSettingsApiParams - Parameters for the request
-	@return UpdateProjectSettingsApiRequest}}
+	@return UpdateProjectSettingsApiRequest
 	*/
 	UpdateProjectSettingsWithParams(ctx context.Context, args *UpdateProjectSettingsApiParams) UpdateProjectSettingsApiRequest
 

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -29,9 +29,18 @@ type RollingIndexApi interface {
 	@return CreateRollingIndexApiRequest
 	*/
 	CreateRollingIndex(ctx context.Context, groupId string, clusterName string) CreateRollingIndexApiRequest
+	/*
+	CreateRollingIndex Create One Rolling Index
 
-	// CreateRollingIndexExecute executes the request
-	CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateRollingIndexApiParams - Parameters for the request
+	@return CreateRollingIndexApiRequest}}
+	*/
+	CreateRollingIndexWithParams(ctx context.Context, args *CreateRollingIndexApiParams) CreateRollingIndexApiRequest
+
+	// Interface only available internally
+	createRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error)
 }
 
 // RollingIndexApiService RollingIndexApi service
@@ -51,6 +60,16 @@ type CreateRollingIndexApiParams struct {
 		IndexRequest *IndexRequest
 }
 
+func (a *RollingIndexApiService) CreateRollingIndexWithParams(ctx context.Context, args *CreateRollingIndexApiParams) CreateRollingIndexApiRequest {
+	return CreateRollingIndexApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		indexRequest: args.IndexRequest,
+	}
+}
+
 // Rolling index to create on the specified cluster.
 func (r CreateRollingIndexApiRequest) IndexRequest(indexRequest IndexRequest) CreateRollingIndexApiRequest {
 	r.indexRequest = &indexRequest
@@ -58,14 +77,7 @@ func (r CreateRollingIndexApiRequest) IndexRequest(indexRequest IndexRequest) Cr
 }
 
 func (r CreateRollingIndexApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.CreateRollingIndexExecute(r)
-}
-
-func (r CreateRollingIndexApiRequest) ExecuteWithParams(params *CreateRollingIndexApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.indexRequest = params.IndexRequest 
-	return r.Execute()
+	return r.ApiService.createRollingIndexExecute(r)
 }
 
 /*
@@ -88,7 +100,7 @@ func (a *RollingIndexApiService) CreateRollingIndex(ctx context.Context, groupId
 }
 
 // Execute executes the request
-func (a *RollingIndexApiService) CreateRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error) {
+func (a *RollingIndexApiService) createRollingIndexExecute(r CreateRollingIndexApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -61,6 +61,13 @@ func (r CreateRollingIndexApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.CreateRollingIndexExecute(r)
 }
 
+func (r CreateRollingIndexApiRequest) ExecuteWithParams(params *CreateRollingIndexApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.indexRequest = params.IndexRequest 
+	return r.Execute()
+}
+
 /*
 CreateRollingIndex Create One Rolling Index
 

--- a/mongodbatlasv2/api_rolling_index.go
+++ b/mongodbatlasv2/api_rolling_index.go
@@ -35,7 +35,7 @@ type RollingIndexApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateRollingIndexApiParams - Parameters for the request
-	@return CreateRollingIndexApiRequest}}
+	@return CreateRollingIndexApiRequest
 	*/
 	CreateRollingIndexWithParams(ctx context.Context, args *CreateRollingIndexApiParams) CreateRollingIndexApiRequest
 

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -47,6 +47,10 @@ func (r GetSystemStatusApiRequest) Execute() (*SystemStatus, *http.Response, err
 	return r.ApiService.GetSystemStatusExecute(r)
 }
 
+func (r GetSystemStatusApiRequest) ExecuteWithParams(params *GetSystemStatusApiParams) (*SystemStatus, *http.Response, error) {
+	return r.Execute()
+}
+
 /*
 GetSystemStatus Return the status of this MongoDB application
 

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -32,7 +32,7 @@ type RootApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetSystemStatusApiParams - Parameters for the request
-	@return GetSystemStatusApiRequest}}
+	@return GetSystemStatusApiRequest
 	*/
 	GetSystemStatusWithParams(ctx context.Context, args *GetSystemStatusApiParams) GetSystemStatusApiRequest
 

--- a/mongodbatlasv2/api_root.go
+++ b/mongodbatlasv2/api_root.go
@@ -26,10 +26,18 @@ type RootApi interface {
 	@return GetSystemStatusApiRequest
 	*/
 	GetSystemStatus(ctx context.Context) GetSystemStatusApiRequest
+	/*
+	GetSystemStatus Return the status of this MongoDB application
 
-	// GetSystemStatusExecute executes the request
-	//  @return SystemStatus
-	GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetSystemStatusApiParams - Parameters for the request
+	@return GetSystemStatusApiRequest}}
+	*/
+	GetSystemStatusWithParams(ctx context.Context, args *GetSystemStatusApiParams) GetSystemStatusApiRequest
+
+	// Interface only available internally
+	getSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error)
 }
 
 // RootApiService RootApi service
@@ -43,12 +51,15 @@ type GetSystemStatusApiRequest struct {
 type GetSystemStatusApiParams struct {
 }
 
-func (r GetSystemStatusApiRequest) Execute() (*SystemStatus, *http.Response, error) {
-	return r.ApiService.GetSystemStatusExecute(r)
+func (a *RootApiService) GetSystemStatusWithParams(ctx context.Context, args *GetSystemStatusApiParams) GetSystemStatusApiRequest {
+	return GetSystemStatusApiRequest{
+		ApiService: a,
+		ctx: ctx,
+	}
 }
 
-func (r GetSystemStatusApiRequest) ExecuteWithParams(params *GetSystemStatusApiParams) (*SystemStatus, *http.Response, error) {
-	return r.Execute()
+func (r GetSystemStatusApiRequest) Execute() (*SystemStatus, *http.Response, error) {
+	return r.ApiService.getSystemStatusExecute(r)
 }
 
 /*
@@ -68,7 +79,7 @@ func (a *RootApiService) GetSystemStatus(ctx context.Context) GetSystemStatusApi
 
 // Execute executes the request
 //  @return SystemStatus
-func (a *RootApiService) GetSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error) {
+func (a *RootApiService) getSystemStatusExecute(r GetSystemStatusApiRequest) (*SystemStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -34,7 +34,7 @@ type ServerlessInstancesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateServerlessInstanceApiParams - Parameters for the request
-	@return CreateServerlessInstanceApiRequest}}
+	@return CreateServerlessInstanceApiRequest
 	*/
 	CreateServerlessInstanceWithParams(ctx context.Context, args *CreateServerlessInstanceApiParams) CreateServerlessInstanceApiRequest
 
@@ -58,7 +58,7 @@ type ServerlessInstancesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteServerlessInstanceApiParams - Parameters for the request
-	@return DeleteServerlessInstanceApiRequest}}
+	@return DeleteServerlessInstanceApiRequest
 	*/
 	DeleteServerlessInstanceWithParams(ctx context.Context, args *DeleteServerlessInstanceApiParams) DeleteServerlessInstanceApiRequest
 
@@ -82,7 +82,7 @@ type ServerlessInstancesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetServerlessInstanceApiParams - Parameters for the request
-	@return GetServerlessInstanceApiRequest}}
+	@return GetServerlessInstanceApiRequest
 	*/
 	GetServerlessInstanceWithParams(ctx context.Context, args *GetServerlessInstanceApiParams) GetServerlessInstanceApiRequest
 
@@ -105,7 +105,7 @@ type ServerlessInstancesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListServerlessInstancesApiParams - Parameters for the request
-	@return ListServerlessInstancesApiRequest}}
+	@return ListServerlessInstancesApiRequest
 	*/
 	ListServerlessInstancesWithParams(ctx context.Context, args *ListServerlessInstancesApiParams) ListServerlessInstancesApiRequest
 
@@ -129,7 +129,7 @@ type ServerlessInstancesApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateServerlessInstanceApiParams - Parameters for the request
-	@return UpdateServerlessInstanceApiRequest}}
+	@return UpdateServerlessInstanceApiRequest
 	*/
 	UpdateServerlessInstanceWithParams(ctx context.Context, args *UpdateServerlessInstanceApiParams) UpdateServerlessInstanceApiRequest
 

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -28,10 +28,18 @@ type ServerlessInstancesApi interface {
 	@return CreateServerlessInstanceApiRequest
 	*/
 	CreateServerlessInstance(ctx context.Context, groupId string) CreateServerlessInstanceApiRequest
+	/*
+	CreateServerlessInstance Create One Serverless Instance in One Project
 
-	// CreateServerlessInstanceExecute executes the request
-	//  @return ServerlessInstanceDescription
-	CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateServerlessInstanceApiParams - Parameters for the request
+	@return CreateServerlessInstanceApiRequest}}
+	*/
+	CreateServerlessInstanceWithParams(ctx context.Context, args *CreateServerlessInstanceApiParams) CreateServerlessInstanceApiRequest
+
+	// Interface only available internally
+	createServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
 	DeleteServerlessInstance Remove One Serverless Instance from One Project
@@ -44,9 +52,18 @@ type ServerlessInstancesApi interface {
 	@return DeleteServerlessInstanceApiRequest
 	*/
 	DeleteServerlessInstance(ctx context.Context, groupId string, name string) DeleteServerlessInstanceApiRequest
+	/*
+	DeleteServerlessInstance Remove One Serverless Instance from One Project
 
-	// DeleteServerlessInstanceExecute executes the request
-	DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteServerlessInstanceApiParams - Parameters for the request
+	@return DeleteServerlessInstanceApiRequest}}
+	*/
+	DeleteServerlessInstanceWithParams(ctx context.Context, args *DeleteServerlessInstanceApiParams) DeleteServerlessInstanceApiRequest
+
+	// Interface only available internally
+	deleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (*http.Response, error)
 
 	/*
 	GetServerlessInstance Return One Serverless Instance from One Project
@@ -59,10 +76,18 @@ type ServerlessInstancesApi interface {
 	@return GetServerlessInstanceApiRequest
 	*/
 	GetServerlessInstance(ctx context.Context, groupId string, name string) GetServerlessInstanceApiRequest
+	/*
+	GetServerlessInstance Return One Serverless Instance from One Project
 
-	// GetServerlessInstanceExecute executes the request
-	//  @return ServerlessInstanceDescription
-	GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetServerlessInstanceApiParams - Parameters for the request
+	@return GetServerlessInstanceApiRequest}}
+	*/
+	GetServerlessInstanceWithParams(ctx context.Context, args *GetServerlessInstanceApiParams) GetServerlessInstanceApiRequest
+
+	// Interface only available internally
+	getServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 
 	/*
 	ListServerlessInstances Return All Serverless Instances from One Project
@@ -74,10 +99,18 @@ type ServerlessInstancesApi interface {
 	@return ListServerlessInstancesApiRequest
 	*/
 	ListServerlessInstances(ctx context.Context, groupId string) ListServerlessInstancesApiRequest
+	/*
+	ListServerlessInstances Return All Serverless Instances from One Project
 
-	// ListServerlessInstancesExecute executes the request
-	//  @return PaginatedServerlessInstanceDescription
-	ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListServerlessInstancesApiParams - Parameters for the request
+	@return ListServerlessInstancesApiRequest}}
+	*/
+	ListServerlessInstancesWithParams(ctx context.Context, args *ListServerlessInstancesApiParams) ListServerlessInstancesApiRequest
+
+	// Interface only available internally
+	listServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error)
 
 	/*
 	UpdateServerlessInstance Update One Serverless Instance in One Project
@@ -90,10 +123,18 @@ type ServerlessInstancesApi interface {
 	@return UpdateServerlessInstanceApiRequest
 	*/
 	UpdateServerlessInstance(ctx context.Context, groupId string, name string) UpdateServerlessInstanceApiRequest
+	/*
+	UpdateServerlessInstance Update One Serverless Instance in One Project
 
-	// UpdateServerlessInstanceExecute executes the request
-	//  @return ServerlessInstanceDescription
-	UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateServerlessInstanceApiParams - Parameters for the request
+	@return UpdateServerlessInstanceApiRequest}}
+	*/
+	UpdateServerlessInstanceWithParams(ctx context.Context, args *UpdateServerlessInstanceApiParams) UpdateServerlessInstanceApiRequest
+
+	// Interface only available internally
+	updateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error)
 }
 
 // ServerlessInstancesApiService ServerlessInstancesApi service
@@ -111,6 +152,15 @@ type CreateServerlessInstanceApiParams struct {
 		ServerlessInstanceDescriptionCreate *ServerlessInstanceDescriptionCreate
 }
 
+func (a *ServerlessInstancesApiService) CreateServerlessInstanceWithParams(ctx context.Context, args *CreateServerlessInstanceApiParams) CreateServerlessInstanceApiRequest {
+	return CreateServerlessInstanceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		serverlessInstanceDescriptionCreate: args.ServerlessInstanceDescriptionCreate,
+	}
+}
+
 // Create One Serverless Instance in One Project.
 func (r CreateServerlessInstanceApiRequest) ServerlessInstanceDescriptionCreate(serverlessInstanceDescriptionCreate ServerlessInstanceDescriptionCreate) CreateServerlessInstanceApiRequest {
 	r.serverlessInstanceDescriptionCreate = &serverlessInstanceDescriptionCreate
@@ -118,13 +168,7 @@ func (r CreateServerlessInstanceApiRequest) ServerlessInstanceDescriptionCreate(
 }
 
 func (r CreateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.CreateServerlessInstanceExecute(r)
-}
-
-func (r CreateServerlessInstanceApiRequest) ExecuteWithParams(params *CreateServerlessInstanceApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.serverlessInstanceDescriptionCreate = params.ServerlessInstanceDescriptionCreate 
-	return r.Execute()
+	return r.ApiService.createServerlessInstanceExecute(r)
 }
 
 /*
@@ -146,7 +190,7 @@ func (a *ServerlessInstancesApiService) CreateServerlessInstance(ctx context.Con
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) CreateServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) createServerlessInstanceExecute(r CreateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -251,14 +295,17 @@ type DeleteServerlessInstanceApiParams struct {
 		Name string
 }
 
-func (r DeleteServerlessInstanceApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteServerlessInstanceExecute(r)
+func (a *ServerlessInstancesApiService) DeleteServerlessInstanceWithParams(ctx context.Context, args *DeleteServerlessInstanceApiParams) DeleteServerlessInstanceApiRequest {
+	return DeleteServerlessInstanceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		name: args.Name,
+	}
 }
 
-func (r DeleteServerlessInstanceApiRequest) ExecuteWithParams(params *DeleteServerlessInstanceApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.name = params.Name 
-	return r.Execute()
+func (r DeleteServerlessInstanceApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteServerlessInstanceExecute(r)
 }
 
 /*
@@ -281,7 +328,7 @@ func (a *ServerlessInstancesApiService) DeleteServerlessInstance(ctx context.Con
 }
 
 // Execute executes the request
-func (a *ServerlessInstancesApiService) DeleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (*http.Response, error) {
+func (a *ServerlessInstancesApiService) deleteServerlessInstanceExecute(r DeleteServerlessInstanceApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -378,14 +425,17 @@ type GetServerlessInstanceApiParams struct {
 		Name string
 }
 
-func (r GetServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.GetServerlessInstanceExecute(r)
+func (a *ServerlessInstancesApiService) GetServerlessInstanceWithParams(ctx context.Context, args *GetServerlessInstanceApiParams) GetServerlessInstanceApiRequest {
+	return GetServerlessInstanceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		name: args.Name,
+	}
 }
 
-func (r GetServerlessInstanceApiRequest) ExecuteWithParams(params *GetServerlessInstanceApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.name = params.Name 
-	return r.Execute()
+func (r GetServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
+	return r.ApiService.getServerlessInstanceExecute(r)
 }
 
 /*
@@ -409,7 +459,7 @@ func (a *ServerlessInstancesApiService) GetServerlessInstance(ctx context.Contex
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) GetServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) getServerlessInstanceExecute(r GetServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -520,6 +570,17 @@ type ListServerlessInstancesApiParams struct {
 		PageNum *int32
 }
 
+func (a *ServerlessInstancesApiService) ListServerlessInstancesWithParams(ctx context.Context, args *ListServerlessInstancesApiParams) ListServerlessInstancesApiRequest {
+	return ListServerlessInstancesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListServerlessInstancesApiRequest) IncludeCount(includeCount bool) ListServerlessInstancesApiRequest {
 	r.includeCount = &includeCount
@@ -539,15 +600,7 @@ func (r ListServerlessInstancesApiRequest) PageNum(pageNum int32) ListServerless
 }
 
 func (r ListServerlessInstancesApiRequest) Execute() (*PaginatedServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.ListServerlessInstancesExecute(r)
-}
-
-func (r ListServerlessInstancesApiRequest) ExecuteWithParams(params *ListServerlessInstancesApiParams) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listServerlessInstancesExecute(r)
 }
 
 /*
@@ -569,7 +622,7 @@ func (a *ServerlessInstancesApiService) ListServerlessInstances(ctx context.Cont
 
 // Execute executes the request
 //  @return PaginatedServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) ListServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) listServerlessInstancesExecute(r ListServerlessInstancesApiRequest) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -692,6 +745,16 @@ type UpdateServerlessInstanceApiParams struct {
 		ServerlessInstanceDescriptionUpdate *ServerlessInstanceDescriptionUpdate
 }
 
+func (a *ServerlessInstancesApiService) UpdateServerlessInstanceWithParams(ctx context.Context, args *UpdateServerlessInstanceApiParams) UpdateServerlessInstanceApiRequest {
+	return UpdateServerlessInstanceApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		name: args.Name,
+		serverlessInstanceDescriptionUpdate: args.ServerlessInstanceDescriptionUpdate,
+	}
+}
+
 // Update One Serverless Instance in One Project.
 func (r UpdateServerlessInstanceApiRequest) ServerlessInstanceDescriptionUpdate(serverlessInstanceDescriptionUpdate ServerlessInstanceDescriptionUpdate) UpdateServerlessInstanceApiRequest {
 	r.serverlessInstanceDescriptionUpdate = &serverlessInstanceDescriptionUpdate
@@ -699,14 +762,7 @@ func (r UpdateServerlessInstanceApiRequest) ServerlessInstanceDescriptionUpdate(
 }
 
 func (r UpdateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
-	return r.ApiService.UpdateServerlessInstanceExecute(r)
-}
-
-func (r UpdateServerlessInstanceApiRequest) ExecuteWithParams(params *UpdateServerlessInstanceApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.name = params.Name 
-	r.serverlessInstanceDescriptionUpdate = params.ServerlessInstanceDescriptionUpdate 
-	return r.Execute()
+	return r.ApiService.updateServerlessInstanceExecute(r)
 }
 
 /*
@@ -730,7 +786,7 @@ func (a *ServerlessInstancesApiService) UpdateServerlessInstance(ctx context.Con
 
 // Execute executes the request
 //  @return ServerlessInstanceDescription
-func (a *ServerlessInstancesApiService) UpdateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
+func (a *ServerlessInstancesApiService) updateServerlessInstanceExecute(r UpdateServerlessInstanceApiRequest) (*ServerlessInstanceDescription, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_serverless_instances.go
+++ b/mongodbatlasv2/api_serverless_instances.go
@@ -121,6 +121,12 @@ func (r CreateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescri
 	return r.ApiService.CreateServerlessInstanceExecute(r)
 }
 
+func (r CreateServerlessInstanceApiRequest) ExecuteWithParams(params *CreateServerlessInstanceApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.serverlessInstanceDescriptionCreate = params.ServerlessInstanceDescriptionCreate 
+	return r.Execute()
+}
+
 /*
 CreateServerlessInstance Create One Serverless Instance in One Project
 
@@ -249,6 +255,12 @@ func (r DeleteServerlessInstanceApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteServerlessInstanceExecute(r)
 }
 
+func (r DeleteServerlessInstanceApiRequest) ExecuteWithParams(params *DeleteServerlessInstanceApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.name = params.Name 
+	return r.Execute()
+}
+
 /*
 DeleteServerlessInstance Remove One Serverless Instance from One Project
 
@@ -368,6 +380,12 @@ type GetServerlessInstanceApiParams struct {
 
 func (r GetServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.GetServerlessInstanceExecute(r)
+}
+
+func (r GetServerlessInstanceApiRequest) ExecuteWithParams(params *GetServerlessInstanceApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.name = params.Name 
+	return r.Execute()
 }
 
 /*
@@ -524,6 +542,14 @@ func (r ListServerlessInstancesApiRequest) Execute() (*PaginatedServerlessInstan
 	return r.ApiService.ListServerlessInstancesExecute(r)
 }
 
+func (r ListServerlessInstancesApiRequest) ExecuteWithParams(params *ListServerlessInstancesApiParams) (*PaginatedServerlessInstanceDescription, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListServerlessInstances Return All Serverless Instances from One Project
 
@@ -674,6 +700,13 @@ func (r UpdateServerlessInstanceApiRequest) ServerlessInstanceDescriptionUpdate(
 
 func (r UpdateServerlessInstanceApiRequest) Execute() (*ServerlessInstanceDescription, *http.Response, error) {
 	return r.ApiService.UpdateServerlessInstanceExecute(r)
+}
+
+func (r UpdateServerlessInstanceApiRequest) ExecuteWithParams(params *UpdateServerlessInstanceApiParams) (*ServerlessInstanceDescription, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.name = params.Name 
+	r.serverlessInstanceDescriptionUpdate = params.ServerlessInstanceDescriptionUpdate 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -37,7 +37,7 @@ type ServerlessPrivateEndpointsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateServerlessPrivateEndpointApiParams - Parameters for the request
-	@return CreateServerlessPrivateEndpointApiRequest}}
+	@return CreateServerlessPrivateEndpointApiRequest
 	*/
 	CreateServerlessPrivateEndpointWithParams(ctx context.Context, args *CreateServerlessPrivateEndpointApiParams) CreateServerlessPrivateEndpointApiRequest
 
@@ -62,7 +62,7 @@ type ServerlessPrivateEndpointsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteServerlessPrivateEndpointApiParams - Parameters for the request
-	@return DeleteServerlessPrivateEndpointApiRequest}}
+	@return DeleteServerlessPrivateEndpointApiRequest
 	*/
 	DeleteServerlessPrivateEndpointWithParams(ctx context.Context, args *DeleteServerlessPrivateEndpointApiParams) DeleteServerlessPrivateEndpointApiRequest
 
@@ -87,7 +87,7 @@ type ServerlessPrivateEndpointsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetServerlessPrivateEndpointApiParams - Parameters for the request
-	@return GetServerlessPrivateEndpointApiRequest}}
+	@return GetServerlessPrivateEndpointApiRequest
 	*/
 	GetServerlessPrivateEndpointWithParams(ctx context.Context, args *GetServerlessPrivateEndpointApiParams) GetServerlessPrivateEndpointApiRequest
 
@@ -111,7 +111,7 @@ type ServerlessPrivateEndpointsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListServerlessPrivateEndpointsApiParams - Parameters for the request
-	@return ListServerlessPrivateEndpointsApiRequest}}
+	@return ListServerlessPrivateEndpointsApiRequest
 	*/
 	ListServerlessPrivateEndpointsWithParams(ctx context.Context, args *ListServerlessPrivateEndpointsApiParams) ListServerlessPrivateEndpointsApiRequest
 
@@ -136,7 +136,7 @@ type ServerlessPrivateEndpointsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateServerlessPrivateEndpointApiParams - Parameters for the request
-	@return UpdateServerlessPrivateEndpointApiRequest}}
+	@return UpdateServerlessPrivateEndpointApiRequest
 	*/
 	UpdateServerlessPrivateEndpointWithParams(ctx context.Context, args *UpdateServerlessPrivateEndpointApiParams) UpdateServerlessPrivateEndpointApiRequest
 

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -31,10 +31,18 @@ type ServerlessPrivateEndpointsApi interface {
 	@return CreateServerlessPrivateEndpointApiRequest
 	*/
 	CreateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string) CreateServerlessPrivateEndpointApiRequest
+	/*
+	CreateServerlessPrivateEndpoint Create One Private Endpoint for One Serverless Instance
 
-	// CreateServerlessPrivateEndpointExecute executes the request
-	//  @return ServerlessTenantEndpoint
-	CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateServerlessPrivateEndpointApiParams - Parameters for the request
+	@return CreateServerlessPrivateEndpointApiRequest}}
+	*/
+	CreateServerlessPrivateEndpointWithParams(ctx context.Context, args *CreateServerlessPrivateEndpointApiParams) CreateServerlessPrivateEndpointApiRequest
+
+	// Interface only available internally
+	createServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 	DeleteServerlessPrivateEndpoint Remove One Private Endpoint for One Serverless Instance
@@ -48,9 +56,18 @@ type ServerlessPrivateEndpointsApi interface {
 	@return DeleteServerlessPrivateEndpointApiRequest
 	*/
 	DeleteServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) DeleteServerlessPrivateEndpointApiRequest
+	/*
+	DeleteServerlessPrivateEndpoint Remove One Private Endpoint for One Serverless Instance
 
-	// DeleteServerlessPrivateEndpointExecute executes the request
-	DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteServerlessPrivateEndpointApiParams - Parameters for the request
+	@return DeleteServerlessPrivateEndpointApiRequest}}
+	*/
+	DeleteServerlessPrivateEndpointWithParams(ctx context.Context, args *DeleteServerlessPrivateEndpointApiParams) DeleteServerlessPrivateEndpointApiRequest
+
+	// Interface only available internally
+	deleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (*http.Response, error)
 
 	/*
 	GetServerlessPrivateEndpoint Return One Private Endpoint for One Serverless Instance
@@ -64,10 +81,18 @@ type ServerlessPrivateEndpointsApi interface {
 	@return GetServerlessPrivateEndpointApiRequest
 	*/
 	GetServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) GetServerlessPrivateEndpointApiRequest
+	/*
+	GetServerlessPrivateEndpoint Return One Private Endpoint for One Serverless Instance
 
-	// GetServerlessPrivateEndpointExecute executes the request
-	//  @return ServerlessTenantEndpoint
-	GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetServerlessPrivateEndpointApiParams - Parameters for the request
+	@return GetServerlessPrivateEndpointApiRequest}}
+	*/
+	GetServerlessPrivateEndpointWithParams(ctx context.Context, args *GetServerlessPrivateEndpointApiParams) GetServerlessPrivateEndpointApiRequest
+
+	// Interface only available internally
+	getServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 	ListServerlessPrivateEndpoints Return All Private Endpoints for One Serverless Instance
@@ -80,10 +105,18 @@ type ServerlessPrivateEndpointsApi interface {
 	@return ListServerlessPrivateEndpointsApiRequest
 	*/
 	ListServerlessPrivateEndpoints(ctx context.Context, groupId string, instanceName string) ListServerlessPrivateEndpointsApiRequest
+	/*
+	ListServerlessPrivateEndpoints Return All Private Endpoints for One Serverless Instance
 
-	// ListServerlessPrivateEndpointsExecute executes the request
-	//  @return []ServerlessTenantEndpoint
-	ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListServerlessPrivateEndpointsApiParams - Parameters for the request
+	@return ListServerlessPrivateEndpointsApiRequest}}
+	*/
+	ListServerlessPrivateEndpointsWithParams(ctx context.Context, args *ListServerlessPrivateEndpointsApiParams) ListServerlessPrivateEndpointsApiRequest
+
+	// Interface only available internally
+	listServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error)
 
 	/*
 	UpdateServerlessPrivateEndpoint Update One Private Endpoint for One Serverless Instance
@@ -97,10 +130,18 @@ type ServerlessPrivateEndpointsApi interface {
 	@return UpdateServerlessPrivateEndpointApiRequest
 	*/
 	UpdateServerlessPrivateEndpoint(ctx context.Context, groupId string, instanceName string, endpointId string) UpdateServerlessPrivateEndpointApiRequest
+	/*
+	UpdateServerlessPrivateEndpoint Update One Private Endpoint for One Serverless Instance
 
-	// UpdateServerlessPrivateEndpointExecute executes the request
-	//  @return ServerlessTenantEndpoint
-	UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateServerlessPrivateEndpointApiParams - Parameters for the request
+	@return UpdateServerlessPrivateEndpointApiRequest}}
+	*/
+	UpdateServerlessPrivateEndpointWithParams(ctx context.Context, args *UpdateServerlessPrivateEndpointApiParams) UpdateServerlessPrivateEndpointApiRequest
+
+	// Interface only available internally
+	updateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error)
 }
 
 // ServerlessPrivateEndpointsApiService ServerlessPrivateEndpointsApi service
@@ -120,6 +161,16 @@ type CreateServerlessPrivateEndpointApiParams struct {
 		ServerlessTenantEndpointCreate *ServerlessTenantEndpointCreate
 }
 
+func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointWithParams(ctx context.Context, args *CreateServerlessPrivateEndpointApiParams) CreateServerlessPrivateEndpointApiRequest {
+	return CreateServerlessPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		instanceName: args.InstanceName,
+		serverlessTenantEndpointCreate: args.ServerlessTenantEndpointCreate,
+	}
+}
+
 // Information about the Private Endpoint to create for the Serverless Instance.
 func (r CreateServerlessPrivateEndpointApiRequest) ServerlessTenantEndpointCreate(serverlessTenantEndpointCreate ServerlessTenantEndpointCreate) CreateServerlessPrivateEndpointApiRequest {
 	r.serverlessTenantEndpointCreate = &serverlessTenantEndpointCreate
@@ -127,14 +178,7 @@ func (r CreateServerlessPrivateEndpointApiRequest) ServerlessTenantEndpointCreat
 }
 
 func (r CreateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.CreateServerlessPrivateEndpointExecute(r)
-}
-
-func (r CreateServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *CreateServerlessPrivateEndpointApiParams) (*ServerlessTenantEndpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.instanceName = params.InstanceName 
-	r.serverlessTenantEndpointCreate = params.ServerlessTenantEndpointCreate 
-	return r.Execute()
+	return r.ApiService.createServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -160,7 +204,7 @@ func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpoint(c
 
 // Execute executes the request
 //  @return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) CreateServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) createServerlessPrivateEndpointExecute(r CreateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -271,15 +315,18 @@ type DeleteServerlessPrivateEndpointApiParams struct {
 		EndpointId string
 }
 
-func (r DeleteServerlessPrivateEndpointApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteServerlessPrivateEndpointExecute(r)
+func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointWithParams(ctx context.Context, args *DeleteServerlessPrivateEndpointApiParams) DeleteServerlessPrivateEndpointApiRequest {
+	return DeleteServerlessPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		instanceName: args.InstanceName,
+		endpointId: args.EndpointId,
+	}
 }
 
-func (r DeleteServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *DeleteServerlessPrivateEndpointApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.instanceName = params.InstanceName 
-	r.endpointId = params.EndpointId 
-	return r.Execute()
+func (r DeleteServerlessPrivateEndpointApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -304,7 +351,7 @@ func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpoint(c
 }
 
 // Execute executes the request
-func (a *ServerlessPrivateEndpointsApiService) DeleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (*http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) deleteServerlessPrivateEndpointExecute(r DeleteServerlessPrivateEndpointApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -407,15 +454,18 @@ type GetServerlessPrivateEndpointApiParams struct {
 		EndpointId string
 }
 
-func (r GetServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.GetServerlessPrivateEndpointExecute(r)
+func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointWithParams(ctx context.Context, args *GetServerlessPrivateEndpointApiParams) GetServerlessPrivateEndpointApiRequest {
+	return GetServerlessPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		instanceName: args.InstanceName,
+		endpointId: args.EndpointId,
+	}
 }
 
-func (r GetServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *GetServerlessPrivateEndpointApiParams) (*ServerlessTenantEndpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.instanceName = params.InstanceName 
-	r.endpointId = params.EndpointId 
-	return r.Execute()
+func (r GetServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
+	return r.ApiService.getServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -441,7 +491,7 @@ func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpoint(ctx 
 
 // Execute executes the request
 //  @return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) GetServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) getServerlessPrivateEndpointExecute(r GetServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -552,14 +602,17 @@ type ListServerlessPrivateEndpointsApiParams struct {
 		InstanceName string
 }
 
-func (r ListServerlessPrivateEndpointsApiRequest) Execute() ([]ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.ListServerlessPrivateEndpointsExecute(r)
+func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsWithParams(ctx context.Context, args *ListServerlessPrivateEndpointsApiParams) ListServerlessPrivateEndpointsApiRequest {
+	return ListServerlessPrivateEndpointsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		instanceName: args.InstanceName,
+	}
 }
 
-func (r ListServerlessPrivateEndpointsApiRequest) ExecuteWithParams(params *ListServerlessPrivateEndpointsApiParams) ([]ServerlessTenantEndpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.instanceName = params.InstanceName 
-	return r.Execute()
+func (r ListServerlessPrivateEndpointsApiRequest) Execute() ([]ServerlessTenantEndpoint, *http.Response, error) {
+	return r.ApiService.listServerlessPrivateEndpointsExecute(r)
 }
 
 /*
@@ -583,7 +636,7 @@ func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpoints(ct
 
 // Execute executes the request
 //  @return []ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) ListServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) listServerlessPrivateEndpointsExecute(r ListServerlessPrivateEndpointsApiRequest) ([]ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -691,21 +744,24 @@ type UpdateServerlessPrivateEndpointApiParams struct {
 		ServerlessTenantEndpointUpdate *ServerlessTenantEndpointUpdate
 }
 
+func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpointWithParams(ctx context.Context, args *UpdateServerlessPrivateEndpointApiParams) UpdateServerlessPrivateEndpointApiRequest {
+	return UpdateServerlessPrivateEndpointApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		instanceName: args.InstanceName,
+		endpointId: args.EndpointId,
+		serverlessTenantEndpointUpdate: args.ServerlessTenantEndpointUpdate,
+	}
+}
+
 func (r UpdateServerlessPrivateEndpointApiRequest) ServerlessTenantEndpointUpdate(serverlessTenantEndpointUpdate ServerlessTenantEndpointUpdate) UpdateServerlessPrivateEndpointApiRequest {
 	r.serverlessTenantEndpointUpdate = &serverlessTenantEndpointUpdate
 	return r
 }
 
 func (r UpdateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
-	return r.ApiService.UpdateServerlessPrivateEndpointExecute(r)
-}
-
-func (r UpdateServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *UpdateServerlessPrivateEndpointApiParams) (*ServerlessTenantEndpoint, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.instanceName = params.InstanceName 
-	r.endpointId = params.EndpointId 
-	r.serverlessTenantEndpointUpdate = params.ServerlessTenantEndpointUpdate 
-	return r.Execute()
+	return r.ApiService.updateServerlessPrivateEndpointExecute(r)
 }
 
 /*
@@ -731,7 +787,7 @@ func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpoint(c
 
 // Execute executes the request
 //  @return ServerlessTenantEndpoint
-func (a *ServerlessPrivateEndpointsApiService) UpdateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
+func (a *ServerlessPrivateEndpointsApiService) updateServerlessPrivateEndpointExecute(r UpdateServerlessPrivateEndpointApiRequest) (*ServerlessTenantEndpoint, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_serverless_private_endpoints.go
+++ b/mongodbatlasv2/api_serverless_private_endpoints.go
@@ -130,6 +130,13 @@ func (r CreateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantE
 	return r.ApiService.CreateServerlessPrivateEndpointExecute(r)
 }
 
+func (r CreateServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *CreateServerlessPrivateEndpointApiParams) (*ServerlessTenantEndpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.instanceName = params.InstanceName 
+	r.serverlessTenantEndpointCreate = params.ServerlessTenantEndpointCreate 
+	return r.Execute()
+}
+
 /*
 CreateServerlessPrivateEndpoint Create One Private Endpoint for One Serverless Instance
 
@@ -268,6 +275,13 @@ func (r DeleteServerlessPrivateEndpointApiRequest) Execute() (*http.Response, er
 	return r.ApiService.DeleteServerlessPrivateEndpointExecute(r)
 }
 
+func (r DeleteServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *DeleteServerlessPrivateEndpointApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.instanceName = params.InstanceName 
+	r.endpointId = params.EndpointId 
+	return r.Execute()
+}
+
 /*
 DeleteServerlessPrivateEndpoint Remove One Private Endpoint for One Serverless Instance
 
@@ -395,6 +409,13 @@ type GetServerlessPrivateEndpointApiParams struct {
 
 func (r GetServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
 	return r.ApiService.GetServerlessPrivateEndpointExecute(r)
+}
+
+func (r GetServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *GetServerlessPrivateEndpointApiParams) (*ServerlessTenantEndpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.instanceName = params.InstanceName 
+	r.endpointId = params.EndpointId 
+	return r.Execute()
 }
 
 /*
@@ -535,6 +556,12 @@ func (r ListServerlessPrivateEndpointsApiRequest) Execute() ([]ServerlessTenantE
 	return r.ApiService.ListServerlessPrivateEndpointsExecute(r)
 }
 
+func (r ListServerlessPrivateEndpointsApiRequest) ExecuteWithParams(params *ListServerlessPrivateEndpointsApiParams) ([]ServerlessTenantEndpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.instanceName = params.InstanceName 
+	return r.Execute()
+}
+
 /*
 ListServerlessPrivateEndpoints Return All Private Endpoints for One Serverless Instance
 
@@ -671,6 +698,14 @@ func (r UpdateServerlessPrivateEndpointApiRequest) ServerlessTenantEndpointUpdat
 
 func (r UpdateServerlessPrivateEndpointApiRequest) Execute() (*ServerlessTenantEndpoint, *http.Response, error) {
 	return r.ApiService.UpdateServerlessPrivateEndpointExecute(r)
+}
+
+func (r UpdateServerlessPrivateEndpointApiRequest) ExecuteWithParams(params *UpdateServerlessPrivateEndpointApiParams) (*ServerlessTenantEndpoint, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.instanceName = params.InstanceName 
+	r.endpointId = params.EndpointId 
+	r.serverlessTenantEndpointUpdate = params.ServerlessTenantEndpointUpdate 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -95,6 +95,13 @@ func (r CreateSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore
 	return r.ApiService.CreateSharedClusterBackupRestoreJobExecute(r)
 }
 
+func (r CreateSharedClusterBackupRestoreJobApiRequest) ExecuteWithParams(params *CreateSharedClusterBackupRestoreJobApiParams) (*TenantRestore, *http.Response, error) {
+	r.clusterName = params.ClusterName 
+	r.groupId = params.GroupId 
+	r.tenantRestore = params.TenantRestore 
+	return r.Execute()
+}
+
 /*
 CreateSharedClusterBackupRestoreJob Create One Restore Job from One M2 or M5 Cluster
 
@@ -232,6 +239,13 @@ type GetSharedClusterBackupRestoreJobApiParams struct {
 
 func (r GetSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
 	return r.ApiService.GetSharedClusterBackupRestoreJobExecute(r)
+}
+
+func (r GetSharedClusterBackupRestoreJobApiRequest) ExecuteWithParams(params *GetSharedClusterBackupRestoreJobApiParams) (*TenantRestore, *http.Response, error) {
+	r.clusterName = params.ClusterName 
+	r.groupId = params.GroupId 
+	r.restoreId = params.RestoreId 
+	return r.Execute()
 }
 
 /*
@@ -373,6 +387,12 @@ type ListSharedClusterBackupRestoreJobsApiParams struct {
 
 func (r ListSharedClusterBackupRestoreJobsApiRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {
 	return r.ApiService.ListSharedClusterBackupRestoreJobsExecute(r)
+}
+
+func (r ListSharedClusterBackupRestoreJobsApiRequest) ExecuteWithParams(params *ListSharedClusterBackupRestoreJobsApiParams) (*PaginatedTenantRestore, *http.Response, error) {
+	r.clusterName = params.ClusterName 
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -35,7 +35,7 @@ type SharedTierRestoreJobsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateSharedClusterBackupRestoreJobApiParams - Parameters for the request
-	@return CreateSharedClusterBackupRestoreJobApiRequest}}
+	@return CreateSharedClusterBackupRestoreJobApiRequest
 	*/
 	CreateSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *CreateSharedClusterBackupRestoreJobApiParams) CreateSharedClusterBackupRestoreJobApiRequest
 
@@ -60,7 +60,7 @@ type SharedTierRestoreJobsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetSharedClusterBackupRestoreJobApiParams - Parameters for the request
-	@return GetSharedClusterBackupRestoreJobApiRequest}}
+	@return GetSharedClusterBackupRestoreJobApiRequest
 	*/
 	GetSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *GetSharedClusterBackupRestoreJobApiParams) GetSharedClusterBackupRestoreJobApiRequest
 
@@ -84,7 +84,7 @@ type SharedTierRestoreJobsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListSharedClusterBackupRestoreJobsApiParams - Parameters for the request
-	@return ListSharedClusterBackupRestoreJobsApiRequest}}
+	@return ListSharedClusterBackupRestoreJobsApiRequest
 	*/
 	ListSharedClusterBackupRestoreJobsWithParams(ctx context.Context, args *ListSharedClusterBackupRestoreJobsApiParams) ListSharedClusterBackupRestoreJobsApiRequest
 

--- a/mongodbatlasv2/api_shared_tier_restore_jobs.go
+++ b/mongodbatlasv2/api_shared_tier_restore_jobs.go
@@ -29,10 +29,18 @@ type SharedTierRestoreJobsApi interface {
 	@return CreateSharedClusterBackupRestoreJobApiRequest
 	*/
 	CreateSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string) CreateSharedClusterBackupRestoreJobApiRequest
+	/*
+	CreateSharedClusterBackupRestoreJob Create One Restore Job from One M2 or M5 Cluster
 
-	// CreateSharedClusterBackupRestoreJobExecute executes the request
-	//  @return TenantRestore
-	CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateSharedClusterBackupRestoreJobApiParams - Parameters for the request
+	@return CreateSharedClusterBackupRestoreJobApiRequest}}
+	*/
+	CreateSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *CreateSharedClusterBackupRestoreJobApiParams) CreateSharedClusterBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	createSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 	GetSharedClusterBackupRestoreJob Return One Restore Job for One M2 or M5 Cluster
@@ -46,10 +54,18 @@ type SharedTierRestoreJobsApi interface {
 	@return GetSharedClusterBackupRestoreJobApiRequest
 	*/
 	GetSharedClusterBackupRestoreJob(ctx context.Context, clusterName string, groupId string, restoreId string) GetSharedClusterBackupRestoreJobApiRequest
+	/*
+	GetSharedClusterBackupRestoreJob Return One Restore Job for One M2 or M5 Cluster
 
-	// GetSharedClusterBackupRestoreJobExecute executes the request
-	//  @return TenantRestore
-	GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetSharedClusterBackupRestoreJobApiParams - Parameters for the request
+	@return GetSharedClusterBackupRestoreJobApiRequest}}
+	*/
+	GetSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *GetSharedClusterBackupRestoreJobApiParams) GetSharedClusterBackupRestoreJobApiRequest
+
+	// Interface only available internally
+	getSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 	ListSharedClusterBackupRestoreJobs Return All Restore Jobs for One M2 or M5 Cluster
@@ -62,10 +78,18 @@ type SharedTierRestoreJobsApi interface {
 	@return ListSharedClusterBackupRestoreJobsApiRequest
 	*/
 	ListSharedClusterBackupRestoreJobs(ctx context.Context, clusterName string, groupId string) ListSharedClusterBackupRestoreJobsApiRequest
+	/*
+	ListSharedClusterBackupRestoreJobs Return All Restore Jobs for One M2 or M5 Cluster
 
-	// ListSharedClusterBackupRestoreJobsExecute executes the request
-	//  @return PaginatedTenantRestore
-	ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListSharedClusterBackupRestoreJobsApiParams - Parameters for the request
+	@return ListSharedClusterBackupRestoreJobsApiRequest}}
+	*/
+	ListSharedClusterBackupRestoreJobsWithParams(ctx context.Context, args *ListSharedClusterBackupRestoreJobsApiParams) ListSharedClusterBackupRestoreJobsApiRequest
+
+	// Interface only available internally
+	listSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error)
 }
 
 // SharedTierRestoreJobsApiService SharedTierRestoreJobsApi service
@@ -85,6 +109,16 @@ type CreateSharedClusterBackupRestoreJobApiParams struct {
 		TenantRestore *TenantRestore
 }
 
+func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *CreateSharedClusterBackupRestoreJobApiParams) CreateSharedClusterBackupRestoreJobApiRequest {
+	return CreateSharedClusterBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		clusterName: args.ClusterName,
+		groupId: args.GroupId,
+		tenantRestore: args.TenantRestore,
+	}
+}
+
 // The restore job details.
 func (r CreateSharedClusterBackupRestoreJobApiRequest) TenantRestore(tenantRestore TenantRestore) CreateSharedClusterBackupRestoreJobApiRequest {
 	r.tenantRestore = &tenantRestore
@@ -92,14 +126,7 @@ func (r CreateSharedClusterBackupRestoreJobApiRequest) TenantRestore(tenantResto
 }
 
 func (r CreateSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
-	return r.ApiService.CreateSharedClusterBackupRestoreJobExecute(r)
-}
-
-func (r CreateSharedClusterBackupRestoreJobApiRequest) ExecuteWithParams(params *CreateSharedClusterBackupRestoreJobApiParams) (*TenantRestore, *http.Response, error) {
-	r.clusterName = params.ClusterName 
-	r.groupId = params.GroupId 
-	r.tenantRestore = params.TenantRestore 
-	return r.Execute()
+	return r.ApiService.createSharedClusterBackupRestoreJobExecute(r)
 }
 
 /*
@@ -123,7 +150,7 @@ func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJob(ct
 
 // Execute executes the request
 //  @return TenantRestore
-func (a *SharedTierRestoreJobsApiService) CreateSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) createSharedClusterBackupRestoreJobExecute(r CreateSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -237,15 +264,18 @@ type GetSharedClusterBackupRestoreJobApiParams struct {
 		RestoreId string
 }
 
-func (r GetSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
-	return r.ApiService.GetSharedClusterBackupRestoreJobExecute(r)
+func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobWithParams(ctx context.Context, args *GetSharedClusterBackupRestoreJobApiParams) GetSharedClusterBackupRestoreJobApiRequest {
+	return GetSharedClusterBackupRestoreJobApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		clusterName: args.ClusterName,
+		groupId: args.GroupId,
+		restoreId: args.RestoreId,
+	}
 }
 
-func (r GetSharedClusterBackupRestoreJobApiRequest) ExecuteWithParams(params *GetSharedClusterBackupRestoreJobApiParams) (*TenantRestore, *http.Response, error) {
-	r.clusterName = params.ClusterName 
-	r.groupId = params.GroupId 
-	r.restoreId = params.RestoreId 
-	return r.Execute()
+func (r GetSharedClusterBackupRestoreJobApiRequest) Execute() (*TenantRestore, *http.Response, error) {
+	return r.ApiService.getSharedClusterBackupRestoreJobExecute(r)
 }
 
 /*
@@ -271,7 +301,7 @@ func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJob(ctx c
 
 // Execute executes the request
 //  @return TenantRestore
-func (a *SharedTierRestoreJobsApiService) GetSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) getSharedClusterBackupRestoreJobExecute(r GetSharedClusterBackupRestoreJobApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -385,14 +415,17 @@ type ListSharedClusterBackupRestoreJobsApiParams struct {
 		GroupId string
 }
 
-func (r ListSharedClusterBackupRestoreJobsApiRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {
-	return r.ApiService.ListSharedClusterBackupRestoreJobsExecute(r)
+func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobsWithParams(ctx context.Context, args *ListSharedClusterBackupRestoreJobsApiParams) ListSharedClusterBackupRestoreJobsApiRequest {
+	return ListSharedClusterBackupRestoreJobsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		clusterName: args.ClusterName,
+		groupId: args.GroupId,
+	}
 }
 
-func (r ListSharedClusterBackupRestoreJobsApiRequest) ExecuteWithParams(params *ListSharedClusterBackupRestoreJobsApiParams) (*PaginatedTenantRestore, *http.Response, error) {
-	r.clusterName = params.ClusterName 
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r ListSharedClusterBackupRestoreJobsApiRequest) Execute() (*PaginatedTenantRestore, *http.Response, error) {
+	return r.ApiService.listSharedClusterBackupRestoreJobsExecute(r)
 }
 
 /*
@@ -416,7 +449,7 @@ func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobs(ctx
 
 // Execute executes the request
 //  @return PaginatedTenantRestore
-func (a *SharedTierRestoreJobsApiService) ListSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error) {
+func (a *SharedTierRestoreJobsApiService) listSharedClusterBackupRestoreJobsExecute(r ListSharedClusterBackupRestoreJobsApiRequest) (*PaginatedTenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -35,7 +35,7 @@ type SharedTierSnapshotsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DownloadSharedClusterBackupApiParams - Parameters for the request
-	@return DownloadSharedClusterBackupApiRequest}}
+	@return DownloadSharedClusterBackupApiRequest
 	*/
 	DownloadSharedClusterBackupWithParams(ctx context.Context, args *DownloadSharedClusterBackupApiParams) DownloadSharedClusterBackupApiRequest
 
@@ -60,7 +60,7 @@ type SharedTierSnapshotsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetSharedClusterBackupApiParams - Parameters for the request
-	@return GetSharedClusterBackupApiRequest}}
+	@return GetSharedClusterBackupApiRequest
 	*/
 	GetSharedClusterBackupWithParams(ctx context.Context, args *GetSharedClusterBackupApiParams) GetSharedClusterBackupApiRequest
 
@@ -84,7 +84,7 @@ type SharedTierSnapshotsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListSharedClusterBackupsApiParams - Parameters for the request
-	@return ListSharedClusterBackupsApiRequest}}
+	@return ListSharedClusterBackupsApiRequest
 	*/
 	ListSharedClusterBackupsWithParams(ctx context.Context, args *ListSharedClusterBackupsApiParams) ListSharedClusterBackupsApiRequest
 

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -29,10 +29,18 @@ type SharedTierSnapshotsApi interface {
 	@return DownloadSharedClusterBackupApiRequest
 	*/
 	DownloadSharedClusterBackup(ctx context.Context, clusterName string, groupId string) DownloadSharedClusterBackupApiRequest
+	/*
+	DownloadSharedClusterBackup Download One M2 or M5 Cluster Snapshot
 
-	// DownloadSharedClusterBackupExecute executes the request
-	//  @return TenantRestore
-	DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DownloadSharedClusterBackupApiParams - Parameters for the request
+	@return DownloadSharedClusterBackupApiRequest}}
+	*/
+	DownloadSharedClusterBackupWithParams(ctx context.Context, args *DownloadSharedClusterBackupApiParams) DownloadSharedClusterBackupApiRequest
+
+	// Interface only available internally
+	downloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error)
 
 	/*
 	GetSharedClusterBackup Return One Snapshot for One M2 or M5 Cluster
@@ -46,10 +54,18 @@ type SharedTierSnapshotsApi interface {
 	@return GetSharedClusterBackupApiRequest
 	*/
 	GetSharedClusterBackup(ctx context.Context, groupId string, clusterName string, snapshotId string) GetSharedClusterBackupApiRequest
+	/*
+	GetSharedClusterBackup Return One Snapshot for One M2 or M5 Cluster
 
-	// GetSharedClusterBackupExecute executes the request
-	//  @return TenantSnapshot
-	GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*TenantSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetSharedClusterBackupApiParams - Parameters for the request
+	@return GetSharedClusterBackupApiRequest}}
+	*/
+	GetSharedClusterBackupWithParams(ctx context.Context, args *GetSharedClusterBackupApiParams) GetSharedClusterBackupApiRequest
+
+	// Interface only available internally
+	getSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*TenantSnapshot, *http.Response, error)
 
 	/*
 	ListSharedClusterBackups Return All Snapshots for One M2 or M5 Cluster
@@ -62,10 +78,18 @@ type SharedTierSnapshotsApi interface {
 	@return ListSharedClusterBackupsApiRequest
 	*/
 	ListSharedClusterBackups(ctx context.Context, groupId string, clusterName string) ListSharedClusterBackupsApiRequest
+	/*
+	ListSharedClusterBackups Return All Snapshots for One M2 or M5 Cluster
 
-	// ListSharedClusterBackupsExecute executes the request
-	//  @return PaginatedTenantSnapshot
-	ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListSharedClusterBackupsApiParams - Parameters for the request
+	@return ListSharedClusterBackupsApiRequest}}
+	*/
+	ListSharedClusterBackupsWithParams(ctx context.Context, args *ListSharedClusterBackupsApiParams) ListSharedClusterBackupsApiRequest
+
+	// Interface only available internally
+	listSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error)
 }
 
 // SharedTierSnapshotsApiService SharedTierSnapshotsApi service
@@ -85,6 +109,16 @@ type DownloadSharedClusterBackupApiParams struct {
 		TenantRestore *TenantRestore
 }
 
+func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupWithParams(ctx context.Context, args *DownloadSharedClusterBackupApiParams) DownloadSharedClusterBackupApiRequest {
+	return DownloadSharedClusterBackupApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		clusterName: args.ClusterName,
+		groupId: args.GroupId,
+		tenantRestore: args.TenantRestore,
+	}
+}
+
 // Snapshot to be downloaded.
 func (r DownloadSharedClusterBackupApiRequest) TenantRestore(tenantRestore TenantRestore) DownloadSharedClusterBackupApiRequest {
 	r.tenantRestore = &tenantRestore
@@ -92,14 +126,7 @@ func (r DownloadSharedClusterBackupApiRequest) TenantRestore(tenantRestore Tenan
 }
 
 func (r DownloadSharedClusterBackupApiRequest) Execute() (*TenantRestore, *http.Response, error) {
-	return r.ApiService.DownloadSharedClusterBackupExecute(r)
-}
-
-func (r DownloadSharedClusterBackupApiRequest) ExecuteWithParams(params *DownloadSharedClusterBackupApiParams) (*TenantRestore, *http.Response, error) {
-	r.clusterName = params.ClusterName 
-	r.groupId = params.GroupId 
-	r.tenantRestore = params.TenantRestore 
-	return r.Execute()
+	return r.ApiService.downloadSharedClusterBackupExecute(r)
 }
 
 /*
@@ -123,7 +150,7 @@ func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackup(ctx context.
 
 // Execute executes the request
 //  @return TenantRestore
-func (a *SharedTierSnapshotsApiService) DownloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) downloadSharedClusterBackupExecute(r DownloadSharedClusterBackupApiRequest) (*TenantRestore, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -237,15 +264,18 @@ type GetSharedClusterBackupApiParams struct {
 		SnapshotId string
 }
 
-func (r GetSharedClusterBackupApiRequest) Execute() (*TenantSnapshot, *http.Response, error) {
-	return r.ApiService.GetSharedClusterBackupExecute(r)
+func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupWithParams(ctx context.Context, args *GetSharedClusterBackupApiParams) GetSharedClusterBackupApiRequest {
+	return GetSharedClusterBackupApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+		snapshotId: args.SnapshotId,
+	}
 }
 
-func (r GetSharedClusterBackupApiRequest) ExecuteWithParams(params *GetSharedClusterBackupApiParams) (*TenantSnapshot, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	r.snapshotId = params.SnapshotId 
-	return r.Execute()
+func (r GetSharedClusterBackupApiRequest) Execute() (*TenantSnapshot, *http.Response, error) {
+	return r.ApiService.getSharedClusterBackupExecute(r)
 }
 
 /*
@@ -271,7 +301,7 @@ func (a *SharedTierSnapshotsApiService) GetSharedClusterBackup(ctx context.Conte
 
 // Execute executes the request
 //  @return TenantSnapshot
-func (a *SharedTierSnapshotsApiService) GetSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*TenantSnapshot, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) getSharedClusterBackupExecute(r GetSharedClusterBackupApiRequest) (*TenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -385,14 +415,17 @@ type ListSharedClusterBackupsApiParams struct {
 		ClusterName string
 }
 
-func (r ListSharedClusterBackupsApiRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {
-	return r.ApiService.ListSharedClusterBackupsExecute(r)
+func (a *SharedTierSnapshotsApiService) ListSharedClusterBackupsWithParams(ctx context.Context, args *ListSharedClusterBackupsApiParams) ListSharedClusterBackupsApiRequest {
+	return ListSharedClusterBackupsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		clusterName: args.ClusterName,
+	}
 }
 
-func (r ListSharedClusterBackupsApiRequest) ExecuteWithParams(params *ListSharedClusterBackupsApiParams) (*PaginatedTenantSnapshot, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.clusterName = params.ClusterName 
-	return r.Execute()
+func (r ListSharedClusterBackupsApiRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {
+	return r.ApiService.listSharedClusterBackupsExecute(r)
 }
 
 /*
@@ -416,7 +449,7 @@ func (a *SharedTierSnapshotsApiService) ListSharedClusterBackups(ctx context.Con
 
 // Execute executes the request
 //  @return PaginatedTenantSnapshot
-func (a *SharedTierSnapshotsApiService) ListSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error) {
+func (a *SharedTierSnapshotsApiService) listSharedClusterBackupsExecute(r ListSharedClusterBackupsApiRequest) (*PaginatedTenantSnapshot, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_shared_tier_snapshots.go
+++ b/mongodbatlasv2/api_shared_tier_snapshots.go
@@ -95,6 +95,13 @@ func (r DownloadSharedClusterBackupApiRequest) Execute() (*TenantRestore, *http.
 	return r.ApiService.DownloadSharedClusterBackupExecute(r)
 }
 
+func (r DownloadSharedClusterBackupApiRequest) ExecuteWithParams(params *DownloadSharedClusterBackupApiParams) (*TenantRestore, *http.Response, error) {
+	r.clusterName = params.ClusterName 
+	r.groupId = params.GroupId 
+	r.tenantRestore = params.TenantRestore 
+	return r.Execute()
+}
+
 /*
 DownloadSharedClusterBackup Download One M2 or M5 Cluster Snapshot
 
@@ -232,6 +239,13 @@ type GetSharedClusterBackupApiParams struct {
 
 func (r GetSharedClusterBackupApiRequest) Execute() (*TenantSnapshot, *http.Response, error) {
 	return r.ApiService.GetSharedClusterBackupExecute(r)
+}
+
+func (r GetSharedClusterBackupApiRequest) ExecuteWithParams(params *GetSharedClusterBackupApiParams) (*TenantSnapshot, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	r.snapshotId = params.SnapshotId 
+	return r.Execute()
 }
 
 /*
@@ -373,6 +387,12 @@ type ListSharedClusterBackupsApiParams struct {
 
 func (r ListSharedClusterBackupsApiRequest) Execute() (*PaginatedTenantSnapshot, *http.Response, error) {
 	return r.ApiService.ListSharedClusterBackupsExecute(r)
+}
+
+func (r ListSharedClusterBackupsApiRequest) ExecuteWithParams(params *ListSharedClusterBackupsApiParams) (*PaginatedTenantSnapshot, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.clusterName = params.ClusterName 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -246,6 +246,12 @@ func (r AddAllTeamsToProjectApiRequest) Execute() (*PaginatedTeamRole, *http.Res
 	return r.ApiService.AddAllTeamsToProjectExecute(r)
 }
 
+func (r AddAllTeamsToProjectApiRequest) ExecuteWithParams(params *AddAllTeamsToProjectApiParams) (*PaginatedTeamRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.teamRole = params.TeamRole 
+	return r.Execute()
+}
+
 /*
 AddAllTeamsToProject Add One or More Teams to One Project
 
@@ -380,6 +386,13 @@ func (r AddTeamUserApiRequest) AddUserToTeam(addUserToTeam []AddUserToTeam) AddT
 
 func (r AddTeamUserApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
 	return r.ApiService.AddTeamUserExecute(r)
+}
+
+func (r AddTeamUserApiRequest) ExecuteWithParams(params *AddTeamUserApiParams) (*PaginatedApiAppUser, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.teamId = params.TeamId 
+	r.addUserToTeam = params.AddUserToTeam 
+	return r.Execute()
 }
 
 /*
@@ -525,6 +538,12 @@ func (r CreateTeamApiRequest) Execute() (*Team, *http.Response, error) {
 	return r.ApiService.CreateTeamExecute(r)
 }
 
+func (r CreateTeamApiRequest) ExecuteWithParams(params *CreateTeamApiParams) (*Team, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.team = params.Team 
+	return r.Execute()
+}
+
 /*
 CreateTeam Create One Team in One Organization
 
@@ -653,6 +672,12 @@ func (r DeleteTeamApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.DeleteTeamExecute(r)
 }
 
+func (r DeleteTeamApiRequest) ExecuteWithParams(params *DeleteTeamApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	r.teamId = params.TeamId 
+	return r.Execute()
+}
+
 /*
 DeleteTeam Remove One Team from One Organization
 
@@ -772,6 +797,12 @@ type GetTeamByIdApiParams struct {
 
 func (r GetTeamByIdApiRequest) Execute() (*TeamResponse, *http.Response, error) {
 	return r.ApiService.GetTeamByIdExecute(r)
+}
+
+func (r GetTeamByIdApiRequest) ExecuteWithParams(params *GetTeamByIdApiParams) (*TeamResponse, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.teamId = params.TeamId 
+	return r.Execute()
 }
 
 /*
@@ -904,6 +935,12 @@ type GetTeamByNameApiParams struct {
 
 func (r GetTeamByNameApiRequest) Execute() (*TeamResponse, *http.Response, error) {
 	return r.ApiService.GetTeamByNameExecute(r)
+}
+
+func (r GetTeamByNameApiRequest) ExecuteWithParams(params *GetTeamByNameApiParams) (*TeamResponse, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.teamName = params.TeamName 
+	return r.Execute()
 }
 
 /*
@@ -1052,6 +1089,14 @@ func (r ListOrganizationTeamsApiRequest) PageNum(pageNum int32) ListOrganization
 
 func (r ListOrganizationTeamsApiRequest) Execute() (*PaginatedTeam, *http.Response, error) {
 	return r.ApiService.ListOrganizationTeamsExecute(r)
+}
+
+func (r ListOrganizationTeamsApiRequest) ExecuteWithParams(params *ListOrganizationTeamsApiParams) (*PaginatedTeam, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.includeCount = params.IncludeCount 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -1220,6 +1265,14 @@ func (r ListProjectTeamsApiRequest) Execute() (*PaginatedTeamRole, *http.Respons
 	return r.ApiService.ListProjectTeamsExecute(r)
 }
 
+func (r ListProjectTeamsApiRequest) ExecuteWithParams(params *ListProjectTeamsApiParams) (*PaginatedTeamRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListProjectTeams Return All Teams in One Project
 
@@ -1380,6 +1433,14 @@ func (r ListTeamUsersApiRequest) Execute() (*PaginatedApiAppUser, *http.Response
 	return r.ApiService.ListTeamUsersExecute(r)
 }
 
+func (r ListTeamUsersApiRequest) ExecuteWithParams(params *ListTeamUsersApiParams) (*PaginatedApiAppUser, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.teamId = params.TeamId 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 ListTeamUsers Return All MongoDB Cloud Users Assigned to One Team
 
@@ -1526,6 +1587,12 @@ func (r RemoveProjectTeamApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveProjectTeamExecute(r)
 }
 
+func (r RemoveProjectTeamApiRequest) ExecuteWithParams(params *RemoveProjectTeamApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.teamId = params.TeamId 
+	return r.Execute()
+}
+
 /*
 RemoveProjectTeam Remove One Team from One Project
 
@@ -1647,6 +1714,13 @@ type RemoveTeamUserApiParams struct {
 
 func (r RemoveTeamUserApiRequest) Execute() (*http.Response, error) {
 	return r.ApiService.RemoveTeamUserExecute(r)
+}
+
+func (r RemoveTeamUserApiRequest) ExecuteWithParams(params *RemoveTeamUserApiParams) (*http.Response, error) {
+	r.orgId = params.OrgId 
+	r.teamId = params.TeamId 
+	r.userId = params.UserId 
+	return r.Execute()
 }
 
 /*
@@ -1785,6 +1859,13 @@ func (r RenameTeamApiRequest) Team(team Team) RenameTeamApiRequest {
 
 func (r RenameTeamApiRequest) Execute() (*TeamResponse, *http.Response, error) {
 	return r.ApiService.RenameTeamExecute(r)
+}
+
+func (r RenameTeamApiRequest) ExecuteWithParams(params *RenameTeamApiParams) (*TeamResponse, *http.Response, error) {
+	r.orgId = params.OrgId 
+	r.teamId = params.TeamId 
+	r.team = params.Team 
+	return r.Execute()
 }
 
 /*
@@ -1930,6 +2011,13 @@ func (r UpdateTeamRolesApiRequest) TeamRole(teamRole TeamRole) UpdateTeamRolesAp
 
 func (r UpdateTeamRolesApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
 	return r.ApiService.UpdateTeamRolesExecute(r)
+}
+
+func (r UpdateTeamRolesApiRequest) ExecuteWithParams(params *UpdateTeamRolesApiParams) (*PaginatedTeamRole, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.teamId = params.TeamId 
+	r.teamRole = params.TeamRole 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -28,10 +28,18 @@ type TeamsApi interface {
 	@return AddAllTeamsToProjectApiRequest
 	*/
 	AddAllTeamsToProject(ctx context.Context, groupId string) AddAllTeamsToProjectApiRequest
+	/*
+	AddAllTeamsToProject Add One or More Teams to One Project
 
-	// AddAllTeamsToProjectExecute executes the request
-	//  @return PaginatedTeamRole
-	AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param AddAllTeamsToProjectApiParams - Parameters for the request
+	@return AddAllTeamsToProjectApiRequest}}
+	*/
+	AddAllTeamsToProjectWithParams(ctx context.Context, args *AddAllTeamsToProjectApiParams) AddAllTeamsToProjectApiRequest
+
+	// Interface only available internally
+	addAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
 	AddTeamUser Assign MongoDB Cloud Users from One Organization to One Team
@@ -44,10 +52,18 @@ type TeamsApi interface {
 	@return AddTeamUserApiRequest
 	*/
 	AddTeamUser(ctx context.Context, orgId string, teamId string) AddTeamUserApiRequest
+	/*
+	AddTeamUser Assign MongoDB Cloud Users from One Organization to One Team
 
-	// AddTeamUserExecute executes the request
-	//  @return PaginatedApiAppUser
-	AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param AddTeamUserApiParams - Parameters for the request
+	@return AddTeamUserApiRequest}}
+	*/
+	AddTeamUserWithParams(ctx context.Context, args *AddTeamUserApiParams) AddTeamUserApiRequest
+
+	// Interface only available internally
+	addTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 	CreateTeam Create One Team in One Organization
@@ -59,10 +75,18 @@ type TeamsApi interface {
 	@return CreateTeamApiRequest
 	*/
 	CreateTeam(ctx context.Context, orgId string) CreateTeamApiRequest
+	/*
+	CreateTeam Create One Team in One Organization
 
-	// CreateTeamExecute executes the request
-	//  @return Team
-	CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateTeamApiParams - Parameters for the request
+	@return CreateTeamApiRequest}}
+	*/
+	CreateTeamWithParams(ctx context.Context, args *CreateTeamApiParams) CreateTeamApiRequest
+
+	// Interface only available internally
+	createTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error)
 
 	/*
 	DeleteTeam Remove One Team from One Organization
@@ -75,9 +99,18 @@ type TeamsApi interface {
 	@return DeleteTeamApiRequest
 	*/
 	DeleteTeam(ctx context.Context, orgId string, teamId string) DeleteTeamApiRequest
+	/*
+	DeleteTeam Remove One Team from One Organization
 
-	// DeleteTeamExecute executes the request
-	DeleteTeamExecute(r DeleteTeamApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteTeamApiParams - Parameters for the request
+	@return DeleteTeamApiRequest}}
+	*/
+	DeleteTeamWithParams(ctx context.Context, args *DeleteTeamApiParams) DeleteTeamApiRequest
+
+	// Interface only available internally
+	deleteTeamExecute(r DeleteTeamApiRequest) (*http.Response, error)
 
 	/*
 	GetTeamById Return One Team using its ID
@@ -90,10 +123,18 @@ type TeamsApi interface {
 	@return GetTeamByIdApiRequest
 	*/
 	GetTeamById(ctx context.Context, orgId string, teamId string) GetTeamByIdApiRequest
+	/*
+	GetTeamById Return One Team using its ID
 
-	// GetTeamByIdExecute executes the request
-	//  @return TeamResponse
-	GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetTeamByIdApiParams - Parameters for the request
+	@return GetTeamByIdApiRequest}}
+	*/
+	GetTeamByIdWithParams(ctx context.Context, args *GetTeamByIdApiParams) GetTeamByIdApiRequest
+
+	// Interface only available internally
+	getTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 	GetTeamByName Return One Team using its Name
@@ -106,10 +147,18 @@ type TeamsApi interface {
 	@return GetTeamByNameApiRequest
 	*/
 	GetTeamByName(ctx context.Context, orgId string, teamName string) GetTeamByNameApiRequest
+	/*
+	GetTeamByName Return One Team using its Name
 
-	// GetTeamByNameExecute executes the request
-	//  @return TeamResponse
-	GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetTeamByNameApiParams - Parameters for the request
+	@return GetTeamByNameApiRequest}}
+	*/
+	GetTeamByNameWithParams(ctx context.Context, args *GetTeamByNameApiParams) GetTeamByNameApiRequest
+
+	// Interface only available internally
+	getTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 	ListOrganizationTeams Return All Teams in One Organization
@@ -121,10 +170,18 @@ type TeamsApi interface {
 	@return ListOrganizationTeamsApiRequest
 	*/
 	ListOrganizationTeams(ctx context.Context, orgId string) ListOrganizationTeamsApiRequest
+	/*
+	ListOrganizationTeams Return All Teams in One Organization
 
-	// ListOrganizationTeamsExecute executes the request
-	//  @return PaginatedTeam
-	ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListOrganizationTeamsApiParams - Parameters for the request
+	@return ListOrganizationTeamsApiRequest}}
+	*/
+	ListOrganizationTeamsWithParams(ctx context.Context, args *ListOrganizationTeamsApiParams) ListOrganizationTeamsApiRequest
+
+	// Interface only available internally
+	listOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error)
 
 	/*
 	ListProjectTeams Return All Teams in One Project
@@ -136,10 +193,18 @@ type TeamsApi interface {
 	@return ListProjectTeamsApiRequest
 	*/
 	ListProjectTeams(ctx context.Context, groupId string) ListProjectTeamsApiRequest
+	/*
+	ListProjectTeams Return All Teams in One Project
 
-	// ListProjectTeamsExecute executes the request
-	//  @return PaginatedTeamRole
-	ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListProjectTeamsApiParams - Parameters for the request
+	@return ListProjectTeamsApiRequest}}
+	*/
+	ListProjectTeamsWithParams(ctx context.Context, args *ListProjectTeamsApiParams) ListProjectTeamsApiRequest
+
+	// Interface only available internally
+	listProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error)
 
 	/*
 	ListTeamUsers Return All MongoDB Cloud Users Assigned to One Team
@@ -152,10 +217,18 @@ type TeamsApi interface {
 	@return ListTeamUsersApiRequest
 	*/
 	ListTeamUsers(ctx context.Context, orgId string, teamId string) ListTeamUsersApiRequest
+	/*
+	ListTeamUsers Return All MongoDB Cloud Users Assigned to One Team
 
-	// ListTeamUsersExecute executes the request
-	//  @return PaginatedApiAppUser
-	ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListTeamUsersApiParams - Parameters for the request
+	@return ListTeamUsersApiRequest}}
+	*/
+	ListTeamUsersWithParams(ctx context.Context, args *ListTeamUsersApiParams) ListTeamUsersApiRequest
+
+	// Interface only available internally
+	listTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error)
 
 	/*
 	RemoveProjectTeam Remove One Team from One Project
@@ -168,9 +241,18 @@ type TeamsApi interface {
 	@return RemoveProjectTeamApiRequest
 	*/
 	RemoveProjectTeam(ctx context.Context, groupId string, teamId string) RemoveProjectTeamApiRequest
+	/*
+	RemoveProjectTeam Remove One Team from One Project
 
-	// RemoveProjectTeamExecute executes the request
-	RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param RemoveProjectTeamApiParams - Parameters for the request
+	@return RemoveProjectTeamApiRequest}}
+	*/
+	RemoveProjectTeamWithParams(ctx context.Context, args *RemoveProjectTeamApiParams) RemoveProjectTeamApiRequest
+
+	// Interface only available internally
+	removeProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error)
 
 	/*
 	RemoveTeamUser Remove One MongoDB Cloud User from One Team
@@ -184,9 +266,18 @@ type TeamsApi interface {
 	@return RemoveTeamUserApiRequest
 	*/
 	RemoveTeamUser(ctx context.Context, orgId string, teamId string, userId string) RemoveTeamUserApiRequest
+	/*
+	RemoveTeamUser Remove One MongoDB Cloud User from One Team
 
-	// RemoveTeamUserExecute executes the request
-	RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param RemoveTeamUserApiParams - Parameters for the request
+	@return RemoveTeamUserApiRequest}}
+	*/
+	RemoveTeamUserWithParams(ctx context.Context, args *RemoveTeamUserApiParams) RemoveTeamUserApiRequest
+
+	// Interface only available internally
+	removeTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error)
 
 	/*
 	RenameTeam Rename One Team
@@ -199,10 +290,18 @@ type TeamsApi interface {
 	@return RenameTeamApiRequest
 	*/
 	RenameTeam(ctx context.Context, orgId string, teamId string) RenameTeamApiRequest
+	/*
+	RenameTeam Rename One Team
 
-	// RenameTeamExecute executes the request
-	//  @return TeamResponse
-	RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param RenameTeamApiParams - Parameters for the request
+	@return RenameTeamApiRequest}}
+	*/
+	RenameTeamWithParams(ctx context.Context, args *RenameTeamApiParams) RenameTeamApiRequest
+
+	// Interface only available internally
+	renameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error)
 
 	/*
 	UpdateTeamRoles Update Team Roles in One Project
@@ -215,10 +314,18 @@ type TeamsApi interface {
 	@return UpdateTeamRolesApiRequest
 	*/
 	UpdateTeamRoles(ctx context.Context, groupId string, teamId string) UpdateTeamRolesApiRequest
+	/*
+	UpdateTeamRoles Update Team Roles in One Project
 
-	// UpdateTeamRolesExecute executes the request
-	//  @return PaginatedTeamRole
-	UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateTeamRolesApiParams - Parameters for the request
+	@return UpdateTeamRolesApiRequest}}
+	*/
+	UpdateTeamRolesWithParams(ctx context.Context, args *UpdateTeamRolesApiParams) UpdateTeamRolesApiRequest
+
+	// Interface only available internally
+	updateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error)
 }
 
 // TeamsApiService TeamsApi service
@@ -236,6 +343,15 @@ type AddAllTeamsToProjectApiParams struct {
 		TeamRole *[]TeamRole
 }
 
+func (a *TeamsApiService) AddAllTeamsToProjectWithParams(ctx context.Context, args *AddAllTeamsToProjectApiParams) AddAllTeamsToProjectApiRequest {
+	return AddAllTeamsToProjectApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		teamRole: args.TeamRole,
+	}
+}
+
 // Team to add to the specified project.
 func (r AddAllTeamsToProjectApiRequest) TeamRole(teamRole []TeamRole) AddAllTeamsToProjectApiRequest {
 	r.teamRole = &teamRole
@@ -243,13 +359,7 @@ func (r AddAllTeamsToProjectApiRequest) TeamRole(teamRole []TeamRole) AddAllTeam
 }
 
 func (r AddAllTeamsToProjectApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
-	return r.ApiService.AddAllTeamsToProjectExecute(r)
-}
-
-func (r AddAllTeamsToProjectApiRequest) ExecuteWithParams(params *AddAllTeamsToProjectApiParams) (*PaginatedTeamRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.teamRole = params.TeamRole 
-	return r.Execute()
+	return r.ApiService.addAllTeamsToProjectExecute(r)
 }
 
 /*
@@ -271,7 +381,7 @@ func (a *TeamsApiService) AddAllTeamsToProject(ctx context.Context, groupId stri
 
 // Execute executes the request
 //  @return PaginatedTeamRole
-func (a *TeamsApiService) AddAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) addAllTeamsToProjectExecute(r AddAllTeamsToProjectApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -378,6 +488,16 @@ type AddTeamUserApiParams struct {
 		AddUserToTeam *[]AddUserToTeam
 }
 
+func (a *TeamsApiService) AddTeamUserWithParams(ctx context.Context, args *AddTeamUserApiParams) AddTeamUserApiRequest {
+	return AddTeamUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		teamId: args.TeamId,
+		addUserToTeam: args.AddUserToTeam,
+	}
+}
+
 // One or more MongoDB Cloud users that you want to add to the specified team.
 func (r AddTeamUserApiRequest) AddUserToTeam(addUserToTeam []AddUserToTeam) AddTeamUserApiRequest {
 	r.addUserToTeam = &addUserToTeam
@@ -385,14 +505,7 @@ func (r AddTeamUserApiRequest) AddUserToTeam(addUserToTeam []AddUserToTeam) AddT
 }
 
 func (r AddTeamUserApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
-	return r.ApiService.AddTeamUserExecute(r)
-}
-
-func (r AddTeamUserApiRequest) ExecuteWithParams(params *AddTeamUserApiParams) (*PaginatedApiAppUser, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.teamId = params.TeamId 
-	r.addUserToTeam = params.AddUserToTeam 
-	return r.Execute()
+	return r.ApiService.addTeamUserExecute(r)
 }
 
 /*
@@ -416,7 +529,7 @@ func (a *TeamsApiService) AddTeamUser(ctx context.Context, orgId string, teamId 
 
 // Execute executes the request
 //  @return PaginatedApiAppUser
-func (a *TeamsApiService) AddTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *TeamsApiService) addTeamUserExecute(r AddTeamUserApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -528,6 +641,15 @@ type CreateTeamApiParams struct {
 		Team *Team
 }
 
+func (a *TeamsApiService) CreateTeamWithParams(ctx context.Context, args *CreateTeamApiParams) CreateTeamApiRequest {
+	return CreateTeamApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		team: args.Team,
+	}
+}
+
 // Team that you want to create in the specified organization.
 func (r CreateTeamApiRequest) Team(team Team) CreateTeamApiRequest {
 	r.team = &team
@@ -535,13 +657,7 @@ func (r CreateTeamApiRequest) Team(team Team) CreateTeamApiRequest {
 }
 
 func (r CreateTeamApiRequest) Execute() (*Team, *http.Response, error) {
-	return r.ApiService.CreateTeamExecute(r)
-}
-
-func (r CreateTeamApiRequest) ExecuteWithParams(params *CreateTeamApiParams) (*Team, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.team = params.Team 
-	return r.Execute()
+	return r.ApiService.createTeamExecute(r)
 }
 
 /*
@@ -563,7 +679,7 @@ func (a *TeamsApiService) CreateTeam(ctx context.Context, orgId string) CreateTe
 
 // Execute executes the request
 //  @return Team
-func (a *TeamsApiService) CreateTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error) {
+func (a *TeamsApiService) createTeamExecute(r CreateTeamApiRequest) (*Team, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -668,14 +784,17 @@ type DeleteTeamApiParams struct {
 		TeamId string
 }
 
-func (r DeleteTeamApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteTeamExecute(r)
+func (a *TeamsApiService) DeleteTeamWithParams(ctx context.Context, args *DeleteTeamApiParams) DeleteTeamApiRequest {
+	return DeleteTeamApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		teamId: args.TeamId,
+	}
 }
 
-func (r DeleteTeamApiRequest) ExecuteWithParams(params *DeleteTeamApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	r.teamId = params.TeamId 
-	return r.Execute()
+func (r DeleteTeamApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteTeamExecute(r)
 }
 
 /*
@@ -698,7 +817,7 @@ func (a *TeamsApiService) DeleteTeam(ctx context.Context, orgId string, teamId s
 }
 
 // Execute executes the request
-func (a *TeamsApiService) DeleteTeamExecute(r DeleteTeamApiRequest) (*http.Response, error) {
+func (a *TeamsApiService) deleteTeamExecute(r DeleteTeamApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -795,14 +914,17 @@ type GetTeamByIdApiParams struct {
 		TeamId string
 }
 
-func (r GetTeamByIdApiRequest) Execute() (*TeamResponse, *http.Response, error) {
-	return r.ApiService.GetTeamByIdExecute(r)
+func (a *TeamsApiService) GetTeamByIdWithParams(ctx context.Context, args *GetTeamByIdApiParams) GetTeamByIdApiRequest {
+	return GetTeamByIdApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		teamId: args.TeamId,
+	}
 }
 
-func (r GetTeamByIdApiRequest) ExecuteWithParams(params *GetTeamByIdApiParams) (*TeamResponse, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.teamId = params.TeamId 
-	return r.Execute()
+func (r GetTeamByIdApiRequest) Execute() (*TeamResponse, *http.Response, error) {
+	return r.ApiService.getTeamByIdExecute(r)
 }
 
 /*
@@ -826,7 +948,7 @@ func (a *TeamsApiService) GetTeamById(ctx context.Context, orgId string, teamId 
 
 // Execute executes the request
 //  @return TeamResponse
-func (a *TeamsApiService) GetTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) getTeamByIdExecute(r GetTeamByIdApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -933,14 +1055,17 @@ type GetTeamByNameApiParams struct {
 		TeamName string
 }
 
-func (r GetTeamByNameApiRequest) Execute() (*TeamResponse, *http.Response, error) {
-	return r.ApiService.GetTeamByNameExecute(r)
+func (a *TeamsApiService) GetTeamByNameWithParams(ctx context.Context, args *GetTeamByNameApiParams) GetTeamByNameApiRequest {
+	return GetTeamByNameApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		teamName: args.TeamName,
+	}
 }
 
-func (r GetTeamByNameApiRequest) ExecuteWithParams(params *GetTeamByNameApiParams) (*TeamResponse, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.teamName = params.TeamName 
-	return r.Execute()
+func (r GetTeamByNameApiRequest) Execute() (*TeamResponse, *http.Response, error) {
+	return r.ApiService.getTeamByNameExecute(r)
 }
 
 /*
@@ -964,7 +1089,7 @@ func (a *TeamsApiService) GetTeamByName(ctx context.Context, orgId string, teamN
 
 // Execute executes the request
 //  @return TeamResponse
-func (a *TeamsApiService) GetTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) getTeamByNameExecute(r GetTeamByNameApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1069,6 +1194,17 @@ type ListOrganizationTeamsApiParams struct {
 		PageNum *int32
 }
 
+func (a *TeamsApiService) ListOrganizationTeamsWithParams(ctx context.Context, args *ListOrganizationTeamsApiParams) ListOrganizationTeamsApiRequest {
+	return ListOrganizationTeamsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		itemsPerPage: args.ItemsPerPage,
+		includeCount: args.IncludeCount,
+		pageNum: args.PageNum,
+	}
+}
+
 // Number of items that the response returns per page.
 func (r ListOrganizationTeamsApiRequest) ItemsPerPage(itemsPerPage int32) ListOrganizationTeamsApiRequest {
 	r.itemsPerPage = &itemsPerPage
@@ -1088,15 +1224,7 @@ func (r ListOrganizationTeamsApiRequest) PageNum(pageNum int32) ListOrganization
 }
 
 func (r ListOrganizationTeamsApiRequest) Execute() (*PaginatedTeam, *http.Response, error) {
-	return r.ApiService.ListOrganizationTeamsExecute(r)
-}
-
-func (r ListOrganizationTeamsApiRequest) ExecuteWithParams(params *ListOrganizationTeamsApiParams) (*PaginatedTeam, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.includeCount = params.IncludeCount 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listOrganizationTeamsExecute(r)
 }
 
 /*
@@ -1118,7 +1246,7 @@ func (a *TeamsApiService) ListOrganizationTeams(ctx context.Context, orgId strin
 
 // Execute executes the request
 //  @return PaginatedTeam
-func (a *TeamsApiService) ListOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error) {
+func (a *TeamsApiService) listOrganizationTeamsExecute(r ListOrganizationTeamsApiRequest) (*PaginatedTeam, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1243,6 +1371,17 @@ type ListProjectTeamsApiParams struct {
 		PageNum *int32
 }
 
+func (a *TeamsApiService) ListProjectTeamsWithParams(ctx context.Context, args *ListProjectTeamsApiParams) ListProjectTeamsApiRequest {
+	return ListProjectTeamsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListProjectTeamsApiRequest) IncludeCount(includeCount bool) ListProjectTeamsApiRequest {
 	r.includeCount = &includeCount
@@ -1262,15 +1401,7 @@ func (r ListProjectTeamsApiRequest) PageNum(pageNum int32) ListProjectTeamsApiRe
 }
 
 func (r ListProjectTeamsApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
-	return r.ApiService.ListProjectTeamsExecute(r)
-}
-
-func (r ListProjectTeamsApiRequest) ExecuteWithParams(params *ListProjectTeamsApiParams) (*PaginatedTeamRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listProjectTeamsExecute(r)
 }
 
 /*
@@ -1292,7 +1423,7 @@ func (a *TeamsApiService) ListProjectTeams(ctx context.Context, groupId string) 
 
 // Execute executes the request
 //  @return PaginatedTeamRole
-func (a *TeamsApiService) ListProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) listProjectTeamsExecute(r ListProjectTeamsApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1417,6 +1548,17 @@ type ListTeamUsersApiParams struct {
 		PageNum *int32
 }
 
+func (a *TeamsApiService) ListTeamUsersWithParams(ctx context.Context, args *ListTeamUsersApiParams) ListTeamUsersApiRequest {
+	return ListTeamUsersApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		teamId: args.TeamId,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Number of items that the response returns per page.
 func (r ListTeamUsersApiRequest) ItemsPerPage(itemsPerPage int32) ListTeamUsersApiRequest {
 	r.itemsPerPage = &itemsPerPage
@@ -1430,15 +1572,7 @@ func (r ListTeamUsersApiRequest) PageNum(pageNum int32) ListTeamUsersApiRequest 
 }
 
 func (r ListTeamUsersApiRequest) Execute() (*PaginatedApiAppUser, *http.Response, error) {
-	return r.ApiService.ListTeamUsersExecute(r)
-}
-
-func (r ListTeamUsersApiRequest) ExecuteWithParams(params *ListTeamUsersApiParams) (*PaginatedApiAppUser, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.teamId = params.TeamId 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listTeamUsersExecute(r)
 }
 
 /*
@@ -1462,7 +1596,7 @@ func (a *TeamsApiService) ListTeamUsers(ctx context.Context, orgId string, teamI
 
 // Execute executes the request
 //  @return PaginatedApiAppUser
-func (a *TeamsApiService) ListTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
+func (a *TeamsApiService) listTeamUsersExecute(r ListTeamUsersApiRequest) (*PaginatedApiAppUser, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -1583,14 +1717,17 @@ type RemoveProjectTeamApiParams struct {
 		TeamId string
 }
 
-func (r RemoveProjectTeamApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.RemoveProjectTeamExecute(r)
+func (a *TeamsApiService) RemoveProjectTeamWithParams(ctx context.Context, args *RemoveProjectTeamApiParams) RemoveProjectTeamApiRequest {
+	return RemoveProjectTeamApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		teamId: args.TeamId,
+	}
 }
 
-func (r RemoveProjectTeamApiRequest) ExecuteWithParams(params *RemoveProjectTeamApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.teamId = params.TeamId 
-	return r.Execute()
+func (r RemoveProjectTeamApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.removeProjectTeamExecute(r)
 }
 
 /*
@@ -1613,7 +1750,7 @@ func (a *TeamsApiService) RemoveProjectTeam(ctx context.Context, groupId string,
 }
 
 // Execute executes the request
-func (a *TeamsApiService) RemoveProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error) {
+func (a *TeamsApiService) removeProjectTeamExecute(r RemoveProjectTeamApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1712,15 +1849,18 @@ type RemoveTeamUserApiParams struct {
 		UserId string
 }
 
-func (r RemoveTeamUserApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.RemoveTeamUserExecute(r)
+func (a *TeamsApiService) RemoveTeamUserWithParams(ctx context.Context, args *RemoveTeamUserApiParams) RemoveTeamUserApiRequest {
+	return RemoveTeamUserApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		teamId: args.TeamId,
+		userId: args.UserId,
+	}
 }
 
-func (r RemoveTeamUserApiRequest) ExecuteWithParams(params *RemoveTeamUserApiParams) (*http.Response, error) {
-	r.orgId = params.OrgId 
-	r.teamId = params.TeamId 
-	r.userId = params.UserId 
-	return r.Execute()
+func (r RemoveTeamUserApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.removeTeamUserExecute(r)
 }
 
 /*
@@ -1745,7 +1885,7 @@ func (a *TeamsApiService) RemoveTeamUser(ctx context.Context, orgId string, team
 }
 
 // Execute executes the request
-func (a *TeamsApiService) RemoveTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error) {
+func (a *TeamsApiService) removeTeamUserExecute(r RemoveTeamUserApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -1851,6 +1991,16 @@ type RenameTeamApiParams struct {
 		Team *Team
 }
 
+func (a *TeamsApiService) RenameTeamWithParams(ctx context.Context, args *RenameTeamApiParams) RenameTeamApiRequest {
+	return RenameTeamApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: args.OrgId,
+		teamId: args.TeamId,
+		team: args.Team,
+	}
+}
+
 // Details to update on the specified team.
 func (r RenameTeamApiRequest) Team(team Team) RenameTeamApiRequest {
 	r.team = &team
@@ -1858,14 +2008,7 @@ func (r RenameTeamApiRequest) Team(team Team) RenameTeamApiRequest {
 }
 
 func (r RenameTeamApiRequest) Execute() (*TeamResponse, *http.Response, error) {
-	return r.ApiService.RenameTeamExecute(r)
-}
-
-func (r RenameTeamApiRequest) ExecuteWithParams(params *RenameTeamApiParams) (*TeamResponse, *http.Response, error) {
-	r.orgId = params.OrgId 
-	r.teamId = params.TeamId 
-	r.team = params.Team 
-	return r.Execute()
+	return r.ApiService.renameTeamExecute(r)
 }
 
 /*
@@ -1889,7 +2032,7 @@ func (a *TeamsApiService) RenameTeam(ctx context.Context, orgId string, teamId s
 
 // Execute executes the request
 //  @return TeamResponse
-func (a *TeamsApiService) RenameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error) {
+func (a *TeamsApiService) renameTeamExecute(r RenameTeamApiRequest) (*TeamResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}
@@ -2003,6 +2146,16 @@ type UpdateTeamRolesApiParams struct {
 		TeamRole *TeamRole
 }
 
+func (a *TeamsApiService) UpdateTeamRolesWithParams(ctx context.Context, args *UpdateTeamRolesApiParams) UpdateTeamRolesApiRequest {
+	return UpdateTeamRolesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		teamId: args.TeamId,
+		teamRole: args.TeamRole,
+	}
+}
+
 // The project roles assigned to the specified team.
 func (r UpdateTeamRolesApiRequest) TeamRole(teamRole TeamRole) UpdateTeamRolesApiRequest {
 	r.teamRole = &teamRole
@@ -2010,14 +2163,7 @@ func (r UpdateTeamRolesApiRequest) TeamRole(teamRole TeamRole) UpdateTeamRolesAp
 }
 
 func (r UpdateTeamRolesApiRequest) Execute() (*PaginatedTeamRole, *http.Response, error) {
-	return r.ApiService.UpdateTeamRolesExecute(r)
-}
-
-func (r UpdateTeamRolesApiRequest) ExecuteWithParams(params *UpdateTeamRolesApiParams) (*PaginatedTeamRole, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.teamId = params.TeamId 
-	r.teamRole = params.TeamRole 
-	return r.Execute()
+	return r.ApiService.updateTeamRolesExecute(r)
 }
 
 /*
@@ -2041,7 +2187,7 @@ func (a *TeamsApiService) UpdateTeamRoles(ctx context.Context, groupId string, t
 
 // Execute executes the request
 //  @return PaginatedTeamRole
-func (a *TeamsApiService) UpdateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error) {
+func (a *TeamsApiService) updateTeamRolesExecute(r UpdateTeamRolesApiRequest) (*PaginatedTeamRole, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPatch
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_teams.go
+++ b/mongodbatlasv2/api_teams.go
@@ -34,7 +34,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param AddAllTeamsToProjectApiParams - Parameters for the request
-	@return AddAllTeamsToProjectApiRequest}}
+	@return AddAllTeamsToProjectApiRequest
 	*/
 	AddAllTeamsToProjectWithParams(ctx context.Context, args *AddAllTeamsToProjectApiParams) AddAllTeamsToProjectApiRequest
 
@@ -58,7 +58,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param AddTeamUserApiParams - Parameters for the request
-	@return AddTeamUserApiRequest}}
+	@return AddTeamUserApiRequest
 	*/
 	AddTeamUserWithParams(ctx context.Context, args *AddTeamUserApiParams) AddTeamUserApiRequest
 
@@ -81,7 +81,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateTeamApiParams - Parameters for the request
-	@return CreateTeamApiRequest}}
+	@return CreateTeamApiRequest
 	*/
 	CreateTeamWithParams(ctx context.Context, args *CreateTeamApiParams) CreateTeamApiRequest
 
@@ -105,7 +105,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteTeamApiParams - Parameters for the request
-	@return DeleteTeamApiRequest}}
+	@return DeleteTeamApiRequest
 	*/
 	DeleteTeamWithParams(ctx context.Context, args *DeleteTeamApiParams) DeleteTeamApiRequest
 
@@ -129,7 +129,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetTeamByIdApiParams - Parameters for the request
-	@return GetTeamByIdApiRequest}}
+	@return GetTeamByIdApiRequest
 	*/
 	GetTeamByIdWithParams(ctx context.Context, args *GetTeamByIdApiParams) GetTeamByIdApiRequest
 
@@ -153,7 +153,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetTeamByNameApiParams - Parameters for the request
-	@return GetTeamByNameApiRequest}}
+	@return GetTeamByNameApiRequest
 	*/
 	GetTeamByNameWithParams(ctx context.Context, args *GetTeamByNameApiParams) GetTeamByNameApiRequest
 
@@ -176,7 +176,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListOrganizationTeamsApiParams - Parameters for the request
-	@return ListOrganizationTeamsApiRequest}}
+	@return ListOrganizationTeamsApiRequest
 	*/
 	ListOrganizationTeamsWithParams(ctx context.Context, args *ListOrganizationTeamsApiParams) ListOrganizationTeamsApiRequest
 
@@ -199,7 +199,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListProjectTeamsApiParams - Parameters for the request
-	@return ListProjectTeamsApiRequest}}
+	@return ListProjectTeamsApiRequest
 	*/
 	ListProjectTeamsWithParams(ctx context.Context, args *ListProjectTeamsApiParams) ListProjectTeamsApiRequest
 
@@ -223,7 +223,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListTeamUsersApiParams - Parameters for the request
-	@return ListTeamUsersApiRequest}}
+	@return ListTeamUsersApiRequest
 	*/
 	ListTeamUsersWithParams(ctx context.Context, args *ListTeamUsersApiParams) ListTeamUsersApiRequest
 
@@ -247,7 +247,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param RemoveProjectTeamApiParams - Parameters for the request
-	@return RemoveProjectTeamApiRequest}}
+	@return RemoveProjectTeamApiRequest
 	*/
 	RemoveProjectTeamWithParams(ctx context.Context, args *RemoveProjectTeamApiParams) RemoveProjectTeamApiRequest
 
@@ -272,7 +272,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param RemoveTeamUserApiParams - Parameters for the request
-	@return RemoveTeamUserApiRequest}}
+	@return RemoveTeamUserApiRequest
 	*/
 	RemoveTeamUserWithParams(ctx context.Context, args *RemoveTeamUserApiParams) RemoveTeamUserApiRequest
 
@@ -296,7 +296,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param RenameTeamApiParams - Parameters for the request
-	@return RenameTeamApiRequest}}
+	@return RenameTeamApiRequest
 	*/
 	RenameTeamWithParams(ctx context.Context, args *RenameTeamApiParams) RenameTeamApiRequest
 
@@ -320,7 +320,7 @@ type TeamsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateTeamRolesApiParams - Parameters for the request
-	@return UpdateTeamRolesApiRequest}}
+	@return UpdateTeamRolesApiRequest
 	*/
 	UpdateTeamRolesWithParams(ctx context.Context, args *UpdateTeamRolesApiParams) UpdateTeamRolesApiRequest
 

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -32,7 +32,7 @@ type TestApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param VersionedExampleApiParams - Parameters for the request
-	@return VersionedExampleApiRequest}}
+	@return VersionedExampleApiRequest
 	*/
 	VersionedExampleWithParams(ctx context.Context, args *VersionedExampleApiParams) VersionedExampleApiRequest
 

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -54,6 +54,11 @@ func (r VersionedExampleApiRequest) Execute() (*ExampleResourceResponseView20230
 	return r.ApiService.VersionedExampleExecute(r)
 }
 
+func (r VersionedExampleApiRequest) ExecuteWithParams(params *VersionedExampleApiParams) (*ExampleResourceResponseView20230201, *http.Response, error) {
+	r.additionalInfo = params.AdditionalInfo 
+	return r.Execute()
+}
+
 /*
 VersionedExample Example resource info for versioning of the Atlas API
 

--- a/mongodbatlasv2/api_test_.go
+++ b/mongodbatlasv2/api_test_.go
@@ -26,10 +26,18 @@ type TestApi interface {
 	@return VersionedExampleApiRequest
 	*/
 	VersionedExample(ctx context.Context) VersionedExampleApiRequest
+	/*
+	VersionedExample Example resource info for versioning of the Atlas API
 
-	// VersionedExampleExecute executes the request
-	//  @return ExampleResourceResponseView20230201
-	VersionedExampleExecute(r VersionedExampleApiRequest) (*ExampleResourceResponseView20230201, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param VersionedExampleApiParams - Parameters for the request
+	@return VersionedExampleApiRequest}}
+	*/
+	VersionedExampleWithParams(ctx context.Context, args *VersionedExampleApiParams) VersionedExampleApiRequest
+
+	// Interface only available internally
+	versionedExampleExecute(r VersionedExampleApiRequest) (*ExampleResourceResponseView20230201, *http.Response, error)
 }
 
 // TestApiService TestApi service
@@ -45,18 +53,21 @@ type VersionedExampleApiParams struct {
 		AdditionalInfo *bool
 }
 
+func (a *TestApiService) VersionedExampleWithParams(ctx context.Context, args *VersionedExampleApiParams) VersionedExampleApiRequest {
+	return VersionedExampleApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		additionalInfo: args.AdditionalInfo,
+	}
+}
+
 func (r VersionedExampleApiRequest) AdditionalInfo(additionalInfo bool) VersionedExampleApiRequest {
 	r.additionalInfo = &additionalInfo
 	return r
 }
 
 func (r VersionedExampleApiRequest) Execute() (*ExampleResourceResponseView20230201, *http.Response, error) {
-	return r.ApiService.VersionedExampleExecute(r)
-}
-
-func (r VersionedExampleApiRequest) ExecuteWithParams(params *VersionedExampleApiParams) (*ExampleResourceResponseView20230201, *http.Response, error) {
-	r.additionalInfo = params.AdditionalInfo 
-	return r.Execute()
+	return r.ApiService.versionedExampleExecute(r)
 }
 
 /*
@@ -76,7 +87,7 @@ func (a *TestApiService) VersionedExample(ctx context.Context) VersionedExampleA
 
 // Execute executes the request
 //  @return ExampleResourceResponseView20230201
-func (a *TestApiService) VersionedExampleExecute(r VersionedExampleApiRequest) (*ExampleResourceResponseView20230201, *http.Response, error) {
+func (a *TestApiService) versionedExampleExecute(r VersionedExampleApiRequest) (*ExampleResourceResponseView20230201, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -148,6 +148,16 @@ func (r CreateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration,
 	return r.ApiService.CreateThirdPartyIntegrationExecute(r)
 }
 
+func (r CreateThirdPartyIntegrationApiRequest) ExecuteWithParams(params *CreateThirdPartyIntegrationApiParams) (*PaginatedIntegration, *http.Response, error) {
+	r.integrationType = params.IntegrationType 
+	r.groupId = params.GroupId 
+	r.integration = params.Integration 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
+}
+
 /*
 CreateThirdPartyIntegration Configure One Third-Party Service Integration
 
@@ -300,6 +310,12 @@ func (r DeleteThirdPartyIntegrationApiRequest) Execute() (*http.Response, error)
 	return r.ApiService.DeleteThirdPartyIntegrationExecute(r)
 }
 
+func (r DeleteThirdPartyIntegrationApiRequest) ExecuteWithParams(params *DeleteThirdPartyIntegrationApiParams) (*http.Response, error) {
+	r.integrationType = params.IntegrationType 
+	r.groupId = params.GroupId 
+	return r.Execute()
+}
+
 /*
 DeleteThirdPartyIntegration Remove One Third-Party Service Integration
 
@@ -413,6 +429,12 @@ type GetThirdPartyIntegrationApiParams struct {
 
 func (r GetThirdPartyIntegrationApiRequest) Execute() (*Integration, *http.Response, error) {
 	return r.ApiService.GetThirdPartyIntegrationExecute(r)
+}
+
+func (r GetThirdPartyIntegrationApiRequest) ExecuteWithParams(params *GetThirdPartyIntegrationApiParams) (*Integration, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.integrationType = params.IntegrationType 
+	return r.Execute()
 }
 
 /*
@@ -561,6 +583,14 @@ func (r ListThirdPartyIntegrationsApiRequest) PageNum(pageNum int32) ListThirdPa
 
 func (r ListThirdPartyIntegrationsApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
 	return r.ApiService.ListThirdPartyIntegrationsExecute(r)
+}
+
+func (r ListThirdPartyIntegrationsApiRequest) ExecuteWithParams(params *ListThirdPartyIntegrationsApiParams) (*PaginatedIntegration, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*
@@ -737,6 +767,16 @@ func (r UpdateThirdPartyIntegrationApiRequest) PageNum(pageNum int32) UpdateThir
 
 func (r UpdateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
 	return r.ApiService.UpdateThirdPartyIntegrationExecute(r)
+}
+
+func (r UpdateThirdPartyIntegrationApiRequest) ExecuteWithParams(params *UpdateThirdPartyIntegrationApiParams) (*PaginatedIntegration, *http.Response, error) {
+	r.integrationType = params.IntegrationType 
+	r.groupId = params.GroupId 
+	r.integration = params.Integration 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -29,10 +29,18 @@ type ThirdPartyIntegrationsApi interface {
 	@return CreateThirdPartyIntegrationApiRequest
 	*/
 	CreateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) CreateThirdPartyIntegrationApiRequest
+	/*
+	CreateThirdPartyIntegration Configure One Third-Party Service Integration
 
-	// CreateThirdPartyIntegrationExecute executes the request
-	//  @return PaginatedIntegration
-	CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateThirdPartyIntegrationApiParams - Parameters for the request
+	@return CreateThirdPartyIntegrationApiRequest}}
+	*/
+	CreateThirdPartyIntegrationWithParams(ctx context.Context, args *CreateThirdPartyIntegrationApiParams) CreateThirdPartyIntegrationApiRequest
+
+	// Interface only available internally
+	createThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
 	DeleteThirdPartyIntegration Remove One Third-Party Service Integration
@@ -45,9 +53,18 @@ type ThirdPartyIntegrationsApi interface {
 	@return DeleteThirdPartyIntegrationApiRequest
 	*/
 	DeleteThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) DeleteThirdPartyIntegrationApiRequest
+	/*
+	DeleteThirdPartyIntegration Remove One Third-Party Service Integration
 
-	// DeleteThirdPartyIntegrationExecute executes the request
-	DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DeleteThirdPartyIntegrationApiParams - Parameters for the request
+	@return DeleteThirdPartyIntegrationApiRequest}}
+	*/
+	DeleteThirdPartyIntegrationWithParams(ctx context.Context, args *DeleteThirdPartyIntegrationApiParams) DeleteThirdPartyIntegrationApiRequest
+
+	// Interface only available internally
+	deleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (*http.Response, error)
 
 	/*
 	GetThirdPartyIntegration Return One Third-Party Service Integration
@@ -60,10 +77,18 @@ type ThirdPartyIntegrationsApi interface {
 	@return GetThirdPartyIntegrationApiRequest
 	*/
 	GetThirdPartyIntegration(ctx context.Context, groupId string, integrationType string) GetThirdPartyIntegrationApiRequest
+	/*
+	GetThirdPartyIntegration Return One Third-Party Service Integration
 
-	// GetThirdPartyIntegrationExecute executes the request
-	//  @return Integration
-	GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*Integration, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param GetThirdPartyIntegrationApiParams - Parameters for the request
+	@return GetThirdPartyIntegrationApiRequest}}
+	*/
+	GetThirdPartyIntegrationWithParams(ctx context.Context, args *GetThirdPartyIntegrationApiParams) GetThirdPartyIntegrationApiRequest
+
+	// Interface only available internally
+	getThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*Integration, *http.Response, error)
 
 	/*
 	ListThirdPartyIntegrations Return All Active Third-Party Service Integrations
@@ -75,10 +100,18 @@ type ThirdPartyIntegrationsApi interface {
 	@return ListThirdPartyIntegrationsApiRequest
 	*/
 	ListThirdPartyIntegrations(ctx context.Context, groupId string) ListThirdPartyIntegrationsApiRequest
+	/*
+	ListThirdPartyIntegrations Return All Active Third-Party Service Integrations
 
-	// ListThirdPartyIntegrationsExecute executes the request
-	//  @return PaginatedIntegration
-	ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListThirdPartyIntegrationsApiParams - Parameters for the request
+	@return ListThirdPartyIntegrationsApiRequest}}
+	*/
+	ListThirdPartyIntegrationsWithParams(ctx context.Context, args *ListThirdPartyIntegrationsApiParams) ListThirdPartyIntegrationsApiRequest
+
+	// Interface only available internally
+	listThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error)
 
 	/*
 	UpdateThirdPartyIntegration Update One Third-Party Service Integration
@@ -91,10 +124,18 @@ type ThirdPartyIntegrationsApi interface {
 	@return UpdateThirdPartyIntegrationApiRequest
 	*/
 	UpdateThirdPartyIntegration(ctx context.Context, integrationType string, groupId string) UpdateThirdPartyIntegrationApiRequest
+	/*
+	UpdateThirdPartyIntegration Update One Third-Party Service Integration
 
-	// UpdateThirdPartyIntegrationExecute executes the request
-	//  @return PaginatedIntegration
-	UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param UpdateThirdPartyIntegrationApiParams - Parameters for the request
+	@return UpdateThirdPartyIntegrationApiRequest}}
+	*/
+	UpdateThirdPartyIntegrationWithParams(ctx context.Context, args *UpdateThirdPartyIntegrationApiParams) UpdateThirdPartyIntegrationApiRequest
+
+	// Interface only available internally
+	updateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error)
 }
 
 // ThirdPartyIntegrationsApiService ThirdPartyIntegrationsApi service
@@ -118,6 +159,19 @@ type CreateThirdPartyIntegrationApiParams struct {
 		IncludeCount *bool
 		ItemsPerPage *int32
 		PageNum *int32
+}
+
+func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegrationWithParams(ctx context.Context, args *CreateThirdPartyIntegrationApiParams) CreateThirdPartyIntegrationApiRequest {
+	return CreateThirdPartyIntegrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		integrationType: args.IntegrationType,
+		groupId: args.GroupId,
+		integration: args.Integration,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
 }
 
 // Third-party integration that you want to configure for your project.
@@ -145,17 +199,7 @@ func (r CreateThirdPartyIntegrationApiRequest) PageNum(pageNum int32) CreateThir
 }
 
 func (r CreateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
-	return r.ApiService.CreateThirdPartyIntegrationExecute(r)
-}
-
-func (r CreateThirdPartyIntegrationApiRequest) ExecuteWithParams(params *CreateThirdPartyIntegrationApiParams) (*PaginatedIntegration, *http.Response, error) {
-	r.integrationType = params.IntegrationType 
-	r.groupId = params.GroupId 
-	r.integration = params.Integration 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.createThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -179,7 +223,7 @@ func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegration(ctx conte
 
 // Execute executes the request
 //  @return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) CreateThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) createThirdPartyIntegrationExecute(r CreateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -306,14 +350,17 @@ type DeleteThirdPartyIntegrationApiParams struct {
 		GroupId string
 }
 
-func (r DeleteThirdPartyIntegrationApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.DeleteThirdPartyIntegrationExecute(r)
+func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationWithParams(ctx context.Context, args *DeleteThirdPartyIntegrationApiParams) DeleteThirdPartyIntegrationApiRequest {
+	return DeleteThirdPartyIntegrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		integrationType: args.IntegrationType,
+		groupId: args.GroupId,
+	}
 }
 
-func (r DeleteThirdPartyIntegrationApiRequest) ExecuteWithParams(params *DeleteThirdPartyIntegrationApiParams) (*http.Response, error) {
-	r.integrationType = params.IntegrationType 
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r DeleteThirdPartyIntegrationApiRequest) Execute() (*http.Response, error) {
+	return r.ApiService.deleteThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -336,7 +383,7 @@ func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegration(ctx conte
 }
 
 // Execute executes the request
-func (a *ThirdPartyIntegrationsApiService) DeleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (*http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) deleteThirdPartyIntegrationExecute(r DeleteThirdPartyIntegrationApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -427,14 +474,17 @@ type GetThirdPartyIntegrationApiParams struct {
 		IntegrationType string
 }
 
-func (r GetThirdPartyIntegrationApiRequest) Execute() (*Integration, *http.Response, error) {
-	return r.ApiService.GetThirdPartyIntegrationExecute(r)
+func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationWithParams(ctx context.Context, args *GetThirdPartyIntegrationApiParams) GetThirdPartyIntegrationApiRequest {
+	return GetThirdPartyIntegrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		integrationType: args.IntegrationType,
+	}
 }
 
-func (r GetThirdPartyIntegrationApiRequest) ExecuteWithParams(params *GetThirdPartyIntegrationApiParams) (*Integration, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.integrationType = params.IntegrationType 
-	return r.Execute()
+func (r GetThirdPartyIntegrationApiRequest) Execute() (*Integration, *http.Response, error) {
+	return r.ApiService.getThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -458,7 +508,7 @@ func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegration(ctx context.
 
 // Execute executes the request
 //  @return Integration
-func (a *ThirdPartyIntegrationsApiService) GetThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*Integration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) getThirdPartyIntegrationExecute(r GetThirdPartyIntegrationApiRequest) (*Integration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -563,6 +613,17 @@ type ListThirdPartyIntegrationsApiParams struct {
 		PageNum *int32
 }
 
+func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrationsWithParams(ctx context.Context, args *ListThirdPartyIntegrationsApiParams) ListThirdPartyIntegrationsApiRequest {
+	return ListThirdPartyIntegrationsApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListThirdPartyIntegrationsApiRequest) IncludeCount(includeCount bool) ListThirdPartyIntegrationsApiRequest {
 	r.includeCount = &includeCount
@@ -582,15 +643,7 @@ func (r ListThirdPartyIntegrationsApiRequest) PageNum(pageNum int32) ListThirdPa
 }
 
 func (r ListThirdPartyIntegrationsApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
-	return r.ApiService.ListThirdPartyIntegrationsExecute(r)
-}
-
-func (r ListThirdPartyIntegrationsApiRequest) ExecuteWithParams(params *ListThirdPartyIntegrationsApiParams) (*PaginatedIntegration, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listThirdPartyIntegrationsExecute(r)
 }
 
 /*
@@ -612,7 +665,7 @@ func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrations(ctx contex
 
 // Execute executes the request
 //  @return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) ListThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) listThirdPartyIntegrationsExecute(r ListThirdPartyIntegrationsApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -741,6 +794,19 @@ type UpdateThirdPartyIntegrationApiParams struct {
 		PageNum *int32
 }
 
+func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegrationWithParams(ctx context.Context, args *UpdateThirdPartyIntegrationApiParams) UpdateThirdPartyIntegrationApiRequest {
+	return UpdateThirdPartyIntegrationApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		integrationType: args.IntegrationType,
+		groupId: args.GroupId,
+		integration: args.Integration,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Third-party integration that you want to configure for your project.
 func (r UpdateThirdPartyIntegrationApiRequest) Integration(integration Integration) UpdateThirdPartyIntegrationApiRequest {
 	r.integration = &integration
@@ -766,17 +832,7 @@ func (r UpdateThirdPartyIntegrationApiRequest) PageNum(pageNum int32) UpdateThir
 }
 
 func (r UpdateThirdPartyIntegrationApiRequest) Execute() (*PaginatedIntegration, *http.Response, error) {
-	return r.ApiService.UpdateThirdPartyIntegrationExecute(r)
-}
-
-func (r UpdateThirdPartyIntegrationApiRequest) ExecuteWithParams(params *UpdateThirdPartyIntegrationApiParams) (*PaginatedIntegration, *http.Response, error) {
-	r.integrationType = params.IntegrationType 
-	r.groupId = params.GroupId 
-	r.integration = params.Integration 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.updateThirdPartyIntegrationExecute(r)
 }
 
 /*
@@ -800,7 +856,7 @@ func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegration(ctx conte
 
 // Execute executes the request
 //  @return PaginatedIntegration
-func (a *ThirdPartyIntegrationsApiService) UpdateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
+func (a *ThirdPartyIntegrationsApiService) updateThirdPartyIntegrationExecute(r UpdateThirdPartyIntegrationApiRequest) (*PaginatedIntegration, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPut
 		localVarPostBody     interface{}

--- a/mongodbatlasv2/api_third_party_integrations.go
+++ b/mongodbatlasv2/api_third_party_integrations.go
@@ -35,7 +35,7 @@ type ThirdPartyIntegrationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateThirdPartyIntegrationApiParams - Parameters for the request
-	@return CreateThirdPartyIntegrationApiRequest}}
+	@return CreateThirdPartyIntegrationApiRequest
 	*/
 	CreateThirdPartyIntegrationWithParams(ctx context.Context, args *CreateThirdPartyIntegrationApiParams) CreateThirdPartyIntegrationApiRequest
 
@@ -59,7 +59,7 @@ type ThirdPartyIntegrationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DeleteThirdPartyIntegrationApiParams - Parameters for the request
-	@return DeleteThirdPartyIntegrationApiRequest}}
+	@return DeleteThirdPartyIntegrationApiRequest
 	*/
 	DeleteThirdPartyIntegrationWithParams(ctx context.Context, args *DeleteThirdPartyIntegrationApiParams) DeleteThirdPartyIntegrationApiRequest
 
@@ -83,7 +83,7 @@ type ThirdPartyIntegrationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param GetThirdPartyIntegrationApiParams - Parameters for the request
-	@return GetThirdPartyIntegrationApiRequest}}
+	@return GetThirdPartyIntegrationApiRequest
 	*/
 	GetThirdPartyIntegrationWithParams(ctx context.Context, args *GetThirdPartyIntegrationApiParams) GetThirdPartyIntegrationApiRequest
 
@@ -106,7 +106,7 @@ type ThirdPartyIntegrationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListThirdPartyIntegrationsApiParams - Parameters for the request
-	@return ListThirdPartyIntegrationsApiRequest}}
+	@return ListThirdPartyIntegrationsApiRequest
 	*/
 	ListThirdPartyIntegrationsWithParams(ctx context.Context, args *ListThirdPartyIntegrationsApiParams) ListThirdPartyIntegrationsApiRequest
 
@@ -130,7 +130,7 @@ type ThirdPartyIntegrationsApi interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param UpdateThirdPartyIntegrationApiParams - Parameters for the request
-	@return UpdateThirdPartyIntegrationApiRequest}}
+	@return UpdateThirdPartyIntegrationApiRequest
 	*/
 	UpdateThirdPartyIntegrationWithParams(ctx context.Context, args *UpdateThirdPartyIntegrationApiParams) UpdateThirdPartyIntegrationApiRequest
 

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -39,7 +39,7 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param CreateDatabaseUserCertificateApiParams - Parameters for the request
-	@return CreateDatabaseUserCertificateApiRequest}}
+	@return CreateDatabaseUserCertificateApiRequest
 	*/
 	CreateDatabaseUserCertificateWithParams(ctx context.Context, args *CreateDatabaseUserCertificateApiParams) CreateDatabaseUserCertificateApiRequest
 
@@ -64,7 +64,7 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param DisableCustomerManagedX509ApiParams - Parameters for the request
-	@return DisableCustomerManagedX509ApiRequest}}
+	@return DisableCustomerManagedX509ApiRequest
 	*/
 	DisableCustomerManagedX509WithParams(ctx context.Context, args *DisableCustomerManagedX509ApiParams) DisableCustomerManagedX509ApiRequest
 
@@ -88,7 +88,7 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param ListDatabaseUserCertificatesApiParams - Parameters for the request
-	@return ListDatabaseUserCertificatesApiRequest}}
+	@return ListDatabaseUserCertificatesApiRequest
 	*/
 	ListDatabaseUserCertificatesWithParams(ctx context.Context, args *ListDatabaseUserCertificatesApiParams) ListDatabaseUserCertificatesApiRequest
 

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -98,6 +98,13 @@ func (r CreateDatabaseUserCertificateApiRequest) Execute() (*http.Response, erro
 	return r.ApiService.CreateDatabaseUserCertificateExecute(r)
 }
 
+func (r CreateDatabaseUserCertificateApiRequest) ExecuteWithParams(params *CreateDatabaseUserCertificateApiParams) (*http.Response, error) {
+	r.groupId = params.GroupId 
+	r.username = params.Username 
+	r.userCert = params.UserCert 
+	return r.Execute()
+}
+
 /*
 CreateDatabaseUserCertificate Create One X.509 Certificate for One MongoDB User
 
@@ -218,6 +225,11 @@ type DisableCustomerManagedX509ApiParams struct {
 
 func (r DisableCustomerManagedX509ApiRequest) Execute() (*UserSecurity, *http.Response, error) {
 	return r.ApiService.DisableCustomerManagedX509Execute(r)
+}
+
+func (r DisableCustomerManagedX509ApiRequest) ExecuteWithParams(params *DisableCustomerManagedX509ApiParams) (*UserSecurity, *http.Response, error) {
+	r.groupId = params.GroupId 
+	return r.Execute()
 }
 
 /*
@@ -367,6 +379,15 @@ func (r ListDatabaseUserCertificatesApiRequest) PageNum(pageNum int32) ListDatab
 
 func (r ListDatabaseUserCertificatesApiRequest) Execute() (*PaginatedUserCert, *http.Response, error) {
 	return r.ApiService.ListDatabaseUserCertificatesExecute(r)
+}
+
+func (r ListDatabaseUserCertificatesApiRequest) ExecuteWithParams(params *ListDatabaseUserCertificatesApiParams) (*PaginatedUserCert, *http.Response, error) {
+	r.groupId = params.GroupId 
+	r.username = params.Username 
+	r.includeCount = params.IncludeCount 
+	r.itemsPerPage = params.ItemsPerPage 
+	r.pageNum = params.PageNum 
+	return r.Execute()
 }
 
 /*

--- a/mongodbatlasv2/api_x509_authentication.go
+++ b/mongodbatlasv2/api_x509_authentication.go
@@ -33,9 +33,18 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 	@return CreateDatabaseUserCertificateApiRequest
 	*/
 	CreateDatabaseUserCertificate(ctx context.Context, groupId string, username string) CreateDatabaseUserCertificateApiRequest
+	/*
+	CreateDatabaseUserCertificate Create One X.509 Certificate for One MongoDB User
 
-	// CreateDatabaseUserCertificateExecute executes the request
-	CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (*http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param CreateDatabaseUserCertificateApiParams - Parameters for the request
+	@return CreateDatabaseUserCertificateApiRequest}}
+	*/
+	CreateDatabaseUserCertificateWithParams(ctx context.Context, args *CreateDatabaseUserCertificateApiParams) CreateDatabaseUserCertificateApiRequest
+
+	// Interface only available internally
+	createDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (*http.Response, error)
 
 	/*
 	DisableCustomerManagedX509 Disable Customer-Managed X.509
@@ -49,10 +58,18 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 	@return DisableCustomerManagedX509ApiRequest
 	*/
 	DisableCustomerManagedX509(ctx context.Context, groupId string) DisableCustomerManagedX509ApiRequest
+	/*
+	DisableCustomerManagedX509 Disable Customer-Managed X.509
 
-	// DisableCustomerManagedX509Execute executes the request
-	//  @return UserSecurity
-	DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param DisableCustomerManagedX509ApiParams - Parameters for the request
+	@return DisableCustomerManagedX509ApiRequest}}
+	*/
+	DisableCustomerManagedX509WithParams(ctx context.Context, args *DisableCustomerManagedX509ApiParams) DisableCustomerManagedX509ApiRequest
+
+	// Interface only available internally
+	disableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error)
 
 	/*
 	ListDatabaseUserCertificates Return All X.509 Certificates Assigned to One MongoDB User
@@ -65,10 +82,18 @@ If you are managing your own Certificate Authority (CA) in Self-Managed X.509 mo
 	@return ListDatabaseUserCertificatesApiRequest
 	*/
 	ListDatabaseUserCertificates(ctx context.Context, groupId string, username string) ListDatabaseUserCertificatesApiRequest
+	/*
+	ListDatabaseUserCertificates Return All X.509 Certificates Assigned to One MongoDB User
 
-	// ListDatabaseUserCertificatesExecute executes the request
-	//  @return PaginatedUserCert
-	ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param ListDatabaseUserCertificatesApiParams - Parameters for the request
+	@return ListDatabaseUserCertificatesApiRequest}}
+	*/
+	ListDatabaseUserCertificatesWithParams(ctx context.Context, args *ListDatabaseUserCertificatesApiParams) ListDatabaseUserCertificatesApiRequest
+
+	// Interface only available internally
+	listDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error)
 }
 
 // X509AuthenticationApiService X509AuthenticationApi service
@@ -88,6 +113,16 @@ type CreateDatabaseUserCertificateApiParams struct {
 		UserCert *UserCert
 }
 
+func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateWithParams(ctx context.Context, args *CreateDatabaseUserCertificateApiParams) CreateDatabaseUserCertificateApiRequest {
+	return CreateDatabaseUserCertificateApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		username: args.Username,
+		userCert: args.UserCert,
+	}
+}
+
 // Generates one X.509 certificate for the specified MongoDB user.
 func (r CreateDatabaseUserCertificateApiRequest) UserCert(userCert UserCert) CreateDatabaseUserCertificateApiRequest {
 	r.userCert = &userCert
@@ -95,14 +130,7 @@ func (r CreateDatabaseUserCertificateApiRequest) UserCert(userCert UserCert) Cre
 }
 
 func (r CreateDatabaseUserCertificateApiRequest) Execute() (*http.Response, error) {
-	return r.ApiService.CreateDatabaseUserCertificateExecute(r)
-}
-
-func (r CreateDatabaseUserCertificateApiRequest) ExecuteWithParams(params *CreateDatabaseUserCertificateApiParams) (*http.Response, error) {
-	r.groupId = params.GroupId 
-	r.username = params.Username 
-	r.userCert = params.UserCert 
-	return r.Execute()
+	return r.ApiService.createDatabaseUserCertificateExecute(r)
 }
 
 /*
@@ -129,7 +157,7 @@ func (a *X509AuthenticationApiService) CreateDatabaseUserCertificate(ctx context
 }
 
 // Execute executes the request
-func (a *X509AuthenticationApiService) CreateDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (*http.Response, error) {
+func (a *X509AuthenticationApiService) createDatabaseUserCertificateExecute(r CreateDatabaseUserCertificateApiRequest) (*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
@@ -223,13 +251,16 @@ type DisableCustomerManagedX509ApiParams struct {
 		GroupId string
 }
 
-func (r DisableCustomerManagedX509ApiRequest) Execute() (*UserSecurity, *http.Response, error) {
-	return r.ApiService.DisableCustomerManagedX509Execute(r)
+func (a *X509AuthenticationApiService) DisableCustomerManagedX509WithParams(ctx context.Context, args *DisableCustomerManagedX509ApiParams) DisableCustomerManagedX509ApiRequest {
+	return DisableCustomerManagedX509ApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+	}
 }
 
-func (r DisableCustomerManagedX509ApiRequest) ExecuteWithParams(params *DisableCustomerManagedX509ApiParams) (*UserSecurity, *http.Response, error) {
-	r.groupId = params.GroupId 
-	return r.Execute()
+func (r DisableCustomerManagedX509ApiRequest) Execute() (*UserSecurity, *http.Response, error) {
+	return r.ApiService.disableCustomerManagedX509Execute(r)
 }
 
 /*
@@ -253,7 +284,7 @@ func (a *X509AuthenticationApiService) DisableCustomerManagedX509(ctx context.Co
 
 // Execute executes the request
 //  @return UserSecurity
-func (a *X509AuthenticationApiService) DisableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error) {
+func (a *X509AuthenticationApiService) disableCustomerManagedX509Execute(r DisableCustomerManagedX509ApiRequest) (*UserSecurity, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodDelete
 		localVarPostBody     interface{}
@@ -359,6 +390,18 @@ type ListDatabaseUserCertificatesApiParams struct {
 		PageNum *int32
 }
 
+func (a *X509AuthenticationApiService) ListDatabaseUserCertificatesWithParams(ctx context.Context, args *ListDatabaseUserCertificatesApiParams) ListDatabaseUserCertificatesApiRequest {
+	return ListDatabaseUserCertificatesApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		groupId: args.GroupId,
+		username: args.Username,
+		includeCount: args.IncludeCount,
+		itemsPerPage: args.ItemsPerPage,
+		pageNum: args.PageNum,
+	}
+}
+
 // Flag that indicates whether the response returns the total number of items (**totalCount**) in the response.
 func (r ListDatabaseUserCertificatesApiRequest) IncludeCount(includeCount bool) ListDatabaseUserCertificatesApiRequest {
 	r.includeCount = &includeCount
@@ -378,16 +421,7 @@ func (r ListDatabaseUserCertificatesApiRequest) PageNum(pageNum int32) ListDatab
 }
 
 func (r ListDatabaseUserCertificatesApiRequest) Execute() (*PaginatedUserCert, *http.Response, error) {
-	return r.ApiService.ListDatabaseUserCertificatesExecute(r)
-}
-
-func (r ListDatabaseUserCertificatesApiRequest) ExecuteWithParams(params *ListDatabaseUserCertificatesApiParams) (*PaginatedUserCert, *http.Response, error) {
-	r.groupId = params.GroupId 
-	r.username = params.Username 
-	r.includeCount = params.IncludeCount 
-	r.itemsPerPage = params.ItemsPerPage 
-	r.pageNum = params.PageNum 
-	return r.Execute()
+	return r.ApiService.listDatabaseUserCertificatesExecute(r)
 }
 
 /*
@@ -411,7 +445,7 @@ func (a *X509AuthenticationApiService) ListDatabaseUserCertificates(ctx context.
 
 // Execute executes the request
 //  @return PaginatedUserCert
-func (a *X509AuthenticationApiService) ListDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error) {
+func (a *X509AuthenticationApiService) listDatabaseUserCertificatesExecute(r ListDatabaseUserCertificatesApiRequest) (*PaginatedUserCert, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -33,13 +33,23 @@ type {{classname}} interface {
 	{{/isDeprecated}}
 	*/
 	{{{nickname}}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{operationId}}ApiRequest
+	{{!X-GEN-CUSTOM}}
+	/*
+	{{operationId}} {{{summary}}}{{^summary}}Method for {{operationId}}{{/summary}}
 
-	// {{nickname}}Execute executes the request{{#returnType}}
-	//  @return {{{.}}}{{/returnType}}
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param {{operationId}}ApiParams - Parameters for the request
+	@return {{operationId}}ApiRequest}}
 	{{#isDeprecated}}
-	// Deprecated
+
+	Deprecated
 	{{/isDeprecated}}
-	{{nickname}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
+	*/
+	{{nickname}}WithParams(ctx context.Context, args *{{operationId}}ApiParams) {{operationId}}ApiRequest
+
+	// Interface only available internally
+	{{#lambda.camelcase}}{{{nickname}}}{{/lambda.camelcase}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -61,11 +71,22 @@ type {{operationId}}ApiRequest struct {
 
 {{!X-GEN-CUSTOM}}
 type {{operationId}}ApiParams struct {
-	{{#allParams}}
+{{#allParams}}
 		{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
-	{{/allParams}}
+{{/allParams}}
 }
 
+func (a *{{{classname}}}Service) {{{nickname}}}WithParams(ctx context.Context, args *{{operationId}}ApiParams) {{operationId}}ApiRequest {
+	return {{operationId}}ApiRequest{
+		ApiService: a,
+		ctx: ctx,
+		{{#allParams}}
+		{{paramName}}: args.{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}},
+		{{/allParams}}
+	}
+}
+
+{{!/X-GEN-CUSTOM}}
 {{#allParams}}
 {{^isPathParam}}
 {{#description}}
@@ -82,15 +103,7 @@ func (r {{operationId}}ApiRequest) {{vendorExtensions.x-export-param-name}}({{pa
 {{/isPathParam}}
 {{/allParams}}
 func (r {{operationId}}ApiRequest) Execute() ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
-	return r.ApiService.{{nickname}}Execute(r)
-}
-
-{{!X-GEN-CUSTOM}}
-func (r {{operationId}}ApiRequest) ExecuteWithParams(params *{{operationId}}ApiParams) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
-{{#allParams}}
-	r.{{paramName}} = params.{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}} 
-{{/allParams}}
-	return r.Execute()
+	return r.ApiService.{{#lambda.camelcase}}{{{nickname}}}{{/lambda.camelcase}}Execute(r)
 }
 
 /*
@@ -123,7 +136,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#pathParams
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+func (a *{{{classname}}}Service) {{#lambda.camelcase}}{{{nickname}}}{{/lambda.camelcase}}Execute(r {{operationId}}ApiRequest) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.Method{{httpMethod}}
 		localVarPostBody     interface{}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -43,7 +43,7 @@ type {{classname}} interface {
 	@return {{operationId}}ApiRequest}}
 	{{#isDeprecated}}
 
-	Deprecated
+	Deprecated: Method have been deprecated. Please check the latest resource version for {{classname}}
 	{{/isDeprecated}}
 	*/
 	{{nickname}}WithParams(ctx context.Context, args *{{operationId}}ApiParams) {{operationId}}ApiRequest

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -85,6 +85,14 @@ func (r {{operationId}}ApiRequest) Execute() ({{#returnType}}{{^isArray}}{{^retu
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
+{{!X-GEN-CUSTOM}}
+func (r {{operationId}}ApiRequest) ExecuteWithParams(params *{{operationId}}ApiParams) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+{{#allParams}}
+	r.{{paramName}} = params.{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}} 
+{{/allParams}}
+	return r.Execute()
+}
+
 /*
 {{operationId}} {{{summary}}}{{^summary}}Method for {{operationId}}{{/summary}}
 {{#notes}}

--- a/tools/config/go-templates/api.mustache
+++ b/tools/config/go-templates/api.mustache
@@ -29,7 +29,7 @@ type {{classname}} interface {
 	@return {{operationId}}ApiRequest
 	{{#isDeprecated}}
 	
-	Deprecated: Method have been deprecated. Please check the latest resource version for {{classname}}
+	Deprecated: this method has been deprecated. Please check the latest resource version for {{classname}}
 	{{/isDeprecated}}
 	*/
 	{{{nickname}}}(ctx context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{operationId}}ApiRequest
@@ -40,10 +40,10 @@ type {{classname}} interface {
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param {{operationId}}ApiParams - Parameters for the request
-	@return {{operationId}}ApiRequest}}
+	@return {{operationId}}ApiRequest
 	{{#isDeprecated}}
 
-	Deprecated: Method have been deprecated. Please check the latest resource version for {{classname}}
+	Deprecated: this method has been deprecated. Please check the latest resource version for {{classname}}
 	{{/isDeprecated}}
 	*/
 	{{nickname}}WithParams(ctx context.Context, args *{{operationId}}ApiParams) {{operationId}}ApiRequest


### PR DESCRIPTION
One of the biggest problems integrations might face is that fluent API forces end users to use specific interface (chain of operations/builder pattern-like) solutions. In many cases, this will mean that migration between SDKv1 and SDKv2 will be quite painful.

This PR introduces a new method to the API object that can accept structs. 

As result, users will get:

- Clean, effortless migration path from v1 to v2 (removing a lot of manual steps and a complete rewrite of the data layer or even the application layer)
- Access to individual resources without the need to duplicate all requirement
- Simple means to understand what arguments are required for each API method (right now users need to discover various objects. 


While this change might look big due to the number of files changed what we changing here is only a single template that adds a new method.
I will be looking to adopt this upstream as well. Change is not breaking - it doesn't affect any goals and existing documentation etc.

## Notes about recent updates

1. I have made this feature experimental for now. Fluent API is still the default feature
2. I will focus on small breaking changes for fluent API in separate PR to simplify the review. 
This PR contains all non-breaking changes for atlas CLI (tested end to end)