### PR TITLE
INTMDB-931: Add support for OIDCAuthType to database user

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -72,6 +72,7 @@ type DatabaseUser struct {
 	Scopes          []Scope `json:"scopes"`
 	Password        string  `json:"password,omitempty"`
 	Username        string  `json:"username,omitempty"`
+	OIDCAuthType    string  `json:"oidcAuthType,omitempty"`
 }
 
 // GetAuthDB determines the authentication database based on the type of user.

--- a/mongodbatlas/database_users_test.go
+++ b/mongodbatlas/database_users_test.go
@@ -291,6 +291,60 @@ func TestDatabaseUsers_CreateWithAWSIAMType(t *testing.T) {
 	}
 }
 
+func TestDatabaseUsers_CreateWithOIDC(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	groupID := "1"
+
+	createRequest := &DatabaseUser{
+		DatabaseName: "$external",
+		Username:     "0oaqyt9fc2ySTWnA0357/test-cfn-config-name",
+		GroupID:      groupID,
+		OIDCAuthType: "IDP_GROUP",
+		Scopes:       []Scope{},
+	}
+
+	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/databaseUsers", groupID), func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"databaseName": "$external",
+			"username":     "0oaqyt9fc2ySTWnA0357/test-cfn-config-name",
+			"groupId":      groupID,
+			"oidcAuthType": "IDP_GROUP",
+			"scopes":       []interface{}{},
+		}
+
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprint(w, `{
+			"databaseName": "$external",
+			"username":     "0oaqyt9fc2ySTWnA0357/test-cfn-config-name",
+			"groupId": "1",
+			"oidcAuthType": "IDP_GROUP",
+			"scopes" : []
+		}`)
+	})
+
+	dbUser, _, err := client.DatabaseUsers.Create(ctx, groupID, createRequest)
+	if err != nil {
+		t.Errorf("DatabaseUsers.Create returned error: %v", err)
+	}
+	if username := dbUser.Username; username != "0oaqyt9fc2ySTWnA0357/test-cfn-config-name" {
+		t.Errorf("expected username '%s', received '%s'", "0oaqyt9fc2ySTWnA0357/test-cfn-config-name", username)
+	}
+	if id := dbUser.GroupID; id != groupID {
+		t.Errorf("expected groupId '%s', received '%s'", groupID, id)
+	}
+}
+
 func TestDatabaseUsers_Create(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
## Description

This PR adds support for `OIDCAuthType` to the database user service (endpoint: [createDatabaseUser](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v1/#tag/Database-Users/operation/createDatabaseUser))

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

