### PR TITLE
feat: Adds acceptDataRisksAndForceReplicaSetReconfig parameter in cluster and advanced cluster

### DIFF
--- a/mongodbatlas/advanced_clusters.go
+++ b/mongodbatlas/advanced_clusters.go
@@ -44,27 +44,28 @@ var _ AdvancedClustersService = &AdvancedClustersServiceOp{}
 
 // AdvancedCluster represents MongoDB cluster.
 type AdvancedCluster struct {
-	BackupEnabled                *bool                      `json:"backupEnabled,omitempty"`
-	BiConnector                  *BiConnector               `json:"biConnector,omitempty"`
-	ClusterType                  string                     `json:"clusterType,omitempty"`
-	ConnectionStrings            *ConnectionStrings         `json:"connectionStrings,omitempty"`
-	DiskSizeGB                   *float64                   `json:"diskSizeGB,omitempty"`
-	EncryptionAtRestProvider     string                     `json:"encryptionAtRestProvider,omitempty"`
-	GroupID                      string                     `json:"groupId,omitempty"`
-	ID                           string                     `json:"id,omitempty"`
-	Labels                       []Label                    `json:"labels,omitempty"`
-	MongoDBMajorVersion          string                     `json:"mongoDBMajorVersion,omitempty"`
-	MongoDBVersion               string                     `json:"mongoDBVersion,omitempty"`
-	Name                         string                     `json:"name,omitempty"`
-	Paused                       *bool                      `json:"paused,omitempty"`
-	PitEnabled                   *bool                      `json:"pitEnabled,omitempty"`
-	StateName                    string                     `json:"stateName,omitempty"`
-	ReplicationSpecs             []*AdvancedReplicationSpec `json:"replicationSpecs,omitempty"`
-	CreateDate                   string                     `json:"createDate,omitempty"`
-	RootCertType                 string                     `json:"rootCertType,omitempty"`
-	VersionReleaseSystem         string                     `json:"versionReleaseSystem,omitempty"`
-	TerminationProtectionEnabled *bool                      `json:"terminationProtectionEnabled,omitempty"`
-	Tags                         []*Tag                     `json:"tags,omitempty"`
+	AcceptDataRisksAndForceReplicaSetReconfig string                     `json:"acceptDataRisksAndForceReplicaSetReconfig,omitempty"`
+	BackupEnabled                             *bool                      `json:"backupEnabled,omitempty"`
+	BiConnector                               *BiConnector               `json:"biConnector,omitempty"`
+	ClusterType                               string                     `json:"clusterType,omitempty"`
+	ConnectionStrings                         *ConnectionStrings         `json:"connectionStrings,omitempty"`
+	DiskSizeGB                                *float64                   `json:"diskSizeGB,omitempty"`
+	EncryptionAtRestProvider                  string                     `json:"encryptionAtRestProvider,omitempty"`
+	GroupID                                   string                     `json:"groupId,omitempty"`
+	ID                                        string                     `json:"id,omitempty"`
+	Labels                                    []Label                    `json:"labels,omitempty"`
+	MongoDBMajorVersion                       string                     `json:"mongoDBMajorVersion,omitempty"`
+	MongoDBVersion                            string                     `json:"mongoDBVersion,omitempty"`
+	Name                                      string                     `json:"name,omitempty"`
+	Paused                                    *bool                      `json:"paused,omitempty"`
+	PitEnabled                                *bool                      `json:"pitEnabled,omitempty"`
+	StateName                                 string                     `json:"stateName,omitempty"`
+	ReplicationSpecs                          []*AdvancedReplicationSpec `json:"replicationSpecs,omitempty"`
+	CreateDate                                string                     `json:"createDate,omitempty"`
+	RootCertType                              string                     `json:"rootCertType,omitempty"`
+	VersionReleaseSystem                      string                     `json:"versionReleaseSystem,omitempty"`
+	TerminationProtectionEnabled              *bool                      `json:"terminationProtectionEnabled,omitempty"`
+	Tags                                      []*Tag                     `json:"tags,omitempty"`
 }
 
 type AdvancedReplicationSpec struct {

--- a/mongodbatlas/advanced_clusters_test.go
+++ b/mongodbatlas/advanced_clusters_test.go
@@ -48,6 +48,7 @@ func TestAdvancedClusters_List(t *testing.T) {
 						"readPreference": "secondary"
 					  },
 					  "clusterType": "REPLICASET",
+						"acceptDataRisksAndForceReplicaSetReconfig": "2021-03-02T22:25:18Z",
 					  "createDate": "2021-03-02T22:25:18Z",
 					  "diskSizeGB": 10.0,
 					  "encryptionAtRestProvider": "NONE",
@@ -112,6 +113,7 @@ func TestAdvancedClusters_List(t *testing.T) {
 							"readPreference": "secondary"
 						  },
 						  "clusterType": "GEOSHARDED",
+							"acceptDataRisksAndForceReplicaSetReconfig": "2021-03-02T22:27:46Z",
 						  "createDate": "2021-03-02T22:27:46Z",
 						  "diskSizeGB": 40.0,
 						  "encryptionAtRestProvider": "NONE",
@@ -294,7 +296,8 @@ func TestAdvancedClusters_List(t *testing.T) {
 						},
 					},
 				},
