### PR TITLE
Removed omitempty from tags in ServerlessUpdateRequestParams

### DIFF
--- a/mongodbatlas/serverless_instances.go
+++ b/mongodbatlas/serverless_instances.go
@@ -57,7 +57,7 @@ type ServerlessCreateRequestParams struct {
 type ServerlessUpdateRequestParams struct {
 	ServerlessBackupOptions      *ServerlessBackupOptions `json:"serverlessBackupOptions"`
 	TerminationProtectionEnabled *bool                    `json:"terminationProtectionEnabled,omitempty"`
-	Tag                          []*Tag                   `json:"tags,omitempty"`
+	Tag                          []*Tag                   `json:"tags"`
 }
 
 // ServerlessProviderSettings represents the Provider Settings of serverless instances.


### PR DESCRIPTION
This will allow for operators to remove all tags from Serverless Instances as tags will not be omitted when sending an empty array of tags.

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments
This is a minor change to allow AKO to remove all tags from a Serverless Instance
