### PR TITLE
CLOUDP-175598: openapi pipeline to run client test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -58,8 +58,5 @@ openapi-pipeline:
 	echo "Running client generation"
 	$(MAKE) -C tools generate_client
 	echo "Validating generated SDK"
-	$(MAKE) v2-examples-build
+	go test go.mongodb.org/atlas/test  
 
-.PHONY: v2-examples-build
-v2-examples-build:
-	go build "./examples/example_cluster_aws.go"

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"testing"
+
+	mongodbatlas "go.mongodb.org/atlas/mongodbatlasv2"
+)
+
+func Test_Client_Config(t *testing.T) {
+	apiKey := "test"
+	apiSecret := "test"
+	host := "https://cloud.mongodb.com"
+
+	sdk, err := mongodbatlas.NewClient(
+		mongodbatlas.UseDigestAuth(apiKey, apiSecret),
+		mongodbatlas.UseBaseURL(host),
+		mongodbatlas.UseDebug(false))
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	serverURL := sdk.GetConfig().Servers[0].URL
+
+	if serverURL != host {
+		t.Errorf("Expected %s, got %s", host, serverURL)
+	}
+}

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -1,12 +1,12 @@
 package test
 
 import (
-	"testing"
+	"fmt"
 
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
-func Test_Client_Config(t *testing.T) {
+func ExampleNewClient() {
 	apiKey := "test"
 	apiSecret := "test"
 	host := "https://cloud.mongodb.com"
@@ -17,12 +17,11 @@ func Test_Client_Config(t *testing.T) {
 		mongodbatlas.UseDebug(false))
 
 	if err != nil {
-		t.Error(err)
+		panic(err)
 	}
 
 	serverURL := sdk.GetConfig().Servers[0].URL
-
-	if serverURL != host {
-		t.Errorf("Expected %s, got %s", host, serverURL)
-	}
+	fmt.Println(serverURL)
+	// Output:
+	// https://cloud.mongodb.com
 }


### PR DESCRIPTION
## Description

Example application is subject to be broken when a new Resource version of the API will be introduced that changes the resources it uses. That is fine for us as then update PRs will fail and will require manual correction (which we want).

However, example applications were also used as tests for CI/CD processes which is not desired breaking changes will also break the job.  This PR improves the openapi pipeline to rely on client test (it will compile entire client codebase by running the test).

## Verification done
```
make openapi_pipeline
```

Running tests with broken codebase:
```
# go.mongodb.org/atlas/mongodbatlasv2
mongodbatlasv2/api_clusters.go:87:36: undefined: CloudProviderRegionsApi
FAIL    go.mongodb.org/atlas/test [build failed]
FAIL
```