-				CreateDate:   "2021-03-02T22:25:18Z",
+				CreateDate: "2021-03-02T22:25:18Z",
+				AcceptDataRisksAndForceReplicaSetReconfig: "2021-03-02T22:25:18Z",
 				RootCertType: "DST",
 			},
 			{
@@ -393,6 +396,7 @@ func TestAdvancedClusters_List(t *testing.T) {
 							},
 						},
 					}},
+				AcceptDataRisksAndForceReplicaSetReconfig: "2021-03-02T22:27:46Z",
 				CreateDate:           "2021-03-02T22:27:46Z",
 				RootCertType:         "DST",
 				VersionReleaseSystem: "LTS",
@@ -636,6 +640,7 @@ func TestAdvancedClusters_Create(t *testing.T) {
 							"readPreference": "secondary"
 						  },
 						  "clusterType": "GEOSHARDED",
+							"acceptDataRisksAndForceReplicaSetReconfig": "2021-03-02T22:27:46Z",
 						  "createDate": "2021-03-02T22:27:46Z",
 						  "diskSizeGB": 40.0,
 						  "encryptionAtRestProvider": "NONE",
@@ -832,6 +837,7 @@ func TestAdvancedClusters_Create(t *testing.T) {
 					},
 				},
 			}},
+		AcceptDataRisksAndForceReplicaSetReconfig: "2021-03-02T22:27:46Z",
 		CreateDate:           "2021-03-02T22:27:46Z",
 		RootCertType:         "DST",
 		VersionReleaseSystem: "LTS",
@@ -938,6 +944,7 @@ func TestAdvancedClusters_Create(t *testing.T) {
 					},
 				},
 			}},
+		AcceptDataRisksAndForceReplicaSetReconfig: "2021-03-02T22:27:46Z",
 		CreateDate:           "2021-03-02T22:27:46Z",
 		RootCertType:         "DST",
 		VersionReleaseSystem: "LTS",
@@ -960,6 +967,7 @@ func TestAdvancedClusters_Update(t *testing.T) {
 							"readPreference": "secondary"
 						  },
 						  "clusterType": "GEOSHARDED",
+							"acceptDataRisksAndForceReplicaSetReconfig": "2021-03-02T22:27:46Z",
 						  "createDate": "2021-03-02T22:27:46Z",
 						  "diskSizeGB": 40.0,
 						  "encryptionAtRestProvider": "NONE",
@@ -1149,6 +1157,7 @@ func TestAdvancedClusters_Update(t *testing.T) {
 					},
 				},
 			}},
+		AcceptDataRisksAndForceReplicaSetReconfig: "2021-03-02T22:27:46Z",
 		CreateDate:   "2021-03-02T22:27:46Z",
 		RootCertType: "DST",
 	}
@@ -1248,6 +1257,7 @@ func TestAdvancedClusters_Update(t *testing.T) {
 					},
 				},
 			}},
