### PR TITLE
INTMDB-781: Query Parameter Add: retainBackups in Cluster and Advanced_Cluster

### DIFF
--- a/mongodbatlas/advanced_clusters.go
+++ b/mongodbatlas/advanced_clusters.go
@@ -111,7 +111,7 @@ type AdvancedClustersResponse struct {
 
 type DeleteAdvanceClusterOptions struct {
 	// Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.
-	RetainBackups bool `url:"retainBackups,omitempty"`
+	RetainBackups *bool `url:"retainBackups,omitempty"`
 }
 
 // List all clusters in the project associated to {GROUP-ID}.
@@ -243,12 +243,6 @@ func (s *AdvancedClustersServiceOp) Delete(ctx context.Context, groupID, cluster
 	basePath := fmt.Sprintf(advancedClustersPath, groupID)
 	escapedEntry := url.PathEscape(clusterName)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
-
-	if options == nil {
-		options = &DeleteAdvanceClusterOptions{
-			RetainBackups: false,
-		}
-	}
 
 	// Add query params from options
 	path, err := setListOptions(path, options)

--- a/mongodbatlas/advanced_clusters.go
+++ b/mongodbatlas/advanced_clusters.go
@@ -32,7 +32,7 @@ type AdvancedClustersService interface {
 	Get(ctx context.Context, groupID, clusterName string) (*AdvancedCluster, *Response, error)
 	Create(ctx context.Context, groupID string, cluster *AdvancedCluster) (*AdvancedCluster, *Response, error)
 	Update(ctx context.Context, groupID, clusterName string, cluster *AdvancedCluster) (*AdvancedCluster, *Response, error)
-	Delete(ctx context.Context, groupID, clusterName string) (*Response, error)
+	Delete(ctx context.Context, groupID, clusterName string, options *DeleteAdvanceClusterOptions) (*Response, error)
 	TestFailover(ctx context.Context, groupID, clusterName string) (*Response, error)
 }
 
@@ -107,6 +107,11 @@ type AdvancedClustersResponse struct {
 	Links      []*Link            `json:"links,omitempty"`
 	Results    []*AdvancedCluster `json:"results,omitempty"`
 	TotalCount int                `json:"totalCount,omitempty"`
+}
+
+type DeleteAdvanceClusterOptions struct {
+	// Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.
+	RetainBackups bool `url:"retainBackups,omitempty"`
 }
 
 // List all clusters in the project associated to {GROUP-ID}.
@@ -227,7 +232,7 @@ func (s *AdvancedClustersServiceOp) Update(ctx context.Context, groupID, cluster
 }
 
 // Delete the cluster specified to {CLUSTER-NAME} from the project associated to {GROUP-ID}.
-func (s *AdvancedClustersServiceOp) Delete(ctx context.Context, groupID, clusterName string) (*Response, error) {
+func (s *AdvancedClustersServiceOp) Delete(ctx context.Context, groupID, clusterName string, options *DeleteAdvanceClusterOptions) (*Response, error) {
 	if groupID == "" {
 		return nil, NewArgError("groupId", "must be set")
 	}
@@ -238,6 +243,18 @@ func (s *AdvancedClustersServiceOp) Delete(ctx context.Context, groupID, cluster
 	basePath := fmt.Sprintf(advancedClustersPath, groupID)
 	escapedEntry := url.PathEscape(clusterName)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
+
+	if options == nil {
+		options = &DeleteAdvanceClusterOptions{
+			RetainBackups: false,
+		}
+	}
+
+	// Add query params from options
+	path, err := setListOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {

--- a/mongodbatlas/advanced_clusters_test.go
+++ b/mongodbatlas/advanced_clusters_test.go
@@ -1266,7 +1266,7 @@ func TestAdvancedClusters_Delete(t *testing.T) {
 	})
 
 	options := &DeleteAdvanceClusterOptions{
-		RetainBackups: true,
+		RetainBackups: pointer(true),
 	}
 	_, err := client.AdvancedClusters.Delete(ctx, groupID, clusterName, options)
 	if err != nil {

--- a/mongodbatlas/advanced_clusters_test.go
+++ b/mongodbatlas/advanced_clusters_test.go
@@ -1265,7 +1265,10 @@ func TestAdvancedClusters_Delete(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
-	_, err := client.AdvancedClusters.Delete(ctx, groupID, clusterName)
+	options := &DeleteAdvanceClusterOptions{
+		RetainBackups: true,
+	}
+	_, err := client.AdvancedClusters.Delete(ctx, groupID, clusterName, options)
 	if err != nil {
 		t.Fatalf("Cluster.Delete returned error: %v", err)
 	}

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -434,12 +434,6 @@ func (s *ClustersServiceOp) Delete(ctx context.Context, groupID, clusterName str
 	escapedEntry := url.PathEscape(clusterName)
 	path := fmt.Sprintf("%s/%s", basePath, escapedEntry)
 
-	if options == nil {
-		options = &DeleteAdvanceClusterOptions{
-			RetainBackups: false,
-		}
-	}
-
 	// Add query params from options
 	path, err := setListOptions(path, options)
 	if err != nil {

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -745,7 +745,11 @@ func TestClusters_Delete(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
-	_, err := client.Clusters.Delete(ctx, groupID, name)
+	options := &DeleteAdvanceClusterOptions{
+		RetainBackups: true,
+	}
+
+	_, err := client.Clusters.Delete(ctx, groupID, name, options)
 	if err != nil {
 		t.Fatalf("Cluster.Delete returned error: %v", err)
 	}

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -746,7 +746,7 @@ func TestClusters_Delete(t *testing.T) {
 	})
 
 	options := &DeleteAdvanceClusterOptions{
-		RetainBackups: true,
+		RetainBackups: pointer(true),
 	}
 
 	_, err := client.Clusters.Delete(ctx, groupID, name, options)


### PR DESCRIPTION
## Description

This PR adds support for the query param `retainBackups` in cluster and advance cluster

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

