### PR TITLE
INTMDB-860: [GO SDK] Add missing endpoint to organization resource

### DIFF
--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -29,6 +29,7 @@ type OrganizationsService interface {
 	List(context.Context, *OrganizationsListOptions) (*Organizations, *Response, error)
 	Invitations(context.Context, string, *InvitationOptions) ([]*Invitation, *Response, error)
 	Get(context.Context, string) (*Organization, *Response, error)
+	Update(context.Context, string, *Organization) (*Organization, *Response, error)
 	Create(context.Context, *CreateOrganizationRequest) (*CreateOrganizationResponse, *Response, error)
 	Invitation(context.Context, string, string) (*Invitation, *Response, error)
 	Projects(context.Context, string, *ProjectsListOptions) (*Projects, *Response, error)
@@ -125,6 +126,30 @@ func (s *OrganizationsServiceOp) Get(ctx context.Context, orgID string) (*Organi
 	path := fmt.Sprintf("%s/%s", orgsBasePath, orgID)
 
 	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(Organization)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Update updates a single organization.
+//
+// See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Organizations/operation/renameOrganization
+func (s *OrganizationsServiceOp) Update(ctx context.Context, orgID string, org *Organization) (*Organization, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+
+	path := fmt.Sprintf("%s/%s", orgsBasePath, orgID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, org)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mongodbatlas/organizations_test.go
+++ b/mongodbatlas/organizations_test.go
@@ -210,6 +210,45 @@ func TestOrganizationsServiceOp_Get(t *testing.T) {
 	}
 }
 
+func TestOrganizationsServiceOp_Update(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/%s/%s", orgsBasePath, orgID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		_, _ = fmt.Fprint(w, `{
+		"id": "5a0a1e7e0f2912c554080adc",
+		"lastActiveAgent": "2016-03-09T18:19:37Z",
+		"links": [{
+			"href": "https://cloud.mongodb.com/api/public/v1.0/orgs/5a0a1e7e0f2912c554080adc",
+			"rel": "self"
+		}],
+		"name": "test"
+	  }`)
+	})
+
+	body := &Organization{Name: "test"}
+	response, _, err := client.Organizations.Update(ctx, orgID, body)
+	if err != nil {
+		t.Fatalf("Organizations.Update returned error: %v", err)
+	}
+
+	expected := &Organization{
+		ID: "5a0a1e7e0f2912c554080adc",
+		Links: []*Link{
+			{
+				Href: "https://cloud.mongodb.com/api/public/v1.0/orgs/5a0a1e7e0f2912c554080adc",
+				Rel:  "self",
+			},
+		},
+		Name: "test",
+	}
+
+	if diff := deep.Equal(response, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
 func TestOrganizationsServiceOp_Projects(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
## Description

This PR adds the [renameOrganization](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Organizations/operation/renameOrganization) supports to organization.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

