### PR TITLE
INTMDB-813: 0.26.0 pre-release

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,4 +1,4 @@
-future-release=v0.25.0
-since-tag=v0.24.0
+future-release=v0.26.0
+since-tag=v0.25.0
 date-format=%B %d, %Y
 base=CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.26.0](https://github.com/mongodb/go-client-mongodb-atlas/tree/v0.26.0) (May 11, 2023)
+
+[Full Changelog](https://github.com/mongodb/go-client-mongodb-atlas/compare/v0.25.0...v0.26.0)
+
+**Closed issues:**
+
+- `setListOptions` does not include options from embedded `ListOptions` [\#381](https://github.com/mongodb/go-client-mongodb-atlas/issues/381)
+
+**Merged pull requests:**
+
+- INTMDB-801: Add Data Federation to the go client [\#472](https://github.com/mongodb/go-client-mongodb-atlas/pull/472) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- task: lower stale action permissions [\#469](https://github.com/mongodb/go-client-mongodb-atlas/pull/469) ([gssbzn](https://github.com/gssbzn))
+- test: update actions to use the new go action values [\#468](https://github.com/mongodb/go-client-mongodb-atlas/pull/468) ([gssbzn](https://github.com/gssbzn))
+- Revert "CLOUDP-169104: Fix encoding for AWS IAM usernames \(\#452\)" [\#465](https://github.com/mongodb/go-client-mongodb-atlas/pull/465) ([matt-condon](https://github.com/matt-condon))
+
 ## [v0.25.0](https://github.com/mongodb/go-client-mongodb-atlas/tree/v0.25.0) (April 17, 2023)
 
 [Full Changelog](https://github.com/mongodb/go-client-mongodb-atlas/compare/v0.24.0...v0.25.0)

--- a/mongodbatlas/mongodbatlas.go
+++ b/mongodbatlas/mongodbatlas.go
@@ -41,7 +41,7 @@ const (
 	gzipMediaType  = "application/gzip"
 	libraryName    = "go-mongodbatlas"
 	// Version the version of the current API client. Should be set to the next version planned to be released.
-	Version = "0.25.0"
+	Version = "0.26.0"
 )
 
 var (


### PR DESCRIPTION
## Description

Releasing new version of Atlas go-client to support fix for [INTMDB-809](https://jira.mongodb.org/browse/INTMDB-809) ([#465](https://github.com/mongodb/go-client-mongodb-atlas/pull/465) is the main fix) and adding support for Data Federation.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

