### PR TITLE
INTMDB-137: Fix output of CloudProviderAccessService.GetRole

### DIFF
--- a/mongodbatlas/cloud_provider_access.go
+++ b/mongodbatlas/cloud_provider_access.go
@@ -27,7 +27,7 @@ const cloudProviderAccessPath = "api/atlas/v1.0/groups/%s/cloudProviderAccess"
 // See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access
 type CloudProviderAccessService interface {
 	ListRoles(context.Context, string) (*CloudProviderAccessRoles, *Response, error)
-	GetRole(context.Context, string, string) (*CloudProviderAccessRoles, *Response, error)
+	GetRole(context.Context, string, string) (*AWSIAMRole, *Response, error)
 	CreateRole(context.Context, string, *CloudProviderAccessRoleRequest) (*AWSIAMRole, *Response, error)
 	AuthorizeRole(context.Context, string, string, *CloudProviderAuthorizationRequest) (*AWSIAMRole, *Response, error)
 	DeauthorizeRole(context.Context, *CloudProviderDeauthorizationRequest) (*Response, error)
@@ -83,7 +83,7 @@ type CloudProviderDeauthorizationRequest struct {
 // with the specified id and with access to the specified project.
 //
 // See more: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/getCloudProviderAccessRole
-func (s *CloudProviderAccessServiceOp) GetRole(ctx context.Context, groupID, roleID string) (*CloudProviderAccessRoles, *Response, error) {
+func (s *CloudProviderAccessServiceOp) GetRole(ctx context.Context, groupID, roleID string) (*AWSIAMRole, *Response, error) {
 	if groupID == "" {
 		return nil, nil, NewArgError("groupId", "must be set")
 	}
@@ -98,7 +98,7 @@ func (s *CloudProviderAccessServiceOp) GetRole(ctx context.Context, groupID, rol
 		return nil, nil, err
 	}
 
-	root := new(CloudProviderAccessRoles)
+	root := new(AWSIAMRole)
 	resp, err := s.Client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err

--- a/mongodbatlas/cloud_provider_access_test.go
+++ b/mongodbatlas/cloud_provider_access_test.go
@@ -89,7 +89,7 @@ func TestCloudProviderAccessServiceOp_GetRole(t *testing.T) {
 
 	roles, _, err := client.CloudProviderAccess.GetRole(ctx, groupID, roleID)
 	if err != nil {
-		t.Fatalf("CloudProviderAccess.ListRoles returned error: %v", err)
+		t.Fatalf("CloudProviderAccess.GetRole returned error: %v", err)
 	}
 
 	expected := &CloudProviderAccessRoles{

--- a/mongodbatlas/cloud_provider_access_test.go
+++ b/mongodbatlas/cloud_provider_access_test.go
@@ -67,6 +67,50 @@ func TestCloudProviderAccessServiceOp_ListRoles(t *testing.T) {
 	}
 }
 
+func TestCloudProviderAccessServiceOp_GetRole(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+	roleID := "1"
+	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/1/cloudProviderAccess/%s", roleID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+		  "awsIamRoles": [{
+			"atlasAWSAccountArn": "arn:aws:iam::123456789012:root",
+			"atlasAssumedRoleExternalId": "3192be49-6e76-4b7d-a7b8-b486a8fc4483",
+			"authorizedDate": "2020-08-03T20:42:49Z",
+			"createdDate": "2020-07-30T20:20:36Z",
+			"featureUsages": [],
+			"iamAssumedRoleArn": "arn:aws:iam::772401394250:role/my-test-aws-role",
+			"providerName": "AWS",
+			"roleId": "5f232b94af0a6b41747bcc2d"
+		  }]
+		}`)
+	})
+
+	roles, _, err := client.CloudProviderAccess.GetRole(ctx, groupID, roleID)
+	if err != nil {
+		t.Fatalf("CloudProviderAccess.ListRoles returned error: %v", err)
+	}
+
+	expected := &CloudProviderAccessRoles{
+		AWSIAMRoles: []AWSIAMRole{
+			{
+				AtlasAWSAccountARN:         "arn:aws:iam::123456789012:root",
+				AtlasAssumedRoleExternalID: "3192be49-6e76-4b7d-a7b8-b486a8fc4483",
+				AuthorizedDate:             "2020-08-03T20:42:49Z",
+				CreatedDate:                "2020-07-30T20:20:36Z",
+				FeatureUsages:              []*FeatureUsage{},
+				IAMAssumedRoleARN:          "arn:aws:iam::772401394250:role/my-test-aws-role",
+				ProviderName:               "AWS",
+				RoleID:                     "5f232b94af0a6b41747bcc2d",
+			},
+		},
+	}
+	if diff := deep.Equal(roles, expected); diff != nil {
+		t.Error(diff)
+	}
+}
+
 func TestCloudProviderAccessServiceOp_CreateRole(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()

--- a/mongodbatlas/cloud_provider_access_test.go
+++ b/mongodbatlas/cloud_provider_access_test.go
@@ -74,7 +74,6 @@ func TestCloudProviderAccessServiceOp_GetRole(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/1/cloudProviderAccess/%s", roleID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
-		  "awsIamRoles": [{
 			"atlasAWSAccountArn": "arn:aws:iam::123456789012:root",
 			"atlasAssumedRoleExternalId": "3192be49-6e76-4b7d-a7b8-b486a8fc4483",
 			"authorizedDate": "2020-08-03T20:42:49Z",
@@ -83,7 +82,6 @@ func TestCloudProviderAccessServiceOp_GetRole(t *testing.T) {
 			"iamAssumedRoleArn": "arn:aws:iam::772401394250:role/my-test-aws-role",
 			"providerName": "AWS",
 			"roleId": "5f232b94af0a6b41747bcc2d"
-		  }]
 		}`)
 	})
 
