### PR TITLE
CLOUDP-175206: remove openapi file override

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,4 @@
 export OPENAPI_FOLDER=../openapi
-export OPENAPI_FILE_NAME=atlas-api.yaml
 export SDK_FOLDER=../mongodbatlasv2
 
 .DEFAULT_GOAL := generate_client

--- a/tools/scripts/generate.sh
+++ b/tools/scripts/generate.sh
@@ -19,7 +19,7 @@ client_package="mongodbatlasv2"
 openapiFileLocation="$OPENAPI_FOLDER/$transformed_file"
 
 echo "# Running generation pipeline"
-echo "# Running transformation from $transformed_file OpenAPI from $OPENAPI_FILE_NAME"
+echo "# Running transformation based on $OPENAPI_FILE_NAME to the $transformed_file"
 cp "$OPENAPI_FOLDER/$OPENAPI_FILE_NAME" "$openapiFileLocation"
 
 npm install


### PR DESCRIPTION
## Description

Nit: OpenAPI file env var is not taken into account and not needed when calling generate. 
Found out during investigation of the evergreen issues