### PR TITLE
INTMDB-801: Add Data Federation to the go client

### DIFF
--- a/mongodbatlas/data_federation.go
+++ b/mongodbatlas/data_federation.go
@@ -1,0 +1,251 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	dataFederationBasePath = "api/atlas/v1.0/groups/%s/dataFederation"
+)
+
+// DataFederationService is an interface for interfacing with the Data Federation endpoints of the MongoDB Atlas API.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation
+type DataFederationService interface {
+	List(context.Context, string) ([]*DataFederationInstance, *Response, error)
+	Get(context.Context, string, string) (*DataFederationInstance, *Response, error)
+	Create(context.Context, string, *DataFederationInstance) (*DataFederationInstance, *Response, error)
+	Update(context.Context, string, string, *DataFederationInstance) (*DataFederationInstance, *Response, error)
+	Delete(context.Context, string, string) (*Response, error)
+}
+
+// DataFederationServiceOp handles communication with the DataFederationService related methods of the
+// MongoDB Atlas API.
+type DataFederationServiceOp service
+
+var _ DataFederationService = &DataFederationServiceOp{}
+
+// DataFederationInstance is the data federation configuration.
+type DataFederationInstance struct {
+	CloudProviderConfig *CloudProviderConfig   `json:"cloudProviderConfig,omitempty"`
+	DataProcessRegion   *DataProcessRegion     `json:"dataProcessRegion,omitempty"`
+	Storage             *DataFederationStorage `json:"storage,omitempty"`
+	Name                string                 `json:"name,omitempty"`
+}
+
+// DataFederationStorage represents the storage configuration for a data lake.
+type DataFederationStorage struct {
+	Databases []*DataFederationDatabase `json:"databases,omitempty"`
+	Stores    []*DataFederationStore    `json:"stores,omitempty"`
+}
+
+// DataFederationDatabase represents queryable databases and collections for this data federation
+type DataFederationDatabase struct {
+	Collections            []*DataFederationCollection   `json:"collections,omitempty"`
+	Views                  []*DataFederationDatabaseView `json:"views,omitempty"`
+	MaxWildcardCollections int32                         `json:"maxWildcardCollections,omitempty"`
+	Name                   string                        `json:"name,omitempty"`
+}
+
+// DataFederationCollection represents queryable collections for this data federation
+type DataFederationCollection struct {
+	DataSources []*DataFederationDataSource `json:"dataSources,omitempty"`
+	Name        string                      `json:"name,omitempty"`
+}
+
+// DataFederationDataSource represents data stores that map to a collection for this data federation.
+type DataFederationDataSource struct {
+	AllowInsecure       *bool     `json:"allowInsecure,omitempty"`
+	Collection          string    `json:"collection,omitempty"`
+	CollectionRegex     string    `json:"collectionRegex,omitempty"`
+	Database            string    `json:"database,omitempty"`
+	DatabaseRegex       string    `json:"databaseRegex,omitempty"`
+	DefaultFormat       string    `json:"defaultFormat,omitempty"`
+	Path                string    `json:"path,omitempty"`
+	ProvenanceFieldName string    `json:"provenanceFieldName,omitempty"`
+	StoreName           string    `json:"storeName,omitempty"`
+	Urls                []*string `json:"urls,omitempty"`
+}
+
+// DataFederationDatabaseView represents any view under a DataFederationDatabase.
+type DataFederationDatabaseView struct {
+	Name     string `json:"name,omitempty"`
+	Source   string `json:"source,omitempty"`
+	Pipeline string `json:"pipeline,omitempty"`
+}
+
+// DataFederationStore represents data stores for the data federation.
+type DataFederationStore struct {
+	ReadPreference           *ReadPreferences `json:"readPreference,omitempty"`
+	IncludeTags              *bool            `json:"includeTags,omitempty"`
+	AdditionalStorageClasses []*string        `json:"additionalStorageClasses,omitempty"`
+	Name                     string           `json:"name,omitempty"`
+	Provider                 string           `json:"provider,omitempty"`
+	ClusterName              string           `json:"clusterName,omitempty"`
+	Region                   string           `json:"region,omitempty"`
+	Bucket                   string           `json:"bucket,omitempty"`
+	Prefix                   string           `json:"prefix,omitempty"`
+	Delimiter                string           `json:"delimiter,omitempty"`
+	ProjectID                string           `json:"projectId,omitempty"`
+}
+
+// ReadPreferences describes how to route read requests to the cluster.
+type ReadPreferences struct {
+	MaxStalenessSeconds int32     `json:"maxStalenessSeconds,omitempty"`
+	Mode                string    `json:"mode,omitempty"`
+	TagSets             []*TagSet `json:"tagSets,omitempty"`
+}
+
+// TagSet describes a tag specification document.
+type TagSet struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// List gets the details of all federated database instances in the specified project.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/listFederatedDatabases
+func (s *DataFederationServiceOp) List(ctx context.Context, groupID string) ([]*DataFederationInstance, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	path := fmt.Sprintf(dataFederationBasePath, groupID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var root []*DataFederationInstance
+	resp, err := s.Client.Do(ctx, req, &root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, nil
+}
+
+// Get gets the details of one federated database instance within the specified project.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/getFederatedDatabase
+func (s *DataFederationServiceOp) Get(ctx context.Context, groupID, name string) (*DataFederationInstance, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if name == "" {
+		return nil, nil, NewArgError("name", "must be set")
+	}
+
+	basePath := fmt.Sprintf(dataFederationBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, name)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(DataFederationInstance)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Create creates one federated database instance in the specified project.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/createFederatedDatabase
+func (s *DataFederationServiceOp) Create(ctx context.Context, groupID string, createRequest *DataFederationInstance) (*DataFederationInstance, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "must be set")
+	}
+
+	path := fmt.Sprintf(dataFederationBasePath, groupID)
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(DataFederationInstance)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Update updates the details of one federated database instance in the specified project.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/updateFederatedDatabase
+func (s *DataFederationServiceOp) Update(ctx context.Context, groupID, name string, updateRequest *DataFederationInstance) (*DataFederationInstance, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if name == "" {
+		return nil, nil, NewArgError("name", "must be set")
+	}
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	basePath := fmt.Sprintf(dataFederationBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, name)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(DataFederationInstance)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Delete removes one federated database instance from the specified project.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/deleteFederatedDatabase
+func (s *DataFederationServiceOp) Delete(ctx context.Context, groupID, name string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupId", "must be set")
+	}
+	if name == "" {
+		return nil, NewArgError("name", "must be set")
+	}
+
+	basePath := fmt.Sprintf(dataFederationBasePath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, name)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/mongodbatlas/data_federation_test.go
+++ b/mongodbatlas/data_federation_test.go
@@ -1,0 +1,753 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestDataFederation_List(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation", groupID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[
+			{
+				"cloudProviderConfig": {
+					"aws": {
+					  	"iamAssumedRoleARN": "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+						"externalId": "test",
+						"iamUserARN": "test",
+						"roleId": "test"
+				  	}
+			  	},
+			  	"dataProcessRegion": {
+					"cloudProvider" : "AWS",
+					"region" : "VIRGINIA_USA"
+			  	},
+			  	"name": "UserMetricData",
+			  	"storage": {
+				  	"databases": [
+						{
+							"name": "my.database",
+							"collections": [
+								{
+									"name": "my.collection",
+									"dataSources": [
+										{
+												"storeName" : "store",
+												"defaultFormat" : ".json",
+												"path" : "/path",
+												"allowInsecure": false,
+												"database": "test",
+												"databaseRegex": "test",
+												"collection": "test",
+												"collectionRegex": "test",
+												"provenanceFieldName": "test",
+												"urls": ["test"]
+										}
+									]
+								}
+							],
+							"views": [
+								{
+									"name" : "my.view",
+									"source" : "source",
+									"pipeline" : "my.pipeline"
+								}
+							],
+							"maxWildcardCollections" : 92
+						}
+					],
+					"stores": [
+						{
+							"name": "datacenter-alpha",
+							"provider": "s3",
+						  	"region": "us-east-1",
+						  	"bucket": "datacenter-alpha",
+						  	"prefix": "/metrics",
+						  	"delimiter": "/",
+						  	"includeTags": false,
+							"additionalStorageClasses" : ["STANDARD_IA"]
+						}
+					]
+				}
+			}
+		]`)
+	})
+
+	dataFederationInstances, _, err := client.DataFederation.List(ctx, groupID)
+	if err != nil {
+		t.Fatalf("DataFederation.List returned error: %v", err)
+	}
+
+	expected := []*DataFederationInstance{
+		{
+			CloudProviderConfig: &CloudProviderConfig{
+				AWSConfig: AwsCloudProviderConfig{
+					ExternalID:        "test",
+					IAMAssumedRoleARN: "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+					IAMUserARN:        "test",
+					RoleID:            "test",
+				},
+			},
+			DataProcessRegion: &DataProcessRegion{
+				CloudProvider: "AWS",
+				Region:        "VIRGINIA_USA",
+			},
+			Name: "UserMetricData",
+			Storage: &DataFederationStorage{
+				Databases: []*DataFederationDatabase{
+					{
+						Name: "my.database",
+						Collections: []*DataFederationCollection{
+							{
+								Name: "my.collection",
+								DataSources: []*DataFederationDataSource{
+									{
+										AllowInsecure:       pointer(false),
+										Collection:          "test",
+										CollectionRegex:     "test",
+										Database:            "test",
+										DatabaseRegex:       "test",
+										DefaultFormat:       ".json",
+										Path:                "/path",
+										ProvenanceFieldName: "test",
+										StoreName:           "store",
+										Urls:                []*string{pointer("test")},
+									},
+								},
+							},
+						},
+						Views: []*DataFederationDatabaseView{
+							{
+								Name:     "my.view",
+								Source:   "source",
+								Pipeline: "my.pipeline",
+							},
+						},
+						MaxWildcardCollections: 92,
+					},
+				},
+				Stores: []*DataFederationStore{
+					{
+						Name:                     "datacenter-alpha",
+						Provider:                 "s3",
+						Region:                   "us-east-1",
+						Bucket:                   "datacenter-alpha",
+						Prefix:                   "/metrics",
+						Delimiter:                "/",
+						IncludeTags:              pointer(false),
+						AdditionalStorageClasses: []*string{pointer("STANDARD_IA")},
+					},
+				},
+			},
+		},
+	}
+
+	if diff := deep.Equal(dataFederationInstances, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDataFederation_Get(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+	tenantName := "test"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation/%s", groupID, tenantName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `
+			{
+				"cloudProviderConfig": {
+					"aws": {
+					  	"iamAssumedRoleARN": "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+						"externalId": "test",
+						"iamUserARN": "test",
+						"roleId": "test"
+				  	}
+			  	},
+			  	"dataProcessRegion": {
+					"cloudProvider" : "AWS",
+					"region" : "VIRGINIA_USA"
+			  	},
+			  	"name": "UserMetricData",
+			  	"storage": {
+				  	"databases": [
+						{
+							"name": "my.database",
+							"collections": [
+								{
+									"name": "my.collection",
+									"dataSources": [
+										{
+												"storeName" : "store",
+												"defaultFormat" : ".json",
+												"path" : "/path",
+												"allowInsecure": false,
+												"database": "test",
+												"databaseRegex": "test",
+												"collection": "test",
+												"collectionRegex": "test",
+												"provenanceFieldName": "test",
+												"urls": ["test"]
+										}
+									]
+								}
+							],
+							"views": [
+								{
+									"name" : "my.view",
+									"source" : "source",
+									"pipeline" : "my.pipeline"
+								}
+							],
+							"maxWildcardCollections" : 92
+						}
+					],
+					"stores": [
+						{
+							"name": "datacenter-alpha",
+							"provider": "s3",
+						  	"region": "us-east-1",
+						  	"bucket": "datacenter-alpha",
+						  	"prefix": "/metrics",
+						  	"delimiter": "/",
+						  	"includeTags": false,
+							"additionalStorageClasses" : ["STANDARD_IA"]
+						}
+					]
+				}
+			}`)
+	})
+
+	dataFederationInstance, _, err := client.DataFederation.Get(ctx, groupID, tenantName)
+	if err != nil {
+		t.Fatalf("DataFederation.Get returned error: %v", err)
+	}
+
+	expected := &DataFederationInstance{
+		CloudProviderConfig: &CloudProviderConfig{
+			AWSConfig: AwsCloudProviderConfig{
+				ExternalID:        "test",
+				IAMAssumedRoleARN: "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+				IAMUserARN:        "test",
+				RoleID:            "test",
+			},
+		},
+		DataProcessRegion: &DataProcessRegion{
+			CloudProvider: "AWS",
+			Region:        "VIRGINIA_USA",
+		},
+		Name: "UserMetricData",
+		Storage: &DataFederationStorage{
+			Databases: []*DataFederationDatabase{
+				{
+					Name: "my.database",
+					Collections: []*DataFederationCollection{
+						{
+							Name: "my.collection",
+							DataSources: []*DataFederationDataSource{
+								{
+									AllowInsecure:       pointer(false),
+									Collection:          "test",
+									CollectionRegex:     "test",
+									Database:            "test",
+									DatabaseRegex:       "test",
+									DefaultFormat:       ".json",
+									Path:                "/path",
+									ProvenanceFieldName: "test",
+									StoreName:           "store",
+									Urls:                []*string{pointer("test")},
+								},
+							},
+						},
+					},
+					Views: []*DataFederationDatabaseView{
+						{
+							Name:     "my.view",
+							Source:   "source",
+							Pipeline: "my.pipeline",
+						},
+					},
+					MaxWildcardCollections: 92,
+				},
+			},
+			Stores: []*DataFederationStore{
+				{
+					Name:                     "datacenter-alpha",
+					Provider:                 "s3",
+					Region:                   "us-east-1",
+					Bucket:                   "datacenter-alpha",
+					Prefix:                   "/metrics",
+					Delimiter:                "/",
+					IncludeTags:              pointer(false),
+					AdditionalStorageClasses: []*string{pointer("STANDARD_IA")},
+				},
+			},
+		},
+	}
+
+	if diff := deep.Equal(dataFederationInstance, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDataFederation_Create(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation", groupID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `
+			{
+				"cloudProviderConfig": {
+					"aws": {
+					  	"iamAssumedRoleARN": "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+						"externalId": "test",
+						"iamUserARN": "test",
+						"roleId": "test"
+				  	}
+			  	},
+			  	"dataProcessRegion": {
+					"cloudProvider" : "AWS",
+					"region" : "VIRGINIA_USA"
+			  	},
+			  	"name": "UserMetricData",
+			  	"storage": {
+				  	"databases": [
+						{
+							"name": "my.database",
+							"collections": [
+								{
+									"name": "my.collection",
+									"dataSources": [
+										{
+												"storeName" : "store",
+												"defaultFormat" : ".json",
+												"path" : "/path",
+												"allowInsecure": false,
+												"database": "test",
+												"databaseRegex": "test",
+												"collection": "test",
+												"collectionRegex": "test",
+												"provenanceFieldName": "test",
+												"urls": ["test"]
+										}
+									]
+								}
+							],
+							"views": [
+								{
+									"name" : "my.view",
+									"source" : "source",
+									"pipeline" : "my.pipeline"
+								}
+							],
+							"maxWildcardCollections" : 92
+						}
+					],
+					"stores": [
+						{
+							"name": "datacenter-alpha",
+							"provider": "s3",
+						  	"region": "us-east-1",
+						  	"bucket": "datacenter-alpha",
+						  	"prefix": "/metrics",
+						  	"delimiter": "/",
+						  	"includeTags": false,
+							"additionalStorageClasses" : ["STANDARD_IA"]
+						}
+					]
+				}
+			}`)
+	})
+
+	requestBody := &DataFederationInstance{
+		CloudProviderConfig: &CloudProviderConfig{
+			AWSConfig: AwsCloudProviderConfig{
+				ExternalID:        "test",
+				IAMAssumedRoleARN: "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+				IAMUserARN:        "test",
+				RoleID:            "test",
+			},
+		},
+		DataProcessRegion: &DataProcessRegion{
+			CloudProvider: "AWS",
+			Region:        "VIRGINIA_USA",
+		},
+		Name: "UserMetricData",
+		Storage: &DataFederationStorage{
+			Databases: []*DataFederationDatabase{
+				{
+					Name: "my.database",
+					Collections: []*DataFederationCollection{
+						{
+							Name: "my.collection",
+							DataSources: []*DataFederationDataSource{
+								{
+									AllowInsecure:       pointer(false),
+									Collection:          "test",
+									CollectionRegex:     "test",
+									Database:            "test",
+									DatabaseRegex:       "test",
+									DefaultFormat:       ".json",
+									Path:                "/path",
+									ProvenanceFieldName: "test",
+									StoreName:           "store",
+									Urls:                []*string{pointer("test")},
+								},
+							},
+						},
+					},
+					Views: []*DataFederationDatabaseView{
+						{
+							Name:     "my.view",
+							Source:   "source",
+							Pipeline: "my.pipeline",
+						},
+					},
+					MaxWildcardCollections: 92,
+				},
+			},
+			Stores: []*DataFederationStore{
+				{
+					Name:                     "datacenter-alpha",
+					Provider:                 "s3",
+					Region:                   "us-east-1",
+					Bucket:                   "datacenter-alpha",
+					Prefix:                   "/metrics",
+					Delimiter:                "/",
+					IncludeTags:              pointer(false),
+					AdditionalStorageClasses: []*string{pointer("STANDARD_IA")},
+				},
+			},
+		},
+	}
+	dataFederationInstance, _, err := client.DataFederation.Create(ctx, groupID, requestBody)
+	if err != nil {
+		t.Fatalf("DataFederation.Create returned error: %v", err)
+	}
+
+	expected := &DataFederationInstance{
+		CloudProviderConfig: &CloudProviderConfig{
+			AWSConfig: AwsCloudProviderConfig{
+				ExternalID:        "test",
+				IAMAssumedRoleARN: "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+				IAMUserARN:        "test",
+				RoleID:            "test",
+			},
+		},
+		DataProcessRegion: &DataProcessRegion{
+			CloudProvider: "AWS",
+			Region:        "VIRGINIA_USA",
+		},
+		Name: "UserMetricData",
+		Storage: &DataFederationStorage{
+			Databases: []*DataFederationDatabase{
+				{
+					Name: "my.database",
+					Collections: []*DataFederationCollection{
+						{
+							Name: "my.collection",
+							DataSources: []*DataFederationDataSource{
+								{
+									AllowInsecure:       pointer(false),
+									Collection:          "test",
+									CollectionRegex:     "test",
+									Database:            "test",
+									DatabaseRegex:       "test",
+									DefaultFormat:       ".json",
+									Path:                "/path",
+									ProvenanceFieldName: "test",
+									StoreName:           "store",
+									Urls:                []*string{pointer("test")},
+								},
+							},
+						},
+					},
+					Views: []*DataFederationDatabaseView{
+						{
+							Name:     "my.view",
+							Source:   "source",
+							Pipeline: "my.pipeline",
+						},
+					},
+					MaxWildcardCollections: 92,
+				},
+			},
+			Stores: []*DataFederationStore{
+				{
+					Name:                     "datacenter-alpha",
+					Provider:                 "s3",
+					Region:                   "us-east-1",
+					Bucket:                   "datacenter-alpha",
+					Prefix:                   "/metrics",
+					Delimiter:                "/",
+					IncludeTags:              pointer(false),
+					AdditionalStorageClasses: []*string{pointer("STANDARD_IA")},
+				},
+			},
+		},
+	}
+
+	if diff := deep.Equal(dataFederationInstance, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDataFederation_Update(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+	tenantName := "test"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation/%s", groupID, tenantName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		fmt.Fprint(w, `
+			{
+				"cloudProviderConfig": {
+					"aws": {
+					  	"iamAssumedRoleARN": "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+						"externalId": "test",
+						"iamUserARN": "test",
+						"roleId": "test"
+				  	}
+			  	},
+			  	"dataProcessRegion": {
+					"cloudProvider" : "AWS",
+					"region" : "VIRGINIA_USA"
+			  	},
+			  	"name": "UserMetricData",
+			  	"storage": {
+				  	"databases": [
+						{
+							"name": "my.database",
+							"collections": [
+								{
+									"name": "my.collection",
+									"dataSources": [
+										{
+												"storeName" : "store",
+												"defaultFormat" : ".json",
+												"path" : "/path",
+												"allowInsecure": false,
+												"database": "test",
+												"databaseRegex": "test",
+												"collection": "test",
+												"collectionRegex": "test",
+												"provenanceFieldName": "test",
+												"urls": ["test"]
+										}
+									]
+								}
+							],
+							"views": [
+								{
+									"name" : "my.view",
+									"source" : "source",
+									"pipeline" : "my.pipeline"
+								}
+							],
+							"maxWildcardCollections" : 92
+						}
+					],
+					"stores": [
+						{
+							"name": "datacenter-alpha",
+							"provider": "s3",
+						  	"region": "us-east-1",
+						  	"bucket": "datacenter-alpha",
+						  	"prefix": "/metrics",
+						  	"delimiter": "/",
+						  	"includeTags": false,
+							"additionalStorageClasses" : ["STANDARD_IA"]
+						}
+					]
+				}
+			}`)
+	})
+
+	requestBody := &DataFederationInstance{
+		CloudProviderConfig: &CloudProviderConfig{
+			AWSConfig: AwsCloudProviderConfig{
+				ExternalID:        "test",
+				IAMAssumedRoleARN: "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+				IAMUserARN:        "test",
+				RoleID:            "test",
+			},
+		},
+		DataProcessRegion: &DataProcessRegion{
+			CloudProvider: "AWS",
+			Region:        "VIRGINIA_USA",
+		},
+		Name: "UserMetricData",
+		Storage: &DataFederationStorage{
+			Databases: []*DataFederationDatabase{
+				{
+					Name: "my.database",
+					Collections: []*DataFederationCollection{
+						{
+							Name: "my.collection",
+							DataSources: []*DataFederationDataSource{
+								{
+									AllowInsecure:       pointer(false),
+									Collection:          "test",
+									CollectionRegex:     "test",
+									Database:            "test",
+									DatabaseRegex:       "test",
+									DefaultFormat:       ".json",
+									Path:                "/path",
+									ProvenanceFieldName: "test",
+									StoreName:           "store",
+									Urls:                []*string{pointer("test")},
+								},
+							},
+						},
+					},
+					Views: []*DataFederationDatabaseView{
+						{
+							Name:     "my.view",
+							Source:   "source",
+							Pipeline: "my.pipeline",
+						},
+					},
+					MaxWildcardCollections: 92,
+				},
+			},
+			Stores: []*DataFederationStore{
+				{
+					Name:                     "datacenter-alpha",
+					Provider:                 "s3",
+					Region:                   "us-east-1",
+					Bucket:                   "datacenter-alpha",
+					Prefix:                   "/metrics",
+					Delimiter:                "/",
+					IncludeTags:              pointer(false),
+					AdditionalStorageClasses: []*string{pointer("STANDARD_IA")},
+				},
+			},
+		},
+	}
+	dataFederationInstance, _, err := client.DataFederation.Update(ctx, groupID, tenantName, requestBody)
+	if err != nil {
+		t.Fatalf("DataFederation.Update returned error: %v", err)
+	}
+
+	expected := &DataFederationInstance{
+		CloudProviderConfig: &CloudProviderConfig{
+			AWSConfig: AwsCloudProviderConfig{
+				ExternalID:        "test",
+				IAMAssumedRoleARN: "arn:aws:iam::123456789012:role/ReadS3BucketRole",
+				IAMUserARN:        "test",
+				RoleID:            "test",
+			},
+		},
+		DataProcessRegion: &DataProcessRegion{
+			CloudProvider: "AWS",
+			Region:        "VIRGINIA_USA",
+		},
+		Name: "UserMetricData",
+		Storage: &DataFederationStorage{
+			Databases: []*DataFederationDatabase{
+				{
+					Name: "my.database",
+					Collections: []*DataFederationCollection{
+						{
+							Name: "my.collection",
+							DataSources: []*DataFederationDataSource{
+								{
+									AllowInsecure:       pointer(false),
+									Collection:          "test",
+									CollectionRegex:     "test",
+									Database:            "test",
+									DatabaseRegex:       "test",
+									DefaultFormat:       ".json",
+									Path:                "/path",
+									ProvenanceFieldName: "test",
+									StoreName:           "store",
+									Urls:                []*string{pointer("test")},
+								},
+							},
+						},
+					},
+					Views: []*DataFederationDatabaseView{
+						{
+							Name:     "my.view",
+							Source:   "source",
+							Pipeline: "my.pipeline",
+						},
+					},
+					MaxWildcardCollections: 92,
+				},
+			},
+			Stores: []*DataFederationStore{
+				{
+					Name:                     "datacenter-alpha",
+					Provider:                 "s3",
+					Region:                   "us-east-1",
+					Bucket:                   "datacenter-alpha",
+					Prefix:                   "/metrics",
+					Delimiter:                "/",
+					IncludeTags:              pointer(false),
+					AdditionalStorageClasses: []*string{pointer("STANDARD_IA")},
+				},
+			},
+		},
+	}
+
+	if diff := deep.Equal(dataFederationInstance, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDataFederation_Delete(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+	tenantName := "test"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation/%s", groupID, tenantName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.DataFederation.Delete(ctx, groupID, tenantName)
+	if err != nil {
+		t.Fatalf("DataFederation.Delete returned error: %v", err)
+	}
+}

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -153,6 +153,7 @@ type Client struct {
 	CloudProviderSnapshotExportBuckets  CloudProviderSnapshotExportBucketsService
 	CloudProviderSnapshotExportJobs     CloudProviderSnapshotExportJobsService
 	FederatedSettings                   FederatedSettingsService
+	DataFederation                      DataFederationService
 	ClusterOutageSimulation             ClusterOutageSimulationService
 
 	onRequestCompleted  RequestCompletionCallback
@@ -304,6 +305,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.CloudProviderSnapshotExportJobs = &CloudProviderSnapshotExportJobsServiceOp{Client: c}
 	c.FederatedSettings = &FederatedSettingsServiceOp{Client: c}
 	c.ClusterOutageSimulation = &ClusterOutageSimulationServiceOp{Client: c}
+	c.DataFederation = &DataFederationServiceOp{Client: c}
 	return c
 }
 


### PR DESCRIPTION
## Description

This PR adds [Data Federation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation) supports to the Go SDK

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

