### PR TITLE
INTMDB-801: Add State and Hostnames fields to Data Federation

### DIFF
--- a/mongodbatlas/data_federation.go
+++ b/mongodbatlas/data_federation.go
@@ -47,6 +47,8 @@ type DataFederationInstance struct {
 	DataProcessRegion   *DataProcessRegion     `json:"dataProcessRegion,omitempty"`
 	Storage             *DataFederationStorage `json:"storage,omitempty"`
 	Name                string                 `json:"name,omitempty"`
+	State               string                 `json:"state,omitempty"`
+	Hostnames           []string               `json:"hostnames,omitempty"`
 }
 
 // DataFederationStorage represents the storage configuration for a data lake.

--- a/mongodbatlas/data_federation_test.go
+++ b/mongodbatlas/data_federation_test.go
@@ -343,6 +343,8 @@ func TestDataFederation_Create(t *testing.T) {
 					"region" : "VIRGINIA_USA"
 			  	},
 			  	"name": "UserMetricData",
+			  	"state": "ACTIVE",
+			  	"hostnames": ["test.mongodb-dev.net"],
 			  	"storage": {
 				  	"databases": [
 						{
@@ -471,7 +473,9 @@ func TestDataFederation_Create(t *testing.T) {
 			CloudProvider: "AWS",
 			Region:        "VIRGINIA_USA",
 		},
-		Name: "UserMetricData",
+		Name:      "UserMetricData",
+		State:     "ACTIVE",
+		Hostnames: []string{"test.mongodb-dev.net"},
 		Storage: &DataFederationStorage{
 			Databases: []*DataFederationDatabase{
 				{


### PR DESCRIPTION
## Description
Follow-up PR of #475. Adding Hostanames and State fields to Data Federation. 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