+		AcceptDataRisksAndForceReplicaSetReconfig: "2021-03-02T22:27:46Z",
 		CreateDate:   "2021-03-02T22:27:46Z",
 		RootCertType: "DST",
 	}

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -140,39 +140,40 @@ type ConnectionStrings struct {
 
 // Cluster represents MongoDB cluster.
 type Cluster struct {
-	AutoScaling                  *AutoScaling             `json:"autoScaling,omitempty"`
-	BackupEnabled                *bool                    `json:"backupEnabled,omitempty"` // Deprecated: Use ProviderBackupEnabled instead
-	BiConnector                  *BiConnector             `json:"biConnector,omitempty"`
-	ClusterType                  string                   `json:"clusterType,omitempty"`
-	DiskSizeGB                   *float64                 `json:"diskSizeGB,omitempty"`
-	EncryptionAtRestProvider     string                   `json:"encryptionAtRestProvider,omitempty"`
-	Labels                       []Label                  `json:"labels,omitempty"`
-	ID                           string                   `json:"id,omitempty"`
-	GroupID                      string                   `json:"groupId,omitempty"`
-	MongoDBVersion               string                   `json:"mongoDBVersion,omitempty"`
-	MongoDBMajorVersion          string                   `json:"mongoDBMajorVersion,omitempty"`
-	MongoURI                     string                   `json:"mongoURI,omitempty"`
-	MongoURIUpdated              string                   `json:"mongoURIUpdated,omitempty"`
-	MongoURIWithOptions          string                   `json:"mongoURIWithOptions,omitempty"`
-	Name                         string                   `json:"name,omitempty"`
-	CreateDate                   string                   `json:"createDate,omitempty"`
-	NumShards                    *int64                   `json:"numShards,omitempty"`
-	Paused                       *bool                    `json:"paused,omitempty"`
-	PitEnabled                   *bool                    `json:"pitEnabled,omitempty"`
-	ProviderBackupEnabled        *bool                    `json:"providerBackupEnabled,omitempty"`
-	ProviderSettings             *ProviderSettings        `json:"providerSettings,omitempty"`
-	ReplicationFactor            *int64                   `json:"replicationFactor,omitempty"`
-	ReplicationSpec              map[string]RegionsConfig `json:"replicationSpec,omitempty"`
-	ReplicationSpecs             []ReplicationSpec        `json:"replicationSpecs,omitempty"`
-	SrvAddress                   string                   `json:"srvAddress,omitempty"`
-	StateName                    string                   `json:"stateName,omitempty"`
-	ServerlessBackupOptions      *ServerlessBackupOptions `json:"serverlessBackupOptions,omitempty"`
-	ConnectionStrings            *ConnectionStrings       `json:"connectionStrings,omitempty"`
-	Links                        []*Link                  `json:"links,omitempty"`
-	VersionReleaseSystem         string                   `json:"versionReleaseSystem,omitempty"`
-	RootCertType                 string                   `json:"rootCertType,omitempty"`
-	TerminationProtectionEnabled *bool                    `json:"terminationProtectionEnabled,omitempty"`
-	Tags                         *[]*Tag                  `json:"tags,omitempty"`
+	AcceptDataRisksAndForceReplicaSetReconfig string                   `json:"acceptDataRisksAndForceReplicaSetReconfig,omitempty"`
+	AutoScaling                               *AutoScaling             `json:"autoScaling,omitempty"`
+	BackupEnabled                             *bool                    `json:"backupEnabled,omitempty"` // Deprecated: Use ProviderBackupEnabled instead
+	BiConnector                               *BiConnector             `json:"biConnector,omitempty"`
+	ClusterType                               string                   `json:"clusterType,omitempty"`
+	DiskSizeGB                                *float64                 `json:"diskSizeGB,omitempty"`
+	EncryptionAtRestProvider                  string                   `json:"encryptionAtRestProvider,omitempty"`
+	Labels                                    []Label                  `json:"labels,omitempty"`
+	ID                                        string                   `json:"id,omitempty"`
+	GroupID                                   string                   `json:"groupId,omitempty"`
+	MongoDBVersion                            string                   `json:"mongoDBVersion,omitempty"`
+	MongoDBMajorVersion                       string                   `json:"mongoDBMajorVersion,omitempty"`
+	MongoURI                                  string                   `json:"mongoURI,omitempty"`
+	MongoURIUpdated                           string                   `json:"mongoURIUpdated,omitempty"`
+	MongoURIWithOptions                       string                   `json:"mongoURIWithOptions,omitempty"`
+	Name                                      string                   `json:"name,omitempty"`
+	CreateDate                                string                   `json:"createDate,omitempty"`
+	NumShards                                 *int64                   `json:"numShards,omitempty"`
+	Paused                                    *bool                    `json:"paused,omitempty"`
+	PitEnabled                                *bool                    `json:"pitEnabled,omitempty"`
+	ProviderBackupEnabled                     *bool                    `json:"providerBackupEnabled,omitempty"`
+	ProviderSettings                          *ProviderSettings        `json:"providerSettings,omitempty"`
+	ReplicationFactor                         *int64                   `json:"replicationFactor,omitempty"`
+	ReplicationSpec                           map[string]RegionsConfig `json:"replicationSpec,omitempty"`
+	ReplicationSpecs                          []ReplicationSpec        `json:"replicationSpecs,omitempty"`
+	SrvAddress                                string                   `json:"srvAddress,omitempty"`
+	StateName                                 string                   `json:"stateName,omitempty"`
+	ServerlessBackupOptions                   *ServerlessBackupOptions `json:"serverlessBackupOptions,omitempty"`
+	ConnectionStrings                         *ConnectionStrings       `json:"connectionStrings,omitempty"`
+	Links                                     []*Link                  `json:"links,omitempty"`
+	VersionReleaseSystem                      string                   `json:"versionReleaseSystem,omitempty"`
+	RootCertType                              string                   `json:"rootCertType,omitempty"`
+	TerminationProtectionEnabled              *bool                    `json:"terminationProtectionEnabled,omitempty"`
+	Tags                                      *[]*Tag                  `json:"tags,omitempty"`
 }
 
 // ProcessArgs represents the advanced configuration options for the cluster.

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -32,6 +32,7 @@ func TestClusters_ListClusters(t *testing.T) {
 		fmt.Fprint(w, `{
 			"results": [
 				{
+					"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 					"autoScaling": {
 						"diskGBEnabled": true,
 						"compute": {
@@ -109,6 +110,7 @@ func TestClusters_ListClusters(t *testing.T) {
 					"tags": [ { "key": "key1", "value": "value1" } ]
 				},
 				{
+					"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 					"autoScaling": {
 						"diskGBEnabled": true,
 						"compute": {
@@ -196,6 +198,7 @@ func TestClusters_ListClusters(t *testing.T) {
 	}
 
 	cluster1 := Cluster{
+		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AutoScaling: &AutoScaling{
 			DiskGBEnabled: pointer(true),
 			Compute: &Compute{
@@ -363,6 +366,7 @@ func TestClusters_Create(t *testing.T) {
 
 	createRequest := &Cluster{
 		ID: "1",
+		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
 			Compute: &Compute{Enabled: pointer(true), ScaleDownEnabled: pointer(true)}},
 		BackupEnabled:            pointer(true),
@@ -410,6 +414,7 @@ func TestClusters_Create(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters", groupID), func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
 			"id": "1",
+			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"autoScaling": map[string]interface{}{
 				"diskGBEnabled": true,
 				"compute": map[string]interface{}{
@@ -469,6 +474,7 @@ func TestClusters_Create(t *testing.T) {
 		jsonBlob := `
 		{	
 			"id":"1",
+			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"autoScaling": {
                 "diskGBEnabled": true,
 				"compute": {
@@ -565,6 +571,7 @@ func TestClusters_Update(t *testing.T) {
 
 	updateRequest := &Cluster{
 		ID: "1",
+		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
 			Compute: &Compute{Enabled: pointer(true), ScaleDownEnabled: pointer(true)}},
 		BackupEnabled:            pointer(true),
@@ -605,6 +612,7 @@ func TestClusters_Update(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
 			"id": "1",
+			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"autoScaling": map[string]interface{}{
 				"diskGBEnabled": true,
 				"compute": map[string]interface{}{
@@ -656,6 +664,7 @@ func TestClusters_Update(t *testing.T) {
 
 		jsonBlob := `
 		{
+			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"autoScaling": {
                 "diskGBEnabled": true,
 				"compute": {
@@ -894,6 +903,7 @@ func TestClusters_Get(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{	
 			"id":"1",
+			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"autoScaling": {
                 "diskGBEnabled": true
             },
@@ -969,7 +979,8 @@ func TestClusters_Get(t *testing.T) {
 	}
 
 	expected := &Cluster{
-		ID:            "1",
+		ID: "1",
+		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AutoScaling:   &AutoScaling{DiskGBEnabled: pointer(true)},
 		BackupEnabled: pointer(true),
 		BiConnector:   &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},
@@ -1066,7 +1077,8 @@ func TestClusters_LoadSampleDataset(t *testing.T) {
 							 "_id": "1",
 							  "clusterName": "globalCluster",
 							  "completeDate": null,
-							  "createDate": "2021-03-26T16:30:47Z",
+							  "acceptDataRisksAndForceReplicaSetReconfig": "2021-03-26T16:30:47Z",
+								"createDate": "2021-03-26T16:30:47Z",
 							  "errorMessage": null,
 							  "state": "WORKING"}`)
 	})
@@ -1333,6 +1345,7 @@ func TestClusters_Upgrade(t *testing.T) {
 
 	upgradeRequest := &Cluster{
 		ID: "1",
+		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
 			Compute: &Compute{Enabled: pointer(true), ScaleDownEnabled: pointer(true)}},
 		BackupEnabled:            pointer(true),
@@ -1373,6 +1386,7 @@ func TestClusters_Upgrade(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/tenantUpgrade", groupID), func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
 			"id": "1",
+			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"autoScaling": map[string]interface{}{
 				"diskGBEnabled": true,
 				"compute": map[string]interface{}{
@@ -1424,6 +1438,7 @@ func TestClusters_Upgrade(t *testing.T) {
 
 		jsonBlob := `
 		{
+			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"autoScaling": {
                 "diskGBEnabled": true,
 				"compute": {


### PR DESCRIPTION
## Description

Adds acceptDataRisksAndForceReplicaSetReconfig parameter in cluster and advanced cluster.

Ticket: [INTMDB-1236](https://jira.mongodb.org/browse/INTMDB-1236)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

