### PR TITLE
feat: Adds field to ProcessArgs

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -178,17 +178,18 @@ type Cluster struct {
 
 // ProcessArgs represents the advanced configuration options for the cluster.
 type ProcessArgs struct {
-	DefaultReadConcern               string   `json:"defaultReadConcern,omitempty"`
-	DefaultWriteConcern              string   `json:"defaultWriteConcern,omitempty"`
-	MinimumEnabledTLSProtocol        string   `json:"minimumEnabledTlsProtocol,omitempty"`
-	FailIndexKeyTooLong              *bool    `json:"failIndexKeyTooLong,omitempty"`
-	JavascriptEnabled                *bool    `json:"javascriptEnabled,omitempty"`
-	NoTableScan                      *bool    `json:"noTableScan,omitempty"`
-	OplogSizeMB                      *int64   `json:"oplogSizeMB,omitempty"`
-	SampleSizeBIConnector            *int64   `json:"sampleSizeBIConnector,omitempty"`
-	SampleRefreshIntervalBIConnector *int64   `json:"sampleRefreshIntervalBIConnector,omitempty"`
-	TransactionLifetimeLimitSeconds  *int64   `json:"transactionLifetimeLimitSeconds,omitempty"`
-	OplogMinRetentionHours           *float64 `json:"oplogMinRetentionHours,omitempty"`
+	DefaultReadConcern                                    string   `json:"defaultReadConcern,omitempty"`
+	DefaultWriteConcern                                   string   `json:"defaultWriteConcern,omitempty"`
+	MinimumEnabledTLSProtocol                             string   `json:"minimumEnabledTlsProtocol,omitempty"`
+	FailIndexKeyTooLong                                   *bool    `json:"failIndexKeyTooLong,omitempty"`
+	JavascriptEnabled                                     *bool    `json:"javascriptEnabled,omitempty"`
+	NoTableScan                                           *bool    `json:"noTableScan,omitempty"`
+	OplogSizeMB                                           *int64   `json:"oplogSizeMB,omitempty"`
+	SampleSizeBIConnector                                 *int64   `json:"sampleSizeBIConnector,omitempty"`
+	SampleRefreshIntervalBIConnector                      *int64   `json:"sampleRefreshIntervalBIConnector,omitempty"`
+	TransactionLifetimeLimitSeconds                       *int64   `json:"transactionLifetimeLimitSeconds,omitempty"`
+	OplogMinRetentionHours                                *float64 `json:"oplogMinRetentionHours,omitempty"`
+	ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds *int64   `json:"changeStreamOptionsPreAndPostImagesExpireAfterSeconds,omitempty"`
 }
 
 type Tag struct {

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -784,6 +784,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 		SampleSizeBIConnector:            pointer(int64(5000)),
 		SampleRefreshIntervalBIConnector: pointer(int64(300)),
 		TransactionLifetimeLimitSeconds:  pointer(int64(30)),
+		ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds: pointer(int64(-1)),
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/atlas/v1.0/groups/%s/clusters/%s/processArgs", groupID, clusterName), func(w http.ResponseWriter, r *http.Request) {
@@ -799,6 +800,7 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
 			"sampleSizeBIConnector":            float64(5000),
 			"sampleRefreshIntervalBIConnector": float64(300),
 			"transactionLifetimeLimitSeconds":  float64(30),
+			"changeStreamOptionsPreAndPostImagesExpireAfterSeconds": float64(-1),
 		}
 
 		jsonBlob := `
@@ -813,7 +815,8 @@ func TestClusters_UpdateProcessArgs(t *testing.T) {
             "oplogMinRetentionHours": 100,
 			"sampleSizeBIConnector": 5000,
 			"sampleRefreshIntervalBIConnector": 300,
-			"transactionLifetimeLimitSeconds": 30
+			"transactionLifetimeLimitSeconds": 30,
+			"changeStreamOptionsPreAndPostImagesExpireAfterSeconds": -1
 		}
 		`
 
@@ -862,7 +865,8 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 			"oplogSizeMB": 2000,
 			"sampleSizeBIConnector": 5000,
 			"sampleRefreshIntervalBIConnector": 300,
-			"transactionLifetimeLimitSeconds": 30
+			"transactionLifetimeLimitSeconds": 30,
+			"ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds": 113
 		}`)
 	})
 
@@ -882,6 +886,7 @@ func TestClusters_GetProcessArgs(t *testing.T) {
 		SampleSizeBIConnector:            pointer(int64(5000)),
 		SampleRefreshIntervalBIConnector: pointer(int64(300)),
 		TransactionLifetimeLimitSeconds:  pointer(int64(30)),
+		ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds: pointer(int64(113)),
 	}
 
 	if diff := deep.Equal(processArgs, expected); diff != nil {


### PR DESCRIPTION
## Description

Adds field `ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds` to ProcessArgs

Link to any related issue(s): CLOUDP-262526

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

