### PR TITLE
INTMDB-838: Add FederationSettingsId to org

### DIFF
--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -77,7 +77,7 @@ type Organizations struct {
 // CreateOrganizationRequest struct for CreateOrganizationRequest.
 type CreateOrganizationRequest struct {
 	APIKey               *APIKeyInput `json:"apiKey,omitempty"`
-	FederationSettingsId *string      `json:"federationSettingsId,omitempty"`
+	FederationSettingsID *string      `json:"federationSettingsId,omitempty"`
 	Name                 string       `json:"name"`
 	OrgOwnerID           *string      `json:"orgOwnerId,omitempty"`
 }
@@ -85,7 +85,7 @@ type CreateOrganizationRequest struct {
 // CreateOrganizationResponse struct for CreateOrganizationResponse.
 type CreateOrganizationResponse struct {
 	APIKey               *APIKey       `json:"apiKey,omitempty"`
-	FederationSettingsId *string       `json:"federationSettingsId,omitempty"`
+	FederationSettingsID *string       `json:"federationSettingsId,omitempty"`
 	OrgOwnerID           *string       `json:"orgOwnerId,omitempty"`
 	Organization         *Organization `json:"organization,omitempty"`
 }

--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -76,16 +76,18 @@ type Organizations struct {
 
 // CreateOrganizationRequest struct for CreateOrganizationRequest.
 type CreateOrganizationRequest struct {
-	APIKey     *APIKeyInput `json:"apiKey,omitempty"`
-	Name       string       `json:"name"`
-	OrgOwnerID *string      `json:"orgOwnerId,omitempty"`
+	APIKey               *APIKeyInput `json:"apiKey,omitempty"`
+	FederationSettingsId *string      `json:"federationSettingsId,omitempty"`
+	Name                 string       `json:"name"`
+	OrgOwnerID           *string      `json:"orgOwnerId,omitempty"`
 }
 
 // CreateOrganizationResponse struct for CreateOrganizationResponse.
 type CreateOrganizationResponse struct {
-	APIKey       *APIKey       `json:"apiKey,omitempty"`
-	OrgOwnerID   *string       `json:"orgOwnerId,omitempty"`
-	Organization *Organization `json:"organization,omitempty"`
+	APIKey               *APIKey       `json:"apiKey,omitempty"`
+	FederationSettingsId *string       `json:"federationSettingsId,omitempty"`
+	OrgOwnerID           *string       `json:"orgOwnerId,omitempty"`
+	Organization         *Organization `json:"organization,omitempty"`
 }
 
 // List gets all organizations.

--- a/mongodbatlas/organizations_test.go
+++ b/mongodbatlas/organizations_test.go
@@ -465,7 +465,8 @@ func TestOrganizationsServiceOp_Create(t *testing.T) {
 					"roleName": "ORG_OWNER"
 				  }
 				]
-			  },			  
+			  },
+			  "federationSettingsId": "1",
 			  "organization": {
 				"id": "32b6e34b3d91647abb20e7b8",								
 				"name": "test"
@@ -478,7 +479,8 @@ func TestOrganizationsServiceOp_Create(t *testing.T) {
 			Desc:  "string",
 			Roles: []string{"ORG_OWNER"},
 		},
-		Name: "test",
+		Name:                 "test",
+		FederationSettingsId: pointer("1"),
 	}
 
 	response, _, err := client.Organizations.Create(ctx, body)
@@ -500,6 +502,7 @@ func TestOrganizationsServiceOp_Create(t *testing.T) {
 			ID:   "32b6e34b3d91647abb20e7b8",
 			Name: "test",
 		},
+		FederationSettingsId: pointer("1"),
 	}
 
 	if diff := deep.Equal(response, expected); diff != nil {

--- a/mongodbatlas/organizations_test.go
+++ b/mongodbatlas/organizations_test.go
@@ -480,7 +480,7 @@ func TestOrganizationsServiceOp_Create(t *testing.T) {
 			Roles: []string{"ORG_OWNER"},
 		},
 		Name:                 "test",
-		FederationSettingsId: pointer("1"),
+		FederationSettingsID: pointer("1"),
 	}
 
 	response, _, err := client.Organizations.Create(ctx, body)
@@ -502,7 +502,7 @@ func TestOrganizationsServiceOp_Create(t *testing.T) {
 			ID:   "32b6e34b3d91647abb20e7b8",
 			Name: "test",
 		},
-		FederationSettingsId: pointer("1"),
+		FederationSettingsID: pointer("1"),
 	}
 
 	if diff := deep.Equal(response, expected); diff != nil {


### PR DESCRIPTION
## Description

This PR adds `FederationSettingsId` to the org service. [Create Organizations](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Organizations/operation/createOrganization) 

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

