### PR TITLE
INTMDB-802: Add Data Federation Query Limit

### DIFF
--- a/mongodbatlas/data_federation.go
+++ b/mongodbatlas/data_federation.go
@@ -34,7 +34,7 @@ type DataFederationService interface {
 	Create(context.Context, string, *DataFederationInstance) (*DataFederationInstance, *Response, error)
 	Update(context.Context, string, string, *DataFederationInstance, *DataFederationUpdateOptions) (*DataFederationInstance, *Response, error)
 	Delete(context.Context, string, string) (*Response, error)
-	ListQueryLimit(context.Context, string, string) ([]*DataFederationQueryLimit, *Response, error)
+	ListQueryLimits(context.Context, string, string) ([]*DataFederationQueryLimit, *Response, error)
 	GetQueryLimit(context.Context, string, string, string) (*DataFederationQueryLimit, *Response, error)
 	ConfigureQueryLimit(context.Context, string, string, string, *DataFederationQueryLimit) (*DataFederationQueryLimit, *Response, error)
 	DeleteQueryLimit(context.Context, string, string, string) (*Response, error)
@@ -374,7 +374,7 @@ func (s *DataFederationServiceOp) GetQueryLimit(ctx context.Context, groupID, na
 	return root, resp, err
 }
 
-func (s *DataFederationServiceOp) ListQueryLimit(ctx context.Context, groupID, name string) ([]*DataFederationQueryLimit, *Response, error) {
+func (s *DataFederationServiceOp) ListQueryLimits(ctx context.Context, groupID, name string) ([]*DataFederationQueryLimit, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}

--- a/mongodbatlas/data_federation.go
+++ b/mongodbatlas/data_federation.go
@@ -290,7 +290,7 @@ func (s *DataFederationServiceOp) Delete(ctx context.Context, groupID, name stri
 // ConfigureQueryLimit Creates or updates one query limit for one federated database instance.
 //
 // See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/createOneDataFederationQueryLimit
-func (s *DataFederationServiceOp) ConfigureQueryLimit(ctx context.Context, groupID string, name string, limitName string, queryLimit *DataFederationQueryLimit) (*DataFederationQueryLimit, *Response, error) {
+func (s *DataFederationServiceOp) ConfigureQueryLimit(ctx context.Context, groupID, name, limitName string, queryLimit *DataFederationQueryLimit) (*DataFederationQueryLimit, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}
@@ -320,7 +320,7 @@ func (s *DataFederationServiceOp) ConfigureQueryLimit(ctx context.Context, group
 	return root, resp, err
 }
 
-func (s *DataFederationServiceOp) DeleteQueryLimit(ctx context.Context, groupID string, name string, limitName string) (*Response, error) {
+func (s *DataFederationServiceOp) DeleteQueryLimit(ctx context.Context, groupID, name, limitName string) (*Response, error) {
 	if groupID == "" {
 		return nil, NewArgError("groupId", "must be set")
 	}
@@ -344,7 +344,7 @@ func (s *DataFederationServiceOp) DeleteQueryLimit(ctx context.Context, groupID 
 	return resp, err
 }
 
-func (s *DataFederationServiceOp) GetQueryLimit(ctx context.Context, groupID string, name string, limitName string) (*DataFederationQueryLimit, *Response, error) {
+func (s *DataFederationServiceOp) GetQueryLimit(ctx context.Context, groupID, name, limitName string) (*DataFederationQueryLimit, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}
@@ -372,7 +372,7 @@ func (s *DataFederationServiceOp) GetQueryLimit(ctx context.Context, groupID str
 	return root, resp, err
 }
 
-func (s *DataFederationServiceOp) ListQueryLimit(ctx context.Context, groupID string, name string) ([]*DataFederationQueryLimit, *Response, error) {
+func (s *DataFederationServiceOp) ListQueryLimit(ctx context.Context, groupID, name string) ([]*DataFederationQueryLimit, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupID", "must be set")
 	}

--- a/mongodbatlas/data_federation_test.go
+++ b/mongodbatlas/data_federation_test.go
@@ -777,7 +777,7 @@ func TestDataFederationQueryLimit_List(t *testing.T) {
     	}]`)
 	})
 
-	dataFederationQueryLimits, _, err := client.DataFederation.ListQueryLimit(ctx, groupID, tenantName)
+	dataFederationQueryLimits, _, err := client.DataFederation.ListQueryLimits(ctx, groupID, tenantName)
 	if err != nil {
 		t.Fatalf("DataFederation.ListQueryLimit returned error: %v", err)
 	}

--- a/mongodbatlas/data_federation_test.go
+++ b/mongodbatlas/data_federation_test.go
@@ -835,7 +835,7 @@ func TestDataFederationQueryLimit_Get(t *testing.T) {
 	}
 }
 
-func TestDataFederation_Configure_Create(t *testing.T) {
+func TestDataFederation_Configure(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
 

--- a/mongodbatlas/data_federation_test.go
+++ b/mongodbatlas/data_federation_test.go
@@ -751,3 +751,148 @@ func TestDataFederation_Delete(t *testing.T) {
 		t.Fatalf("DataFederation.Delete returned error: %v", err)
 	}
 }
+
+func TestDataFederationQueryLimit_List(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+	tenantName := "TestInstance"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation/%s/limits", groupID, tenantName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[{
+        	"currentUsage": 0,
+        	"lastModifiedDate": "2023-05-12T10:41:03Z",
+			"name": "bytesProcessed.daily",
+        	"overrunPolicy": "BLOCK",
+        	"tenantName": "TestInstance",
+        	"value": 2147483648
+    	}]`)
+	})
+
+	dataFederationQueryLimits, _, err := client.DataFederation.ListQueryLimit(ctx, groupID, tenantName)
+	if err != nil {
+		t.Fatalf("DataFederation.ListQueryLimit returned error: %v", err)
+	}
+
+	expected := []*DataFederationQueryLimit{
+		{
+			CurrentUsage:     0,
+			LastModifiedDate: "2023-05-12T10:41:03Z",
+			Name:             "bytesProcessed.daily",
+			OverrunPolicy:    "BLOCK",
+			TenantName:       "TestInstance",
+			Value:            2147483648,
+		},
+	}
+
+	if diff := deep.Equal(dataFederationQueryLimits, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDataFederationQueryLimit_Get(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+	tenantName := "TestInstance"
+	limitName := "bytesProcessed.daily"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation/%s/limits/%s", groupID, tenantName, limitName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+    		"currentUsage": 0,
+    		"lastModifiedDate": "2023-05-12T10:41:03Z",
+    		"name": "bytesProcessed.daily",
+    		"overrunPolicy": "BLOCK",
+    		"tenantName": "TestInstance",
+    		"value": 2147483648
+		}`)
+	})
+
+	dataFederationQueryLimits, _, err := client.DataFederation.GetQueryLimit(ctx, groupID, tenantName, limitName)
+	if err != nil {
+		t.Fatalf("DataFederation.GetQueryLimit returned error: %v", err)
+	}
+
+	expected := DataFederationQueryLimit{
+		CurrentUsage:     0,
+		LastModifiedDate: "2023-05-12T10:41:03Z",
+		Name:             "bytesProcessed.daily",
+		OverrunPolicy:    "BLOCK",
+		TenantName:       "TestInstance",
+		Value:            2147483648,
+	}
+
+	if diff := deep.Equal(*dataFederationQueryLimits, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDataFederation_Configure_Create(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+	tenantName := "TestInstance"
+	limitName := "bytesProcessed.daily"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation/%s/limits/%s", groupID, tenantName, limitName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		fmt.Fprint(w, `{
+    		"currentUsage": 0,
+    		"lastModifiedDate": "2023-05-12T10:41:03Z",
+    		"name": "bytesProcessed.daily",
+    		"overrunPolicy": "BLOCK",
+    		"tenantName": "TestInstance",
+    		"value": 2147483648
+		}`)
+	})
+
+	requestBody := &DataFederationQueryLimit{OverrunPolicy: "BLOCK", Value: 2147483648}
+	dataFederationQueryLimit, _, err := client.DataFederation.ConfigureQueryLimit(ctx, groupID, tenantName, limitName, requestBody)
+	if err != nil {
+		t.Fatalf("DataFederation.ConfigureQueryLimit returned error: %v", err)
+	}
+
+	expected := DataFederationQueryLimit{
+		CurrentUsage:     0,
+		LastModifiedDate: "2023-05-12T10:41:03Z",
+		Name:             "bytesProcessed.daily",
+		OverrunPolicy:    "BLOCK",
+		TenantName:       "TestInstance",
+		Value:            2147483648,
+	}
+
+	if diff := deep.Equal(*dataFederationQueryLimit, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDataFederationQueryLimit_Delete(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "6c7498dg87d9e6526801572b"
+	tenantName := "TestInstance"
+	limitName := "bytesProcessed.daily"
+
+	path := fmt.Sprintf("/api/atlas/v1.0/groups/%s/dataFederation/%s/limits/%s", groupID, tenantName, limitName)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.DataFederation.DeleteQueryLimit(ctx, groupID, tenantName, limitName)
+	if err != nil {
+		t.Fatalf("DataFederation.DeleteQueryLimit returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Add Data Federation Query Limit to go-client.

Link to any related issue(s): [INTMDB-802](https://jira.mongodb.org/browse/INTMDB-802)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

