### PR TITLE
feat: Adds AdvancedConfiguration attribute

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -174,7 +174,16 @@ type Cluster struct {
 	RootCertType                              string                   `json:"rootCertType,omitempty"`
 	TerminationProtectionEnabled              *bool                    `json:"terminationProtectionEnabled,omitempty"`
 	Tags                                      *[]*Tag                  `json:"tags,omitempty"`
+	AdvancedConfiguration					  *AdvancedConfiguration   `json:"advancedConfiguration,omitempty"`
 }
+
+// AdvancedConfiguration group of settings that configures a subset of the advanced configuration details
+type AdvancedConfiguration struct {
+	CustomOpensslCipherConfigTls12 *[]string `json:"customOpensslCipherConfigTls12,omitempty"`
+	MinimumEnabledTlsProtocol *string `json:"minimumEnabledTlsProtocol,omitempty"`
+	TlsCipherConfigMode *string `json:"tlsCipherConfigMode,omitempty"`
+}
+
 
 // ProcessArgs represents the advanced configuration options for the cluster.
 type ProcessArgs struct {

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -174,16 +174,15 @@ type Cluster struct {
 	RootCertType                              string                   `json:"rootCertType,omitempty"`
 	TerminationProtectionEnabled              *bool                    `json:"terminationProtectionEnabled,omitempty"`
 	Tags                                      *[]*Tag                  `json:"tags,omitempty"`
-	AdvancedConfiguration					  *AdvancedConfiguration   `json:"advancedConfiguration,omitempty"`
+	AdvancedConfiguration                     *AdvancedConfiguration   `json:"advancedConfiguration,omitempty"`
 }
 
-// AdvancedConfiguration group of settings that configures a subset of the advanced configuration details
+// AdvancedConfiguration group of settings that configures a subset of the advanced configuration details.
 type AdvancedConfiguration struct {
-	CustomOpensslCipherConfigTls12 *[]string `json:"customOpensslCipherConfigTls12,omitempty"`
-	MinimumEnabledTlsProtocol *string `json:"minimumEnabledTlsProtocol,omitempty"`
-	TlsCipherConfigMode *string `json:"tlsCipherConfigMode,omitempty"`
+	CustomOpensslCipherConfigTLS12 *[]string `json:"customOpensslCipherConfigTls12,omitempty"`
+	MinimumEnabledTLSProtocol      *string   `json:"minimumEnabledTlsProtocol,omitempty"`
+	TLSCipherConfigMode            *string   `json:"tlsCipherConfigMode,omitempty"`
 }
-
 
 // ProcessArgs represents the advanced configuration options for the cluster.
 type ProcessArgs struct {

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -367,9 +367,9 @@ func TestClusters_Create(t *testing.T) {
 	createRequest := &Cluster{
 		ID: "1",
 		AdvancedConfiguration: &AdvancedConfiguration{
-			MinimumEnabledTlsProtocol: pointer("TLS1_2"),
-			TlsCipherConfigMode: pointer("CUSTOM"),
-			CustomOpensslCipherConfigTls12: &[]string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			MinimumEnabledTLSProtocol:      pointer("TLS1_2"),
+			TLSCipherConfigMode:            pointer("CUSTOM"),
+			CustomOpensslCipherConfigTLS12: &[]string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
 		},
 		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
@@ -422,9 +422,9 @@ func TestClusters_Create(t *testing.T) {
 			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
 			"advancedConfiguration": map[string]interface{}{
 				"customOpensslCipherConfigTls12": []interface{}{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
-				"minimumEnabledTlsProtocol": "TLS1_2",
-				"tlsCipherConfigMode": "CUSTOM",
-			   },
+				"minimumEnabledTlsProtocol":      "TLS1_2",
+				"tlsCipherConfigMode":            "CUSTOM",
+			},
 			"autoScaling": map[string]interface{}{
 				"diskGBEnabled": true,
 				"compute": map[string]interface{}{
@@ -1008,8 +1008,8 @@ func TestClusters_Get(t *testing.T) {
 		ID: "1",
 		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AdvancedConfiguration: &AdvancedConfiguration{
-			MinimumEnabledTlsProtocol: pointer("TLS1_2"),
-			TlsCipherConfigMode: pointer("DEFAULT"),
+			MinimumEnabledTLSProtocol: pointer("TLS1_2"),
+			TLSCipherConfigMode:       pointer("DEFAULT"),
 		},
 		AutoScaling:   &AutoScaling{DiskGBEnabled: pointer(true)},
 		BackupEnabled: pointer(true),

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -366,6 +366,11 @@ func TestClusters_Create(t *testing.T) {
 
 	createRequest := &Cluster{
 		ID: "1",
+		AdvancedConfiguration: &AdvancedConfiguration{
+			MinimumEnabledTlsProtocol: pointer("TLS1_2"),
+			TlsCipherConfigMode: pointer("CUSTOM"),
+			CustomOpensslCipherConfigTls12: &[]string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+		},
 		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
 		AutoScaling: &AutoScaling{DiskGBEnabled: pointer(true),
 			Compute: &Compute{Enabled: pointer(true), ScaleDownEnabled: pointer(true)}},
@@ -415,6 +420,11 @@ func TestClusters_Create(t *testing.T) {
 		expected := map[string]interface{}{
 			"id": "1",
 			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
+			"advancedConfiguration": map[string]interface{}{
+				"customOpensslCipherConfigTls12": []interface{}{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+				"minimumEnabledTlsProtocol": "TLS1_2",
+				"tlsCipherConfigMode": "CUSTOM",
+			   },
 			"autoScaling": map[string]interface{}{
 				"diskGBEnabled": true,
 				"compute": map[string]interface{}{
@@ -475,6 +485,13 @@ func TestClusters_Create(t *testing.T) {
 		{	
 			"id":"1",
 			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
+			"advancedConfiguration": {
+				"customOpensslCipherConfigTls12": [
+				 "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+				],
+				"minimumEnabledTlsProtocol": "TLS1_2",
+				"tlsCipherConfigMode": "CUSTOM"
+			},
 			"autoScaling": {
                 "diskGBEnabled": true,
 				"compute": {
@@ -909,6 +926,10 @@ func TestClusters_Get(t *testing.T) {
 		fmt.Fprint(w, `{	
 			"id":"1",
 			"acceptDataRisksAndForceReplicaSetReconfig": "2017-10-23T21:26:17Z",
+			"advancedConfiguration": {
+				"minimumEnabledTlsProtocol": "TLS1_2",
+				"tlsCipherConfigMode": "DEFAULT"
+			},
 			"autoScaling": {
                 "diskGBEnabled": true
             },
@@ -986,6 +1007,10 @@ func TestClusters_Get(t *testing.T) {
 	expected := &Cluster{
 		ID: "1",
 		AcceptDataRisksAndForceReplicaSetReconfig: "2017-10-23T21:26:17Z",
+		AdvancedConfiguration: &AdvancedConfiguration{
+			MinimumEnabledTlsProtocol: pointer("TLS1_2"),
+			TlsCipherConfigMode: pointer("DEFAULT"),
+		},
 		AutoScaling:   &AutoScaling{DiskGBEnabled: pointer(true)},
 		BackupEnabled: pointer(true),
 		BiConnector:   &BiConnector{Enabled: pointer(false), ReadPreference: "secondary"},


### PR DESCRIPTION
## Description

Adds AdvancedConfiguration attribute support in Cluster APIs.
Ref: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createCluster 

Link to any related issue(s): [CLOUDP-296222](https://jira.mongodb.org/browse/CLOUDP-296222)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