@@ -92,19 +90,15 @@ func TestCloudProviderAccessServiceOp_GetRole(t *testing.T) {
 		t.Fatalf("CloudProviderAccess.GetRole returned error: %v", err)
 	}
 
-	expected := &CloudProviderAccessRoles{
-		AWSIAMRoles: []AWSIAMRole{
-			{
-				AtlasAWSAccountARN:         "arn:aws:iam::123456789012:root",
-				AtlasAssumedRoleExternalID: "3192be49-6e76-4b7d-a7b8-b486a8fc4483",
-				AuthorizedDate:             "2020-08-03T20:42:49Z",
-				CreatedDate:                "2020-07-30T20:20:36Z",
-				FeatureUsages:              []*FeatureUsage{},
-				IAMAssumedRoleARN:          "arn:aws:iam::772401394250:role/my-test-aws-role",
-				ProviderName:               "AWS",
-				RoleID:                     "5f232b94af0a6b41747bcc2d",
-			},
-		},
+	expected := &AWSIAMRole{
+		AtlasAWSAccountARN:         "arn:aws:iam::123456789012:root",
+		AtlasAssumedRoleExternalID: "3192be49-6e76-4b7d-a7b8-b486a8fc4483",
+		AuthorizedDate:             "2020-08-03T20:42:49Z",
+		CreatedDate:                "2020-07-30T20:20:36Z",
+		FeatureUsages:              []*FeatureUsage{},
+		IAMAssumedRoleARN:          "arn:aws:iam::772401394250:role/my-test-aws-role",
+		ProviderName:               "AWS",
+		RoleID:                     "5f232b94af0a6b41747bcc2d",
 	}
 	if diff := deep.Equal(roles, expected); diff != nil {
 		t.Error(diff)


### PR DESCRIPTION
## Description

`CloudProviderAccessService.GetRole` returns `AWSIAMRole` instead of an array as the [Open API spec suggests](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Provider-Access/operation/deauthorizeCloudProviderAccessRole). Fixing the Open API spec in [#76871](https://github.com/10gen/mms/pull/76871)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

