### PR TITLE
feat: adds fields to backup_compliance_policy.

### DIFF
--- a/mongodbatlas/backup_compliance_policy.go
+++ b/mongodbatlas/backup_compliance_policy.go
@@ -42,6 +42,8 @@ var _ BackupCompliancePolicyService = &BackupCompliancePolicyServiceOp{}
 // BackupCompliancePolicy represents a backup compiance policy.
 type BackupCompliancePolicy struct {
 	AuthorizedEmail         string                `json:"authorizedEmail,omitempty"`
+	AuthorizedUserFirstName string                `json:"authorizedUserFirstName,omitempty"`
+	AuthorizedUserLastName  string                `json:"authorizedUserLastName,omitempty"`
 	CopyProtectionEnabled   *bool                 `json:"copyProtectionEnabled,omitempty"`
 	EncryptionAtRestEnabled *bool                 `json:"encryptionAtRestEnabled,omitempty"`
 	OnDemandPolicyItem      PolicyItem            `json:"onDemandPolicyItem,omitempty"`

--- a/mongodbatlas/backup_compliance_policy_test.go
+++ b/mongodbatlas/backup_compliance_policy_test.go
@@ -33,6 +33,8 @@ func TestBackupCompliancePolicy_Get(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
 			"authorizedEmail": "user@example.com",
+			"authorizedUserFirstName":  "first",
+			"authorizedUserLastName":  "last",
 			"copyProtectionEnabled": false,
 			"encryptionAtRestEnabled": false,
 			"onDemandPolicyItem": 
@@ -76,6 +78,8 @@ func TestBackupCompliancePolicy_Get(t *testing.T) {
 
 	expected := &BackupCompliancePolicy{
 		AuthorizedEmail:         "user@example.com",
+		AuthorizedUserFirstName: "first",
+		AuthorizedUserLastName:  "last",
 		CopyProtectionEnabled:   pointer(false),
 		EncryptionAtRestEnabled: pointer(false),
 		ProjectID:               "32b6e34b3d91647abb20e7b8",
@@ -125,6 +129,8 @@ func TestBackupCompliancePolicy_Update(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
 			"authorizedEmail":         "user@example.com",
+			"authorizedUserFirstName": "first",
+			"authorizedUserLastName":  "last",
 			"copyProtectionEnabled":   false,
 			"encryptionAtRestEnabled": false,
 			"updatedDate":             "2019-08-24T14:15:22Z",
@@ -170,6 +176,8 @@ func TestBackupCompliancePolicy_Update(t *testing.T) {
 
 		fmt.Fprint(w, `{
 			"authorizedEmail": "user@example.com",
+			"authorizedUserFirstName": "first",
+			"authorizedUserLastName":  "last",
 			"copyProtectionEnabled": false,
 			"encryptionAtRestEnabled": false,
 			"onDemandPolicyItem": 
@@ -208,6 +216,8 @@ func TestBackupCompliancePolicy_Update(t *testing.T) {
 
 	updateRequest := &BackupCompliancePolicy{
 		AuthorizedEmail:         "user@example.com",
+		AuthorizedUserFirstName: "first",
+		AuthorizedUserLastName:  "last",
 		CopyProtectionEnabled:   pointer(false),
 		EncryptionAtRestEnabled: pointer(false),
 		ProjectID:               "32b6e34b3d91647abb20e7b8",
@@ -248,6 +258,8 @@ func TestBackupCompliancePolicy_Update(t *testing.T) {
 
 	expected := &BackupCompliancePolicy{
 		AuthorizedEmail:         "user@example.com",
+		AuthorizedUserFirstName: "first",
+		AuthorizedUserLastName:  "last",
 		CopyProtectionEnabled:   pointer(false),
 		EncryptionAtRestEnabled: pointer(false),
 		ProjectID:               "32b6e34b3d91647abb20e7b8",


### PR DESCRIPTION
## Description

As [per documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v1/#tag/Cloud-Backups/operation/updateDataProtectionSettings), we are adding the two new fields `authorizedUserFirstName` and `authorizedUserLastName` to `backup_compliance_policy`.

Link to any related issue(s):  https://jira.mongodb.org/browse/INTMDB-1072

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

