### PR TITLE
INTMDB-874:  Support transactionLifetimeLimitSeconds parameter in Cluster and Advanced Cluser

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -186,8 +186,8 @@ type ProcessArgs struct {
 	OplogSizeMB                      *int64   `json:"oplogSizeMB,omitempty"`
 	SampleSizeBIConnector            *int64   `json:"sampleSizeBIConnector,omitempty"`
 	SampleRefreshIntervalBIConnector *int64   `json:"sampleRefreshIntervalBIConnector,omitempty"`
+	TransactionLifetimeLimitSeconds  *int64   `json:"transactionLifetimeLimitSeconds,omitempty"`
 	OplogMinRetentionHours           *float64 `json:"oplogMinRetentionHours,omitempty"`
-	TransactionLifetimeLimitSeconds  *float64 `json:"transactionLifetimeLimitSeconds,omitempty"`
 }
 
 type Tag struct {

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -187,6 +187,7 @@ type ProcessArgs struct {
 	SampleSizeBIConnector            *int64   `json:"sampleSizeBIConnector,omitempty"`
 	SampleRefreshIntervalBIConnector *int64   `json:"sampleRefreshIntervalBIConnector,omitempty"`
 	OplogMinRetentionHours           *float64 `json:"oplogMinRetentionHours,omitempty"`
+	TransactionLifetimeLimitSeconds  *float64 `json:"transactionLifetimeLimitSeconds,omitempty"`
 }
 
 type Tag struct {

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -774,6 +774,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		OplogMinRetentionHours:           pointer(100.0),
 		SampleSizeBIConnector:            pointer(int64(5000)),
 		SampleRefreshIntervalBIConnector: pointer(int64(300)),
+		TransactionLifetimeLimitSeconds:  pointer(float64(30)),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/processArgs", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
@@ -788,6 +789,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 			"oplogMinRetentionHours":           float64(100),
 			"sampleSizeBIConnector":            float64(5000),
 			"sampleRefreshIntervalBIConnector": float64(300),
+			"transactionLifetimeLimitSeconds":  float64(30),
 		}
 
 		jsonBlob := `
@@ -801,7 +803,8 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 			"oplogSizeMB": 2000,
             "oplogMinRetentionHours": 100,
 			"sampleSizeBIConnector": 5000,
-			"sampleRefreshIntervalBIConnector": 300
+			"sampleRefreshIntervalBIConnector": 300,
+			"transactionLifetimeLimitSeconds": 30
 		}
 		`
 
@@ -849,7 +852,8 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 			"noTableScan": true,
 			"oplogSizeMB": 2000,
 			"sampleSizeBIConnector": 5000,
-			"sampleRefreshIntervalBIConnector": 300
+			"sampleRefreshIntervalBIConnector": 300,
+			"transactionLifetimeLimitSeconds": 30
 		}`)
 	})
 
@@ -868,6 +872,7 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 		OplogSizeMB:                      pointer(int64(2000)),
 		SampleSizeBIConnector:            pointer(int64(5000)),
 		SampleRefreshIntervalBIConnector: pointer(int64(300)),
+		TransactionLifetimeLimitSeconds:  pointer(float64(30)),
 	}
 
 	if diff := deep.Equal(processArgs, expected); diff != nil {

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -774,7 +774,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		OplogMinRetentionHours:           pointer(100.0),
 		SampleSizeBIConnector:            pointer(int64(5000)),
 		SampleRefreshIntervalBIConnector: pointer(int64(300)),
-		TransactionLifetimeLimitSeconds:  pointer(float64(30)),
+		TransactionLifetimeLimitSeconds:  pointer(int64(30)),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/processArgs", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
@@ -872,7 +872,7 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 		OplogSizeMB:                      pointer(int64(2000)),
 		SampleSizeBIConnector:            pointer(int64(5000)),
 		SampleRefreshIntervalBIConnector: pointer(int64(300)),
-		TransactionLifetimeLimitSeconds:  pointer(float64(30)),
+		TransactionLifetimeLimitSeconds:  pointer(int64(30)),
 	}
 
 	if diff := deep.Equal(processArgs, expected); diff != nil {


### PR DESCRIPTION
## Description

This PR adds support `transactionLifetimeLimitSeconds` parameter for `ProcessArgs`. This param was added in [CLOUDP-183132](https://jira.mongodb.org/browse/CLOUDP-183132)

Link to any related issue(s): [INTMDB-874](https://jira.mongodb.org/browse/INTMDB-874)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

