### PR TITLE
Revert "CLOUDP-169104: Fix encoding for AWS IAM usernames (#452)"

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -161,7 +161,7 @@ func (s *DatabaseUsersServiceOp) Get(ctx context.Context, databaseName, groupID,
 	}
 
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
-	escapedEntry := url.QueryEscape(username)
+	escapedEntry := url.PathEscape(username)
 	path := fmt.Sprintf("%s/%s/%s", basePath, databaseName, escapedEntry)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)


### PR DESCRIPTION
This reverts commit 056a7562abcd0ef7ac75fff5f1a924dc4dc51460.

## Description

The root cause was query encoding occurring on the CLI and the SDK, so this change was not required 

Keeping PathEscape for consistency across the API and v2sdk as it works as expected

Link to any related issue(s): 
https://github.com/mongodb/mongodb-atlas-cli/issues/1817

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

